### PR TITLE
feat: add @tank/bdd-issue-fixer skill

### DIFF
--- a/skills/bdd-issue-fixer/SKILL.md
+++ b/skills/bdd-issue-fixer/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: bdd-issue-fixer
+description: |
+  Resolve GitHub issues using BDD — read the issue, write a behavioral test,
+  confirm it fails (RED), fix the code, confirm it passes (GREEN), open a PR
+  with test + fix as proof. Covers issue triage (bug vs feature vs invalid vs
+  duplicate), issue-to-Gherkin translation, the relentless RED-GREEN fix cycle,
+  fix verification, PR submission with evidence, and related issue detection.
+  Synthesizes Smart/Molak (BDD in Action), Beck (TDD By Example), Nicieja
+  (Writing Great Specifications), SWE-bench (Princeton NLP), and Sweep.dev
+  patterns.
+
+  Trigger phrases: "fix this issue", "resolve issue", "fix GitHub issue",
+  "BDD fix", "issue to test", "write test for issue", "red green fix",
+  "triage issue", "duplicate issue", "related issues", "fix and PR",
+  "issue fixer", "auto-fix issue", "resolve bug report"
+---
+
+# BDD Issue Fixer
+
+## Hard Rules
+
+These are non-negotiable. Violating any of these means the work is wrong.
+
+1. **Never weaken a test.** When a test fails, the CODE is wrong. Fix the
+   code, not the test. Never skip, mock, or reduce assertion precision.
+
+2. **Test behavior, not implementation.** The Gherkin scenario captures what
+   the user expects. Write declarative scenarios from the user's perspective,
+   never imperative UI scripts.
+
+3. **Iterate until fixed.** Try up to 5 different fix strategies. If approach
+   1 fails, analyze why and try approach 2. Never give up after one attempt.
+   Escalate only after 5 genuine attempts.
+
+4. **Not every issue deserves a fix.** Triage first. Duplicates, questions,
+   invalid reports, and vague wishlists are not fixable issues. Classify
+   before coding.
+
+5. **Document everything.** Every fix produces findings, resolutions, and a
+   PR with evidence. The BDD scenario in the PR IS the proof.
+
+## Core Workflow
+
+This is the mandatory sequence. Execute in order. Do not skip steps.
+
+```
+1. TRIAGE  →  Read issue, classify, check for duplicates/related
+     ↓
+2. GHERKIN →  Translate fixable issue into behavioral test
+     ↓
+3. RED     →  Run test, confirm it fails (bug exists)
+     ↓
+4. FIX     →  Implement minimal code change
+     ↓
+5. GREEN?  →  Run test again
+     ↓ YES         ↓ NO
+6. VERIFY      Back to step 4 (max 5 iterations)
+     ↓
+7. PR      →  Create PR with test + fix + evidence
+```
+
+## Quick-Start
+
+### "I have a GitHub issue to fix"
+
+| Step | Action |
+|------|--------|
+| 1. Read issue | `gh issue view {N} --json title,body,labels,comments` |
+| 2. Triage | Classify: bug / feature / question / invalid / duplicate. See `references/issue-triage.md` |
+| 3. Check related | Search for duplicates and same-root-cause issues. See `references/related-issues.md` |
+| 4. Write Gherkin | Translate issue into `.bdd/features/{domain}/{slug}.feature`. See `references/issue-to-gherkin.md` |
+| 5. RED-GREEN cycle | Run test → fix code → run test → repeat until GREEN. See `references/red-green-fix-cycle.md` |
+| 6. Verify | Full suite, no regressions, document findings. See `references/fix-verification.md` |
+| 7. PR | Branch, commit (test, fix, docs), push, create PR. See `references/pr-and-git-workflow.md` |
+
+### "The issue seems invalid or incomplete"
+
+| Signal | Action | Reference |
+|--------|--------|-----------|
+| Can't reproduce | Ask for clarification with template | `references/issue-triage.md` |
+| User confusion, not a bug | Answer the question, close | `references/issue-triage.md` |
+| Same as existing issue | Link to original, close as duplicate | `references/related-issues.md` |
+| Vague wishlist, no criteria | Label "needs-discussion", don't fix | `references/issue-triage.md` |
+| Requires breaking changes | Escalate to maintainer | `references/issue-triage.md` |
+
+### "My fix broke other tests"
+
+| Symptom | Fix | Reference |
+|---------|-----|-----------|
+| Target test passes but other tests fail | Adjust fix to satisfy both behaviors | `references/fix-verification.md` |
+| Flaky test fails intermittently | Run 3x — if pre-existing flake, note and move on | `references/fix-verification.md` |
+| Type/lint errors in changed files | Fix them — never suppress with ts-ignore or rule disabling | `references/fix-verification.md` |
+
+### "Multiple issues seem related"
+
+| Relationship | Action | Reference |
+|-------------|--------|-----------|
+| Duplicate (same bug) | Close duplicate, fix canonical | `references/related-issues.md` |
+| Same root cause | Write Gherkin for ALL, fix root cause once | `references/related-issues.md` |
+| Blocked by another issue | Fix blocker first | `references/related-issues.md` |
+| Parent-child | Fix parent, check if child resolves | `references/related-issues.md` |
+
+## Decision Trees
+
+### Should I fix this issue?
+
+| Signal | Decision |
+|--------|----------|
+| Clear bug with repro steps | Fix it |
+| Feature request with acceptance criteria | Fix it |
+| Vague report, can infer expected behavior | Fix it, note assumptions |
+| No expected behavior, can't infer | Ask for clarification |
+| User error or confusion | Answer and close |
+| Duplicate of existing issue | Close, link to original |
+| Requires architectural changes | Escalate, label "needs-design" |
+| Security vulnerability | Private disclosure, do not fix in public PR |
+
+### Which fix iteration strategy?
+
+| Iteration | Strategy |
+|-----------|----------|
+| 1 | Direct fix — most obvious change |
+| 2 | Root cause analysis — trace the stack trace deeper |
+| 3 | Broader context — read surrounding code, understand data flow |
+| 4 | Alternative approach — different algorithm or code path |
+| 5 | Minimal viable — simplest possible code that makes it work |
+| After 5 | Escalate — document all attempts, label "needs-human-review" |
+
+## Commit and PR Structure
+
+Three atomic commits per fix:
+
+| Commit | Content | Message format |
+|--------|---------|----------------|
+| 1 | Gherkin scenario (the failing test) | `test: add BDD scenario for #{N}` |
+| 2 | Code fix | `fix: {description} (#{N})` |
+| 3 | QA documentation (findings + resolution) | `docs: add QA findings for #{N}` |
+
+PR body must include: the Gherkin scenario, verification results, iteration
+count, and `Fixes #{N}` for auto-close. See `references/pr-and-git-workflow.md`.
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/issue-triage.md` | Issue classification, extraction protocol, gh CLI commands, when NOT to fix, clarification templates, priority signals |
+| `references/issue-to-gherkin.md` | Translating issues into Gherkin scenarios, bug-to-Gherkin, feature-to-Gherkin, handling vague issues, file placement, quality rules |
+| `references/red-green-fix-cycle.md` | The relentless fix loop: RED confirmation, fix strategies per iteration, failure analysis, never-weaken rule, escalation protocol |
+| `references/fix-verification.md` | Post-fix verification suite, regression handling, findings/resolution documentation format, verification checklist |
+| `references/pr-and-git-workflow.md` | Branch strategy, 3-commit structure, PR title/body template, gh CLI commands, auto-close keywords, non-fix outcomes |
+| `references/related-issues.md` | Duplicate detection, same-root-cause clustering, blocked-by chains, batch fixing, gh CLI search patterns |

--- a/skills/bdd-issue-fixer/references/fix-verification.md
+++ b/skills/bdd-issue-fixer/references/fix-verification.md
@@ -1,0 +1,218 @@
+# Fix Verification
+
+Sources: Smart/Molak (BDD in Action), Khorikov (Unit Testing Principles), SWE-bench verification patterns
+
+Covers: post-fix verification suite, regression detection, findings/resolution documentation, verification checklist.
+
+The fix is not done when the target test passes. It is done when the target
+test passes, the existing suite still passes, the build succeeds, and the
+fix is documented. Verification is proof, not hope.
+
+## The Verification Suite
+
+After the RED-GREEN fix cycle produces a GREEN result, execute this verification
+sequence in order. Do not skip steps.
+
+| Step | Command | Pass criteria |
+|------|---------|---------------|
+| 1. Target scenario | `[test-runner] --grep "@issue-{N}"` | Scenario PASSES |
+| 2. Full test suite | `[test-runner]` | Same pass count as before fix (no regressions) |
+| 3. Linter | `[linter]` | No new errors in changed files |
+| 4. Type checker | `[type-checker]` | No new type errors in changed files |
+| 5. Build | `[build-command]` | Exit code 0 |
+
+### Step 1: Run Target Scenario in Isolation
+
+Confirm the fix works for the specific issue.
+
+```bash
+# Run only the tagged scenario
+[test-runner] --grep "@issue-42"
+```
+
+If this fails, you are still in the RED-GREEN fix cycle. Go back to
+`red-green-fix-cycle.md`.
+
+### Step 2: Run the Full Test Suite
+
+This catches regressions. The fix may have broken something else.
+
+```bash
+# Run the entire test suite
+[test-runner]
+
+# Record the results
+# Before fix: 142/145 passed (3 pre-existing failures)
+# After fix:  143/145 passed (same 2 pre-existing failures + new issue test)
+```
+
+Compare the before-fix and after-fix results. The pass count should be
+equal or higher (the new test adds one more pass). The fail count should
+be equal or lower.
+
+### Step 3-5: Linter, Type Checker, Build
+
+Run each on the changed files. Fix any issues introduced by the fix.
+
+**Non-negotiable rules:**
+- Never use `@ts-ignore`, `@ts-expect-error`, or `as any` to suppress type errors
+- Never disable a lint rule with `// eslint-disable` or equivalent
+- Never skip the build step for "small changes"
+
+If linting or type checking fails on unchanged files, those are pre-existing
+issues. Note them but do not fix them (unless the fix caused them).
+
+## Handling Regressions
+
+When the full suite reveals failures that did not exist before the fix:
+
+| Regression type | Diagnosis | Action |
+|----------------|-----------|--------|
+| Unrelated test fails, was passing before | Your fix changed shared state or a shared dependency. | Investigate the connection. Adjust fix to preserve both behaviors. |
+| Related test fails (same feature area) | Your fix changed behavior that another test depends on. | Adjust fix to satisfy BOTH the target scenario and the related test. |
+| Flaky test fails intermittently | Run 3 times. If it passes 2/3, it is a pre-existing flake. | Note the flake in findings. Not caused by your fix. Move on. |
+| Type error in changed file | Your fix has a type issue. | Fix the type error properly. No type suppression. |
+| Lint error in changed file | Your fix violates a lint rule. | Fix the lint violation. Do not disable the rule. |
+| Build fails | Your fix broke compilation or bundling. | Fix the build error. Check imports, exports, and module resolution. |
+
+### The Regression Fix Protocol
+
+1. Do NOT revert and give up.
+2. Understand what the regression reveals. Maybe the fix needs broader scope.
+3. Adjust the fix to satisfy BOTH the target scenario AND the regressed test.
+4. If the regression is in a genuinely unrelated area, investigate if there is
+   a shared dependency (shared module, global state, database fixture).
+5. After fixing the regression, run the FULL verification suite again.
+6. Repeat until clean.
+
+## Documenting Findings
+
+After the fix cycle completes (whether successful or escalated), document
+what happened. Create or update a findings file in `.bdd/qa/findings/`.
+
+### Findings File Format
+
+```markdown
+# {Issue Title} Findings
+
+Issue: #{issue_number}
+Date: {ISO date}
+Branch: fix/issue-{number}-{short-slug}
+
+## Scenario: {Scenario name from .feature file}
+- Status: PASSED (after {N} iterations)
+- Iterations required: {N}
+- Final fix: {One-line description of the change}
+
+## Regression Check
+- Full suite: {X}/{Y} passed (same as baseline)
+- New failures: none
+- Pre-existing failures: {list if any, or "none"}
+- Flaky tests noted: {list if any, or "none"}
+
+## Evidence
+- Test output: {inline or path to log}
+- Changed files: {list of files modified}
+```
+
+### File Naming
+
+- File name: `{domain}-{slug}.md` matching the feature file
+- Example: `export-csv-encoding.md` for `features/export/csv-encoding.feature`
+- One findings file per issue
+
+## Documenting Resolutions
+
+Create a resolution file in `.bdd/qa/resolutions/` that explains the fix.
+This is the audit trail.
+
+### Resolution File Format
+
+```markdown
+# Resolution: {Issue Title}
+
+Issue: #{issue_number}
+Date: {ISO date}
+
+## Root Cause
+{What was actually broken and why. Be specific: "The CSV serializer used
+the system default encoding (Latin-1 on Windows) instead of explicitly
+specifying UTF-8. The encoding parameter was missing from the
+`createWriteStream` call in `src/export/csv-writer.ts:47`."}
+
+## Fix Applied
+{What was changed. Reference specific files and functions.}
+
+## Iteration History
+1. {Attempt 1}: {What was tried}. Result: {Why it failed}.
+2. {Attempt 2}: {What was tried}. Result: {Why it failed}.
+3. {Attempt 3}: {What was tried}. Result: PASSED.
+
+## Verification
+- Target scenario: PASSED
+- Full suite: {X}/{Y} passed, no regressions
+- Build: PASSED
+- Lint: Clean on changed files
+- Type check: Clean on changed files
+```
+
+### When the Fix Was Escalated
+
+If the fix cycle ended in escalation (5 failed iterations), the resolution
+file documents the attempts:
+
+```markdown
+# Resolution: {Issue Title} (ESCALATED)
+
+Issue: #{issue_number}
+Date: {ISO date}
+Status: ESCALATED - needs human review
+
+## Root Cause Hypothesis
+{Best understanding of what is broken, even though the fix failed}
+
+## Attempted Fixes
+1. {Attempt 1}: {strategy, change, result}
+2. {Attempt 2}: {strategy, change, result}
+3. {Attempt 3}: {strategy, change, result}
+4. {Attempt 4}: {strategy, change, result}
+5. {Attempt 5}: {strategy, change, result}
+
+## Why It Resists Fixing
+{Analysis of why 5 approaches failed. What makes this bug hard?}
+
+## Suggested Next Steps
+{Recommendations for a human reviewer}
+```
+
+## Verification Checklist
+
+Before proceeding to PR creation (see `pr-and-git-workflow.md`), every item
+must be checked.
+
+| # | Check | Status |
+|---|-------|--------|
+| 1 | Target scenario GREEN | Required |
+| 2 | Full test suite: no new failures | Required |
+| 3 | Build succeeds | Required |
+| 4 | Linter clean on changed files | Required |
+| 5 | Type checker clean on changed files | Required |
+| 6 | Findings file created in `.bdd/qa/findings/` | Required |
+| 7 | Resolution file created in `.bdd/qa/resolutions/` | Required |
+
+All 7 checks must pass before creating a PR. If any check fails, fix it
+before proceeding. Do not create a PR with known issues and hope reviewers
+will not notice.
+
+## When Verification Reveals a Deeper Problem
+
+Sometimes verification uncovers something unexpected:
+- The fix works but reveals that the test infrastructure is brittle
+- The fix works but another feature silently depends on the old broken behavior
+- The fix works but performance degrades significantly
+
+In these cases:
+1. Complete the current fix (it fixes the reported issue)
+2. File NEW issues for the discovered problems
+3. Reference the new issues in the PR body
+4. Do not scope-creep the current fix to address everything

