### PR TITLE
feat(desktop-app-dev): add cross-platform desktop app skill

### DIFF
--- a/skills/desktop-app-dev/SKILL.md
+++ b/skills/desktop-app-dev/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: "@tank/desktop-app-dev"
+description: |
+  Build, convert, and ship cross-platform desktop applications from web
+  projects using Electron, Tauri v2, or Wails. Covers framework selection
+  and automatic project detection, architecture and IPC patterns, native
+  desktop APIs (menus, tray, notifications, file system, dialogs, shortcuts,
+  clipboard), packaging and distribution (installers, code signing,
+  notarization, auto-update), migration patterns (web-to-desktop conversion,
+  Electron-to-Tauri migration), and CI/CD build pipelines. Synthesizes
+  Electron v40 docs, Tauri v2 docs, Wails v2/v3 docs, and 2025-2026
+  ecosystem research.
+
+  Trigger phrases: "Electron", "Tauri", "Wails", "desktop app",
+  "desktop application", "web to desktop", "convert to desktop app",
+  "cross-platform app", "native app", "electron-builder", "electron-forge",
+  "electron-vite", "tauri command", "system tray", "auto-update",
+  "code signing", "notarize", "DMG", "MSI", "AppImage",
+  "package desktop app", "IPC", "main process", "preload script",
+  "BrowserWindow", "wails build", "desktop wrapper",
+  "ship desktop app", "distribute app", "Electron to Tauri",
+  "migrate from Electron", "wrap web app"
+---
+
+# Desktop App Development
+
+Build cross-platform desktop apps from web projects. Three production-ready
+frameworks: Electron (Node.js), Tauri v2 (Rust), and Wails (Go). Each uses
+a web frontend with a native backend for OS access.
+
+## Core Philosophy
+
+1. **Detect before recommending** -- Check the project for existing framework
+   signals before suggesting one. Never assume.
+2. **Web skills transfer** -- All three frameworks use HTML/CSS/JS frontends.
+   The backend language (Node.js, Rust, Go) is the key differentiator.
+3. **Size and performance matter** -- Users notice 150 MB downloads and 300 MB
+   memory usage. Choose the lightest framework that meets requirements.
+4. **Ship incrementally** -- Get a working desktop wrapper first, then add
+   native features (tray, auto-update, deep links) one at a time.
+5. **Test on all platforms** -- Tauri and Wails use OS WebViews that render
+   differently. Electron bundles Chromium for consistency but at size cost.
+
+## Quick-Start
+
+### "I want to turn my web app into a desktop app"
+
+| Step | Action | Reference |
+|------|--------|-----------|
+| 1 | Detect existing framework (see detection below) | This file |
+| 2 | If none detected, choose framework via decision matrix | `references/framework-selection.md` |
+| 3 | Set up the chosen framework in the project | Framework-specific guide |
+| 4 | Add native features as needed (menus, tray, dialogs) | `references/native-apis.md` |
+| 5 | Package for distribution | `references/packaging-distribution.md` |
+
+### "I already have an Electron app and want to migrate to Tauri"
+
+| Step | Action |
+|------|--------|
+| 1 | Run feasibility assessment (score IPC complexity, Node.js usage, native modules) |
+| 2 | Map Electron IPC handlers to Tauri commands |
+| 3 | Replace Node.js dependencies with Rust equivalents |
+| 4 | Port incrementally: both can coexist during migration |
+-> See `references/migration-patterns.md`
+
+### "I need to package and distribute my desktop app"
+
+| Step | Action |
+|------|--------|
+| 1 | Configure platform-specific installer formats (DMG, MSI, AppImage) |
+| 2 | Set up code signing (macOS: Apple Developer cert, Windows: Authenticode) |
+| 3 | Configure auto-update mechanism |
+| 4 | Set up CI/CD matrix build (Ubuntu, macOS, Windows) |
+-> See `references/packaging-distribution.md`
+
+## Project Detection
+
+Before recommending a framework, check for existing signals:
+
+| Signal | Framework | Files to Check |
+|--------|-----------|----------------|
+| `electron` in package.json deps | Electron | `package.json`, `main.js`, `preload.js` |
+| `src-tauri/` directory exists | Tauri | `tauri.conf.json`, `src-tauri/Cargo.toml` |
+| `wails.json` exists | Wails | `wails.json`, `go.mod` |
+| `@tauri-apps/api` in deps | Tauri | `package.json` |
+| `electron-builder.yml` exists | Electron | project root |
+| `electron-forge` in deps | Electron | `package.json` |
+| None of the above | No framework | -> Use decision matrix |
+
+If no framework is detected, ask the user their preference. Recommend based
+on the decision matrix in `references/framework-selection.md`.
+
+## Decision Trees
+
+### Framework Selection (Quick)
+
+| Signal | Recommendation |
+|--------|---------------|
+| Pure web dev team, no Rust/Go experience | Electron |
+| Bundle size and memory are critical | Tauri |
+| Team already uses Go | Wails |
+| Need mobile + desktop from one codebase | Tauri v2 |
+| Need pixel-perfect cross-platform rendering | Electron |
+| Maximum security, minimal attack surface | Tauri |
+| Wrapping existing Next.js / Node.js backend | Electron |
+| Greenfield project, performance matters | Tauri |
+
+### Framework Comparison (2026)
+
+| Aspect | Electron | Tauri v2 | Wails |
+|--------|----------|----------|-------|
+| Bundle size | 80-150 MB | 3-8 MB | 10-15 MB |
+| Memory (idle) | ~150 MB | ~30-60 MB | ~40-80 MB |
+| Backend | Node.js | Rust | Go |
+| Rendering | Bundled Chromium | OS WebView | OS WebView |
+| GitHub stars | 120K | 103K | 33K |
+| Mobile support | No | Yes (v2) | No |
+| Auto-update | Built-in | Plugin | Manual |
+| Learning curve | Low (JS/TS only) | Medium (Rust) | Medium (Go) |
+
+### Architecture Pattern
+
+| App Type | Approach |
+|----------|----------|
+| Static site / SPA | Load index.html directly |
+| SPA with REST API | Bundle API server or use local HTTP |
+| Next.js / SSR app | Electron + custom server, or export static |
+| Real-time app (WebSocket) | Run WS server in backend process |
+| Heavy computation | Offload to native backend (Rust/Go) |
+
+## Anti-Patterns
+
+| Don't | Do Instead | Why |
+|-------|-----------|-----|
+| Expose Node.js to renderer (Electron) | Use preload + contextBridge | Security: renderer is untrusted |
+| Skip code signing | Sign and notarize for all platforms | Users get scary warnings otherwise |
+| Bundle dev dependencies | Production build with tree-shaking | Bloats installer unnecessarily |
+| Use localStorage for sensitive data | Use OS keychain or encrypted store | localStorage is plaintext |
+| Ignore platform differences | Test on macOS, Windows, Linux | WebView rendering varies |
+| Port everything at once (migration) | Migrate incrementally | Lower risk, faster feedback |
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/framework-selection.md` | Decision matrices, project detection details, team skill assessment, architecture overviews, ecosystem maturity comparison, frontend framework compatibility |
+| `references/electron-guide.md` | Electron architecture (main/renderer/preload), project setup (electron-forge, electron-vite), IPC patterns, BrowserWindow configuration, security best practices, TypeScript setup |
+| `references/tauri-guide.md` | Tauri v2 architecture, project setup, commands and events, plugin system, capabilities/permissions, tauri.conf.json, frontend integration, mobile support, Rust state management |
+| `references/wails-guide.md` | Wails architecture, project setup, Go method binding with auto-generated TypeScript, events system, window management, v2 vs v3 comparison |
+| `references/native-apis.md` | Cross-framework native APIs: menus, system tray, notifications, file system, dialogs, keyboard shortcuts, clipboard, deep links, multi-window, with code examples for each framework |
+| `references/packaging-distribution.md` | Platform installers (DMG/MSI/AppImage), code signing (macOS/Windows), notarization, auto-update mechanisms, CI/CD build pipelines, distribution channels, bundle size optimization |
+| `references/migration-patterns.md` | Web-to-desktop conversion (Electron/Tauri/Wails), Electron-to-Tauri migration (feasibility scoring, IPC mapping, Node.js-to-Rust equivalents), incremental migration strategy, common pitfalls |

--- a/skills/desktop-app-dev/references/electron-guide.md
+++ b/skills/desktop-app-dev/references/electron-guide.md
@@ -1,0 +1,356 @@
+# Electron Development Guide
+
+Sources: Electron v40 documentation (2026), electron-forge docs, electron-vite docs, Electron Fiddle examples
+
+Covers: architecture, project setup, IPC patterns, preload scripts, main/renderer processes, electron-forge, electron-vite, BrowserWindow configuration, security best practices.
+
+## Architecture
+
+Electron runs two types of processes:
+
+- **Main process**: Node.js runtime with full OS access. Manages app lifecycle,
+  creates BrowserWindows, handles native APIs. One per app.
+- **Renderer process**: Chromium instance running your web UI. Sandboxed by
+  default. One per window.
+- **Preload script**: Runs in renderer context but with access to Node.js APIs.
+  Uses `contextBridge` to safely expose functions to the web page.
+
+```
+┌─────────────────────┐     IPC      ┌────────────────────────┐
+│    Main Process      │◄────────────►│   Renderer Process     │
+│    (Node.js)         │              │   (Chromium)           │
+│                      │              │                        │
+│  - app lifecycle     │   preload.js │  - Your web UI         │
+│  - BrowserWindow     │──────────────│  - HTML/CSS/JS         │
+│  - native APIs       │ contextBridge│  - React/Vue/Svelte    │
+│  - file system       │              │  - Sandboxed           │
+└─────────────────────┘              └────────────────────────┘
+```
+
+## Project Setup
+
+### Option 1: electron-vite (Recommended for New Projects)
+
+```bash
+npm create electron-vite@latest my-app
+cd my-app
+npm install
+npm run dev
+```
+
+Project structure:
+
+```
+my-app/
+├── electron.vite.config.ts
+├── package.json
+├── src/
+│   ├── main/           # Main process
+│   │   └── index.ts
+│   ├── preload/        # Preload scripts
+│   │   └── index.ts
+│   └── renderer/       # Web UI (React/Vue/etc.)
+│       ├── index.html
+│       └── src/
+```
+
+### Option 2: electron-forge (Official)
+
+```bash
+npm init electron-app@latest my-app -- --template=vite-typescript
+cd my-app
+npm start
+```
+
+### electron-vite vs electron-forge
+
+| Aspect | electron-vite | electron-forge |
+|--------|--------------|----------------|
+| Maintainer | Community (alex.wei) | Electron team |
+| Vite support | Native, stable | Plugin, "experimental" |
+| HMR speed | Fast | Fast |
+| Configuration | Minimal | More boilerplate |
+| Maker ecosystem | Use electron-builder | Built-in makers |
+| Recommendation | New projects | Need forge-specific makers |
+
+### Adding Electron to an Existing Web Project
+
+```bash
+npm install --save-dev electron electron-vite
+```
+
+Create `electron.vite.config.ts`, `src/main/index.ts`, and `src/preload/index.ts`.
+Point the main process to load your existing frontend.
+
+## IPC Patterns
+
+IPC (Inter-Process Communication) is how main and renderer exchange data.
+All IPC must go through the preload script for security.
+
+### Pattern 1: Renderer → Main (Request-Response)
+
+Use `ipcRenderer.invoke` / `ipcMain.handle` for async request-response:
+
+```typescript
+// src/preload/index.ts
+import { contextBridge, ipcRenderer } from 'electron';
+contextBridge.exposeInMainWorld('api', {
+  readFile: (path: string) => ipcRenderer.invoke('read-file', path),
+  saveFile: (path: string, data: string) => ipcRenderer.invoke('save-file', path, data),
+});
+
+// src/main/index.ts
+import { ipcMain } from 'electron';
+import { readFile, writeFile } from 'fs/promises';
+ipcMain.handle('read-file', async (_event, path: string) => {
+  return readFile(path, 'utf-8');
+});
+ipcMain.handle('save-file', async (_event, path: string, data: string) => {
+  await writeFile(path, data, 'utf-8');
+});
+
+// src/renderer (your web app)
+const content = await window.api.readFile('/path/to/file');
+await window.api.saveFile('/path/to/file', 'new content');
+```
+
+### Pattern 2: Main → Renderer (Push Notifications)
+
+Use `webContents.send` / `ipcRenderer.on` for main-initiated messages:
+
+```typescript
+// src/main/index.ts
+mainWindow.webContents.send('download-progress', { percent: 75 });
+
+// src/preload/index.ts
+contextBridge.exposeInMainWorld('api', {
+  onDownloadProgress: (callback: (data: any) => void) => {
+    ipcRenderer.on('download-progress', (_event, data) => callback(data));
+  },
+});
+
+// src/renderer
+window.api.onDownloadProgress((data) => {
+  console.log(`Download: ${data.percent}%`);
+});
+```
+
+### Pattern 3: Two-Way Channel
+
+For streams or ongoing communication, combine both patterns.
+
+### IPC Best Practices
+
+| Do | Don't |
+|----|-------|
+| Use `invoke`/`handle` for request-response | Use `send`/`on` for request-response |
+| Validate all inputs in main process handlers | Trust data from renderer |
+| Type the exposed API with TypeScript interfaces | Expose raw `ipcRenderer` |
+| Use descriptive channel names (`file:read`) | Use generic names (`data`) |
+| Return serializable data only | Return functions or class instances |
+
+## Preload Script
+
+The preload script is the security boundary between main and renderer.
+
+### Rules
+
+1. Always use `contextBridge.exposeInMainWorld`
+2. Never expose `ipcRenderer` directly to the renderer
+3. Never expose Node.js APIs directly (`require`, `fs`, `path`)
+4. Validate and sanitize all data crossing the bridge
+5. Expose minimal API surface — only what the renderer needs
+
+### TypeScript Typing
+
+```typescript
+// src/preload/index.ts
+const api = {
+  readFile: (path: string): Promise<string> => ipcRenderer.invoke('read-file', path),
+  getAppVersion: (): Promise<string> => ipcRenderer.invoke('get-app-version'),
+};
+contextBridge.exposeInMainWorld('api', api);
+
+// src/preload/index.d.ts (or global declaration)
+declare global {
+  interface Window {
+    api: {
+      readFile: (path: string) => Promise<string>;
+      getAppVersion: () => Promise<string>;
+    };
+  }
+}
+```
+
+## BrowserWindow Configuration
+
+```typescript
+import { BrowserWindow } from 'electron';
+const mainWindow = new BrowserWindow({
+  width: 1200,
+  height: 800,
+  minWidth: 800,
+  minHeight: 600,
+  webPreferences: {
+    preload: join(__dirname, '../preload/index.js'),
+    sandbox: true,           // Default: true (keep it)
+    contextIsolation: true,  // Default: true (keep it)
+    nodeIntegration: false,  // Default: false (keep it)
+  },
+  // macOS specific
+  titleBarStyle: 'hiddenInset', // For custom title bar
+  trafficLightPosition: { x: 15, y: 10 },
+  // General
+  show: false, // Show after ready-to-show to avoid flash
+});
+mainWindow.once('ready-to-show', () => mainWindow.show());
+```
+
+### Key webPreferences
+
+| Option | Default | Keep Default? | Why |
+|--------|---------|---------------|-----|
+| `sandbox` | true | Yes | Restricts renderer capabilities |
+| `contextIsolation` | true | Yes | Prevents prototype pollution |
+| `nodeIntegration` | false | Yes | No Node.js in renderer |
+| `webSecurity` | true | Yes | Enforces same-origin policy |
+| `preload` | none | Set it | Required for safe IPC |
+
+## Security Best Practices
+
+### Content Security Policy
+
+Add CSP to restrict what the renderer can load:
+
+```typescript
+// In main process, set CSP header
+session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+  callback({
+    responseHeaders: {
+      ...details.responseHeaders,
+      'Content-Security-Policy': [
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'",
+      ],
+    },
+  });
+});
+```
+
+### Restrict Navigation
+
+```typescript
+mainWindow.webContents.on('will-navigate', (event, url) => {
+  const allowed = ['http://localhost:5173']; // dev server
+  if (!allowed.some((a) => url.startsWith(a))) event.preventDefault();
+});
+app.on('web-contents-created', (_event, contents) => {
+  contents.setWindowOpenHandler(() => ({ action: 'deny' }));
+});
+```
+
+### Session Permissions
+
+```typescript
+session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
+  const allowed = ['clipboard-read', 'clipboard-write'];
+  callback(allowed.includes(permission));
+});
+```
+
+## TypeScript Configuration
+
+Use separate tsconfig for each process:
+
+```jsonc
+// tsconfig.node.json (main + preload)
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "strict": true,
+    "outDir": "./out"
+  },
+  "include": ["src/main/**/*", "src/preload/**/*"]
+}
+
+// tsconfig.web.json (renderer)
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "strict": true,
+    "jsx": "react-jsx",
+    "lib": ["DOM", "ESNext"]
+  },
+  "include": ["src/renderer/**/*"]
+}
+```
+
+## Hot Module Replacement
+
+electron-vite and electron-forge+vite both support HMR:
+
+- Frontend changes: Instant HMR in the renderer (same as web dev)
+- Preload changes: Renderer reloads automatically
+- Main process changes: App restarts automatically
+
+No special configuration needed with electron-vite defaults.
+
+## Common Gotchas
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| White screen on startup | Incorrect preload path or build path | Check `join(__dirname, ...)` resolves correctly |
+| Cannot use `require` in renderer | nodeIntegration disabled (correct) | Use IPC through preload instead |
+| CSP blocking inline scripts | Missing or overly strict CSP | Add `'unsafe-inline'` for styles if needed |
+| Large bundle size (200+ MB) | Dev dependencies in production | Use `npm prune --production` or electron-builder |
+| Slow cold startup | Loading heavy modules synchronously | Lazy-load with dynamic `import()` |
+| App crashes on macOS notarization | Missing entitlements | Add `entitlements.mac.plist` with hardened runtime |
+| Window flashes white then loads | Creating visible window before content ready | Use `show: false` + `ready-to-show` event |
+| IPC returns undefined | Forgetting to `return` in handle callback | Ensure handler returns value or Promise |
+| `__dirname` is undefined | ESM mode without polyfill | Use `import.meta.url` or electron-vite auto-polyfill |
+| Multiple windows share state | Using global variables | Use IPC or shared store (electron-store) |
+
+## Debugging
+
+```bash
+# Open DevTools programmatically
+mainWindow.webContents.openDevTools();
+
+# Debug main process with VS Code
+# .vscode/launch.json:
+{
+  "type": "node",
+  "request": "launch",
+  "name": "Debug Main",
+  "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+  "args": ["."],
+  "cwd": "${workspaceFolder}"
+}
+```
+
+## App Lifecycle
+
+```typescript
+import { app, BrowserWindow } from 'electron';
+
+app.whenReady().then(() => {
+  createWindow();
+  // macOS: re-create window when dock icon clicked
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+// Quit when all windows closed (except macOS)
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+// Cleanup before quit
+app.on('before-quit', () => {
+  // Save state, close connections
+});
+```

--- a/skills/desktop-app-dev/references/framework-selection.md
+++ b/skills/desktop-app-dev/references/framework-selection.md
@@ -1,0 +1,259 @@
+# Framework Selection Guide
+
+Sources: Electron v40 docs (2026), Tauri v2 docs (2026), Wails v2/v3 docs, 2025-2026 ecosystem research
+
+Covers: framework comparison, project detection, decision matrices, team skill assessment, architecture overview, ecosystem maturity, frontend compatibility.
+
+## Project Detection
+
+Before recommending a framework, detect what is already in use.
+
+### Detection Procedure
+
+1. Check `package.json` for framework dependencies
+2. Look for framework-specific config files
+3. Inspect directory structure for framework markers
+
+### Detection Signals
+
+| Signal | Framework | Confidence |
+|--------|-----------|------------|
+| `electron` in package.json devDependencies | Electron | High |
+| `@electron-forge/cli` in devDependencies | Electron (Forge) | High |
+| `electron-vite` in devDependencies | Electron (Vite) | High |
+| `electron-builder` in devDependencies | Electron | High |
+| `electron-builder.yml` in project root | Electron | High |
+| `main.js` + `preload.js` pattern | Electron | Medium |
+| `src-tauri/` directory exists | Tauri | High |
+| `tauri.conf.json` exists | Tauri | High |
+| `@tauri-apps/api` in package.json | Tauri | High |
+| `@tauri-apps/cli` in devDependencies | Tauri | High |
+| `src-tauri/Cargo.toml` exists | Tauri | High |
+| `wails.json` in project root | Wails | High |
+| `go.mod` with `wails` import | Wails | High |
+| `main.go` with wails imports | Wails | Medium |
+| `frontend/wailsjs/` directory | Wails | High |
+
+### When Nothing Is Detected
+
+If no framework signals are found, the project is a plain web app. Ask the user
+which framework they prefer and recommend based on the decision matrix below.
+
+Default recommendation for most teams: **Tauri v2** (smallest bundles, best
+performance, mobile support). Fall back to **Electron** if the team cannot
+use Rust at all.
+
+## Framework Comparison (February 2026)
+
+| Aspect | Electron | Tauri v2 | Wails |
+|--------|----------|----------|-------|
+| Current version | v40.0 | v2.6+ | v2.11 (v3 alpha) |
+| Backend language | Node.js (JavaScript/TypeScript) | Rust | Go |
+| Rendering engine | Bundled Chromium | OS WebView | OS WebView |
+| Bundle size (hello world) | 80-150 MB | 3-8 MB | 10-15 MB |
+| Memory usage (idle) | ~150 MB | ~30-60 MB | ~40-80 MB |
+| Startup time | 1-3 seconds | 200-500 ms | 300-800 ms |
+| GitHub stars | 120K | 103K | 33K |
+| npm downloads/month | ~10M | ~1.7M | N/A (Go) |
+| Mobile support | No | Yes (iOS/Android) | No |
+| Auto-update | Built-in (electron-updater) | Plugin (updater) | Manual |
+| Code signing support | Mature (electron-builder) | Built-in (bundler) | Manual |
+| Platforms | Windows, macOS, Linux | Windows, macOS, Linux, iOS, Android | Windows, macOS, Linux |
+
+## Architecture Overview
+
+### Electron
+
+Two-process model with Chromium:
+
+```
+Main Process (Node.js) ←─ IPC ─→ Renderer Process (Chromium)
+     │                              │
+     ├── App lifecycle              ├── Your web UI
+     ├── Native APIs                ├── HTML/CSS/JS
+     ├── File system                └── Sandboxed by default
+     └── Window management
+              │
+         Preload Script
+         (contextBridge)
+```
+
+The main process has full Node.js and OS access. The renderer runs web content
+in a sandboxed Chromium instance. Preload scripts bridge them via `contextBridge`.
+
+### Tauri v2
+
+Rust core with OS-native WebView:
+
+```
+Rust Core Process ←─ Commands/Events ─→ WebView (OS Native)
+     │                                       │
+     ├── App lifecycle                       ├── Your web UI
+     ├── Commands (#[tauri::command])        ├── HTML/CSS/JS
+     ├── Plugin system                       └── @tauri-apps/api
+     ├── Capabilities (permissions)
+     └── State management
+```
+
+The Rust backend defines commands that the frontend calls via `invoke()`. Each
+window has a capability file that explicitly permits which APIs it can access.
+Native features are modular plugins.
+
+### Wails
+
+Go backend with OS-native WebView:
+
+```
+Go Backend ←─ Method Binding ─→ WebView (OS Native)
+     │                               │
+     ├── App lifecycle                ├── Your web UI
+     ├── Bound struct methods         ├── HTML/CSS/JS
+     ├── Runtime APIs                 └── Auto-generated TS bindings
+     └── Event system
+```
+
+Go struct methods are automatically bound to the frontend with auto-generated
+TypeScript definitions. No manual IPC serialization needed.
+
+## Decision Matrix
+
+### Primary Decision: Which Framework?
+
+| Your Situation | Recommendation | Reason |
+|----------------|---------------|--------|
+| Web dev team, no Rust/Go experience | **Electron** | Lowest learning curve, JS/TS only |
+| Bundle size and memory matter | **Tauri** | 96% smaller, 58% less memory |
+| Go team building internal tool | **Wails** | Natural Go integration |
+| Need mobile + desktop | **Tauri v2** | Only framework with mobile support |
+| Wrapping Node.js/Express backend | **Electron** | Run server in main process |
+| Maximum security requirements | **Tauri** | Rust memory safety, capability permissions |
+| Pixel-perfect cross-platform rendering | **Electron** | Bundled Chromium = identical everywhere |
+| Greenfield project, team can learn | **Tauri** | Best performance, growing ecosystem |
+| Existing Electron app | **Stay Electron** | Migration cost often not worth it |
+| Simple desktop wrapper, minimal native | **Tauri** | Smallest footprint |
+| Complex native module integration | **Electron** | Mature native module ecosystem |
+| Need extensive community support | **Electron** | Largest ecosystem, most SO answers |
+
+### Secondary Decision: Tooling
+
+| If Electron | Recommended Tooling |
+|-------------|-------------------|
+| New project | electron-vite (community preferred, faster DX) |
+| Need full maker ecosystem | electron-forge + vite plugin |
+| Packaging | electron-builder (most popular) |
+| TypeScript | Yes, always |
+
+| If Tauri | Recommended Tooling |
+|----------|-------------------|
+| New project | `npm create tauri-app@latest` |
+| Adding to existing | `npx tauri init` |
+| Frontend | Any (React-ts, Vue-ts, Svelte-ts templates) |
+| Plugins | Add as needed from official plugin list |
+
+| If Wails | Recommended Tooling |
+|----------|-------------------|
+| New project | `wails init -n myapp -t react-ts` |
+| Version | v2 for production, evaluate v3 for future |
+| Frontend | Any (React, Vue, Svelte templates) |
+
+## Team Skill Assessment
+
+| Team Background | Framework | Learning Curve | Time to First Build |
+|----------------|-----------|---------------|-------------------|
+| Frontend/React/Vue/Node | Electron | Low (1-2 days) | Hours |
+| Frontend + some Rust | Tauri | Medium (1-2 weeks) | Days |
+| Frontend + some Go | Wails | Medium (1 week) | Days |
+| Full-stack JavaScript | Electron | Low (1-2 days) | Hours |
+| Full-stack Rust | Tauri | Low (2-3 days) | Hours |
+| Full-stack Go | Wails | Low (2-3 days) | Hours |
+| No desktop experience | Electron | Low | Hours |
+
+## WebView Consistency Considerations
+
+Electron bundles Chromium. Tauri and Wails use OS-provided WebViews.
+
+| Platform | Electron Renderer | Tauri/Wails Renderer |
+|----------|------------------|---------------------|
+| macOS | Chromium (bundled) | WebKit (WKWebView) |
+| Windows | Chromium (bundled) | WebView2 (Edge/Chromium) |
+| Linux | Chromium (bundled) | WebKitGTK |
+
+### Implications for Tauri/Wails
+
+- CSS feature support varies between WebKit, WebView2, and WebKitGTK
+- JavaScript engine differs (JavaScriptCore on macOS vs V8 on Windows)
+- Must test on all target platforms, not just development machine
+- Use CSS feature detection and progressive enhancement
+- Avoid bleeding-edge CSS features without fallbacks
+- WebView2 requires Edge runtime on Windows (usually pre-installed)
+- WebKitGTK may lag behind Safari WebKit on macOS
+
+### When Consistent Rendering Is Critical
+
+If the app must look pixel-identical on all platforms (e.g., design tools,
+visual editors), choose Electron. For most business and developer tools,
+the WebView differences are negligible.
+
+## When NOT to Use Each Framework
+
+### Do Not Use Electron When
+
+- Disk space matters (IoT, embedded, disk-constrained environments)
+- Memory is constrained (< 512 MB available)
+- Mobile support is needed
+- Users complain about resource usage and you cannot mitigate it
+- Bundle download size must be under 20 MB
+
+### Do Not Use Tauri When
+
+- Team absolutely cannot learn any Rust (even basic command definitions)
+- App relies heavily on Node.js native modules (better-sqlite3, sharp, etc.)
+- Need pixel-perfect cross-platform rendering (WebView differences matter)
+- Need mature, battle-tested auto-update with complex rollback scenarios
+- Building on top of an existing Electron codebase without clear ROI
+
+### Do Not Use Wails When
+
+- Need mobile support (not available)
+- v3 stability is required now (still alpha as of Feb 2026)
+- Community support is critical (smaller than Electron/Tauri)
+- Need built-in auto-update mechanism
+- Team has no Go experience and no interest in learning
+
+## Ecosystem Maturity
+
+| Dimension | Electron | Tauri v2 | Wails |
+|-----------|----------|----------|-------|
+| Documentation quality | Excellent | Good (improving) | Good |
+| Plugin/extension ecosystem | Massive (npm) | Growing (official plugins) | Small |
+| Community size | Very large | Large, growing fast | Medium |
+| Stack Overflow answers | Thousands | Hundreds | Tens |
+| Production app examples | VS Code, Slack, Discord, Notion | Agents UI, Hopp, Cody | Fewer known |
+| Books/courses available | Several | Few | Very few |
+| Third-party tooling | electron-builder, -forge, -vite | Official CLI + bundler | Built-in CLI |
+| Maturity (years) | 10+ years | 2+ years (v2 since Oct 2024) | 3+ years |
+
+## Frontend Framework Compatibility
+
+All three frameworks support any frontend that compiles to HTML, CSS, and
+JavaScript. The differences are in templates and integrations.
+
+| Frontend | Electron | Tauri | Wails |
+|----------|----------|-------|-------|
+| React | Via electron-vite/forge | Official template (react-ts) | Official template (react-ts) |
+| Vue | Via electron-vite/forge | Official template (vue-ts) | Official template (vue-ts) |
+| Svelte | Via electron-vite/forge | Official template (svelte-ts) | Official template (svelte-ts) |
+| Angular | Via electron-vite/forge | Community template | Community template |
+| SolidJS | Via electron-vite/forge | Official template (solid-ts) | Community template |
+| Next.js | electron-serve or custom | Static export only | Static export only |
+| Nuxt | Custom integration | Static export only | Static export only |
+| Vanilla | Via electron-vite/forge | Official template (vanilla-ts) | Official template (vanilla) |
+
+### Framework-Specific Notes
+
+- **Next.js / Nuxt SSR**: Only works natively with Electron (can run Node.js
+  server in main process). For Tauri/Wails, use static export (`next export`).
+- **Vite-based frameworks**: Best DX across all three desktop frameworks.
+  HMR works out of the box.
+- **Webpack-based frameworks**: Work but may need extra configuration for
+  Tauri/Wails dev server URL setup.

--- a/skills/desktop-app-dev/references/migration-patterns.md
+++ b/skills/desktop-app-dev/references/migration-patterns.md
@@ -1,0 +1,320 @@
+# Migration and Conversion Patterns
+
+Sources: Tauri migration guide (v2.tauri.app), Electron-to-Tauri community experiences (2025-2026), web-to-desktop conversion patterns
+
+Covers: converting existing web apps to desktop, migrating Electron apps to Tauri, IPC mapping between frameworks, handling Node.js dependencies in Tauri, incremental migration strategies.
+
+## Web App to Desktop: Decision Framework
+
+### When to Convert
+
+| Signal | Conversion Makes Sense |
+|--------|----------------------|
+| Users need offline access | Yes |
+| Need native file system access | Yes |
+| Need system tray / background operation | Yes |
+| Need OS-level notifications | Yes |
+| Need deep links (custom protocol) | Yes |
+| Need auto-update mechanism | Yes |
+| App needs local database | Yes |
+| Distribution outside browser | Yes |
+
+### When NOT to Convert
+
+| Signal | Stay Web |
+|--------|----------|
+| Web app works fine in browser | No conversion needed |
+| No native feature requirements | Use PWA instead |
+| Mobile is primary target | PWA or native mobile |
+| Users only need it occasionally | PWA with install prompt |
+| Content-only site | Definitely not |
+
+## Web App to Electron
+
+Electron is the easiest path for web-to-desktop conversion because it runs
+Node.js and Chromium — your web app runs nearly unchanged.
+
+### Step-by-Step: Static SPA
+
+1. Install dependencies:
+   ```bash
+   npm install --save-dev electron electron-vite
+   ```
+
+2. Create main process entry (`src/main/index.ts`):
+   ```typescript
+   import { app, BrowserWindow } from 'electron';
+   import { join } from 'path';
+
+   function createWindow() {
+     const win = new BrowserWindow({
+       width: 1200,
+       height: 800,
+       webPreferences: {
+         preload: join(__dirname, '../preload/index.js'),
+       },
+     });
+     // Production: load built files
+     if (process.env.NODE_ENV === 'production') {
+       win.loadFile(join(__dirname, '../renderer/index.html'));
+     } else {
+       // Dev: load dev server
+       win.loadURL('http://localhost:5173');
+     }
+   }
+
+   app.whenReady().then(createWindow);
+   app.on('window-all-closed', () => {
+     if (process.platform !== 'darwin') app.quit();
+   });
+   ```
+
+3. Create minimal preload script (`src/preload/index.ts`):
+   ```typescript
+   import { contextBridge } from 'electron';
+   contextBridge.exposeInMainWorld('desktop', { isDesktop: true });
+   ```
+
+4. Configure electron-vite to point at your existing frontend.
+
+5. Add npm scripts:
+   ```json
+   { "dev:desktop": "electron-vite dev", "build:desktop": "electron-vite build" }
+   ```
+
+6. Test: `npm run dev:desktop`
+
+### Step-by-Step: SPA with Backend API
+
+If your web app calls a REST API:
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| Bundle API server as child process | Full compatibility | Larger bundle, port conflicts |
+| Run API server in main process | Simpler | Shares main process resources |
+| Keep API remote (cloud) | No changes to backend | Requires internet |
+| Rewrite API calls as IPC | True desktop app | Most work |
+
+**Recommended**: Start with remote API (no backend changes), then incrementally
+move critical endpoints to IPC if offline support is needed.
+
+### Step-by-Step: Next.js / SSR App
+
+Next.js with Electron requires special handling:
+
+```bash
+# Option 1: Static export (simplest)
+next build && next export
+# Load the exported files in Electron
+
+# Option 2: Custom server in main process
+# Run Next.js server inside Electron's main process
+# More complex but preserves SSR
+```
+
+For Tauri/Wails, only static export works (no Node.js server available).
+
+## Web App to Tauri
+
+Tauri requires no backend runtime — your frontend connects to a Rust backend
+for native features.
+
+### Step-by-Step
+
+1. Initialize Tauri in your project:
+   ```bash
+   cd my-web-app
+   npm install --save-dev @tauri-apps/cli
+   npx tauri init
+   ```
+
+2. Answer prompts:
+   - App name: your app name
+   - Window title: your window title
+   - Dev server URL: `http://localhost:5173` (or your dev server)
+   - Frontend dist: `../dist` (or your build output directory)
+
+3. Install Tauri API:
+   ```bash
+   npm install @tauri-apps/api
+   ```
+
+4. Replace browser-only APIs with Tauri plugins:
+
+   | Browser API | Tauri Replacement |
+   |-------------|------------------|
+   | `localStorage` | `@tauri-apps/plugin-store` |
+   | `fetch` (CORS issues) | `@tauri-apps/plugin-http` |
+   | `Notification` | `@tauri-apps/plugin-notification` |
+   | File input element | `@tauri-apps/plugin-dialog` + `@tauri-apps/plugin-fs` |
+   | `navigator.clipboard` | `@tauri-apps/plugin-clipboard-manager` |
+
+5. Add capabilities for required permissions:
+   ```json
+   // src-tauri/capabilities/default.json
+   { "permissions": ["core:default", "store:default", "dialog:default"] }
+   ```
+
+6. Test: `npm run tauri dev`
+
+### Key Constraint: No Node.js
+
+Tauri does not run Node.js. If your web app imports Node.js modules
+(`fs`, `path`, `crypto`, `child_process`), those imports must be:
+
+- Removed (if only used server-side)
+- Replaced with Tauri plugins
+- Moved to Rust commands
+
+This is the biggest conversion effort for complex apps.
+
+## Web App to Wails
+
+### Step-by-Step
+
+1. Install Wails CLI:
+   ```bash
+   go install github.com/wailsapp/wails/v2/cmd/wails@latest
+   ```
+
+2. Initialize project around existing frontend:
+   ```bash
+   wails init -n my-app
+   ```
+
+3. Point `wails.json` to your frontend:
+   ```json
+   {
+     "frontend:install": "npm install",
+     "frontend:build": "npm run build",
+     "frontend:dev:watcher": "npm run dev",
+     "frontend:dev:serverUrl": "auto"
+   }
+   ```
+
+4. Move backend logic to Go methods and bind them.
+
+5. Test: `wails dev`
+
+## Electron to Tauri Migration
+
+### Feasibility Assessment
+
+Score your Electron app on each factor:
+
+| Factor | Easy (1) | Medium (3) | Hard (5) |
+|--------|---------|-----------|---------|
+| IPC handler count | < 10 | 10-30 | 30+ |
+| Node.js native modules | None | 1-2 | 3+ |
+| Node.js API usage (fs, crypto, etc.) | Minimal | Moderate | Heavy |
+| Main process complexity | Simple window management | Some business logic | Complex server |
+| electron-specific APIs used | Basic (dialog, menu) | Moderate | Extensive (protocol, session, etc.) |
+
+**Scoring**: 5-10 = straightforward migration; 11-17 = moderate effort; 18-25 = significant rewrite
+
+### IPC Mapping: Electron to Tauri
+
+| Electron | Tauri Equivalent |
+|----------|-----------------|
+| `ipcMain.handle('channel', handler)` | `#[tauri::command] fn handler()` |
+| `ipcRenderer.invoke('channel', data)` | `invoke('handler', { data })` |
+| `webContents.send('channel', data)` | `app.emit('channel', data)` |
+| `ipcRenderer.on('channel', cb)` | `listen('channel', cb)` |
+| `contextBridge.exposeInMainWorld` | Not needed (invoke is the bridge) |
+| `ipcMain.on('channel', handler)` | `app.listen('channel', handler)` (Rust) |
+| `ipcRenderer.send('channel', data)` | `emit('channel', data)` |
+
+### Node.js to Rust Equivalents
+
+| Node.js Module | Rust Equivalent | Crate |
+|----------------|----------------|-------|
+| `fs` (file system) | `std::fs` or `tokio::fs` | Standard library |
+| `path` | `std::path::PathBuf` | Standard library |
+| `child_process` | `std::process::Command` | Standard or `tauri-plugin-shell` |
+| `crypto` | `ring` or `sha2` | ring, sha2 |
+| `http`/`https` | `reqwest` | reqwest |
+| `os` | `std::env`, `sysinfo` | sysinfo |
+| `better-sqlite3` | `rusqlite` | rusqlite |
+| `node-fetch` | `reqwest` | reqwest |
+| `ws` (WebSocket) | `tokio-tungstenite` | tokio-tungstenite |
+| `sharp` (images) | `image` | image |
+| `electron-store` | `tauri-plugin-store` | Official plugin |
+| `keytar` | `keyring` | keyring |
+
+### Step-by-Step Migration
+
+1. **Audit** — List all `ipcMain.handle` calls, Node.js imports, electron APIs
+2. **Set up Tauri alongside Electron** — Both can coexist in the same project
+3. **Port IPC handlers one by one** — Convert each to a Tauri command
+4. **Replace electron APIs** — Map to Tauri plugins (dialog, menu, tray, etc.)
+5. **Update frontend imports** — `@tauri-apps/api` instead of `electron`
+6. **Conditional runtime detection** — Support both during migration:
+   ```typescript
+   const isElectron = typeof window.electron !== 'undefined';
+   const isTauri = '__TAURI_INTERNALS__' in window;
+   ```
+7. **Test each ported feature** — Verify on all platforms
+8. **Remove Electron** — Once all features are ported and tested
+
+### Incremental Migration Strategy
+
+```
+Phase 1: Run both frameworks side by side
+         ├── Frontend shared (same codebase)
+         ├── Electron IPC still working
+         └── Tauri commands added alongside
+
+Phase 2: Feature-flag new commands
+         ├── New features → Tauri commands only
+         ├── Existing features → Electron IPC still
+         └── Runtime detection picks the right backend
+
+Phase 3: Port remaining Electron features
+         ├── Convert Electron IPC → Tauri commands
+         ├── Replace electron-store → tauri-plugin-store
+         └── Replace native modules → Rust crates
+
+Phase 4: Remove Electron
+         ├── Remove electron dependencies
+         ├── Remove preload scripts
+         ├── Remove main process code
+         └── Clean up runtime detection
+```
+
+## Handling Node.js Dependencies in Tauri
+
+### Decision Framework
+
+| Dependency Type | Action |
+|----------------|--------|
+| Pure JS library (lodash, date-fns) | Keep — works in WebView |
+| Browser-compatible library (axios, zustand) | Keep — works in WebView |
+| Node.js core module usage (fs, path) | Replace with Tauri plugin or Rust |
+| Native module (better-sqlite3, sharp) | Rewrite in Rust |
+| Electron-specific (electron-store, electron-log) | Replace with Tauri plugin |
+| Server framework (Express, Fastify) | Remove — no server in Tauri |
+
+### Common Replacements
+
+```typescript
+// BEFORE (Electron)
+const fs = require('fs');
+const data = fs.readFileSync('config.json', 'utf-8');
+
+// AFTER (Tauri)
+import { readTextFile, BaseDirectory } from '@tauri-apps/plugin-fs';
+const data = await readTextFile('config.json', { baseDir: BaseDirectory.AppData });
+```
+
+## Common Migration Pitfalls
+
+| Pitfall | Impact | Prevention |
+|---------|--------|-----------|
+| Migrating everything at once | Burnout, broken app | Incremental approach, feature flags |
+| Assuming WebView = Chromium | Visual bugs, broken features | Test on all platforms from day one |
+| Ignoring capability permissions | "Not allowed" errors everywhere | Set up capabilities early in migration |
+| Fighting the Rust borrow checker | Slow progress | Learn Rust basics first, start with simple commands |
+| Not testing on Windows | WebView2 vs WebKit differences | CI matrix build from the start |
+| Keeping Node.js patterns in Rust | Unidiomatic, slow code | Learn Rust idioms (Result, Option, traits) |
+| Underestimating native module ports | Timeline blowout | Audit native modules first, assess Rust alternatives |
+| Skipping the feasibility assessment | Wasted effort | Score the migration before committing |

--- a/skills/desktop-app-dev/references/native-apis.md
+++ b/skills/desktop-app-dev/references/native-apis.md
@@ -1,0 +1,405 @@
+# Native Desktop APIs
+
+Sources: Electron v40 API docs, Tauri v2 plugin docs, Wails v2 runtime docs, platform-specific guidelines
+
+Covers: application menus, system tray, notifications, file system access, dialogs, keyboard shortcuts, clipboard, deep links, system information, multi-window management.
+
+## Application Menus
+
+### Electron
+
+```typescript
+import { Menu, MenuItem, app } from 'electron';
+
+const template: Electron.MenuItemConstructorOptions[] = [
+  {
+    label: 'File',
+    submenu: [
+      { label: 'New', accelerator: 'CmdOrCtrl+N', click: () => createFile() },
+      { label: 'Open', accelerator: 'CmdOrCtrl+O', click: () => openFile() },
+      { type: 'separator' },
+      { role: 'quit' },
+    ],
+  },
+  { role: 'editMenu' },   // Built-in edit menu (undo, redo, cut, copy, paste)
+  { role: 'viewMenu' },   // Built-in view menu (zoom, devtools, fullscreen)
+];
+const menu = Menu.buildFromTemplate(template);
+Menu.setApplicationMenu(menu);
+```
+
+### Tauri
+
+```rust
+use tauri::menu::{Menu, MenuBuilder, SubmenuBuilder};
+
+pub fn run() {
+    tauri::Builder::default()
+        .menu(|app| {
+            MenuBuilder::new(app)
+                .items(&[
+                    &SubmenuBuilder::new(app, "File")
+                        .text("new", "New")
+                        .text("open", "Open")
+                        .separator()
+                        .quit()
+                        .build()?,
+                    &SubmenuBuilder::new(app, "Edit")
+                        .undo().redo().separator()
+                        .cut().copy().paste()
+                        .build()?,
+                ])
+                .build()
+        })
+        .on_menu_event(|app, event| {
+            match event.id().as_ref() {
+                "new" => { /* handle new */ },
+                "open" => { /* handle open */ },
+                _ => {}
+            }
+        })
+}
+```
+
+### Wails
+
+```go
+// main.go - configure in app options
+appMenu := menu.NewMenu()
+fileMenu := appMenu.AddSubmenu("File")
+fileMenu.AddText("New", keys.CmdOrCtrl("n"), func(cd *menu.CallbackData) {
+    // handle new
+})
+fileMenu.AddText("Open", keys.CmdOrCtrl("o"), func(cd *menu.CallbackData) {
+    // handle open
+})
+fileMenu.AddSeparator()
+fileMenu.AddText("Quit", keys.CmdOrCtrl("q"), func(cd *menu.CallbackData) {
+    runtime.Quit(app.ctx)
+})
+
+wails.Run(&options.App{
+    Menu: appMenu,
+})
+```
+
+### Context Menus
+
+| Framework | Approach |
+|-----------|----------|
+| Electron | `Menu.popup()` on `contextmenu` event |
+| Tauri | `menu.popup()` from Rust or via event |
+| Wails | No built-in context menu API; use frontend library |
+
+## System Tray
+
+### Electron
+
+```typescript
+import { Tray, Menu, nativeImage } from 'electron';
+
+let tray: Tray;
+app.whenReady().then(() => {
+  const icon = nativeImage.createFromPath('icon.png');
+  tray = new Tray(icon.resize({ width: 16, height: 16 }));
+  tray.setToolTip('My App');
+  tray.setContextMenu(Menu.buildFromTemplate([
+    { label: 'Show App', click: () => mainWindow.show() },
+    { label: 'Quit', click: () => app.quit() },
+  ]));
+  tray.on('click', () => mainWindow.show());
+});
+```
+
+### Tauri
+
+```rust
+use tauri::tray::{TrayIconBuilder, MouseButton, MouseButtonState};
+use tauri::menu::{Menu, MenuItem};
+
+pub fn run() {
+    tauri::Builder::default()
+        .setup(|app| {
+            let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
+            let menu = Menu::with_items(app, &[&quit])?;
+            TrayIconBuilder::new()
+                .icon(app.default_window_icon().unwrap().clone())
+                .menu(&menu)
+                .on_menu_event(|app, event| {
+                    if event.id() == "quit" { app.exit(0); }
+                })
+                .on_tray_icon_event(|tray, event| {
+                    if let tauri::tray::TrayIconEvent::Click {
+                        button: MouseButton::Left,
+                        button_state: MouseButtonState::Up, ..
+                    } = event {
+                        let app = tray.app_handle();
+                        if let Some(w) = app.get_webview_window("main") {
+                            w.show().unwrap();
+                            w.set_focus().unwrap();
+                        }
+                    }
+                })
+                .build(app)?;
+            Ok(())
+        })
+}
+```
+
+### Wails
+
+```go
+wails.Run(&options.App{
+    // v2: Limited system tray via platform-specific packages
+    // v3: Enhanced tray support (in alpha)
+})
+```
+
+For v2, use third-party packages like `getlantern/systray` alongside Wails.
+
+## Notifications
+
+### Electron
+
+```typescript
+// From renderer (Web Notification API works)
+new Notification('Title', { body: 'Message body' });
+
+// From main process
+const { Notification } = require('electron');
+new Notification({ title: 'Title', body: 'Message' }).show();
+```
+
+### Tauri
+
+```bash
+cargo add tauri-plugin-notification
+npm install @tauri-apps/plugin-notification
+```
+
+```typescript
+import { sendNotification, isPermissionGranted, requestPermission }
+  from '@tauri-apps/plugin-notification';
+
+let permitted = await isPermissionGranted();
+if (!permitted) permitted = (await requestPermission()) === 'granted';
+if (permitted) sendNotification({ title: 'Title', body: 'Message body' });
+```
+
+### Wails
+
+No built-in notification API. Use Go libraries:
+
+```go
+import "github.com/gen2brain/beeep"
+
+func (a *App) Notify(title, message string) error {
+    return beeep.Notify(title, message, "")
+}
+```
+
+## File Dialogs
+
+### Electron
+
+```typescript
+import { dialog } from 'electron';
+
+// Open file
+const result = await dialog.showOpenDialog(mainWindow, {
+  properties: ['openFile', 'multiSelections'],
+  filters: [
+    { name: 'Text', extensions: ['txt', 'md'] },
+    { name: 'All Files', extensions: ['*'] },
+  ],
+});
+// result.filePaths: string[]
+
+// Save file
+const saveResult = await dialog.showSaveDialog(mainWindow, {
+  defaultPath: 'document.txt',
+  filters: [{ name: 'Text', extensions: ['txt'] }],
+});
+// saveResult.filePath: string | undefined
+
+// Select directory
+const dirResult = await dialog.showOpenDialog(mainWindow, {
+  properties: ['openDirectory'],
+});
+```
+
+### Tauri
+
+```typescript
+import { open, save } from '@tauri-apps/plugin-dialog';
+
+const file = await open({
+  multiple: false,
+  filters: [{ name: 'Text', extensions: ['txt', 'md'] }],
+});
+// file: string | null
+
+const savePath = await save({
+  defaultPath: 'document.txt',
+  filters: [{ name: 'Text', extensions: ['txt'] }],
+});
+
+const dir = await open({ directory: true });
+```
+
+### Wails
+
+```go
+file, err := runtime.OpenFileDialog(a.ctx, runtime.OpenDialogOptions{
+    Title:   "Open File",
+    Filters: []runtime.FileFilter{
+        {DisplayName: "Text Files", Pattern: "*.txt;*.md"},
+    },
+})
+```
+
+See `references/wails-guide.md` for full dialog examples.
+
+## Keyboard Shortcuts
+
+### Electron (Global Shortcuts)
+
+```typescript
+import { globalShortcut } from 'electron';
+
+app.whenReady().then(() => {
+  globalShortcut.register('CommandOrControl+Shift+I', () => {
+    // Global shortcut (works even when app not focused)
+  });
+});
+app.on('will-quit', () => globalShortcut.unregisterAll());
+```
+
+### Tauri
+
+```bash
+cargo add tauri-plugin-global-shortcut
+npm install @tauri-apps/plugin-global-shortcut
+```
+
+```typescript
+import { register } from '@tauri-apps/plugin-global-shortcut';
+
+await register('CommandOrControl+Shift+C', (event) => {
+  if (event.state === 'Pressed') { /* handle */ }
+});
+```
+
+### Wails
+
+No built-in global shortcut API. Use platform-specific Go libraries or
+handle keyboard events in the frontend (local shortcuts only).
+
+## Clipboard
+
+### Electron
+
+```typescript
+import { clipboard } from 'electron';
+clipboard.writeText('copied text');
+const text = clipboard.readText();
+```
+
+### Tauri
+
+```typescript
+import { writeText, readText } from '@tauri-apps/plugin-clipboard-manager';
+await writeText('copied text');
+const text = await readText();
+```
+
+### Wails
+
+```go
+import "github.com/atotto/clipboard"
+clipboard.WriteAll("copied text")
+text, _ := clipboard.ReadAll()
+```
+
+## Deep Links (Custom Protocol)
+
+Register `myapp://` protocol for deep linking.
+
+### Electron
+
+```typescript
+app.setAsDefaultProtocolClient('myapp');
+// macOS
+app.on('open-url', (event, url) => { handleDeepLink(url); });
+// Windows/Linux
+app.on('second-instance', (_event, argv) => {
+  const url = argv.find(a => a.startsWith('myapp://'));
+  if (url) handleDeepLink(url);
+});
+```
+
+### Tauri
+
+```bash
+cargo add tauri-plugin-deep-link
+npm install @tauri-apps/plugin-deep-link
+```
+
+Configure in `tauri.conf.json` under `plugins.deep-link.desktop.schemes`.
+
+### Wails
+
+No built-in deep link support. Register protocols manually per platform.
+
+## Multi-Window Management
+
+### Electron
+
+```typescript
+const secondWindow = new BrowserWindow({
+  width: 600, height: 400,
+  webPreferences: { preload: join(__dirname, 'preload.js') },
+});
+secondWindow.loadFile('settings.html');
+// Communicate between windows via main process IPC
+```
+
+### Tauri
+
+```rust
+use tauri::WebviewWindowBuilder;
+
+#[tauri::command]
+async fn open_settings(app: tauri::AppHandle) -> Result<(), String> {
+    WebviewWindowBuilder::new(&app, "settings", tauri::WebviewUrl::App("/settings".into()))
+        .title("Settings")
+        .inner_size(600.0, 400.0)
+        .build()
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+```
+
+### Wails
+
+Multi-window is limited in v2 (workarounds exist). Full support in v3 (alpha).
+
+## Feature Support Matrix
+
+| Feature | Electron | Tauri v2 | Wails v2 |
+|---------|----------|----------|----------|
+| Application menus | Built-in | Built-in | Built-in |
+| Context menus | Built-in | Built-in | Frontend only |
+| System tray | Built-in | Built-in | Third-party |
+| Notifications | Built-in | Plugin | Third-party |
+| File dialogs | Built-in | Plugin | Built-in |
+| Global shortcuts | Built-in | Plugin | Third-party |
+| Clipboard | Built-in | Plugin | Third-party |
+| Deep links | Built-in | Plugin | Manual |
+| Multi-window | Full | Full | v3 only |
+| Touch Bar (macOS) | Yes | No | No |
+| Dock badge (macOS) | Yes | No | No |
+| Drag and drop | Full | Via events | Via frontend |
+| Spellcheck | Built-in (Chromium) | WebView-dependent | WebView-dependent |
+| Print | Built-in | Via WebView | Via WebView |
+| Screen capture | desktopCapturer | No built-in | No built-in |

--- a/skills/desktop-app-dev/references/packaging-distribution.md
+++ b/skills/desktop-app-dev/references/packaging-distribution.md
@@ -1,0 +1,432 @@
+# Packaging and Distribution
+
+Sources: electron-builder docs, Tauri bundler docs, Wails build docs, Apple Developer docs, Microsoft Authenticode docs, 2025-2026 distribution patterns
+
+Covers: platform-specific installers, code signing (macOS/Windows), notarization, auto-update mechanisms, CI/CD build pipelines, distribution channels, bundle size optimization.
+
+## Platform Installer Formats
+
+| Platform | Formats | Notes |
+|----------|---------|-------|
+| macOS | `.dmg`, `.pkg`, `.app` (in zip) | DMG most common for direct distribution |
+| Windows | `.exe` (NSIS), `.msi` (WiX) | NSIS for consumer, MSI for enterprise |
+| Linux | `.AppImage`, `.deb`, `.rpm`, `.snap` | AppImage most portable, deb for Ubuntu/Debian |
+
+## Electron Packaging
+
+### electron-builder (Most Popular)
+
+```json
+// package.json
+{
+  "build": {
+    "appId": "com.example.myapp",
+    "productName": "My App",
+    "directories": { "output": "release" },
+    "mac": {
+      "target": ["dmg", "zip"],
+      "category": "public.app-category.developer-tools",
+      "icon": "build/icon.icns",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist"
+    },
+    "win": {
+      "target": ["nsis"],
+      "icon": "build/icon.ico"
+    },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true,
+      "perMachine": false
+    },
+    "linux": {
+      "target": ["AppImage", "deb"],
+      "icon": "build/icons",
+      "category": "Development"
+    }
+  }
+}
+```
+
+Build commands:
+
+```bash
+npx electron-builder --mac     # macOS
+npx electron-builder --win     # Windows
+npx electron-builder --linux   # Linux
+npx electron-builder -mwl      # All platforms (from macOS)
+```
+
+### electron-forge Makers
+
+```json
+// forge.config.ts
+{
+  "makers": [
+    { "name": "@electron-forge/maker-dmg" },
+    { "name": "@electron-forge/maker-squirrel" },
+    { "name": "@electron-forge/maker-deb" }
+  ]
+}
+```
+
+```bash
+npx electron-forge make
+```
+
+### electron-builder vs electron-forge for Packaging
+
+| Aspect | electron-builder | electron-forge |
+|--------|-----------------|----------------|
+| Configuration | package.json or yml | forge.config.ts |
+| Auto-update | electron-updater | Squirrel (Windows), native (macOS) |
+| Platform targets | Extensive | Good |
+| ASAR support | Built-in | Built-in |
+| Code signing | Built-in | Via makers |
+| Recommendation | Most projects | Forge-specific workflows |
+
+## Tauri Packaging
+
+Tauri bundles are configured in `tauri.conf.json`:
+
+```jsonc
+{
+  "bundle": {
+    "active": true,
+    "targets": "all",  // Or: ["dmg", "nsis", "appimage", "deb"]
+    "identifier": "com.example.myapp",
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
+    "resources": [],   // Extra files to bundle
+    "macOS": {
+      "minimumSystemVersion": "10.13",
+      "signingIdentity": null,  // Set for code signing
+      "entitlements": null
+    },
+    "windows": {
+      "wix": null,     // Use WiX for MSI
+      "nsis": null     // Use NSIS for exe installer
+    },
+    "linux": {
+      "deb": { "depends": [] },
+      "appimage": { "bundleMediaFramework": false }
+    }
+  }
+}
+```
+
+```bash
+npx tauri build          # Build for current platform
+npx tauri build --target universal-apple-darwin  # Universal macOS binary
+```
+
+## Wails Packaging
+
+```bash
+wails build              # Production build for current platform
+wails build -platform darwin/universal  # Universal macOS binary
+wails build -nsis        # Windows NSIS installer
+```
+
+For macOS `.dmg` or Windows `.msi`, use platform-specific tools post-build:
+
+```bash
+# macOS DMG (after wails build)
+hdiutil create -volname "My App" -srcfolder build/bin -ov -format UDZO MyApp.dmg
+
+# Windows MSI (use WiX manually)
+```
+
+## Code Signing
+
+### macOS Code Signing
+
+**Required for distribution** — unsigned apps trigger Gatekeeper warnings.
+
+Prerequisites:
+- Apple Developer account ($99/year)
+- Developer ID Application certificate
+- Developer ID Installer certificate (for .pkg)
+
+#### Electron (via electron-builder)
+
+Set environment variables:
+
+```bash
+export APPLE_ID="your@email.com"
+export APPLE_APP_SPECIFIC_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+export APPLE_TEAM_ID="XXXXXXXXXX"
+export CSC_LINK="/path/to/cert.p12"  # Or base64 encoded
+export CSC_KEY_PASSWORD="certificate-password"
+```
+
+electron-builder signs and notarizes automatically when these are set.
+
+#### Tauri
+
+```bash
+export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (XXXXXXXXXX)"
+export APPLE_ID="your@email.com"
+export APPLE_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+export APPLE_TEAM_ID="XXXXXXXXXX"
+```
+
+Tauri signs during `tauri build` when identity is available.
+
+#### Manual Signing (Any Framework)
+
+```bash
+codesign --deep --force --verify --verbose \
+  --sign "Developer ID Application: Your Name" \
+  --options runtime \
+  MyApp.app
+```
+
+### macOS Notarization
+
+Required for apps distributed outside the Mac App Store (macOS 10.15+).
+
+```bash
+# Submit for notarization
+xcrun notarytool submit MyApp.dmg \
+  --apple-id "your@email.com" \
+  --password "xxxx-xxxx-xxxx-xxxx" \
+  --team-id "XXXXXXXXXX" \
+  --wait
+
+# Staple the ticket
+xcrun stapler staple MyApp.dmg
+```
+
+electron-builder and Tauri handle notarization automatically when configured.
+
+### Windows Code Signing
+
+Prerequisites:
+- Code signing certificate from CA (DigiCert, Sectigo, etc.)
+- EV certificate recommended (SmartScreen reputation from day one)
+
+#### Electron
+
+```bash
+export CSC_LINK="/path/to/cert.pfx"
+export CSC_KEY_PASSWORD="password"
+```
+
+#### Tauri
+
+Configure in `tauri.conf.json` or set `TAURI_SIGNING_PRIVATE_KEY`.
+
+#### Manual Signing
+
+```powershell
+signtool sign /f cert.pfx /p password /tr http://timestamp.digicert.com /td sha256 MyApp.exe
+```
+
+### Linux
+
+No mandatory code signing. Optional GPG signing for package repositories.
+
+## Auto-Update Mechanisms
+
+### Electron (electron-updater)
+
+```typescript
+// main process
+import { autoUpdater } from 'electron-updater';
+
+autoUpdater.autoDownload = true;
+autoUpdater.autoInstallOnAppQuit = true;
+
+app.whenReady().then(() => {
+  autoUpdater.checkForUpdatesAndNotify();
+});
+
+autoUpdater.on('update-available', (info) => {
+  mainWindow.webContents.send('update-available', info.version);
+});
+autoUpdater.on('update-downloaded', () => {
+  mainWindow.webContents.send('update-downloaded');
+});
+```
+
+```json
+// package.json
+{
+  "build": {
+    "publish": [{
+      "provider": "github",
+      "owner": "your-org",
+      "repo": "your-app"
+    }]
+  }
+}
+```
+
+Supports: GitHub Releases, S3, generic HTTP server.
+
+### Tauri (updater plugin)
+
+```bash
+cargo add tauri-plugin-updater
+npm install @tauri-apps/plugin-updater
+```
+
+```jsonc
+// tauri.conf.json
+{
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://releases.myapp.com/{{target}}/{{arch}}/{{current_version}}"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ..."  // Required: Ed25519 public key
+    }
+  }
+}
+```
+
+Tauri requires cryptographic signature verification for updates (mandatory).
+
+Generate signing keys:
+
+```bash
+npx tauri signer generate -w ~/.tauri/myapp.key
+```
+
+### Wails
+
+No built-in auto-updater. Implement manually with Go packages:
+
+```go
+import "github.com/blang/semver"
+// Check version endpoint, download new binary, replace and restart
+```
+
+Or use a third-party solution like `go-update`.
+
+## CI/CD Build Pipelines
+
+### GitHub Actions (Recommended)
+
+#### Electron
+
+```yaml
+name: Build
+on: push
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: npm ci
+      - run: npm run build
+      - name: Package
+        run: npx electron-builder --publish never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.os }}
+          path: release/*
+```
+
+#### Tauri
+
+```yaml
+name: Build
+on: push
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - uses: dtolnay/rust-toolchain@stable
+      - run: npm ci
+      - run: npx tauri build
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+```
+
+#### Release Workflow
+
+1. Tag version (`v1.2.3`) triggers CI
+2. Build on all three platforms (matrix strategy)
+3. Sign and notarize (macOS/Windows)
+4. Upload installers to GitHub Releases
+5. Update manifest for auto-updater endpoint
+6. Notify users (in-app or changelog)
+
+## Distribution Channels
+
+| Channel | Electron | Tauri | Wails |
+|---------|----------|-------|-------|
+| GitHub Releases | Yes | Yes | Yes |
+| Website download | Yes | Yes | Yes |
+| Mac App Store | Possible (complex) | Possible | No |
+| Microsoft Store | Possible | Possible | No |
+| Snap Store | Yes | Yes | No |
+| Flathub | Yes | Possible | No |
+| Homebrew Cask | Yes (custom tap) | Yes | Yes |
+| WinGet | Yes | Yes | Yes |
+
+## Bundle Size Optimization
+
+### Electron
+
+| Technique | Impact |
+|-----------|--------|
+| ASAR archive | Default, compresses resources |
+| `npm prune --production` | Remove devDependencies |
+| Tree-shaking (Vite/Webpack) | Remove unused code |
+| Exclude unnecessary files | `.map`, test files, docs |
+| Use `asarUnpack` sparingly | Only for native modules |
+| Avoid large dependencies | Check with `npx cost-of-modules` |
+
+Minimum realistic size: ~80 MB (Chromium is the floor).
+
+### Tauri
+
+Already small (3-8 MB). Further optimization:
+
+```toml
+# src-tauri/Cargo.toml
+[profile.release]
+strip = true          # Strip debug symbols
+lto = true            # Link-time optimization
+codegen-units = 1     # Better optimization
+opt-level = "s"       # Optimize for size (or "z" for smallest)
+panic = "abort"       # Smaller binary
+```
+
+### Wails
+
+```bash
+# Go build flags for smaller binary
+wails build -ldflags "-s -w"
+# Optional: UPX compression
+upx --best build/bin/my-app
+```

--- a/skills/desktop-app-dev/references/tauri-guide.md
+++ b/skills/desktop-app-dev/references/tauri-guide.md
@@ -1,0 +1,400 @@
+# Tauri v2 Development Guide
+
+Sources: Tauri v2 official documentation (2026), tauri.app guides, Tauri v2 plugin ecosystem, 2025-2026 migration experiences
+
+Covers: architecture, project setup, commands and events, plugin system, capabilities and permissions, tauri.conf.json configuration, frontend integration, mobile support, Rust state management.
+
+## Architecture
+
+Tauri uses a Rust core with an OS-native WebView for rendering:
+
+- **Rust core**: Manages app lifecycle, defines commands, runs plugins, enforces
+  permissions. Full OS access through Rust standard library and crates.
+- **WebView frontend**: OS-native rendering (WebKit on macOS, WebView2 on
+  Windows, WebKitGTK on Linux). Runs your HTML/CSS/JS app.
+- **IPC**: Frontend calls Rust functions via `invoke()`. Rust pushes data to
+  frontend via events. Type-safe across the boundary.
+- **Plugin system**: Native features (fs, dialog, shell, etc.) are modular
+  plugins added individually. Nothing enabled by default.
+
+```
+┌───────────────────────┐  Commands   ┌──────────────────────┐
+│   Rust Core Process   │◄───────────►│   WebView (OS)       │
+│                       │   Events    │                      │
+│  - #[tauri::command]  │────────────►│  - Your web UI       │
+│  - Plugin system      │             │  - @tauri-apps/api   │
+│  - State management   │             │  - invoke('cmd')     │
+│  - Capabilities       │             │  - listen('event')   │
+└───────────────────────┘             └──────────────────────┘
+```
+
+## Project Setup
+
+### New Project
+
+```bash
+npm create tauri-app@latest my-app
+cd my-app
+npm install
+npm run tauri dev
+```
+
+Choose a frontend template during setup: React-ts, Vue-ts, Svelte-ts,
+SolidJS-ts, Angular, Vanilla-ts, or others.
+
+### Add Tauri to Existing Web Project
+
+```bash
+cd my-existing-web-app
+npm install --save-dev @tauri-apps/cli@latest
+npx tauri init
+```
+
+Answer the prompts: app name, window title, dev server URL (e.g.,
+`http://localhost:5173`), frontend build output (e.g., `../dist`).
+
+### Project Structure
+
+```
+my-app/
+├── src/                    # Frontend (React/Vue/Svelte/etc.)
+│   ├── App.tsx
+│   └── main.tsx
+├── src-tauri/
+│   ├── src/
+│   │   ├── lib.rs          # App setup, command registrations
+│   │   └── main.rs         # Entry point (don't edit usually)
+│   ├── capabilities/
+│   │   └── default.json    # Permission definitions
+│   ├── icons/              # App icons (all sizes)
+│   ├── Cargo.toml          # Rust dependencies
+│   └── tauri.conf.json     # Tauri configuration
+├── package.json
+└── vite.config.ts          # Frontend build config
+```
+
+## Commands (Frontend to Backend IPC)
+
+Commands are Rust functions callable from the frontend.
+
+### Basic Command
+
+```rust
+// src-tauri/src/lib.rs
+#[tauri::command]
+fn greet(name: &str) -> String {
+    format!("Hello, {}! From Rust.", name)
+}
+
+pub fn run() {
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![greet])
+        .run(tauri::generate_context!())
+        .expect("error running tauri application");
+}
+```
+
+```typescript
+// Frontend
+import { invoke } from '@tauri-apps/api/core';
+const greeting = await invoke<string>('greet', { name: 'World' });
+```
+
+### Async Command
+
+```rust
+#[tauri::command]
+async fn fetch_url(url: String) -> Result<String, String> {
+    reqwest::get(&url)
+        .await.map_err(|e| e.to_string())?
+        .text()
+        .await.map_err(|e| e.to_string())
+}
+```
+
+### Error Handling
+
+Return `Result<T, E>` where E implements `Into<InvokeError>`:
+
+```rust
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+enum AppError {
+    FileNotFound(String),
+    PermissionDenied,
+}
+impl std::fmt::Display for AppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            AppError::FileNotFound(p) => write!(f, "File not found: {}", p),
+            AppError::PermissionDenied => write!(f, "Permission denied"),
+        }
+    }
+}
+
+#[tauri::command]
+fn read_config() -> Result<String, AppError> {
+    // ...
+}
+```
+
+Frontend catches errors normally:
+
+```typescript
+try {
+  const config = await invoke<string>('read_config');
+} catch (error) {
+  console.error('Rust error:', error);
+}
+```
+
+### Registering Multiple Commands
+
+```rust
+tauri::Builder::default()
+    .invoke_handler(tauri::generate_handler![
+        greet,
+        read_config,
+        save_config,
+        fetch_url,
+    ])
+```
+
+## Events (Backend to Frontend)
+
+Events push data from Rust to the frontend asynchronously.
+
+### Emit from Rust
+
+```rust
+use tauri::Emitter;
+
+#[tauri::command]
+async fn start_download(app: tauri::AppHandle, url: String) -> Result<(), String> {
+    // ... download logic ...
+    app.emit("download-progress", 75).map_err(|e| e.to_string())?;
+    app.emit("download-complete", true).map_err(|e| e.to_string())?;
+    Ok(())
+}
+```
+
+### Listen in Frontend
+
+```typescript
+import { listen } from '@tauri-apps/api/event';
+
+const unlisten = await listen<number>('download-progress', (event) => {
+  console.log(`Progress: ${event.payload}%`);
+});
+// Call unlisten() to stop listening
+```
+
+### Emit from Frontend to Backend
+
+```typescript
+import { emit } from '@tauri-apps/api/event';
+await emit('user-action', { type: 'click', target: 'save' });
+```
+
+Listen in Rust with `app.listen(...)`.
+
+## Plugin System
+
+Tauri v2 uses a modular plugin architecture. Native features are opt-in.
+
+### Official Plugins
+
+| Plugin | Crate | JS Package | Purpose |
+|--------|-------|-----------|---------|
+| fs | `tauri-plugin-fs` | `@tauri-apps/plugin-fs` | File system read/write |
+| dialog | `tauri-plugin-dialog` | `@tauri-apps/plugin-dialog` | Open/save file dialogs |
+| shell | `tauri-plugin-shell` | `@tauri-apps/plugin-shell` | Run external commands |
+| notification | `tauri-plugin-notification` | `@tauri-apps/plugin-notification` | System notifications |
+| updater | `tauri-plugin-updater` | `@tauri-apps/plugin-updater` | Auto-updates |
+| store | `tauri-plugin-store` | `@tauri-apps/plugin-store` | Persistent key-value store |
+| clipboard | `tauri-plugin-clipboard-manager` | `@tauri-apps/plugin-clipboard-manager` | Clipboard access |
+| http | `tauri-plugin-http` | `@tauri-apps/plugin-http` | HTTP client |
+| os | `tauri-plugin-os` | `@tauri-apps/plugin-os` | OS information |
+| process | `tauri-plugin-process` | `@tauri-apps/plugin-process` | Process management |
+| global-shortcut | `tauri-plugin-global-shortcut` | `@tauri-apps/plugin-global-shortcut` | Keyboard shortcuts |
+| deep-link | `tauri-plugin-deep-link` | `@tauri-apps/plugin-deep-link` | Custom protocol |
+
+### Adding a Plugin
+
+```bash
+# 1. Add Rust crate
+cargo add tauri-plugin-fs
+# 2. Add JS bindings
+npm install @tauri-apps/plugin-fs
+```
+
+```rust
+// 3. Register in builder (src-tauri/src/lib.rs)
+tauri::Builder::default()
+    .plugin(tauri_plugin_fs::init())
+    .invoke_handler(tauri::generate_handler![...])
+```
+
+```typescript
+// 4. Use in frontend
+import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
+const content = await readTextFile('config.json', { baseDir: BaseDirectory.AppData });
+```
+
+## Capabilities and Permissions
+
+Tauri v2 uses a capability-based security model. Nothing is allowed by default.
+
+### Capability File
+
+```json
+// src-tauri/capabilities/default.json
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Default permissions for the main window",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "fs:default",
+    "dialog:default",
+    "notification:default"
+  ]
+}
+```
+
+### Permission Scopes
+
+Restrict file system access to specific directories:
+
+```json
+{
+  "permissions": [
+    {
+      "identifier": "fs:allow-read-text-file",
+      "allow": [{ "path": "$APPDATA/**" }]
+    }
+  ]
+}
+```
+
+### Security Principle
+
+Grant minimum required permissions. Each window can have its own capability
+file with different permission sets. A settings window needs different access
+than the main editor window.
+
+## tauri.conf.json Configuration
+
+Key sections:
+
+```jsonc
+{
+  "productName": "My App",
+  "version": "1.0.0",
+  "identifier": "com.example.myapp",
+  "build": {
+    "frontendDist": "../dist",       // Production frontend build path
+    "devUrl": "http://localhost:5173" // Dev server URL
+  },
+  "app": {
+    "windows": [{
+      "title": "My App",
+      "width": 1200,
+      "height": 800,
+      "minWidth": 800,
+      "minHeight": 600,
+      "decorations": true,       // Native title bar
+      "resizable": true
+    }]
+  },
+  "bundle": {
+    "active": true,
+    "targets": "all",            // Or ["dmg", "nsis", "appimage"]
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ]
+  }
+}
+```
+
+## State Management in Rust
+
+Share state across commands using `tauri::Manager::manage`:
+
+```rust
+use std::sync::Mutex;
+
+struct AppState {
+    counter: Mutex<i32>,
+    db: Mutex<Option<Database>>,
+}
+
+#[tauri::command]
+fn increment(state: tauri::State<'_, AppState>) -> i32 {
+    let mut counter = state.counter.lock().unwrap();
+    *counter += 1;
+    *counter
+}
+
+pub fn run() {
+    tauri::Builder::default()
+        .manage(AppState {
+            counter: Mutex::new(0),
+            db: Mutex::new(None),
+        })
+        .invoke_handler(tauri::generate_handler![increment])
+        .run(tauri::generate_context!())
+        .expect("error running tauri application");
+}
+```
+
+For async state, use `tokio::sync::Mutex` instead.
+
+## Mobile Support (Tauri v2)
+
+Tauri v2 supports iOS and Android from the same codebase.
+
+```bash
+# Initialize mobile targets
+npx tauri android init
+npx tauri ios init
+
+# Run on device/emulator
+npx tauri android dev
+npx tauri ios dev
+
+# Build for release
+npx tauri android build
+npx tauri ios build
+```
+
+The same Rust commands work on mobile. The WebView is WKWebView (iOS) or
+Android System WebView. Mobile uses the same `tauri.conf.json` with
+optional platform-specific overrides.
+
+### Mobile Considerations
+
+- File paths differ (use Tauri path API, not hardcoded paths)
+- Some plugins have mobile-specific behavior
+- Screen sizes require responsive frontend design
+- Not all desktop plugins are available on mobile
+
+## Common Gotchas
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| "not allowed by permissions" | Missing capability | Add permission to `capabilities/default.json` |
+| WebView looks different on Windows | WebView2 vs WebKit rendering | Test on all platforms, use CSS resets |
+| Rust compilation very slow | Full rebuild | Use `cargo watch`, incremental compilation |
+| Cannot access files | fs plugin not added or not permitted | Add `tauri-plugin-fs` + capability |
+| Frontend cannot find Tauri API | Missing `@tauri-apps/api` | `npm install @tauri-apps/api` |
+| Window blank on first load | Dev server not ready | Ensure dev server starts before Tauri |
+| Build fails with schema error | Outdated capability schema | Run `npx tauri build` to regenerate schemas |
+| Mobile build fails | Missing Android SDK / Xcode | Install platform toolchains per docs |
+| State deadlock | Holding Mutex across await | Use `tokio::sync::Mutex` for async code |

--- a/skills/desktop-app-dev/references/wails-guide.md
+++ b/skills/desktop-app-dev/references/wails-guide.md
@@ -1,0 +1,370 @@
+# Wails Development Guide
+
+Sources: Wails v2 documentation (2025), Wails v3 alpha docs, wails.io guides, Go community patterns
+
+Covers: architecture, project setup, Go method binding, events system, frontend integration, window management, configuration, v2 vs v3 differences.
+
+## Architecture
+
+Wails uses a Go backend with an OS-native WebView:
+
+- **Go backend**: Manages app lifecycle, exposes Go struct methods to the
+  frontend via automatic binding. Full OS access through Go standard library.
+- **WebView frontend**: WebView2 on Windows, WebKit on macOS and Linux.
+  Runs your HTML/CSS/JS application.
+- **Method binding**: Go struct methods are automatically exposed to the
+  frontend. Wails generates TypeScript definitions for type safety.
+- **Events**: Bidirectional event system between Go and frontend.
+
+```
+┌──────────────────────┐  Method Binding  ┌──────────────────────┐
+│   Go Backend         │◄────────────────►│   WebView (OS)       │
+│                      │  (auto-gen TS)   │                      │
+│  - Struct methods    │                  │  - Your web UI       │
+│  - runtime.* APIs    │   Events         │  - wailsjs/ bindings │
+│  - App lifecycle     │◄────────────────►│  - runtime.* JS APIs │
+│  - Full Go stdlib    │                  │                      │
+└──────────────────────┘                  └──────────────────────┘
+```
+
+## Project Setup
+
+### Prerequisites
+
+- Go 1.21+ installed
+- Node.js 18+ installed
+- Platform dependencies (see gotchas section for Linux)
+
+### Install Wails CLI
+
+```bash
+go install github.com/wailsapp/wails/v2/cmd/wails@latest
+wails doctor  # Verify installation
+```
+
+### Create New Project
+
+```bash
+wails init -n my-app -t react-ts
+cd my-app
+wails dev    # Development with hot reload
+wails build  # Production build
+```
+
+Available templates: `react-ts`, `vue-ts`, `svelte-ts`, `lit-ts`,
+`preact-ts`, `vanilla-ts`, `react`, `vue`, `svelte`, `vanilla`.
+
+### Project Structure
+
+```
+my-app/
+├── app.go              # App struct with lifecycle methods
+├── main.go             # Entry point, app configuration
+├── wails.json          # Wails configuration
+├── go.mod              # Go module definition
+├── frontend/
+│   ├── src/            # Your frontend code
+│   ├── wailsjs/        # Auto-generated bindings
+│   │   ├── go/         # Go method bindings (TypeScript)
+│   │   └── runtime/    # Wails runtime API (TypeScript)
+│   ├── package.json
+│   └── vite.config.ts
+└── build/              # Build output
+```
+
+## Method Binding (Go to JavaScript)
+
+The core feature of Wails. Expose Go methods directly to the frontend.
+
+### Define Methods on a Struct
+
+```go
+// app.go
+package main
+
+import "context"
+
+type App struct {
+    ctx context.Context
+}
+
+func NewApp() *App {
+    return &App{}
+}
+
+func (a *App) startup(ctx context.Context) {
+    a.ctx = ctx
+}
+
+// Exported methods (capitalized) are auto-bound to frontend
+func (a *App) Greet(name string) string {
+    return fmt.Sprintf("Hello %s, from Go!", name)
+}
+
+func (a *App) ReadFile(path string) (string, error) {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return "", err
+    }
+    return string(data), nil
+}
+```
+
+### Bind in Main
+
+```go
+// main.go
+func main() {
+    app := NewApp()
+    err := wails.Run(&options.App{
+        Title:  "My App",
+        Width:  1024,
+        Height: 768,
+        OnStartup: app.startup,
+        Bind: []interface{}{
+            app,
+        },
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+### Call from Frontend (Auto-Generated TypeScript)
+
+```typescript
+// Auto-generated at frontend/wailsjs/go/main/App.ts
+import { Greet, ReadFile } from '../wailsjs/go/main/App';
+
+const greeting = await Greet("World");
+console.log(greeting); // "Hello World, from Go!"
+
+try {
+    const content = await ReadFile("/path/to/file");
+} catch (err) {
+    console.error("Go error:", err);
+}
+```
+
+Wails auto-generates TypeScript types from Go types. Structs become
+interfaces, errors become rejected promises.
+
+### Complex Types
+
+```go
+type FileInfo struct {
+    Name string `json:"name"`
+    Size int64  `json:"size"`
+    IsDir bool  `json:"isDir"`
+}
+
+func (a *App) ListFiles(dir string) ([]FileInfo, error) {
+    // ... returns typed data
+}
+```
+
+Frontend receives properly typed objects:
+
+```typescript
+import { ListFiles } from '../wailsjs/go/main/App';
+import { main } from '../wailsjs/go/models';
+
+const files: main.FileInfo[] = await ListFiles("/home");
+```
+
+## Events System
+
+Bidirectional event communication between Go and frontend.
+
+### Go to Frontend
+
+```go
+import "github.com/wailsapp/wails/v2/pkg/runtime"
+
+func (a *App) StartProcess() {
+    for i := 0; i <= 100; i += 10 {
+        runtime.EventsEmit(a.ctx, "progress", i)
+        time.Sleep(500 * time.Millisecond)
+    }
+    runtime.EventsEmit(a.ctx, "complete", true)
+}
+```
+
+### Frontend Listening
+
+```typescript
+import { EventsOn, EventsOff } from '../wailsjs/runtime/runtime';
+
+EventsOn("progress", (value: number) => {
+    console.log(`Progress: ${value}%`);
+});
+
+EventsOn("complete", () => {
+    console.log("Done!");
+    EventsOff("progress"); // Cleanup
+});
+```
+
+### Frontend to Go
+
+```typescript
+import { EventsEmit } from '../wailsjs/runtime/runtime';
+EventsEmit("user-action", { type: "save" });
+```
+
+```go
+runtime.EventsOn(a.ctx, "user-action", func(data ...interface{}) {
+    // Handle event from frontend
+})
+```
+
+## Application Lifecycle
+
+```go
+wails.Run(&options.App{
+    OnStartup:     app.startup,     // App initialized, context available
+    OnDomReady:    app.domReady,    // Frontend DOM loaded
+    OnBeforeClose: app.beforeClose, // User tries to close (return true to prevent)
+    OnShutdown:    app.shutdown,    // App closing, cleanup here
+})
+```
+
+```go
+func (a *App) beforeClose(ctx context.Context) (prevent bool) {
+    dialog, err := runtime.MessageDialog(ctx, runtime.MessageDialogOptions{
+        Type:    runtime.QuestionDialog,
+        Title:   "Quit?",
+        Message: "Are you sure you want to quit?",
+    })
+    return dialog == "No"
+}
+```
+
+## Window Management
+
+```go
+import "github.com/wailsapp/wails/v2/pkg/runtime"
+
+// Window controls
+runtime.WindowSetTitle(a.ctx, "New Title")
+runtime.WindowSetSize(a.ctx, 1280, 720)
+runtime.WindowSetMinSize(a.ctx, 800, 600)
+runtime.WindowCenter(a.ctx)
+runtime.WindowMaximise(a.ctx)
+runtime.WindowMinimise(a.ctx)
+runtime.WindowToggleMaximise(a.ctx)
+runtime.WindowFullscreen(a.ctx)
+runtime.WindowUnfullscreen(a.ctx)
+runtime.WindowShow(a.ctx)
+runtime.WindowHide(a.ctx)
+
+// Get position and size
+x, y := runtime.WindowGetPosition(a.ctx)
+w, h := runtime.WindowGetSize(a.ctx)
+```
+
+### Frameless Window
+
+```go
+wails.Run(&options.App{
+    Frameless: true,  // No native title bar
+})
+```
+
+Use CSS `-webkit-app-region: drag` for custom drag areas.
+
+## Configuration (wails.json)
+
+```json
+{
+  "name": "my-app",
+  "outputfilename": "my-app",
+  "frontend:install": "npm install",
+  "frontend:build": "npm run build",
+  "frontend:dev:watcher": "npm run dev",
+  "frontend:dev:serverUrl": "auto",
+  "author": {
+    "name": "Your Name",
+    "email": "you@example.com"
+  },
+  "info": {
+    "companyName": "My Company",
+    "productVersion": "1.0.0",
+    "copyright": "Copyright 2026",
+    "comments": "Built with Wails"
+  }
+}
+```
+
+| Field | Purpose |
+|-------|---------|
+| `name` | Application name |
+| `outputfilename` | Binary name after build |
+| `frontend:install` | Command to install frontend deps |
+| `frontend:build` | Command to build frontend for production |
+| `frontend:dev:watcher` | Command to start frontend dev server |
+| `frontend:dev:serverUrl` | Dev server URL (`auto` detects Vite) |
+
+## Wails v2 vs v3
+
+| Feature | v2 (Stable) | v3 (Alpha, Feb 2026) |
+|---------|------------|---------------------|
+| API style | Struct binding | Services + procedural |
+| Multi-window | Limited (workarounds) | Full native support |
+| System tray | Basic | Enhanced |
+| Stability | Production-ready | Alpha, breaking changes |
+| Go version | 1.21+ | 1.22+ |
+| WebView | WebView2 (Win), WebKit | Same |
+| Build system | Wails CLI | Wails CLI (redesigned) |
+
+### Recommendation
+
+Use **v2 for production** projects today. Evaluate **v3** for new projects
+starting mid-2026 or later when it reaches stable. v3 adds proper
+multi-window support and a cleaner API, but expect breaking changes.
+
+## Dialogs
+
+```go
+// Open file dialog
+file, err := runtime.OpenFileDialog(a.ctx, runtime.OpenDialogOptions{
+    Title: "Select File",
+    Filters: []runtime.FileFilter{
+        {DisplayName: "Text Files", Pattern: "*.txt;*.md"},
+        {DisplayName: "All Files", Pattern: "*.*"},
+    },
+})
+
+// Save file dialog
+path, err := runtime.SaveFileDialog(a.ctx, runtime.SaveDialogOptions{
+    Title:           "Save File",
+    DefaultFilename: "document.txt",
+})
+
+// Select directory
+dir, err := runtime.OpenDirectoryDialog(a.ctx, runtime.OpenDialogOptions{
+    Title: "Select Directory",
+})
+
+// Message dialog
+result, err := runtime.MessageDialog(a.ctx, runtime.MessageDialogOptions{
+    Type:    runtime.InfoDialog,
+    Title:   "Information",
+    Message: "Operation complete!",
+})
+```
+
+## Common Gotchas
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| `wails: command not found` | Go bin not in PATH | Add `$GOPATH/bin` to PATH |
+| Frontend changes not reflecting | Stale dev server | Restart `wails dev` |
+| Bindings not generated | Method not exported (lowercase) | Capitalize method name |
+| CGO errors on Linux | Missing build deps | `sudo apt install gcc pkg-config libgtk-3-dev libwebkit2gtk-4.0-dev` |
+| WebView2 missing on Windows | Edge runtime not installed | Bundle WebView2 bootstrapper or use fixed version |
+| Slow build | Full rebuild | Use `wails dev` for incremental |
+| TypeScript types wrong | Stale generated bindings | Delete `frontend/wailsjs/` and rebuild |
+| App icon not showing | Wrong icon format | Use 1024x1024 PNG, `wails generate icons` |
+| Cross-compilation fails | CGO platform mismatch | Use CI matrix build per platform |

--- a/skills/desktop-app-dev/skills.json
+++ b/skills/desktop-app-dev/skills.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tank/desktop-app-dev",
+  "version": "1.0.0",
+  "description": "Build, convert, and ship cross-platform desktop applications from web projects using Electron, Tauri v2, or Wails. Covers framework selection and project detection, architecture and IPC patterns, native desktop APIs (menus, tray, notifications, file system, dialogs, shortcuts, clipboard), packaging and distribution (installers, code signing, notarization, auto-update), migration patterns (web-to-desktop conversion, Electron-to-Tauri migration), and CI/CD build pipelines. Synthesizes Electron v40 docs, Tauri v2 docs, Wails v2/v3 docs, and 2025-2026 ecosystem research. Triggers: Electron, Tauri, Wails, desktop app, desktop application, web to desktop, convert to desktop, cross-platform app, native app, electron-builder, electron-forge, electron-vite, tauri-apps, system tray, auto-update, code signing, notarize, DMG, MSI, AppImage, package desktop app, IPC, main process, preload script, BrowserWindow, tauri command, wails build, desktop wrapper, ship desktop app, distribute desktop app.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

- Adds `@tank/desktop-app-dev` skill for building, converting, and shipping cross-platform desktop apps from web projects
- Covers three production-ready frameworks: **Electron**, **Tauri v2**, and **Wails**
- Agent auto-detects existing framework in the project, or recommends the best fit via decision matrix

## Reference Files (7)

| File | Lines | Coverage |
|------|-------|----------|
| `framework-selection.md` | 259 | Detection signals, comparison table, decision matrix, team assessment |
| `electron-guide.md` | 356 | Architecture, IPC patterns, preload, electron-vite setup, security |
| `tauri-guide.md` | 400 | Commands, events, plugins, capabilities, mobile, Rust state |
| `wails-guide.md` | 370 | Go bindings, auto-generated TS, events, v2 vs v3 |
| `native-apis.md` | 405 | Menus, tray, notifications, dialogs, shortcuts (cross-framework) |
| `packaging-distribution.md` | 432 | Installers, code signing, notarization, auto-update, CI/CD |
| `migration-patterns.md` | 320 | Web-to-desktop, Electron-to-Tauri, IPC mapping, pitfalls |

## Research basis

Based on Feb 2026 ecosystem research: Electron 120K stars, Tauri 103K stars, Wails 33K stars. Tauri v2 is the new recommended default for greenfield projects (96% smaller bundles, 58% less memory), while Electron remains the pragmatic choice for Node.js-heavy teams.