--- a/skills/bdd-issue-fixer/references/issue-to-gherkin.md
+++ b/skills/bdd-issue-fixer/references/issue-to-gherkin.md
@@ -1,0 +1,332 @@
+# Issue to Gherkin Translation
+
+Sources: Nicieja (Writing Great Specifications), Wynne/Hellesoy (The Cucumber Book), Smart/Molak (BDD in Action), SWE-bench issue-to-test patterns
+
+Covers: translating bug reports and feature requests into precise Gherkin scenarios, handling vague issues, file placement, quality enforcement.
+
+## The Translation Pipeline
+
+Every fixable issue goes through this 4-step pipeline before any code is written.
+
+| Step | Input | Output |
+|------|-------|--------|
+| 1. Extract structured data | Raw issue text | Mental extraction template (from `issue-triage.md`) |
+| 2. Identify behavior under test | Structured data | One-sentence behavior statement |
+| 3. Write Gherkin scenario(s) | Behavior statement | `.feature` file with scenarios |
+| 4. Place the file | Feature file | `.bdd/features/{domain}/{slug}.feature` |
+
+The behavior statement is the bridge between the messy human issue and the
+precise Gherkin test. Write it as: "When {action}, the system should {expected
+behavior}, but instead it {actual behavior}."
+
+## Bug Report to Gherkin
+
+The most common translation. A bug report has three signals: what was tried,
+what was expected, and what actually happened.
+
+### Example: Clear Bug Report
+
+**Raw issue:**
+```
+Title: CSV export fails when report has special characters
+Body: When I export a financial report containing names with accents
+(like "Jose Garcia"), the CSV file is corrupted. The special characters
+turn into garbled text.
+Expected: CSV should properly encode UTF-8 characters
+Actual: Characters like e-acute, a-acute become mojibake
+```
+
+**Behavior statement:** "When exporting a report with accented names, the CSV
+should contain valid UTF-8, but instead it produces mojibake."
+
+**Gherkin output:**
+```gherkin
+Feature: CSV export handles special characters
+  Financial reports with international names must export correctly.
+
+  @issue-42
+  Scenario: Report with accented names exports valid UTF-8
+    Given a financial report containing the name "Jose Garcia"
+    When the report is exported as CSV
+    Then the CSV file should contain "Jose Garcia" encoded as valid UTF-8
+    And the CSV should be parseable without encoding errors
+```
+
+### Example: Bug Report with Stack Trace
+
+Users often dump a full stack trace. Extract the behavior, ignore the trace details.
+
+**Raw issue:**
+```
+Title: App crashes when uploading large files
+Body: I try to upload a 50MB report and get this error:
+
+Error: PayloadTooLargeError: request entity too large
+    at readStream (/app/node_modules/raw-body/index.js:155:17)
+    at getRawBody (/app/node_modules/raw-body/index.js:108:12)
+
+Expected: Upload should work for files up to 100MB (as documented)
+```
+
+**Behavior statement:** "When uploading a 50MB file, the upload should succeed,
+but instead it throws PayloadTooLargeError."
+
+**Gherkin output:**
+```gherkin
+Feature: Large file upload support
+  The system must accept file uploads up to the documented 100MB limit.
+
+  @issue-87
+  Scenario: Upload a 50MB file successfully
+    Given a valid report file of 50 megabytes
+    When the file is uploaded
+    Then the upload should complete successfully
+    And the file should be accessible in the system
+
+  Scenario: Upload at the documented limit
+    Given a valid report file of 100 megabytes
+    When the file is uploaded
+    Then the upload should complete successfully
+```
+
+Notice: two scenarios. The reported case (50MB) and the documented limit (100MB).
+Always test the boundary the documentation promises.
+
+### Example: Vague Bug Report
+
+**Raw issue:**
+```
+Title: Search doesn't work
+Body: I type something in the search box and nothing happens.
+```
+
+No expected behavior stated. No error message. No repro steps. But the
+behavior is inferable: search should return results when a query is entered.
+
+**Behavior statement:** "When entering a search query, results should appear,
+but instead nothing happens."
+
+**Gherkin output:**
+```gherkin
+Feature: Search returns relevant results
+  Users searching for content should see matching results.
+
+  @issue-103
+  Scenario: Search with a matching query returns results
+    Given published content containing the word "deployment"
+    When a search is performed for "deployment"
+    Then search results should include content matching "deployment"
+    And the results should appear within 3 seconds
+```
+
+When the issue is vague, write the Gherkin for what SHOULD work based on
+the feature's purpose. Add a note in the PR that the scenario was inferred.
+
+## Feature Request to Gherkin
+
+Feature requests need acceptance criteria. Extract the "Definition of Done"
+from the request.
+
+### Example: Feature Request
+
+**Raw issue:**
+```
+Title: Add dark mode support
+Body: It would be great to have a dark mode toggle in settings.
+The current white background is harsh at night.
+```
+
+**Gherkin output:**
+```gherkin
+Feature: Dark mode support
+  Users should be able to switch between light and dark themes.
+
+  @issue-55
+  Scenario: User enables dark mode
+    Given a user with default light mode settings
+    When dark mode is enabled in settings
+    Then the interface should render with a dark color scheme
+    And the preference should persist across sessions
+
+  Scenario: User switches back to light mode
+    Given a user with dark mode enabled
+    When light mode is selected in settings
+    Then the interface should render with the light color scheme
+
+  Scenario: Dark mode preference persists after logout
+    Given a user who has enabled dark mode
+    When the user logs out and logs back in
+    Then dark mode should still be active
+```
+
+Feature requests typically produce 2-4 scenarios: happy path, the reverse
+action, and persistence/edge cases.
+
+## Gherkin Quality Rules
+
+Every scenario must pass these quality checks.
+
+### Rule 1: Declarative Over Imperative
+
+Describe WHAT the system does, not HOW the user clicks.
+
+| BAD (imperative) | GOOD (declarative) |
+|---|---|
+| Given I click the "Login" button | Given Emma is logged in |
+| When I fill in "email" with "test@example.com" | When Emma signs up with a valid email |
+| Then I should see a green checkmark icon | Then the registration should be confirmed |
+| And I scroll down to the results section | And search results should be visible |
+
+Push all mechanics into step definitions and the interaction layer.
+
+### Rule 2: Use Persona Names
+
+Use "Emma", "Alex", "Sam" — not "the user", "I", or "a customer".
+
+| BAD | GOOD |
+|-----|------|
+| Given the user is logged in | Given Emma is logged in |
+| When a customer adds an item | When Alex adds "Running Shoes" to his cart |
+| Then I should see results | Then Emma should see 5 search results |
+
+### Rule 3: One Behavior Per Scenario
+
+Each scenario tests exactly ONE behavior. If you write "And" more than twice
+in the Then section, you are testing multiple behaviors.
+
+| BAD (multiple behaviors) | GOOD (split) |
+|---|---|
+| Scenario: User signs up and sets preferences and gets welcome email | Scenario: New user signs up successfully |
+| | Scenario: New user receives welcome email |
+| | Scenario: New user can set preferences |
+
+### Rule 4: Use Background for Shared Setup
+
+```gherkin
+Feature: Shopping cart management
+
+  Background:
+    Given Emma is a returning customer
+    And "Running Shoes" is available for $89.99
+    And "Water Bottle" is available for $12.99
+
+  Scenario: Add single item to cart
+    When Emma adds "Running Shoes" to her cart
+    Then her cart should contain 1 item
+    And her cart total should be $89.99
+
+  Scenario: Add multiple items to cart
+    When Emma adds "Running Shoes" to her cart
+    And Emma adds "Water Bottle" to her cart
+    Then her cart should contain 2 items
+```
+
+### Rule 5: Use Scenario Outline for Data Variants
+
+```gherkin
+Scenario Outline: Validate password strength
+  Given a new user registration form
+  When a password of "<password>" is entered
+  Then the strength indicator should show "<strength>"
+
+  Examples:
+    | password    | strength |
+    | abc         | weak     |
+    | Abc123      | medium   |
+    | Abc123!@#XY | strong   |
+```
+
+### Rule 6: Never Reference UI Elements
+
+No "click button", "fill field", "see text on screen". Scenarios describe
+business behavior, not UI interaction.
+
+| BAD | GOOD |
+|-----|------|
+| When I click the "Delete" button on the first row | When Emma removes the first item from her cart |
+| Then the error toast should appear at the top | Then an error message should indicate invalid input |
+| And the submit button should be disabled | And the form should prevent submission |
+
+## Handling Vague Issues
+
+| Issue clarity | Action |
+|--------------|--------|
+| Clear expected/actual behavior stated | Direct translation to Gherkin |
+| Has repro steps but no expected behavior | Infer expected from the feature's documented purpose |
+| Vague but the symptom is reproducible | Write test for the reported symptom, note the assumption |
+| Completely vague, no repro possible | Ask for clarification (see `issue-triage.md`) |
+| Contradicts documentation | Test against what documentation promises |
+| Multiple behaviors described in one issue | Split into multiple scenarios |
+
+When inferring expected behavior:
+1. Check existing tests for the related feature — what do they assert?
+2. Read the code to understand current behavior
+3. Check documentation or README for stated behavior
+4. Write the Gherkin for what SHOULD work based on reasonable expectations
+5. Add a comment in the PR: "Expected behavior inferred from [source]"
+
+## File Placement
+
+### Directory Structure
+
+Place feature files in `.bdd/features/` organized by functional domain:
+
+```
+.bdd/features/
+  auth/
+    login.feature
+    signup.feature
+  export/
+    csv-encoding.feature      <-- issue-42
+  search/
+    basic-search.feature      <-- issue-103
+  settings/
+    dark-mode.feature         <-- issue-55
+```
+
+### Naming Convention
+
+| Component | Format | Example |
+|-----------|--------|---------|
+| Directory | Domain name, lowercase | `export/`, `auth/`, `billing/` |
+| File name | Kebab-case of core behavior | `csv-encoding.feature` |
+| Feature tag | `@issue-{number}` | `@issue-42` |
+
+### One Issue, One Feature File
+
+Each issue gets its own `.feature` file. If an issue touches multiple domains
+(rare), pick the PRIMARY domain and reference the others in a comment.
+
+```gherkin
+# This issue also affects the billing domain.
+# See related test in billing/invoice-export.feature if applicable.
+@issue-42
+Feature: CSV export handles special characters
+  ...
+```
+
+## The Golden Test Rule
+
+Once a Gherkin scenario is written, it becomes the source of truth.
+
+**NEVER** change a scenario to match what the code currently does. The scenario
+captures what the USER EXPECTS. If the scenario fails, the code is wrong.
+
+**NEVER** add `@skip` or `.skip()` to a scenario. If it fails, fix the code.
+
+**NEVER** reduce assertion precision. If the scenario says "should contain
+exactly 5 items", do not change it to "should contain items" because the code
+returns 4.
+
+**NEVER** mock a dependency to avoid a failure. The test runs against the real
+system.
+
+The ONLY time to modify a scenario is when the issue itself is updated or
+clarified by the reporter. If the reporter says "actually I meant X not Y",
+update the scenario to match the new understanding.
+
+If the scenario seems wrong after reading the code, re-read the issue. The
+issue defines the behavior. The code conforms to the issue. Not the other way
+around.
+
+For the fix cycle that comes next, see `references/red-green-fix-cycle.md`.

--- a/skills/bdd-issue-fixer/references/issue-triage.md
+++ b/skills/bdd-issue-fixer/references/issue-triage.md
@@ -1,0 +1,143 @@
+# Issue Triage
+
+Sources: GitHub issue management patterns, SWE-bench (Princeton), Sweep.dev triage heuristics, BDD in Action (Smart/Molak)
+
+Triage is the first and most critical step in the BDD-fixer lifecycle. If you get triage wrong, you waste tokens and compute time trying to fix problems that are not fixable, not bugs, or not understood. You are a senior engineer. Do not approach an issue with the assumption that the user is right or that the code is wrong. Approach it with skepticism.
+
+## Section 1: Classification Matrix
+
+Before touching any code, classify the issue. Use the following matrix to decide your immediate next step.
+
+| Category | Signal patterns | Action |
+|----------|-----------------|--------|
+| Bug report | Explicit repro steps, error messages, "expected vs actual" sections, tracebacks, clear regression signals. | Proceed to verification and fix. |
+| Feature request | Phrases like "it would be nice", "can you add", "support for X", enhancement labels, lack of error signals. | Write acceptance test, then implement. |
+| Question | Phrases like "how do I", "is it possible", "what is the best way", lack of repro steps or expected behavior. | Answer the question, link to docs, and close. |
+| Invalid | Reports that contradict documentation, issues that cannot be reproduced after 3 attempts, user error in setup. | Close with a detailed explanation of why it is not a bug. |
+| Duplicate | Same root cause, identical error messages, or identical repro steps as an existing open/closed issue. | Link to the original issue and close as duplicate. |
+| Incomplete | Missing repro steps, no version info, vague descriptions like "it does not work" or "I get an error". | Ask for clarification using the standard template. |
+
+## Section 2: Reading an Issue (Extraction Protocol)
+
+A human issue is a messy narrative. Your job is to extract structured data from that narrative. Use this protocol to parse every issue before moving to the Gherkin phase.
+
+### Title Analysis
+Do not trust the title. Users often describe their attempted solution ("Cannot find module X") instead of the actual problem ("Installation fails on Windows").
+- Is the title a symptom or a guessed cause?
+- Does the title match the body? If not, the body is the source of truth.
+
+### Body Parsing: The Signal Search
+Scan the body for the following technical artifacts:
+- Code blocks: Look for configuration snippets, CLI invocations, or API usage.
+- Error messages: Find the specific exception name or error code.
+- Stack traces: Identify the deepest frame that belongs to the current repository.
+- Versions: Look for runtime versions, OS details, and package versions.
+
+### Expected vs Actual Behavior
+This is the core of the BDD contract. If these are not explicitly stated, you must infer them or ask.
+- Expected: What is the "happy path" or the correct contract?
+- Actual: What is the specific deviation? Is it a crash, a wrong value, or a hang?
+
+### Repro Steps Verification
+Check if the repro steps are "Turnkey".
+- Are they specific enough to automate?
+- Do they include the necessary data/input?
+- Do they assume a specific environment you do not have?
+
+### Mental Extraction Template
+Before proceeding, you should be able to fill out this mental model:
+- Primary Goal: [What is the user trying to do?]
+- Technical Blocker: [What specific error/behavior stops them?]
+- Scope: [Is it one function, one CLI command, or the whole app?]
+- Repro Complexity: [Can I replicate this with a single test case?]
+
+## Section 3: The gh CLI for Issue Reading
+
+Use the GitHub CLI to gather all context. Do not rely on just the initial issue body; comments often contain the "missing link" for reproduction.
+
+### Viewing the Issue Metadata
+Get the full picture including labels and assignees to ensure no one else is already working on it.
+```bash
+gh issue view 123 --json title,body,labels,comments,assignees,state
+```
+
+### Searching for Context
+Check if this is a recurring problem or a known regression.
+```bash
+gh issue list --label "bug" --state open --json number,title
+```
+
+### Extracting Comment Data
+Users often provide the actual repro steps in the third or fourth comment after being prompted by others.
+```bash
+gh issue view 123 --json comments --jq '.comments[].body'
+```
+
+### Analyzing the JSON Output
+When parsing the JSON, prioritize the `body` and `comments`. Use `jq` filters to isolate code blocks if the issue is long.
+
+## Section 4: When NOT to Fix
+
+Knowing when to walk away is what separates seniors from juniors. If an issue meets any of the following criteria, stop the fix process and label/comment instead.
+
+| Signal | Action | Reason |
+|--------|--------|--------|
+| No clear expected behavior | Ask for clarification | You cannot write a test for an undefined state. |
+| Affects deprecated API | Close or Redirect | We do not fix bugs in code that is slated for removal. |
+| Requires breaking changes | Escalate to Maintainer | Architectural shifts require human consensus, not auto-fixes. |
+| Wishlist / No criteria | Label "needs-discussion" | Vague enhancements lead to scope creep and bloat. |
+| User confusion | Answer and Close | Documentation issues are not code bugs. |
+| Security vulnerability | Private Disclosure | Never fix security bugs in public PRs without a coordinated disclosure. |
+| Out of scope | Close as "Won't Fix" | The tool should not do things it was never intended to do. |
+
+### Decision Heuristics
+- If the fix takes more than 50 lines of code change but the issue is "minor", it might be an architectural problem.
+- If you find yourself needing to change 3+ unrelated files, the issue is likely a "Feature Request" disguised as a "Bug".
+
+## Section 5: Asking for Clarification
+
+If an issue is incomplete, do not guess. Guessing leads to "works on my machine" PRs that get rejected. Use the following template to respond to the user.
+
+### Clarification Template
+```markdown
+Thanks for reporting this! To help fix this, I need a few more details:
+
+1. **What did you expect to happen?**
+2. **What actually happened?** (Please provide the exact error message or a description of the behavior)
+3. **Steps to reproduce:** (A minimal, self-contained code snippet or CLI command sequence)
+4. **Environment:** (OS, runtime version, package version)
+```
+
+### When to Ask vs. Close
+- Ask: If the user provided some signal but missed the "how" (e.g., they gave an error but no repro).
+- Close: If the issue is a single sentence with no context and the user has a history of "drive-by" low-quality reports.
+- Proceed: Only if you can recreate the failure locally using the information provided.
+
+## Section 6: Priority Signals
+
+Not all bugs are equal. Use these signals to determine which issues to prioritize if multiple are assigned to you.
+
+### P0: Critical
+- Data loss or corruption.
+- Security vulnerabilities (CRITICAL: handle via private channels).
+- Complete service outage or "cannot start" regressions.
+- Affects 100% of users on a major platform.
+
+### P1: High
+- Core feature is broken with no easy workaround.
+- Significant performance degradation (e.g., 10x slower).
+- Regressions in the most used API endpoints or CLI commands.
+
+### P2: Medium
+- Edge case bugs affecting specific configurations.
+- Minor features not working as documented.
+- UI/UX papercuts that do not block functionality.
+- Has a known, simple workaround.
+
+### P3: Low
+- Cosmetic issues (typos, alignment).
+- Refactoring suggestions with no functional impact.
+- Nice-to-have enhancements for niche use cases.
+
+### Crowdsourced Urgency
+Watch the "reactions" and "me too" comments. If an issue has 5+ thumbs up or 3+ duplicate reports within 24 hours, escalate the priority regardless of the technical severity. High-volume "papercuts" are often more damaging to reputation than a silent P1.

--- a/skills/bdd-issue-fixer/references/pr-and-git-workflow.md
+++ b/skills/bdd-issue-fixer/references/pr-and-git-workflow.md
@@ -1,0 +1,332 @@
+# PR and Git Workflow
+
+Sources: GitHub CLI documentation, conventional commits, Sweep.dev PR patterns, SWE-bench submission format
+
+Covers: branch strategy, 3-commit structure, PR title/body template, gh CLI commands, auto-close keywords, handling non-fix outcomes.
+
+## Branch Strategy
+
+Every issue fix gets its own branch. One branch per issue. Never combine
+multiple issue fixes in one branch.
+
+### Branch Naming
+
+Format: `fix/issue-{number}-{short-slug}`
+
+```bash
+# Examples
+fix/issue-42-csv-encoding
+fix/issue-87-large-file-upload
+fix/issue-103-search-results
+feat/issue-55-dark-mode
+```
+
+Use `fix/` for bug fixes and `feat/` for feature requests.
+
+### Creating the Branch
+
+Always branch from the default branch with the latest changes.
+
+```bash
+# Ensure you are on the default branch with latest
+git checkout main && git pull origin main
+
+# Create the fix branch
+git checkout -b fix/issue-42-csv-encoding
+```
+
+If the project uses a branch other than `main` (e.g., `master`, `develop`),
+use that instead.
+
+## Commit Strategy
+
+Three atomic commits per fix. This structure makes it easy for reviewers to
+see the before/after and verify the fix methodology.
+
+### Commit 1: The Test (RED)
+
+Add the Gherkin scenario and any supporting step definitions. On this commit,
+the test SHOULD fail — it captures the broken behavior.
+
+```bash
+git add .bdd/features/ .bdd/steps/ .bdd/interactions/ .bdd/support/
+git commit -m "test: add BDD scenario for #42"
+```
+
+### Commit 2: The Fix (GREEN)
+
+Add the code change that makes the test pass. Only application code goes in
+this commit.
+
+```bash
+git add src/
+# Or whatever the project's source directory is
+git commit -m "fix: handle UTF-8 encoding in CSV export (#42)"
+```
+
+For feature requests, use `feat:` instead of `fix:`:
+```bash
+git commit -m "feat: add dark mode toggle in settings (#55)"
+```
+
+### Commit 3: The Documentation
+
+Add the QA findings and resolution files.
+
+```bash
+git add .bdd/qa/
+git commit -m "docs: add QA findings and resolution for #42"
+```
+
+### Why Three Commits
+
+| Commit | Purpose for reviewers |
+|--------|----------------------|
+| 1 (test) | "Here is the behavior that was broken. You can check out this commit and see it fail." |
+| 2 (fix) | "Here is the minimal change that makes it pass." |
+| 3 (docs) | "Here is the evidence trail: what was found, what was tried, what worked." |
+
+Do not squash these into one commit. The separation is intentional.
+
+## PR Title and Body
+
+The PR is proof that the fix works. It must include evidence.
+
+### PR Title Format
+
+```
+fix: {short description} (#{issue_number})
+```
+
+Examples:
+```
+fix: handle UTF-8 encoding in CSV export (#42)
+feat: add dark mode toggle in settings (#55)
+fix: accept file uploads up to documented 100MB limit (#87)
+```
+
+### PR Body Template
+
+```markdown
+## Fixes #{issue_number}
+
+### Problem
+{One paragraph describing the bug from the issue. What was broken and
+what the user experienced.}
+
+### Solution
+{One paragraph describing the fix. What was changed and why this
+approach was chosen.}
+
+### BDD Scenario
+```gherkin
+{The full Gherkin scenario. Copy-paste from the .feature file.}
+```
+
+### Verification
+- Target scenario: PASSED
+- Full test suite: {X}/{Y} passed (no regressions)
+- Build: PASSED
+- Lint: Clean
+- Type check: Clean
+
+### Iterations
+{N} iteration(s) required.
+1. {Brief description of attempt 1 and result}
+2. {Brief description of attempt 2 and result}
+3. {Brief description of attempt 3 — PASSED}
+
+### Files Changed
+- `src/export/csv-writer.ts` — Added explicit UTF-8 encoding parameter
+- `.bdd/features/export/csv-encoding.feature` — New BDD scenario
+- `.bdd/qa/findings/export-csv-encoding.md` — Test findings
+- `.bdd/qa/resolutions/export-csv-encoding.md` — Fix documentation
+```
+
+## Creating the PR with gh CLI
+
+### Push and Create
+
+```bash
+# Push the branch
+git push -u origin fix/issue-42-csv-encoding
+
+# Create the PR
+gh pr create \
+  --title "fix: handle UTF-8 encoding in CSV export (#42)" \
+  --body-file .bdd/qa/pr-body.md
+```
+
+For simpler PRs, use inline body with heredoc:
+
+```bash
+gh pr create \
+  --title "fix: handle UTF-8 encoding in CSV export (#42)" \
+  --body "$(cat <<'EOF'
+## Fixes #42
+
+### Problem
+CSV export corrupts special characters (accented names appear as mojibake).
+
+### Solution
+Added explicit UTF-8 encoding to the CSV write stream. The serializer was
+using the system default encoding (Latin-1) instead of UTF-8.
+
+### Verification
+- Target scenario: PASSED
+- Full test suite: 143/145 passed (no regressions)
+- Build: PASSED
+EOF
+)"
+```
+
+### Adding Labels
+
+```bash
+gh pr edit --add-label "bug-fix"
+```
+
+### Requesting Review
+
+```bash
+gh pr edit --add-reviewer username
+```
+
+## Auto-Close Keywords
+
+GitHub automatically closes the linked issue when the PR merges. Use these
+keywords in the PR BODY (not just the title — title keywords are unreliable).
+
+| Keyword | Example |
+|---------|---------|
+| `Fixes` | `Fixes #42` |
+| `Closes` | `Closes #42` |
+| `Resolves` | `Resolves #42` |
+
+Always use `Fixes #{number}` as the first line of the PR body.
+
+For multiple issues (same root cause):
+```markdown
+Fixes #42, Fixes #43, Fixes #44
+```
+
+## Non-Fix Outcomes
+
+Not every issue results in a code change. Handle these with comments, not PRs.
+
+### Issue is Invalid / Not a Bug
+
+```bash
+gh issue comment 42 --body "$(cat <<'EOF'
+## Triage Result: Not a Bug
+
+**Investigation:** Reproduced the reported behavior. This is working as
+designed — the CSV export uses the system locale encoding, which is
+documented in the README under "Export Configuration."
+
+**Evidence:** Tested with locale set to UTF-8; export produces correct
+output. The issue is a configuration problem, not a code bug.
+
+**Recommendation:** Set the `LANG` environment variable to `en_US.UTF-8`
+before running the export.
+EOF
+)"
+
+gh issue close 42 --reason "not planned"
+```
+
+### Issue Needs More Information
+
+```bash
+gh issue comment 42 --body "$(cat <<'EOF'
+## Needs More Information
+
+I attempted to reproduce this but need additional details:
+
+1. **What operating system are you using?** (encoding defaults vary by OS)
+2. **What is the output of `locale` in your terminal?**
+3. **Can you attach a sample CSV file showing the corruption?**
+
+Adding the `needs-info` label. Will investigate further once details are provided.
+EOF
+)"
+
+gh issue edit 42 --add-label "needs-info"
+```
+
+### Issue is a Duplicate
+
+```bash
+gh issue comment 42 --body "Duplicate of #38. The root cause is the same \
+(system encoding not explicitly set in CSV serializer). Fix is being \
+tracked in #38."
+
+gh issue close 42 --reason "not planned"
+```
+
+### Fix Was Escalated
+
+```bash
+gh issue comment 42 --body "$(cat <<'EOF'
+## Automated Fix Attempted — Escalated
+
+5 fix iterations were attempted. The issue resists automated fixing due to
+the complexity of the serialization pipeline. See detailed analysis below.
+
+[Paste escalation summary from red-green-fix-cycle.md]
+
+Adding `needs-human-review` label for maintainer attention.
+EOF
+)"
+
+gh issue edit 42 --add-label "needs-human-review"
+```
+
+## Responding to PR Review Comments
+
+When a PR receives review feedback:
+
+1. Read ALL comments before responding to any.
+2. For each comment, either:
+   - Make the requested code change, OR
+   - Explain why the current approach is correct (with evidence)
+3. Push changes as a NEW commit (do not force-push during review).
+4. Reply to each review comment with what was done.
+
+```bash
+# After addressing review feedback
+git add .
+git commit -m "fix: address review feedback on #42"
+git push
+```
+
+Do not amend or squash during review. Reviewers need to see what changed
+between rounds.
+
+## Complete Workflow Summary
+
+```bash
+# 1. Branch
+git checkout main && git pull
+git checkout -b fix/issue-42-csv-encoding
+
+# 2. Write test (commit 1)
+# ... create .bdd/features/export/csv-encoding.feature
+git add .bdd/
+git commit -m "test: add BDD scenario for #42"
+
+# 3. Fix code (commit 2)
+# ... fix src/export/csv-writer.ts
+git add src/
+git commit -m "fix: handle UTF-8 encoding in CSV export (#42)"
+
+# 4. Document (commit 3)
+# ... create .bdd/qa/findings/ and .bdd/qa/resolutions/
+git add .bdd/qa/
+git commit -m "docs: add QA findings and resolution for #42"
+
+# 5. Push and PR
+git push -u origin fix/issue-42-csv-encoding
+gh pr create --title "fix: handle UTF-8 encoding in CSV export (#42)" \
+  --body-file .bdd/qa/pr-body.md
+```

--- a/skills/bdd-issue-fixer/references/red-green-fix-cycle.md
+++ b/skills/bdd-issue-fixer/references/red-green-fix-cycle.md
@@ -1,0 +1,234 @@
+# The RED-GREEN Fix Cycle
+
+Sources: Beck (TDD By Example), Smart/Molak (BDD in Action), SWE-bench (Princeton NLP), REFINE pattern (Microsoft Research), Sweep.dev iteration patterns
+
+Covers: confirming the bug (RED), implementing fixes with escalating strategies, analyzing failures between iterations, the never-weaken rule, escalation protocol.
+
+This is the core of the skill. The Gherkin scenario is written. Now make it pass.
+Do not give up. Do not weaken the test. Iterate until GREEN or escalate after
+5 genuine attempts.
+
+## The Cycle
+
+```
+Gherkin scenario exists (from issue-to-gherkin step)
+         |
+         v
+   Run scenario against current code
+         |
+    PASS? ---YES---> Issue already fixed. Close it. Done.
+         |
+        NO (RED confirmed)
+         |
+         v
+   Read test output. Understand WHY it fails.
+         |
+         v
+   Implement minimal fix (iteration N)
+         |
+         v
+   Run scenario again
+         |
+    PASS? ---YES---> Proceed to verification (fix-verification.md)
+         |
+        NO
+         |
+         v
+   Analyze new failure. Is it DIFFERENT from before?
+         |
+         v
+   Adjust approach. Go to "Implement minimal fix" (iteration N+1)
+         |
+   N >= 5? ---YES---> Escalate (do NOT abandon)
+```
+
+Maximum 5 iterations. Each iteration uses a progressively broader strategy.
+
+## RED Phase: Confirming the Bug
+
+Before writing ANY fix, run the Gherkin scenario and confirm it fails. This is
+non-negotiable.
+
+```bash
+# Run the specific scenario tagged with the issue number
+[test-runner] --grep "@issue-42"
+```
+
+### Interpreting RED Results
+
+| Test output | Meaning | Action |
+|-------------|---------|--------|
+| Assertion failure (expected X, got Y) | Bug confirmed. The code produces wrong behavior. | Proceed to fix. |
+| Timeout (scenario hangs) | Feature is broken OR test infrastructure is wrong. | Check if the feature works at all. If feature works but test hangs, fix the step definition. |
+| Runtime error in step code (import error, undefined function) | Step implementation has a bug. | Fix the step code, NOT the application. Then re-run. |
+| Setup/infrastructure error (DB not running, server not started) | Test environment issue. | Fix infrastructure. Start required services. Then re-run. |
+| Scenario PASSES | Bug does not exist, or was already fixed. | Verify manually. If truly fixed, close the issue. If not, the test is wrong — revisit the Gherkin. |
+
+If the scenario passes when the bug clearly exists, the Gherkin does not
+capture the actual broken behavior. Go back to `issue-to-gherkin.md` and
+rewrite the scenario with more precision.
+
+## Implementing the Fix
+
+### The Five Rules of Fixing
+
+1. **Read the failing test output FIRST.** Understand exactly which assertion
+   failed, what the expected value was, and what the actual value was.
+
+2. **Trace from test to code.** Use the Given/When/Then steps to find the
+   relevant source code. The When step tells you what function is being
+   exercised. The Then step tells you what output is wrong.
+
+3. **Make the MINIMAL change.** The smallest edit that makes the test pass.
+   Do not improve code style, rename variables, or restructure while fixing.
+
+4. **Fix one thing at a time.** Do not fix adjacent issues you notice. One
+   issue per fix cycle. File new issues for other problems.
+
+5. **Do not refactor while fixing.** Fix the bug. Commit. Refactor later if
+   needed. Mixing fix and refactor makes it impossible to verify which change
+   fixed the bug.
+
+### Iteration Strategies
+
+Each iteration uses a progressively broader approach. Do not skip to iteration
+3 on the first try. The simplest fix is often the correct one.
+
+| Iteration | Strategy | Description |
+|-----------|----------|-------------|
+| 1 | **Direct fix** | The most obvious change. If the error says "expected UTF-8 but got Latin-1", add the encoding parameter. |
+| 2 | **Root cause analysis** | The direct fix did not work. Read the stack trace more carefully. Find the ACTUAL function where the bug originates, not just where it manifests. |
+| 3 | **Broader context** | Read surrounding code. Understand the data flow. Maybe the bug is in a function upstream that passes bad data to the function you fixed. |
+| 4 | **Alternative approach** | The code path you have been fixing might be fundamentally wrong. Try a different algorithm, a different library function, or a different code path entirely. |
+| 5 | **Minimal viable fix** | All elegant solutions have failed. Write the simplest, most brute-force code that makes the test pass. Correctness over elegance. |
+
+### What to Do Between Iterations
+
+After each failed fix attempt:
+
+1. Read the ENTIRE test output, not just the first error line.
+2. Compare the new failure to the previous failure.
+3. Check: is the error DIFFERENT from before? If yes, that is progress.
+4. Check: did the fix actually get loaded? (Did you save the file? Is the
+   test hitting the right code path?)
+5. Revert the failed fix if it made things worse. Keep it if the error changed
+   in a promising direction.
+
+## Analyzing Test Failures
+
+After each iteration, the test either passes (done) or fails (continue). When
+it fails, use this table to diagnose:
+
+| Failure pattern | Diagnosis | Next action |
+|-----------------|-----------|-------------|
+| Same assertion, same expected/actual values | Fix had zero effect. | Verify fix was saved. Check if the test is hitting the right code path. The fix may be in the wrong file or function. |
+| Same assertion, different actual value | Fix partially worked. The logic is moving in the right direction. | Adjust the fix. You are close. |
+| Different assertion entirely | Fix changed the behavior in an unexpected way. | Analyze which behavior changed. The fix may need to be more targeted. |
+| New runtime error (TypeError, null reference) | Fix introduced a new bug. | Make the fix more defensive. Handle the edge case that caused the new error. |
+| Timeout where assertion used to fail | Fix changed the code path and now it hangs. | The fix may have created an infinite loop or deadlock. Investigate the new code path. |
+| Different scenario fails (regression) | Fix broke adjacent functionality. | The fix needs to handle BOTH the target behavior and the adjacent one. See `fix-verification.md`. |
+
+### Execution-Level Feedback
+
+Between iterations, pass FULL context forward. Do not strip or summarize.
+
+**Required context for each iteration:**
+- Complete test output (stdout and stderr)
+- The exact diff of what was changed
+- Stack traces, if any
+- The assertion: expected value vs actual value
+- Any console output or log messages from the application
+- The iteration number and what strategy was used
+
+Do not pass "the test failed" as context. Pass "the test asserted
+expected='Jose Garcia' but got='JosÃ© GarcÃ­a', suggesting the encoding
+conversion is happening after the export function returns, not before."
+
+## The Never-Weaken Rule
+
+This is the cardinal rule. Violation means the work is invalid.
+
+| Action | Verdict |
+|--------|---------|
+| Change Gherkin scenario to match code behavior | **FORBIDDEN** |
+| Add `@skip` or `.skip()` to the failing scenario | **FORBIDDEN** |
+| Mock a dependency to avoid a real failure | **FORBIDDEN** |
+| Change expected values to match actual values | **FORBIDDEN** |
+| Replace exact assertion with approximate ("close to") | **FORBIDDEN** |
+| Add retry/polling logic to hide flaky behavior | **FORBIDDEN** |
+| Wrap assertion in try-catch and swallow the error | **FORBIDDEN** |
+| Comment out failing assertions | **FORBIDDEN** |
+| Reduce the number of scenarios to "simplify" | **FORBIDDEN** |
+
+If the scenario seems wrong after reading the code, re-read the issue. The
+issue defines the behavior. The code must conform to the issue.
+
+If you genuinely believe the scenario is incorrect (the issue was misunderstood),
+go back to the issue and re-read it from scratch. If the Gherkin truly
+misrepresents the issue, fix the Gherkin — but document WHY in the PR with a
+reference to the specific part of the issue that was re-interpreted.
+
+This is the ONLY exception, and it requires explicit justification.
+
+## When to Escalate
+
+After 5 iterations without GREEN, escalate. Do not abandon.
+
+### Escalation Protocol
+
+1. **Document all 5 attempts.** For each iteration, record:
+   - What strategy was used
+   - What change was made (diff)
+   - What the test output was
+   - Why it did not work
+
+2. **Write a detailed comment on the issue:**
+
+```markdown
+## Automated Fix Attempted
+
+I attempted 5 fix iterations for this issue but could not achieve a passing test.
+
+### Attempts
+1. **Direct fix:** Added UTF-8 encoding parameter to export function.
+   Result: Same garbled output. The encoding happens downstream.
+2. **Root cause:** Found encoding happens in the serializer, not the exporter.
+   Fixed serializer. Result: Different garbled output (progress).
+3. **Broader context:** Traced data flow from DB to export. Found the DB
+   driver strips encoding metadata. Result: Correct encoding but wrong
+   line breaks.
+4. **Alternative approach:** Used Buffer-based encoding instead of stream.
+   Result: Correct encoding, correct line breaks, but headers are duplicated.
+5. **Minimal viable:** Hard-coded BOM + manual header write.
+   Result: Test still fails on the "parseable without errors" assertion.
+
+### Root Cause Hypothesis
+The CSV serialization pipeline has multiple encoding conversion points that
+conflict. A proper fix likely requires refactoring the serializer to use a
+single encoding pass.
+
+### Suggested Next Steps
+- Review the serializer pipeline in `src/export/serializer.ts`
+- Consider replacing the custom serializer with a well-tested CSV library
+```
+
+3. **Label the issue** as `needs-human-review`:
+```bash
+gh issue edit 42 --add-label "needs-human-review"
+```
+
+4. **Do NOT close the issue.** It is still a real bug.
+
+5. **Do NOT merge a partial fix.** If the test does not pass, the fix is
+   not complete. Do not merge code that "mostly works."
+
+## Anti-Patterns
+
+| Anti-pattern | Why it fails | What to do instead |
+|-------------|-------------|-------------------|
+| Giving up after 1 attempt | Most bugs require 2-3 iterations. SWE-bench average is 2.3. | Try all 5 strategies before escalating. |
+| Fixing without reading test output | You are guessing, not debugging. | Read the FULL output before writing code. |
+| Changing test and code simultaneously | You cannot tell which change fixed the bug. | Change code only. The test is immutable. |
+| Making large changes per iteration | Large diffs make it impossible to isolate the fix. | Small, targeted edits. One logical change per iteration. |
+| Ignoring "progress" signals | A DIFFERENT failure is progress, not a new problem. | Track how the failure changes across iterations. |
+| Skipping directly to iteration 5 | Brute-force should be the last resort, not the first. | Follow the iteration ladder in order. |

--- a/skills/bdd-issue-fixer/references/related-issues.md
+++ b/skills/bdd-issue-fixer/references/related-issues.md
@@ -1,0 +1,274 @@
+# Related Issue Detection
+
+Sources: GitHub issue management patterns, SWE-bench issue clustering, Sweep.dev deduplication heuristics
+
+Covers: relationship types, detection signals, scanning workflow, handling each relationship type, batch fixing, avoiding false positives.
+
+A single root cause can spawn 3-5 user reports with different symptoms. Fixing
+one issue might fix 3 others. Fixing an issue might be BLOCKED by another.
+Detecting relationships BEFORE fixing saves time and prevents rework.
+
+## Why Related Issues Matter
+
+| Scenario | Cost of not detecting |
+|----------|----------------------|
+| 3 issues share one root cause | You fix the same bug 3 times instead of once |
+| Issue A is blocked by issue B | You waste iterations on A when B must be fixed first |
+| Issue is a duplicate | You write redundant tests and PRs |
+| Two issues touch the same code | Independent fixes cause merge conflicts |
+| Parent feature is missing | Child issue cannot be fixed without parent |
+
+Always scan for related issues before entering the fix cycle.
+
+## Relationship Types
+
+| Type | Definition | Example | Action |
+|------|-----------|---------|--------|
+| Duplicate | Same bug, different reporter | "CSV fails on accents" + "Export broken for international names" | Link to original, close duplicate |
+| Same root cause | Different symptoms, one underlying bug | "Login slow" + "Dashboard timeout" (both caused by DB connection leak) | Fix root cause once, verify all scenarios |
+| Parent-child | One issue depends on another existing first | "Add dark mode" then "Dark mode doesn't persist" | Fix parent first |
+| Blocked by | Issue cannot be fixed until another is resolved | "Fix payment flow" blocked by "Update Stripe SDK to v3" | Fix blocker first, then return |
+| Related but independent | Touch the same code area, different bugs | "CSV header wrong" + "CSV encoding broken" | Fix one at a time, watch for merge conflicts |
+
+## Detection Signals
+
+### Text Similarity Signals
+
+| Signal | Relationship likely |
+|--------|-------------------|
+| Same error message in two issues | Duplicate or same root cause |
+| Same file or function mentioned | Same root cause or related area |
+| Same reporter filed multiple issues in short timeframe | Often different symptoms of one bug |
+| Issues created within days of each other | Same root cause, likely triggered by a recent release |
+| Same labels applied | Related functional area |
+| One issue explicitly references another | Explicitly related (check if duplicate or dependency) |
+| Same stack trace, different entry points | Same root cause, different code paths |
+
+### Anti-Signals (Probably NOT Related)
+
+| Signal | Likely not related |
+|--------|-------------------|
+| Same feature area but different behavior | Independent bugs in same module |
+| Same error TYPE but different message | Coincidental, different root causes |
+| Same reporter but months apart | Separate issues |
+| Similar title but different technical content | Keyword collision, not same bug |
+
+## The Related Issues Scan
+
+Before starting a fix, execute this scan. It takes 2-5 minutes and can save
+hours of duplicate work.
+
+### Step 1: Extract Key Terms
+
+From the target issue, extract:
+- Error messages (exact strings)
+- File names and function names mentioned
+- Feature area (export, auth, search, etc.)
+- Specific technical terms (encoding, timeout, connection, etc.)
+
+### Step 2: Search Open Issues
+
+```bash
+# Search by key terms from the issue
+gh issue list --state open --search "CSV encoding" --json number,title,labels
+
+# Search by same labels
+gh issue list --state open --label "bug" --label "export" --json number,title
+
+# Search by error message (exact phrase)
+gh issue list --state open --search '"PayloadTooLargeError"' --json number,title
+```
+
+### Step 3: Search Recently Closed Issues
+
+Closed issues might be duplicates that were already fixed, or related issues
+with partial fixes.
+
+```bash
+# Search last 30 days of closed issues
+gh issue list --state closed --search "CSV" --limit 20 \
+  --json number,title,closedAt
+
+# Check if a specific closed issue has a linked PR
+gh issue view 38 --json title,body,comments \
+  --jq '{title: .title, body: .body[:200]}'
+```
+
+### Step 4: Check Cross-References
+
+Look for explicit links between issues.
+
+```bash
+# Check if the target issue mentions other issues
+gh issue view 42 --json body,comments \
+  --jq '[.body, (.comments[].body)] | join("\n")' | grep -iE "related|duplicate|see #|fixes #|blocked|depends"
+```
+
+### Step 5: Build the Relationship Map
+
+After scanning, categorize findings:
+
+```
+Target: #42 (CSV encoding broken)
+  - Duplicate of: none found
+  - Same root cause: #38 (CSV export garbles special chars) — LIKELY DUPLICATE
+  - Blocked by: none
+  - Related: #45 (CSV header row missing) — same module, independent bug
+```
+
+## Handling Each Relationship Type
+
+### Duplicate Detected
+
+1. Compare the two issues side by side. Is it truly the same bug?
+2. Pick the canonical issue (more detailed, or older with more discussion).
+3. Comment on the duplicate:
+
+```bash
+gh issue comment 42 --body "Duplicate of #38. Both report CSV encoding \
+issues with special characters. Tracking the fix in #38."
+
+gh issue close 42 --reason "not planned"
+```
+
+4. Fix the canonical issue (#38), not the duplicate.
+
+### Same Root Cause Detected
+
+When 2-3 issues have different symptoms but one underlying cause:
+
+1. Write Gherkin scenarios for ALL affected issues, not just one.
+2. Tag each scenario with its issue number:
+```gherkin
+@issue-38
+Scenario: CSV export preserves accented characters
+  ...
+
+@issue-42
+Scenario: CSV export preserves CJK characters
+  ...
+
+@issue-44
+Scenario: CSV export preserves emoji
+  ...
+```
+3. Fix the root cause once.
+4. Run ALL tagged scenarios to verify.
+5. Create ONE PR referencing all issues:
+
+```bash
+gh pr create \
+  --title "fix: use explicit UTF-8 encoding in CSV serializer (#38, #42, #44)" \
+  --body "$(cat <<'EOF'
+Fixes #38, Fixes #42, Fixes #44
+
+### Root Cause
+The CSV serializer used system default encoding instead of UTF-8.
+All three issues are different symptoms of this single bug.
+EOF
+)"
+```
+
+### Blocked-By Detected
+
+When fixing issue A requires issue B to be resolved first:
+
+1. Comment on the blocked issue:
+
+```bash
+gh issue comment 42 --body "Blocked by #40 (Stripe SDK upgrade required). \
+Fixing #40 first, then returning to this issue."
+```
+
+2. Fix the blocker (#40) through the full cycle (triage, Gherkin, RED-GREEN,
+   verify, PR).
+3. After the blocker is merged, return to the original issue (#42).
+4. Check if the blocker fix also resolved the original issue. If yes, close
+   it. If no, proceed with the fix cycle.
+
+### Parent-Child Detected
+
+When an issue depends on a parent feature:
+
+1. Fix the parent issue first.
+2. After the parent is merged, check if the child issue is automatically
+   resolved (sometimes it is).
+3. If the child still fails, fix it separately.
+
+### Related But Independent
+
+When issues touch the same code area but have different bugs:
+
+1. Fix them one at a time.
+2. Fix the simpler one first (less risk of breaking the other).
+3. After fixing the first, pull latest before starting the second.
+4. Watch for merge conflicts — they indicate tighter coupling than expected.
+
+## Batch Fixing (Same Root Cause)
+
+When multiple issues share a root cause, batch them.
+
+### Batch Workflow
+
+1. Identify all issues with the same root cause (the scan above).
+2. Write Gherkin for ALL of them before fixing anything.
+3. Run ALL scenarios — they should ALL be RED (confirming they share the bug).
+4. Fix the root cause once.
+5. Run ALL scenarios — they should ALL be GREEN.
+6. Create one PR referencing all issues.
+7. Document findings/resolutions for each issue individually.
+
+### Batch PR Title Format
+
+```
+fix: {root cause description} (#{n1}, #{n2}, #{n3})
+```
+
+### Batch Commit Structure
+
+Same 3-commit structure, but commit 1 includes multiple feature files:
+
+```bash
+# Commit 1: All the tests
+git add .bdd/features/export/csv-encoding.feature
+git add .bdd/features/export/csv-cjk.feature
+git add .bdd/features/export/csv-emoji.feature
+git commit -m "test: add BDD scenarios for #38, #42, #44"
+
+# Commit 2: The single root cause fix
+git add src/export/csv-writer.ts
+git commit -m "fix: use explicit UTF-8 in CSV serializer (#38, #42, #44)"
+
+# Commit 3: Documentation for all issues
+git add .bdd/qa/
+git commit -m "docs: add QA findings for #38, #42, #44"
+```
+
+## Avoiding False Positives
+
+Not every similarly-worded issue is related. Be skeptical.
+
+| Trap | Reality |
+|------|---------|
+| Same feature area mentioned | Different bugs in the same module happen all the time |
+| Same error TYPE (e.g., both are TypeErrors) | TypeError is generic — the causes are usually unrelated |
+| Same reporter | Prolific reporters file many independent issues |
+| Similar title | "Export broken" and "Export slow" are completely different bugs |
+| Same code file mentioned | A file with many responsibilities has many independent bugs |
+
+### When Uncertain
+
+If you are not sure two issues are related:
+
+1. Treat them as independent.
+2. Note the potential relationship in the PR body:
+   ```
+   Note: This issue may share a root cause with #38. If #38 persists
+   after this fix merges, investigate the CSV serializer encoding path.
+   ```
+3. Do not delay fixing one while investigating the relationship.
+
+The cost of treating related issues as independent is duplicate work.
+The cost of treating independent issues as related is scope creep and
+a fix that tries to solve too many problems at once. When in doubt,
+keep the scope small.

--- a/skills/bdd-issue-fixer/skills.json
+++ b/skills/bdd-issue-fixer/skills.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tank/bdd-issue-fixer",
+  "version": "1.0.0",
+  "description": "Resolve GitHub issues using BDD. Triage issues, write Gherkin tests, run RED-GREEN fix cycle (up to 5 iterations), verify with regression checks, submit PR with evidence. Covers triage, issue-to-Gherkin, fix verification, related issue detection, batch fixing. Triggers: fix issue, resolve issue, BDD fix, issue to test, red green fix, triage issue, duplicate issue, related issues, issue fixer, auto-fix, resolve bug report.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary
- New Tank skill: `@tank/bdd-issue-fixer` — resolve GitHub issues using BDD
- 6 reference files (1,533 lines): triage, issue-to-Gherkin, RED-GREEN fix cycle, verification, PR workflow, related issues
- SKILL.md (152 lines) with workflow-based progressive disclosure
- `tank publish --dry-run` passes (62.3 KB, 8 files)