### PR TITLE
feat(party-game-dev): phase 2 — protocol hardening, audio unlock, room forensics, crowd play, content pipeline

### DIFF
--- a/skills/party-game-dev/SKILL.md
+++ b/skills/party-game-dev/SKILL.md
@@ -1,30 +1,18 @@
 ---
 name: "@tank/party-game-dev"
 description: |
-  Build real-time multiplayer party games (Jackbox-style) with full-stack
-  TypeScript. Covers host-player architecture (TV + phones), Socket.IO
-  networking, game state machines, room/lobby management, voting and scoring
-  systems, and BDD testing for multiplayer scenarios with multiple browser
-  contexts. Synthesizes patterns from Jackbox Games reverse engineering,
-  Drawphone, Rocketcrab, Fishbowl OSS implementations, Socket.IO
-  documentation, and Playwright multi-context testing patterns.
+  Build real-time multiplayer party games (Jackbox-style) with full-stack TypeScript. Covers host-player architecture (TV + phones), VIP role (player with elevated control), Socket.IO networking, game state machines, room/lobby management, voting and scoring systems, content safety (profanity filtering, family mode, VIP censoring), and BDD testing with multiple browser contexts. Synthesizes patterns from Jackbox Games, Drawphone, Rocketcrab, Fishbowl, Socket.IO docs, and Playwright multi-context testing.
 
-  Trigger phrases: "party game", "jackbox", "multiplayer game",
-  "real-time game", "game room", "lobby system", "room code",
-  "socket.io game", "websocket game", "game state machine",
-  "voting game", "drawing game", "trivia game", "quiplash",
-  "drawful", "host screen", "player controller",
-  "multiplayer testing", "game server", "party game backend",
-  "prompt and response game", "audience voting", "game lobby",
-  "turn-based multiplayer", "phone controller game",
-  "test multiplayer", "BDD game testing"
+  Trigger phrases: "party game", "jackbox", "multiplayer game", "real-time game", "game room", "lobby system", "room code", "socket.io game", "websocket game", "game state machine", "voting game", "drawing game", "trivia game", "quiplash", "drawful", "host screen", "player controller", "VIP", "game VIP", "room owner", "kick player", "ban player", "multiplayer testing", "game server", "party game backend", "prompt and response game", "audience voting", "game lobby", "turn-based multiplayer", "phone controller game", "content moderation", "profanity filter", "family friendly", "test multiplayer", "BDD game testing"
 ---
 
 # Party Game Development
 
 Build Jackbox-style party games: one shared screen (TV/projector) runs the
-host display, each player uses their phone as a controller. All connected
-via WebSockets with server-authoritative state.
+host display, each player uses their phone as a controller. The first player
+to join becomes the **VIP** — a player with elevated control (start game,
+kick players, censor content). The VIP is NOT the host. The host is the TV.
+All connected via WebSockets with server-authoritative state.
 
 ## Core Philosophy
 
@@ -34,9 +22,11 @@ via WebSockets with server-authoritative state.
    No database needed for the game itself.
 3. **Phones are dumb controllers** — Player devices submit inputs and render
    state. Zero game logic on the client.
-4. **Test with real players** — BDD tests spawn multiple browser contexts.
+4. **VIP controls the game** — First player to join gets elevated privileges
+   (start, kick, censor, settings). Transfers automatically on disconnect.
+5. **Test with real players** — BDD tests spawn multiple browser contexts.
    No mocks. Real WebSocket connections. Real game flow.
-5. **Ship the simplest game first** — Prompt-response (Quiplash pattern) is
+6. **Ship the simplest game first** — Prompt-response (Quiplash pattern) is
    the easiest to build. Start there, add complexity later.
 
 ## Quick-Start
@@ -48,10 +38,12 @@ via WebSockets with server-authoritative state.
 | 1 | Choose game type (prompt-response recommended for first game) | `references/game-types-and-mechanics.md` |
 | 2 | Scaffold project structure (monorepo: server + host + player) | `references/game-architecture.md` |
 | 3 | Set up Socket.IO server with room management | `references/multiplayer-networking.md` |
-| 4 | Implement game state machine (phases, rounds, timers) | `references/game-state-machines.md` |
-| 5 | Build host screen (TV display) and player controller (phone) | `references/frontend-patterns.md` |
-| 6 | Write BDD tests with multiple browser contexts | `references/bdd-multiplayer-testing.md` |
-| 7 | Deploy with WebSocket support | `references/deployment-and-ops.md` |
+| 4 | Implement VIP role, kick/ban, room settings | `references/vip-and-room-authority.md` |
+| 5 | Implement game state machine (phases, rounds, timers) | `references/game-state-machines.md` |
+| 6 | Add content safety (profanity filter, moderation) | `references/content-safety-and-moderation.md` |
+| 7 | Build host screen (TV display) and player controller (phone) | `references/frontend-patterns.md` |
+| 8 | Write BDD tests with multiple browser contexts | `references/bdd-multiplayer-testing.md` |
+| 9 | Deploy with WebSocket support | `references/deployment-and-ops.md` |
 
 ### "I want to add a new game type to an existing project"
 
@@ -76,23 +68,26 @@ via WebSockets with server-authoritative state.
 
 ## Development Workflow
 
-### Phase 1: Lobby
-Build room creation, room codes, player joining, player list display.
-Test: 3 players can join a room and see each other.
+### Phase 1: Lobby + VIP
+Build room creation, room codes, player joining, VIP assignment, player list.
+Test: 3 players join, first player is VIP, VIP badge visible.
 
 ### Phase 2: Game Loop
 Implement phase transitions: Lobby -> Round Start -> Input -> Reveal -> Score.
-Test: A complete round flows from prompt to scoring.
+Test: VIP starts the game, a complete round flows from prompt to scoring.
 
 ### Phase 3: Player Interaction
-Add answer submission, voting, timer countdown.
-Test: Players submit answers, vote, scores update correctly.
+Add answer submission, voting, timer countdown, content filtering.
+Test: Players submit answers, vote, scores update correctly. Profanity filtered.
 
-### Phase 4: Polish
-Animations, sound effects, edge cases (disconnect/reconnect, host migration).
-Test: Player disconnects and reconnects mid-game.
+### Phase 4: Moderation + Edge Cases
+VIP kick/ban, content censoring, disconnect/reconnect, VIP migration.
+Test: VIP kicks player. Player disconnects and reconnects mid-game.
 
-### Phase 5: Deploy
+### Phase 5: Polish
+Animations, sound effects, haptic feedback, accessibility, mobile UX hardening.
+
+### Phase 6: Deploy
 Docker + Fly.io (or Railway). Redis adapter if scaling beyond one server.
 
 ## Decision Trees
@@ -128,12 +123,35 @@ Docker + Fly.io (or Railway). Redis adapter if scaling beyond one server.
 | Custom prompt packs | JSON files or PostgreSQL |
 | Analytics / game stats | Add PostgreSQL |
 
+### VIP vs Host — When to Use Which?
+
+| Concept | Role | Who Controls It |
+|---------|------|-----------------|
+| **Host** | The TV/projector display | The physical device running the app |
+| **VIP** | First player to join | A player on their phone with elevated privileges |
+| **Player** | Participants | Everyone else on their phone |
+
+See `references/vip-and-room-authority.md` for full VIP implementation guide.
+
+### Content Safety Level
+
+| Audience | Filter Level | Moderation |
+|----------|-------------|------------|
+| Private friends | `off` | None |
+| Mixed group / default | `moderate` | Profanity filter |
+| Family / streaming / work | `strict` + `familyFriendly` | Human moderation queue |
+
+See `references/content-safety-and-moderation.md` for implementation.
+
 ## Anti-Patterns
 
 | Don't | Do Instead | Why |
 |-------|-----------|-----|
 | Client-side game logic | Server-authoritative state | Prevents cheating |
 | Polling for game state | WebSocket push | Real-time updates |
+| Use `isHost` for VIP | Use `isVIP` for the controlling player | Host = TV, VIP = player |
+| Trust client for VIP actions | Validate `isVIP` server-side on every action | Security |
+| Skip content filtering | Add profanity filter at `moderate` minimum | Public safety |
 | Shared browser context in tests | Separate `BrowserContext` per player | Isolated sessions |
 | Fixed delays in tests | `waitForSelector` / event-based waits | Reliable timing |
 | Database for live game state | In-memory Map/Object | Speed, simplicity |
@@ -144,10 +162,15 @@ Docker + Fly.io (or Railway). Redis adapter if scaling beyond one server.
 
 | File | Purpose |
 |------|---------|
-| `assets/test-multiplayer-example.ts` | Example: spawn N Socket.IO clients, simulate a game round. Adapt to your event names. |
-| `assets/lobby.feature` | Example: Gherkin feature for lobby creation and joining |
-| `assets/game-round.feature` | Example: Gherkin feature for a complete game round |
-| `assets/edge-cases.feature` | Example: Gherkin feature for disconnect/reconnect scenarios |
+| `assets/test-multiplayer-example.ts` | Spawn N Socket.IO clients, simulate a game round. Adapt to your event names. |
+| `assets/lobby.feature` | Gherkin feature for lobby creation and joining |
+| `assets/game-round.feature` | Gherkin feature for a complete game round |
+| `assets/edge-cases.feature` | Gherkin feature for disconnect/reconnect scenarios |
+| `assets/protocol-envelope.ts` | Event envelope with dedup, version gating, and phase guarding |
+| `assets/audio-unlock-howler.tsx` | iOS audio unlock + preloader React provider (Howler.js) |
+| `assets/room-timeline.ts` | Structured room event log for post-game forensics and debugging |
+| `assets/loadtest-socketio.ts` | Load test harness: spawn virtual players, measure p50/p95/p99 latency |
+| `assets/prompt-pack.schema.ts` | Prompt pack schema, validator, loader, and CLI validation runner |
 
 ## Reference Files
 
@@ -157,6 +180,8 @@ Docker + Fly.io (or Railway). Redis adapter if scaling beyond one server.
 | `references/multiplayer-networking.md` | Socket.IO setup, room management, event protocols, state sync, reconnection, scaling |
 | `references/game-state-machines.md` | Game phases, round loops, timers, player state, game configuration, complete Game class |
 | `references/game-types-and-mechanics.md` | Prompt-response, drawing, trivia, voting systems, scoring, data models per game type |
+| `references/vip-and-room-authority.md` | VIP role (vs host), assignment, transfer, disconnect, kick/ban, room settings, bot replacement |
+| `references/content-safety-and-moderation.md` | Profanity filtering, moderation queues, family mode, censoring, accessibility, mobile UX hardening |
 | `references/frontend-patterns.md` | Host screen (TV), player controller (phone), React components, socket hooks, responsive design |
 | `references/bdd-multiplayer-testing.md` | Multi-client Playwright fixtures, Gherkin multi-actor patterns, page objects, edge case testing |
 | `references/deployment-and-ops.md` | WebSocket hosting, Docker, Redis scaling, sticky sessions, room cleanup, production checklist |

--- a/skills/party-game-dev/assets/audio-unlock-howler.tsx
+++ b/skills/party-game-dev/assets/audio-unlock-howler.tsx
@@ -1,0 +1,173 @@
+// iOS Audio Unlock + Asset Preloader for party games.
+// iOS Safari blocks audio playback until a user gesture triggers it.
+// This component unlocks the AudioContext on the first tap, then preloads
+// all game sounds during the lobby phase so gameplay audio is instant.
+//
+// Usage:
+//   Render <AudioProvider> at the app root.
+//   Call useAudio().play('buzzer') from any component.
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { Howl, Howler } from "howler";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface SoundManifest {
+  [key: string]: string; // name -> URL
+}
+
+interface AudioContextValue {
+  /** Whether the AudioContext is unlocked and ready. */
+  unlocked: boolean;
+  /** Preload progress 0-1. */
+  progress: number;
+  /** Play a named sound. No-op if not yet unlocked. */
+  play: (name: string) => void;
+  /** Stop a named sound. */
+  stop: (name: string) => void;
+  /** Preload all sounds in the manifest. Call during lobby. */
+  preload: (manifest: SoundManifest) => void;
+}
+
+const AudioCtx = createContext<AudioContextValue | null>(null);
+
+// ── Provider ───────────────────────────────────────────────────────────────────
+
+export function AudioProvider({ children }: { children: React.ReactNode }) {
+  const [unlocked, setUnlocked] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const sounds = useRef<Map<string, Howl>>(new Map());
+  const totalCount = useRef(0);
+  const loadedCount = useRef(0);
+
+  // ── iOS unlock ─────────────────────────────────────────────────────────────
+  // A silent Howl triggered by user gesture unlocks the global AudioContext.
+  // We listen on touchstart AND click to cover all mobile browsers.
+  useEffect(() => {
+    if (unlocked) return;
+
+    const unlock = () => {
+      // Howler exposes the global AudioContext — resume it if suspended.
+      const ctx = Howler.ctx;
+      if (ctx && ctx.state === "suspended") {
+        ctx.resume().then(() => {
+          setUnlocked(true);
+          cleanup();
+        });
+      } else {
+        setUnlocked(true);
+        cleanup();
+      }
+    };
+
+    const cleanup = () => {
+      document.removeEventListener("touchstart", unlock, true);
+      document.removeEventListener("click", unlock, true);
+    };
+
+    document.addEventListener("touchstart", unlock, { capture: true, once: false });
+    document.addEventListener("click", unlock, { capture: true, once: false });
+
+    // Already unlocked (desktop browsers usually are)
+    if (Howler.ctx?.state === "running") {
+      setUnlocked(true);
+      cleanup();
+    }
+
+    return cleanup;
+  }, [unlocked]);
+
+  // ── Preload ────────────────────────────────────────────────────────────────
+  const preload = useCallback((manifest: SoundManifest) => {
+    const entries = Object.entries(manifest);
+    totalCount.current = entries.length;
+    loadedCount.current = 0;
+    setProgress(0);
+
+    for (const [name, url] of entries) {
+      if (sounds.current.has(name)) {
+        loadedCount.current++;
+        continue;
+      }
+
+      const howl = new Howl({
+        src: [url],
+        preload: true,
+        onload: () => {
+          loadedCount.current++;
+          setProgress(loadedCount.current / totalCount.current);
+        },
+        onloaderror: (_id, err) => {
+          console.warn(`[audio] Failed to preload "${name}":`, err);
+          loadedCount.current++;
+          setProgress(loadedCount.current / totalCount.current);
+        },
+      });
+
+      sounds.current.set(name, howl);
+    }
+  }, []);
+
+  // ── Play / Stop ────────────────────────────────────────────────────────────
+  const play = useCallback(
+    (name: string) => {
+      if (!unlocked) return;
+      const howl = sounds.current.get(name);
+      if (!howl) {
+        console.warn(`[audio] Sound "${name}" not preloaded`);
+        return;
+      }
+      howl.play();
+    },
+    [unlocked]
+  );
+
+  const stop = useCallback((name: string) => {
+    sounds.current.get(name)?.stop();
+  }, []);
+
+  return (
+    <AudioCtx.Provider value={{ unlocked, progress, play, stop, preload }}>
+      {children}
+    </AudioCtx.Provider>
+  );
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useAudio(): AudioContextValue {
+  const ctx = useContext(AudioCtx);
+  if (!ctx) throw new Error("useAudio must be used within <AudioProvider>");
+  return ctx;
+}
+
+// ── Example usage in a lobby component ───────────────────────────────────────
+//
+// function Lobby() {
+//   const { preload, progress, unlocked } = useAudio();
+//
+//   useEffect(() => {
+//     preload({
+//       'buzzer':  '/sounds/buzzer.mp3',
+//       'correct': '/sounds/correct.mp3',
+//       'tick':    '/sounds/tick.mp3',
+//       'reveal':  '/sounds/reveal.mp3',
+//       'winner':  '/sounds/winner.mp3',
+//     });
+//   }, [preload]);
+//
+//   return (
+//     <div>
+//       {!unlocked && <p>Tap anywhere to enable sound</p>}
+//       {unlocked && progress < 1 && <p>Loading sounds... {Math.round(progress * 100)}%</p>}
+//       {/* lobby UI */}
+//     </div>
+//   );
+// }

--- a/skills/party-game-dev/assets/loadtest-socketio.ts
+++ b/skills/party-game-dev/assets/loadtest-socketio.ts
@@ -1,0 +1,168 @@
+// Load test harness for Socket.IO party game servers.
+// Spawns N virtual players that join rooms, submit answers, and vote.
+// Run: npx tsx loadtest-socketio.ts --url http://localhost:3001 --rooms 10 --players-per-room 8
+//
+// Measures: connection time, join latency, event round-trip, memory (server-side via /health).
+// NOT a replacement for k6 or Artillery — use this for quick smoke tests during development.
+
+import { io, Socket } from "socket.io-client";
+
+interface LoadTestConfig {
+  serverUrl: string;
+  totalRooms: number;
+  playersPerRoom: number;
+  submitDelayMs: number;
+  voteDelayMs: number;
+}
+
+interface LatencyBucket {
+  event: string;
+  startMs: number;
+  endMs: number;
+  durationMs: number;
+}
+
+const latencies: LatencyBucket[] = [];
+
+function recordLatency(event: string, startMs: number): void {
+  const endMs = Date.now();
+  latencies.push({ event, startMs, endMs, durationMs: endMs - startMs });
+}
+
+function generateRoomCode(): string {
+  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  return Array.from({ length: 4 }, () => chars[Math.floor(Math.random() * chars.length)]).join("");
+}
+
+async function connectPlayer(
+  serverUrl: string,
+  roomCode: string,
+  playerName: string
+): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const startMs = Date.now();
+    const socket = io(serverUrl, { transports: ["websocket"], autoConnect: true });
+
+    const timeout = setTimeout(() => {
+      socket.disconnect();
+      reject(new Error(`Connection timeout for ${playerName}`));
+    }, 10_000);
+
+    socket.on("connect", () => {
+      recordLatency("connect", startMs);
+      clearTimeout(timeout);
+
+      const joinStart = Date.now();
+      socket.emit("join-room", { roomCode, playerName });
+
+      socket.once("room:joined", () => {
+        recordLatency("join-room", joinStart);
+        resolve(socket);
+      });
+
+      socket.once("error", (err: { message: string }) => {
+        clearTimeout(timeout);
+        reject(new Error(`Join error for ${playerName}: ${err.message}`));
+      });
+    });
+
+    socket.on("connect_error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function simulateRoom(config: LoadTestConfig, roomIndex: number): Promise<void> {
+  const roomCode = generateRoomCode();
+  const sockets: Socket[] = [];
+
+  try {
+    for (let i = 0; i < config.playersPerRoom; i++) {
+      const name = `Bot-${roomIndex}-${i}`;
+      const socket = await connectPlayer(config.serverUrl, roomCode, name);
+      sockets.push(socket);
+    }
+
+    console.log(`Room ${roomCode}: ${sockets.length} players connected`);
+
+    // Wait for game to start (VIP starts it, or auto-start)
+    await delay(1000);
+
+    // Simulate submit phase
+    for (const socket of sockets) {
+      await delay(config.submitDelayMs * Math.random());
+      const startMs = Date.now();
+      socket.emit("submit-answer", { text: `Answer from ${socket.id}` });
+      socket.once("ack", () => recordLatency("submit-answer", startMs));
+    }
+
+    // Simulate vote phase
+    await delay(2000);
+    for (const socket of sockets) {
+      await delay(config.voteDelayMs * Math.random());
+      const startMs = Date.now();
+      socket.emit("cast-vote", { targetPlayerId: sockets[0].id });
+      socket.once("ack", () => recordLatency("cast-vote", startMs));
+    }
+
+    await delay(3000);
+  } finally {
+    for (const s of sockets) s.disconnect();
+  }
+}
+
+function printReport(): void {
+  const grouped = new Map<string, number[]>();
+  for (const bucket of latencies) {
+    const arr = grouped.get(bucket.event) ?? [];
+    arr.push(bucket.durationMs);
+    grouped.set(bucket.event, arr);
+  }
+
+  console.log("\n--- Load Test Report ---");
+  console.log(`Total events: ${latencies.length}`);
+
+  for (const [event, durations] of grouped) {
+    durations.sort((a, b) => a - b);
+    const avg = durations.reduce((a, b) => a + b, 0) / durations.length;
+    const p50 = durations[Math.floor(durations.length * 0.5)];
+    const p95 = durations[Math.floor(durations.length * 0.95)];
+    const p99 = durations[Math.floor(durations.length * 0.99)];
+    console.log(
+      `  ${event}: count=${durations.length} avg=${avg.toFixed(0)}ms p50=${p50}ms p95=${p95}ms p99=${p99}ms`
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const getArg = (name: string, fallback: string): string => {
+    const idx = args.indexOf(`--${name}`);
+    return idx >= 0 && args[idx + 1] ? args[idx + 1] : fallback;
+  };
+
+  const config: LoadTestConfig = {
+    serverUrl: getArg("url", "http://localhost:3001"),
+    totalRooms: parseInt(getArg("rooms", "5"), 10),
+    playersPerRoom: parseInt(getArg("players-per-room", "8"), 10),
+    submitDelayMs: parseInt(getArg("submit-delay", "200"), 10),
+    voteDelayMs: parseInt(getArg("vote-delay", "150"), 10),
+  };
+
+  console.log("Load test config:", config);
+  console.log(`Spawning ${config.totalRooms * config.playersPerRoom} total connections...\n`);
+
+  const roomPromises = Array.from({ length: config.totalRooms }, (_, i) =>
+    simulateRoom(config, i).catch((err) => console.error(`Room ${i} failed:`, err.message))
+  );
+
+  await Promise.all(roomPromises);
+  printReport();
+}
+
+main().catch(console.error);

--- a/skills/party-game-dev/assets/prompt-pack.schema.ts
+++ b/skills/party-game-dev/assets/prompt-pack.schema.ts
@@ -1,0 +1,159 @@
+// Prompt Pack schema and loader for content-driven party games.
+// A "prompt pack" is a JSON file containing questions, prompts, or challenges
+// that the game engine draws from. This schema supports categories, difficulty,
+// family-mode filtering, and localization.
+//
+// File format: /content/packs/{pack-id}.json
+// Validate at build time: npx tsx prompt-pack.schema.ts --validate ./content/packs/*.json
+
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+
+export interface Prompt {
+  id: string;
+  text: string;
+  category: string;
+  difficulty: "easy" | "medium" | "hard";
+  familySafe: boolean;
+  locale: string;
+  tags?: string[];
+}
+
+export interface PromptPack {
+  id: string;
+  name: string;
+  version: number;
+  locale: string;
+  categories: string[];
+  prompts: Prompt[];
+}
+
+// Validation
+
+interface ValidationError {
+  packId: string;
+  promptId?: string;
+  message: string;
+}
+
+export function validatePack(pack: PromptPack): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const seenIds = new Set<string>();
+
+  if (!pack.id || !pack.name) {
+    errors.push({ packId: pack.id ?? "unknown", message: "Missing id or name" });
+  }
+
+  if (!pack.prompts || pack.prompts.length === 0) {
+    errors.push({ packId: pack.id, message: "Pack has no prompts" });
+    return errors;
+  }
+
+  for (const prompt of pack.prompts) {
+    if (seenIds.has(prompt.id)) {
+      errors.push({ packId: pack.id, promptId: prompt.id, message: "Duplicate prompt id" });
+    }
+    seenIds.add(prompt.id);
+
+    if (!prompt.text || prompt.text.trim().length === 0) {
+      errors.push({ packId: pack.id, promptId: prompt.id, message: "Empty prompt text" });
+    }
+
+    if (!pack.categories.includes(prompt.category)) {
+      errors.push({
+        packId: pack.id,
+        promptId: prompt.id,
+        message: `Category "${prompt.category}" not in pack categories [${pack.categories.join(", ")}]`,
+      });
+    }
+
+    if (!["easy", "medium", "hard"].includes(prompt.difficulty)) {
+      errors.push({
+        packId: pack.id,
+        promptId: prompt.id,
+        message: `Invalid difficulty "${prompt.difficulty}"`,
+      });
+    }
+  }
+
+  return errors;
+}
+
+// Loader with filtering
+
+interface LoadOptions {
+  categories?: string[];
+  difficulty?: Prompt["difficulty"];
+  familySafeOnly?: boolean;
+  locale?: string;
+}
+
+export function loadPack(filePath: string): PromptPack {
+  const raw = readFileSync(filePath, "utf-8");
+  return JSON.parse(raw) as PromptPack;
+}
+
+export function filterPrompts(pack: PromptPack, opts: LoadOptions = {}): Prompt[] {
+  return pack.prompts.filter((p) => {
+    if (opts.categories && !opts.categories.includes(p.category)) return false;
+    if (opts.difficulty && p.difficulty !== opts.difficulty) return false;
+    if (opts.familySafeOnly && !p.familySafe) return false;
+    if (opts.locale && p.locale !== opts.locale) return false;
+    return true;
+  });
+}
+
+// Shuffle using Fisher-Yates (unbiased)
+
+export function shuffle<T>(arr: T[]): T[] {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+// Draw N unique prompts from a pack, respecting filters
+
+export function drawPrompts(pack: PromptPack, count: number, opts: LoadOptions = {}): Prompt[] {
+  const filtered = filterPrompts(pack, opts);
+  const shuffled = shuffle(filtered);
+  return shuffled.slice(0, Math.min(count, shuffled.length));
+}
+
+// CLI validation runner
+
+function runCLIValidation(): void {
+  const args = process.argv.slice(2);
+  if (args[0] !== "--validate" || args.length < 2) {
+    console.log("Usage: npx tsx prompt-pack.schema.ts --validate ./content/packs/*.json");
+    process.exit(1);
+  }
+
+  const files = args.slice(1);
+  let totalErrors = 0;
+
+  for (const file of files) {
+    try {
+      const pack = loadPack(file);
+      const errors = validatePack(pack);
+      if (errors.length > 0) {
+        console.error(`\n${file}: ${errors.length} error(s)`);
+        for (const e of errors) console.error(`  - [${e.promptId ?? "pack"}] ${e.message}`);
+        totalErrors += errors.length;
+      } else {
+        console.log(`${file}: OK (${pack.prompts.length} prompts)`);
+      }
+    } catch (err) {
+      console.error(`${file}: Failed to parse - ${(err as Error).message}`);
+      totalErrors++;
+    }
+  }
+
+  process.exit(totalErrors > 0 ? 1 : 0);
+}
+
+if (process.argv[1]?.endsWith("prompt-pack.schema.ts")) {
+  runCLIValidation();
+}

--- a/skills/party-game-dev/assets/protocol-envelope.ts
+++ b/skills/party-game-dev/assets/protocol-envelope.ts
@@ -1,0 +1,140 @@
+// Protocol Envelope — dedup, version gating, and phase guarding for Socket.IO party games.
+// Wrap every client->server event in a ClientEnvelope. Server responds with ServerAck.
+// Prevents: stale submits after phase change, duplicate events on reconnect, version drift after deploy.
+
+import { randomUUID } from "crypto";
+import type { Socket } from "socket.io";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export interface ClientEnvelope<T = unknown> {
+  protocolVersion: number;
+  roomCode: string;
+  playerId: string;
+  phaseInstanceId: string; // UUID generated each time a phase starts
+  clientSeq: number; // Monotonic per player session — dedup on reconnect
+  sentAt: number; // client Date.now() — for latency tracking
+  payload: T;
+}
+
+export interface ServerAck {
+  clientSeq: number;
+  accepted: boolean;
+  reason?: "PHASE_MISMATCH" | "DUPLICATE" | "VERSION_MISMATCH" | "INVALID";
+  serverTime: number;
+  stateVersion: number;
+}
+
+// ── Server-side processor ──────────────────────────────────────────────────────
+
+/**
+ * Minimum protocol version the server supports. Clients below this are told to
+ * refresh. Bump when you ship breaking event changes.
+ */
+const MIN_SUPPORTED_VERSION = 1;
+
+/** Tracks the highest acked sequence number per player to reject replays. */
+const lastAckedSeq = new Map<string, number>();
+
+interface RoomRef {
+  currentPhaseInstanceId: string;
+  stateVersion: number;
+}
+
+/**
+ * Process an incoming envelope. Returns the unwrapped payload if valid,
+ * or `null` if the message should be silently dropped (ack already sent).
+ */
+export function processEnvelope<T>(
+  envelope: ClientEnvelope<T>,
+  room: RoomRef,
+  socket: Socket
+): T | null {
+  const ack = (accepted: boolean, reason?: ServerAck["reason"]): void => {
+    const response: ServerAck = {
+      clientSeq: envelope.clientSeq,
+      accepted,
+      reason,
+      serverTime: Date.now(),
+      stateVersion: room.stateVersion,
+    };
+    socket.emit("ack", response);
+  };
+
+  // 1. Version gate
+  if (envelope.protocolVersion < MIN_SUPPORTED_VERSION) {
+    ack(false, "VERSION_MISMATCH");
+    socket.emit("force-refresh", {
+      minVersion: MIN_SUPPORTED_VERSION,
+      message: "A new version is available. Please refresh your browser.",
+    });
+    return null;
+  }
+
+  // 2. Dedup — reject replays from reconnection burst
+  const prevSeq = lastAckedSeq.get(envelope.playerId) ?? -1;
+  if (envelope.clientSeq <= prevSeq) {
+    ack(false, "DUPLICATE");
+    return null;
+  }
+  lastAckedSeq.set(envelope.playerId, envelope.clientSeq);
+
+  // 3. Phase guard — reject submits targeting an expired phase
+  if (envelope.phaseInstanceId !== room.currentPhaseInstanceId) {
+    ack(false, "PHASE_MISMATCH");
+    return null;
+  }
+
+  // Valid
+  ack(true);
+  return envelope.payload;
+}
+
+// ── Phase instance ID helper ───────────────────────────────────────────────────
+
+/** Call this every time a phase starts. Store the result in room state. */
+export function newPhaseInstanceId(): string {
+  return randomUUID();
+}
+
+// ── Client-side helper (browser) ───────────────────────────────────────────────
+
+/**
+ * Usage on the client:
+ *
+ * ```ts
+ * const sender = createEnvelopeSender(PROTOCOL_VERSION, roomCode, playerId);
+ *
+ * socket.emit('submit-answer', sender(phaseInstanceId, { text: 'My answer' }));
+ *
+ * socket.on('ack', (ack: ServerAck) => {
+ *   if (!ack.accepted && ack.reason === 'VERSION_MISMATCH') {
+ *     window.location.reload();
+ *   }
+ * });
+ * ```
+ */
+export function createEnvelopeSender(
+  protocolVersion: number,
+  roomCode: string,
+  playerId: string
+) {
+  let seq = 0;
+
+  return <T>(phaseInstanceId: string, payload: T): ClientEnvelope<T> => ({
+    protocolVersion,
+    roomCode,
+    playerId,
+    phaseInstanceId,
+    clientSeq: ++seq,
+    sentAt: Date.now(),
+    payload,
+  });
+}
+
+// ── Cleanup helper ─────────────────────────────────────────────────────────────
+
+/** Call when a player fully leaves (after grace period). */
+export function clearPlayerSeq(playerId: string): void {
+  lastAckedSeq.delete(playerId);
+}

--- a/skills/party-game-dev/assets/room-timeline.ts
+++ b/skills/party-game-dev/assets/room-timeline.ts
@@ -1,0 +1,145 @@
+// Room Timeline — structured event log for post-game forensics.
+// Every significant room event is appended to an in-memory timeline.
+// On game end (or crash), dump to structured JSON for debugging.
+// In production, pipe to your logging service (Loki, Datadog, etc.).
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export type TimelineEventType =
+  | "room:created"
+  | "player:joined"
+  | "player:left"
+  | "player:disconnected"
+  | "player:reconnected"
+  | "player:kicked"
+  | "vip:assigned"
+  | "vip:transferred"
+  | "phase:started"
+  | "phase:ended"
+  | "phase:timeout"
+  | "submit:accepted"
+  | "submit:rejected"
+  | "vote:cast"
+  | "score:awarded"
+  | "game:started"
+  | "game:ended"
+  | "error:caught";
+
+export interface TimelineEntry {
+  ts: number; // Date.now()
+  seq: number; // Monotonic sequence within room
+  event: TimelineEventType;
+  playerId?: string;
+  phase?: string;
+  data?: Record<string, unknown>;
+}
+
+export interface RoomTimeline {
+  roomCode: string;
+  createdAt: number;
+  entries: TimelineEntry[];
+}
+
+// ── Timeline class ─────────────────────────────────────────────────────────────
+
+export class Timeline {
+  private roomCode: string;
+  private createdAt: number;
+  private entries: TimelineEntry[] = [];
+  private seq = 0;
+  private maxEntries: number;
+
+  constructor(roomCode: string, opts?: { maxEntries?: number }) {
+    this.roomCode = roomCode;
+    this.createdAt = Date.now();
+    this.maxEntries = opts?.maxEntries ?? 10_000;
+  }
+
+  /** Append an event. Silently drops if over maxEntries to prevent memory leaks. */
+  push(
+    event: TimelineEventType,
+    details?: { playerId?: string; phase?: string; data?: Record<string, unknown> }
+  ): void {
+    if (this.entries.length >= this.maxEntries) return;
+
+    this.entries.push({
+      ts: Date.now(),
+      seq: this.seq++,
+      event,
+      playerId: details?.playerId,
+      phase: details?.phase,
+      data: details?.data,
+    });
+  }
+
+  /** Return the full timeline as a serializable object. */
+  dump(): RoomTimeline {
+    return {
+      roomCode: this.roomCode,
+      createdAt: this.createdAt,
+      entries: this.entries,
+    };
+  }
+
+  /** Return last N entries (for live debug endpoints). */
+  tail(n = 50): TimelineEntry[] {
+    return this.entries.slice(-n);
+  }
+
+  /** Filter entries by event type. */
+  filter(type: TimelineEventType): TimelineEntry[] {
+    return this.entries.filter((e) => e.event === type);
+  }
+
+  /** Summary stats for quick triage. */
+  summary(): {
+    totalEvents: number;
+    duration: number;
+    playerJoins: number;
+    playerLeaves: number;
+    phaseCount: number;
+    errors: number;
+    submits: number;
+  } {
+    return {
+      totalEvents: this.entries.length,
+      duration: Date.now() - this.createdAt,
+      playerJoins: this.filter("player:joined").length,
+      playerLeaves: this.filter("player:left").length,
+      phaseCount: this.filter("phase:started").length,
+      errors: this.filter("error:caught").length,
+      submits:
+        this.filter("submit:accepted").length +
+        this.filter("submit:rejected").length,
+    };
+  }
+}
+
+// ── Integration example ────────────────────────────────────────────────────────
+//
+// const rooms = new Map<string, { timeline: Timeline; /* ...room state */ }>();
+//
+// function createRoom(code: string) {
+//   const timeline = new Timeline(code);
+//   timeline.push('room:created');
+//   rooms.set(code, { timeline });
+// }
+//
+// // On game end, dump for logging:
+// function endGame(code: string) {
+//   const room = rooms.get(code);
+//   if (!room) return;
+//   const dump = room.timeline.dump();
+//   console.log(JSON.stringify(dump)); // or send to Loki/Datadog
+//   rooms.delete(code);
+// }
+//
+// // Debug endpoint (admin only, behind auth):
+// app.get('/admin/room/:code/timeline', (req, res) => {
+//   const room = rooms.get(req.params.code);
+//   if (!room) return res.status(404).json({ error: 'Room not found' });
+//   res.json({
+//     summary: room.timeline.summary(),
+//     recent: room.timeline.tail(100),
+//   });
+// });

--- a/skills/party-game-dev/references/content-safety-and-moderation.md
+++ b/skills/party-game-dev/references/content-safety-and-moderation.md
@@ -1,0 +1,422 @@
+# Content Safety and Moderation
+
+Sources: Jackbox Party Pack 5-10 moderation features, Rocketcrab chat moderation (tannerkrewson/rocketcrab), Fishbowl content filtering (avimoondra/fishbowl), OWASP input validation guidelines
+
+Covers: Profanity filtering (multi-tier), human moderation queues, family-friendly mode, VIP censoring, chat moderation, accessibility patterns, mobile UX hardening for phone controllers.
+
+## 1. Content Safety Tiers
+
+Jackbox uses a 3-tier content filter system. Implement it as a room-level setting controlled by the VIP.
+
+| Tier | What It Filters | Use Case |
+|------|----------------|----------|
+| **Off** | Nothing filtered | Private games among adults |
+| **Moderate** | Slurs, hate speech, explicit sexual content | Default for most games |
+| **Strict** | All profanity, innuendo, suggestive content | Family gatherings, work events, streaming |
+
+### Configuration
+
+```typescript
+type ContentFilterLevel = 'off' | 'moderate' | 'strict';
+
+interface ContentFilterConfig {
+  level: ContentFilterLevel;
+  customBlocklist: string[];  // Room-specific blocked words
+  allowlist: string[];        // False positive overrides
+}
+
+const FILTER_WORD_LISTS: Record<ContentFilterLevel, string[]> = {
+  off: [],
+  moderate: ['SLURS_LIST', 'EXPLICIT_LIST'],  // Load from JSON files
+  strict: ['SLURS_LIST', 'EXPLICIT_LIST', 'PROFANITY_LIST', 'SUGGESTIVE_LIST'],
+};
+```
+
+## 2. Profanity Filtering
+
+### Regex-Based Matcher
+
+Use a word-boundary regex approach that handles common evasion tactics (letter substitution, spacing, repetition).
+
+```typescript
+class ProfanityFilter {
+  private patterns: RegExp[] = [];
+
+  constructor(wordLists: string[][]) {
+    for (const list of wordLists) {
+      for (const word of list) {
+        // Build pattern that catches: f.u.c.k, f_u_c_k, fuuuck
+        const spaced = word.split('').join('[\\s._\\-*]*');
+        this.patterns.push(new RegExp(`\\b${spaced}\\b`, 'gi'));
+      }
+    }
+  }
+
+  check(text: string): { clean: boolean; matches: string[] } {
+    const normalized = this.normalize(text);
+    const matches: string[] = [];
+
+    for (const pattern of this.patterns) {
+      const found = normalized.match(pattern);
+      if (found) matches.push(...found);
+    }
+
+    return { clean: matches.length === 0, matches };
+  }
+
+  censor(text: string): string {
+    let result = text;
+    for (const pattern of this.patterns) {
+      result = result.replace(pattern, (match) => '*'.repeat(match.length));
+    }
+    return result;
+  }
+
+  private normalize(text: string): string {
+    return text
+      .replace(/0/g, 'o')
+      .replace(/1/g, 'i')
+      .replace(/3/g, 'e')
+      .replace(/4/g, 'a')
+      .replace(/5/g, 's')
+      .replace(/@/g, 'a')
+      .replace(/\$/g, 's');
+  }
+}
+```
+
+### Integration with Answer Submission
+
+```typescript
+const filter = new ProfanityFilter(FILTER_WORD_LISTS[room.settings.contentFilter]);
+
+socket.on('answer:submit', ({ answer }: { answer: string }) => {
+  const room = roomManager.getRoomBySocket(socket.id);
+  if (!room) return;
+
+  // Length validation
+  if (answer.length > 280) {
+    return socket.emit('error', { code: 'TOO_LONG', message: 'Answer too long' });
+  }
+
+  // Profanity check
+  const result = filter.check(answer);
+  if (!result.clean && room.settings.contentFilter !== 'off') {
+    if (room.settings.moderationMode === 'censor') {
+      // Auto-censor and accept
+      room.submitAnswer(socket.id, filter.censor(answer));
+    } else {
+      // Reject submission
+      socket.emit('error', {
+        code: 'CONTENT_FILTERED',
+        message: 'Your answer was filtered. Try again.',
+      });
+      return;
+    }
+  }
+
+  room.submitAnswer(socket.id, answer);
+  socket.emit('answer:accepted');
+});
+```
+
+### Word List Management
+
+Store word lists as JSON files, separated by severity and language:
+
+```text
+packages/shared/
+  wordlists/
+    en/
+      slurs.json         # Hate speech, slurs (always filtered in moderate+)
+      explicit.json      # Sexually explicit terms
+      profanity.json     # Common swear words
+      suggestive.json    # Innuendo, double entendres
+    es/
+      slurs.json
+      profanity.json
+```
+
+## 3. Human Moderation Mode
+
+For streaming or sensitive environments, route all player submissions through a moderation queue before displaying them. The VIP (or a designated moderator) approves or rejects each submission.
+
+```typescript
+interface ModerationItem {
+  id: string;
+  playerId: string;
+  playerName: string;
+  content: string;
+  type: 'answer' | 'drawing' | 'chat';
+  timestamp: number;
+}
+```
+
+Implement a `ModerationManager` with three methods:
+- `submit(item)` → adds to pending queue, returns ID
+- `approve(itemId)` → moves from pending to approved, emits `content:revealed` to room
+- `reject(itemId)` → moves from pending to rejected, emits `content:rejected` to submitter
+
+### VIP Moderation Socket Events
+
+| Event | Direction | Payload | VIP-Only |
+|-------|-----------|---------|----------|
+| `moderation:fetch` | Client → Server | none | Yes |
+| `moderation:queue` | Server → VIP | `ModerationItem[]` | Yes |
+| `moderation:approve` | Client → Server | `{ itemId }` | Yes |
+| `moderation:reject` | Client → Server | `{ itemId }` | Yes |
+| `content:revealed` | Server → All | `{ playerId, content }` | No |
+| `content:rejected` | Server → Player | `{ reason }` | No |
+
+Always check `requireVIP(socket, room)` before processing moderation events.
+
+## 4. VIP Censoring
+
+Jackbox allows the VIP to censor content in real-time during the reveal phase. Censored content is visually "scribbled out" and hidden from all players and audience.
+
+```typescript
+socket.on('content:censor', ({ contentId }: { contentId: string }) => {
+  if (!requireVIP(socket, room)) return;
+
+  room.censorContent(contentId);
+  io.to(room.code).emit('content:censored', { contentId });
+});
+```
+
+### Client-Side Censoring
+
+```tsx
+const AnswerCard = ({ answer, isCensored }: AnswerCardProps) => {
+  if (isCensored) {
+    return (
+      <div className="relative bg-slate-200 p-6 rounded-xl">
+        <p className="text-slate-400 italic line-through decoration-4">
+          [Content removed by VIP]
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white p-6 rounded-xl shadow-md">
+      <p className="text-xl font-bold">{answer.text}</p>
+    </div>
+  );
+};
+```
+
+## 5. Chat Moderation
+
+If the game includes a chat feature, apply rate limiting and content filtering from Rocketcrab's proven pattern.
+
+### Rate Limiting Constants
+
+```typescript
+const CHAT_LIMITS = {
+  MAX_MSG_LENGTH: 100,          // Characters per message
+  MAX_MESSAGES_STORED: 20,      // Chat history limit
+  MIN_MS_BETWEEN_MSGS: 1000,    // 1 second cooldown
+  MAX_MSGS_PER_MINUTE: 10,      // Burst protection
+} as const;
+```
+
+### Chat Handler
+
+```typescript
+const lastMessageTime = new Map<string, number>();
+const messageCount = new Map<string, number[]>();
+
+socket.on('chat:message', ({ text }: { text: string }) => {
+  const room = roomManager.getRoomBySocket(socket.id);
+  if (!room) return;
+
+  // Length check
+  if (text.length > CHAT_LIMITS.MAX_MSG_LENGTH) return;
+  if (text.trim().length === 0) return;
+
+  // Rate limit
+  const now = Date.now();
+  const lastTime = lastMessageTime.get(socket.id) ?? 0;
+  if (now - lastTime < CHAT_LIMITS.MIN_MS_BETWEEN_MSGS) return;
+  lastMessageTime.set(socket.id, now);
+
+  // Burst protection
+  const times = messageCount.get(socket.id) ?? [];
+  const recentTimes = times.filter(t => now - t < 60_000);
+  if (recentTimes.length >= CHAT_LIMITS.MAX_MSGS_PER_MINUTE) return;
+  recentTimes.push(now);
+  messageCount.set(socket.id, recentTimes);
+
+  // Profanity filter
+  const filtered = filter.censor(text);
+
+  const message = {
+    playerId: socket.id,
+    playerName: room.getPlayerBySocketId(socket.id)?.name ?? 'Unknown',
+    text: filtered,
+    timestamp: now,
+  };
+
+  room.addChatMessage(message);
+  io.to(room.code).emit('chat:message', message);
+});
+```
+
+## 6. Family-Friendly Mode
+
+When enabled, filter both prompts and player content for age-appropriate gameplay.
+
+### Implementation
+
+Add `isFamilyFriendly: boolean` to each prompt in the pack. When the room has `familyFriendly: true`, filter prompts before selection: `pack.filter(p => p.isFamilyFriendly)`. When the VIP enables family mode, automatically upgrade `contentFilter` to `'strict'` — the two settings work together. Family mode is a VIP-only setting, controlled during the lobby phase via `settings:update`.
+
+## 7. Accessibility
+
+Party games must accommodate diverse players. Implement these accessibility features as room-level or player-level settings.
+
+### Accessibility Settings Model
+
+```typescript
+interface AccessibilitySettings {
+  fontSize: 'default' | 'large' | 'xlarge';
+  reduceMotion: boolean;
+  highContrast: boolean;
+  colorblindMode: 'none' | 'protanopia' | 'deuteranopia' | 'tritanopia';
+  subtitlesEnabled: boolean;
+  screenReaderHints: boolean;
+}
+
+const DEFAULT_ACCESSIBILITY: AccessibilitySettings = {
+  fontSize: 'default',
+  reduceMotion: false,
+  highContrast: false,
+  colorblindMode: 'none',
+  subtitlesEnabled: true,
+  screenReaderHints: false,
+};
+```
+
+### Implementation Patterns
+
+| Feature | Host Screen (TV) | Player Controller (Phone) |
+|---------|------------------|---------------------------|
+| **Font size** | Already large (32px+) | Apply `text-lg` / `text-xl` / `text-2xl` based on setting |
+| **Reduce motion** | Disable Framer Motion animations | Disable transition effects |
+| **High contrast** | 7:1 ratio minimum (already recommended) | Swap to high-contrast palette |
+| **Colorblind** | Use patterns/shapes alongside color | Same |
+| **Subtitles** | Show text for all audio/voice | N/A (phone has no audio) |
+| **Screen reader** | ARIA live regions for phase changes | ARIA labels on all controls |
+
+### CSS Variables for Accessibility
+
+```css
+:root {
+  --font-scale: 1;
+  --motion-duration: 300ms;
+  --contrast-bg: theme('colors.slate.900');
+  --contrast-text: theme('colors.white');
+}
+
+[data-font-size="large"] { --font-scale: 1.25; }
+[data-font-size="xlarge"] { --font-scale: 1.5; }
+[data-reduce-motion="true"] { --motion-duration: 0ms; }
+[data-high-contrast="true"] {
+  --contrast-bg: #000;
+  --contrast-text: #fff;
+}
+```
+
+### Colorblind-Safe Player Colors
+
+Use shapes alongside colors to distinguish players:
+
+```typescript
+const PLAYER_IDENTIFIERS = [
+  { color: '#3B82F6', shape: 'circle',   label: 'Blue Circle' },
+  { color: '#EF4444', shape: 'square',   label: 'Red Square' },
+  { color: '#10B981', shape: 'triangle', label: 'Green Triangle' },
+  { color: '#F59E0B', shape: 'diamond',  label: 'Yellow Diamond' },
+  { color: '#8B5CF6', shape: 'star',     label: 'Purple Star' },
+  { color: '#EC4899', shape: 'hexagon',  label: 'Pink Hexagon' },
+  { color: '#06B6D4', shape: 'cross',    label: 'Cyan Cross' },
+  { color: '#F97316', shape: 'heart',    label: 'Orange Heart' },
+];
+```
+
+### ARIA for Phase Changes
+
+```tsx
+// Announce game phase changes to screen readers
+const PhaseAnnouncer = ({ phase }: { phase: string }) => (
+  <div role="status" aria-live="polite" className="sr-only">
+    {phase === 'SUBMITTING' && 'Write your answer now. You have 60 seconds.'}
+    {phase === 'VOTING' && 'Vote for your favorite answer now.'}
+    {phase === 'RESULTS' && 'Round results are being shown.'}
+  </div>
+);
+```
+
+## 8. Mobile UX Hardening
+
+Phone controllers are the primary interface for players. Harden them against common mobile browser issues.
+
+Implement these as React hooks. All degrade gracefully when APIs are unavailable.
+
+| Hook | API | Purpose |
+|------|-----|---------|
+| `usePreventExit(active)` | `window.onbeforeunload` | Warn before closing tab during game |
+| `useLockOrientation('portrait')` | `screen.orientation.lock()` | Force portrait mode on phone |
+| `useWakeLock(enabled)` | `navigator.wakeLock.request('screen')` | Prevent screen sleep during rounds |
+| `useHaptics()` | `navigator.vibrate()` | Tactile feedback on button press |
+
+### Haptic Feedback Patterns
+
+```typescript
+const vibrate = (pattern: 'tap' | 'success' | 'error' | 'countdown') => {
+  if (!navigator.vibrate) return;
+  const patterns: Record<string, number | number[]> = {
+    tap: 30, success: [50, 30, 50], error: [100, 50, 100], countdown: 15,
+  };
+  navigator.vibrate(patterns[pattern]);
+};
+```
+
+### Viewport and Touch
+
+Set `<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />` to prevent pinch-zoom. All interactive elements must be at least 48x48px (WCAG 2.5.5). For voting options in fast-paced games, use 64px+ button heights.
+
+## 9. Content Reporting
+
+Allow players to report content that bypasses the profanity filter. Store reports with `reporterId`, `contentId`, `contentType`, and `reason` (offensive/spam/harassment/other). Auto-escalation rule: when 2+ unique players report the same content, notify the VIP via `moderation:alert` so they can censor it.
+
+## 10. Input Validation Checklist
+
+Apply these validations to every player input before processing:
+
+| Input Type | Validation | Max Length | Rate Limit |
+|------------|-----------|------------|------------|
+| Player name | Alphanumeric + spaces, trimmed | 20 chars | 1 per session |
+| Answer text | Profanity filter, trimmed | 280 chars | 1 per phase |
+| Vote | Valid target ID, not self-vote | N/A | 1 per phase |
+| Chat message | Profanity filter, trimmed | 100 chars | 10/min |
+| Drawing data | Max stroke count, max points per stroke | 50KB | 1 per phase |
+| Room code | Uppercase alpha, exact length | 4-6 chars | 5/min |
+| Settings | Zod schema validation | N/A | VIP only |
+
+### Zod Validation Example
+
+```typescript
+import { z } from 'zod';
+
+const answerSchema = z.object({
+  answer: z.string().trim().min(1).max(280),
+});
+
+const voteSchema = z.object({
+  targetId: z.string().uuid(),
+});
+
+const nameSchema = z.object({
+  name: z.string().trim().min(1).max(20).regex(/^[a-zA-Z0-9 ]+$/),
+});
+```

--- a/skills/party-game-dev/references/deployment-and-ops.md
+++ b/skills/party-game-dev/references/deployment-and-ops.md
@@ -309,3 +309,71 @@ process.on("SIGTERM", async () => {
 - **Latency Spikes**: Often caused by large state broadcasts. Optimize by sending deltas instead of full state objects.
 - **Connection Drops**: If players drop simultaneously, check the load balancer timeouts or Redis stability.
 - **CORS Errors**: Verify that the `CORS_ORIGIN` environment variable exactly matches the frontend URL including the protocol and port.
+
+## Room Forensics
+
+When a game session goes wrong — stuck phases, missing votes, phantom disconnects — the most useful debugging tool is a structured timeline of everything that happened in that room. Console logs are insufficient because they mix all rooms together and lack structure.
+
+### Event Timeline
+
+Attach a `Timeline` object to every room at creation. Log every significant event with player ID, phase, and timestamp. On game end (or crash), dump the timeline as structured JSON.
+
+```typescript
+const timeline = new Timeline(roomCode);
+
+// In event handlers:
+timeline.push("player:joined", { playerId, data: { name: player.name } });
+timeline.push("phase:started", { phase: "VOTING", data: { roundNumber: 3 } });
+timeline.push("submit:rejected", { playerId, phase: "INPUT", data: { reason: "PHASE_MISMATCH" } });
+timeline.push("error:caught", { data: { message: err.message, stack: err.stack } });
+```
+
+See `assets/room-timeline.ts` for the complete implementation with summary stats and tail queries.
+
+### Debug Endpoint
+
+Expose a `/admin/room/:code/timeline` endpoint behind authentication. Return the summary (total events, duration, player join/leave counts, error count) and the last N entries. This lets you diagnose stuck games in production without SSH-ing into the server.
+
+```typescript
+app.get("/admin/room/:code/timeline", authMiddleware, (req, res) => {
+  const room = rooms.get(req.params.code);
+  if (!room) return res.status(404).json({ error: "Room not found" });
+  res.json({
+    summary: room.timeline.summary(),
+    recent: room.timeline.tail(100),
+  });
+});
+```
+
+### What To Log
+
+| Event | When | Key Data |
+|-------|------|----------|
+| `room:created` | Room instantiated | config, maxPlayers |
+| `player:joined` / `player:left` | Socket join/leave | playerId, name |
+| `player:disconnected` / `player:reconnected` | Socket drop/restore | playerId, gracePeriod |
+| `vip:assigned` / `vip:transferred` | VIP changes | fromPlayerId, toPlayerId |
+| `phase:started` / `phase:ended` | State machine transitions | phaseName, phaseInstanceId |
+| `phase:timeout` | Timer expired before all submits | phaseName, missingPlayers |
+| `submit:accepted` / `submit:rejected` | Player submits answer/vote | playerId, reason (if rejected) |
+| `error:caught` | Unhandled error in room context | message, stack |
+
+### Memory Safety
+
+Cap the timeline at 10,000 entries per room (configurable). Typical games generate 200-500 events. If a room hits the cap, it indicates a runaway loop — log a warning and stop appending. Clear the timeline when the room is destroyed.
+
+### Production Integration
+
+In development, dump timelines to `console.log`. In production, pipe to a structured logging service (Loki, Datadog, etc.) at game end:
+
+```typescript
+function onGameEnd(room: Room) {
+  const dump = room.timeline.dump();
+  logger.info("game_timeline", dump);
+  rooms.delete(room.code);
+}
+```
+
+### Load Testing
+
+For smoke-testing server capacity before launch, use `assets/loadtest-socketio.ts`. It spawns N virtual players across M rooms, simulates submit and vote phases, and reports p50/p95/p99 latency for each event type. Run it against your staging server to catch memory leaks and latency regressions before real players hit them.

--- a/skills/party-game-dev/references/frontend-patterns.md
+++ b/skills/party-game-dev/references/frontend-patterns.md
@@ -314,3 +314,94 @@ const SynchronizedTimer = ({ expiresAt }: { expiresAt: number }) => {
 
 ### Audio Stack
 - **Howler.js**: Robust audio management for cross-browser support. Use it to handle spatial audio if the Host screen has a surround sound setup. Preload assets during the lobby phase to avoid lag during gameplay.
+
+### iOS Audio Unlock
+
+iOS Safari suspends the `AudioContext` until a user gesture triggers it. Without explicit unlock logic, all game sounds silently fail on iPhones and iPads. The unlock must happen before any `Howl.play()` call.
+
+**The Problem:**
+1. iOS creates `AudioContext` in `suspended` state.
+2. Calling `Howl.play()` while suspended queues the sound but never plays it.
+3. Users hear nothing — no error is thrown.
+
+**The Fix — gesture-triggered resume:**
+
+```tsx
+useEffect(() => {
+  const unlock = () => {
+    const ctx = Howler.ctx;
+    if (ctx?.state === "suspended") {
+      ctx.resume();
+    }
+  };
+  document.addEventListener("touchstart", unlock, { capture: true, once: true });
+  document.addEventListener("click", unlock, { capture: true, once: true });
+  return () => {
+    document.removeEventListener("touchstart", unlock);
+    document.removeEventListener("click", unlock);
+  };
+}, []);
+```
+
+Key rules:
+- Listen on `touchstart` AND `click` — some browsers need one, some the other.
+- Use `capture: true` so the handler fires before any `stopPropagation()` in child components.
+- Trigger on the FIRST user interaction (lobby join button tap is ideal).
+- Check `Howler.ctx.state` — desktop browsers are usually already `"running"`.
+
+See `assets/audio-unlock-howler.tsx` for a complete React provider with unlock + preloading + progress tracking.
+
+### Asset Preloading
+
+Load all game audio and images during the lobby phase, not during gameplay. Players are waiting anyway — use that dead time.
+
+**Audio preloading:**
+```tsx
+const manifest = {
+  buzzer: "/sounds/buzzer.mp3",
+  correct: "/sounds/correct.mp3",
+  tick: "/sounds/tick.mp3",
+  reveal: "/sounds/reveal.mp3",
+};
+
+// In lobby component
+useEffect(() => {
+  Object.values(manifest).forEach((url) => {
+    new Howl({ src: [url], preload: true });
+  });
+}, []);
+```
+
+**Image preloading** (for reveal animations, player avatars):
+```tsx
+function preloadImages(urls: string[]): Promise<void[]> {
+  return Promise.all(
+    urls.map(
+      (url) =>
+        new Promise<void>((resolve) => {
+          const img = new Image();
+          img.onload = () => resolve();
+          img.onerror = () => resolve(); // Don't block on failures
+          img.src = url;
+        })
+    )
+  );
+}
+```
+
+**Loading indicator pattern:**
+Show preload progress on the Host screen during lobby. Use a simple counter:
+
+```tsx
+const [loaded, setLoaded] = useState(0);
+const total = Object.keys(manifest).length;
+
+// In lobby UI
+{loaded < total && (
+  <div className="text-sm text-slate-400">
+    Loading assets... {Math.round((loaded / total) * 100)}%
+  </div>
+)}
+```
+
+Never block game start on preloading — if assets fail to load, the game should still work (sounds are optional, images can lazy-load). The host screen should show "Loading..." but the VIP's "Start Game" button remains enabled.

--- a/skills/party-game-dev/references/game-architecture.md
+++ b/skills/party-game-dev/references/game-architecture.md
@@ -276,6 +276,60 @@ Support "Audience" roles for games played on stream (Twitch/YouTube).
 - **Threshold:** Set `maxPlayers` (e.g., 8). Any player joining after this is assigned `role: 'AUDIENCE'`.
 - **Filtering:** Use `room.players.filter(p => p.role === 'PLAYER')` for game logic and `room.players.filter(p => p.role === 'AUDIENCE')` for crowd-sourced voting.
 
+### Crowd Play and Stream Integration
+
+For Twitch/YouTube streaming, extend Audience Mode into a full "Crowd Play" system where chat viewers participate without joining the game room.
+
+**Architecture:**
+1. The Host screen (TV) runs on the streamer's machine and connects to the game server via Socket.IO as usual.
+2. A Twitch Extension or chat bot relays crowd votes to the game server via HTTP webhook.
+3. The game server aggregates crowd votes into a single "audience choice" during voting phases.
+
+**Twitch Extension approach:**
+```typescript
+// Twitch Extension backend — receives viewer votes via Twitch PubSub
+app.post("/twitch/vote", verifyTwitchJWT, (req, res) => {
+  const { roomCode, optionIndex, viewerId } = req.body;
+  const room = rooms.get(roomCode);
+  if (!room || room.phase !== "VOTING") return res.status(400).end();
+  room.crowdVotes.set(viewerId, optionIndex);
+  res.status(204).end();
+});
+```
+
+**Chat bot approach (simpler, no extension review):**
+- Bot watches chat for `!vote 1`, `!vote 2`, etc.
+- Tallies votes per viewer (one vote per viewer per round).
+- Sends aggregated result to game server when voting phase ends.
+
+**Aggregation:**
+```typescript
+function aggregateCrowdVotes(crowdVotes: Map<string, number>): number {
+  const tally = new Map<number, number>();
+  for (const option of crowdVotes.values()) {
+    tally.set(option, (tally.get(option) ?? 0) + 1);
+  }
+  let maxVotes = 0;
+  let winner = 0;
+  for (const [option, count] of tally) {
+    if (count > maxVotes) {
+      maxVotes = count;
+      winner = option;
+    }
+  }
+  return winner;
+}
+```
+
+**Host screen overlay:**
+Show crowd vote distribution as a live bar chart overlay on the Host screen during voting phases. Update every 2-3 seconds (not every vote — that creates too much visual noise).
+
+**Key constraints:**
+- Crowd votes should be weighted less than player votes (e.g., crowd = 1 player-equivalent vote total, regardless of crowd size).
+- Rate-limit webhook endpoint: max 1 vote per viewer per phase.
+- Clear `crowdVotes` map at the start of each voting phase.
+- Stream delay means crowd sees results 5-15 seconds late — design voting windows to be long enough (30+ seconds).
+
 ### Mobile UI Constraints
 Player controllers must be designed for mobile constraints.
 - **Viewport:** Use `100vh` carefully (or `-webkit-fill-available`) to handle mobile browser address bars.

--- a/skills/party-game-dev/references/game-types-and-mechanics.md
+++ b/skills/party-game-dev/references/game-types-and-mechanics.md
@@ -375,4 +375,54 @@ interface GameState {
 }
 ```
 
+## Content Pipeline
+
+Content-driven games (trivia, prompt-response, fill-in-the-blank) need a structured way to manage prompts, questions, and challenges. Without a pipeline, content ends up hardcoded in source files, making it impossible to add new packs without redeploying.
+
+### Prompt Pack Format
+
+Store content in JSON files following a consistent schema:
+
+```
+/content/packs/
+  general-knowledge.json
+  pop-culture-2024.json
+  family-friendly.json
+```
+
+Each pack contains prompts with category, difficulty, family-safe flag, and locale. See `assets/prompt-pack.schema.ts` for the full TypeScript schema, validation, and CLI validator.
+
+### Build-Time Validation
+
+Validate all prompt packs in CI to catch issues before deploy:
+```bash
+npx tsx assets/prompt-pack.schema.ts --validate ./content/packs/*.json
+```
+
+This checks for: duplicate IDs, empty text, invalid categories, missing required fields.
+
+### Runtime Loading
+
+```typescript
+import { loadPack, drawPrompts } from "./prompt-pack.schema";
+
+const pack = loadPack("./content/packs/general-knowledge.json");
+const roundPrompts = drawPrompts(pack, 8, {
+  difficulty: "medium",
+  familySafeOnly: room.settings.familyMode,
+});
+```
+
+### Content Expansion Without Redeploy
+
+For games that ship new prompt packs regularly:
+1. Store packs in a CDN or object storage (S3, R2).
+2. On game start, fetch the manifest of available packs.
+3. VIP selects which pack(s) to play from.
+4. Cache packs in memory after first fetch — they're immutable.
+
+### Localization
+
+Each prompt includes a `locale` field. When loading, filter by the room's locale setting. For multi-language support, create separate pack files per locale rather than embedding translations inline.
+
 By following these blueprints, developers can ensure that the core loops of their party games are robust, engaging, and technically sound while allowing for creative variation in theme and presentation.

--- a/skills/party-game-dev/references/multiplayer-networking.md
+++ b/skills/party-game-dev/references/multiplayer-networking.md
@@ -415,13 +415,25 @@ server {
 | Volatile Emits | Use `volatile.emit()` | Prevents queue build-up on slow clients |
 | Compression | `perMessageDeflate: true` | Significant bandwidth savings for large state |
 
-### Summary Checklist
+## 8. Protocol Hardening
 
-- Initialize server with appropriate CORS and transports.
-- Use 4-character alphanumeric codes for room access, excluding ambiguous chars.
-- Implement a centralized `RoomManager` for lifecycle management.
-- Define a strictly typed event protocol for consistency and clarity.
-- Enforce server-authoritative state with selective broadcasting of private data.
-- Handle reconnections via persistent session identifiers stored in `socket.data`.
-- Protect the server with async error-handling wrappers for all event listeners.
-- Use a Redis adapter and sticky sessions when scaling horizontally.
+When deploying while games are in progress (or users have cached JS), mismatched event shapes cause ghost bugs: stuck phases, duplicated submits, silent failures. Wrap every client→server event in an envelope with version, dedup, and phase-guarding fields.
+
+Every `ClientEnvelope` carries: `protocolVersion` (bump on breaking changes), `clientSeq` (monotonic per player — dedup on reconnect), and `phaseInstanceId` (UUID generated each phase start — rejects stale submits). The server validates all three before processing the payload, and responds with a `ServerAck` containing `accepted`, `reason`, and `stateVersion`.
+
+Three guards run in order:
+1. **Version gate** — if `protocolVersion < MIN_SUPPORTED_VERSION`, reject and emit `force-refresh`.
+2. **Dedup** — if `clientSeq <= lastAckedSeq`, silently drop (replay from reconnection burst).
+3. **Phase guard** — if `phaseInstanceId !== room.currentPhaseInstanceId`, reject with `PHASE_MISMATCH`.
+
+### Compatibility Policy
+
+| Change | Action | Breaking? |
+|--------|--------|-----------|
+| Add optional field to event | Deploy freely | No |
+| Rename or remove field | Bump `protocolVersion`, add refresh gate | Yes |
+| Change field type | Bump `protocolVersion` | Yes |
+| Add new event name | Deploy freely | No |
+| Remove event name | Deprecate first, remove after one version | Yes |
+
+See `assets/protocol-envelope.ts` for the complete implementation with types, server processor, and client-side sender helper.

--- a/skills/party-game-dev/references/vip-and-room-authority.md
+++ b/skills/party-game-dev/references/vip-and-room-authority.md
@@ -1,0 +1,443 @@
+# VIP and Room Authority
+
+Sources: Jackbox Games official documentation, Rocketcrab OSS (tannerkrewson/rocketcrab), Drawphone (tannerkrewson/drawphone), anime-character-guessr VIP transfer patterns
+
+Covers: VIP concept and distinction from host, VIP assignment and transfer, room settings, kick/ban system, bot replacement on disconnect, implementation patterns with Socket.IO.
+
+## 1. The VIP Concept
+
+In Jackbox-style party games, three distinct roles exist. The existing codebase often conflates "Host" and "VIP" — this section clarifies the correct model.
+
+| Role | What It Is | Where It Lives | Capabilities |
+|------|-----------|----------------|--------------|
+| **Host** | The TV/computer running the game | Physical device (console, PC, projector) | Displays game to all players, plays audio, shows animations |
+| **VIP** | The first player to join the room | Phone/tablet at the game URL | Starts rounds, censors content, kicks players, controls flow, manages settings |
+| **Player** | Any non-VIP participant | Phone/tablet at the game URL | Submits answers, votes, views personal prompts |
+
+The Host is **not a player**. It is a display device. The VIP is a **player with elevated privileges**. In Jackbox's own words: "The VIP is the first person to get in the game and the raw, unmitigated responsibility that comes with it is staggering."
+
+### Why the Distinction Matters
+
+- The Host screen has no input — it cannot start the game or kick players
+- The VIP controls the game flow from their phone
+- If the TV disconnects, the game cannot continue (no display)
+- If the VIP disconnects, their privileges transfer to the next player
+- Streaming setups require the streamer to be VIP so they control pacing
+
+### Data Model
+
+Update the shared `Player` interface to include VIP status:
+
+```typescript
+// packages/shared/src/types.ts
+export interface Player {
+  id: string;
+  socketId: string;
+  name: string;
+  score: number;
+  isVIP: boolean;       // Elevated privileges (start, kick, censor)
+  isConnected: boolean;
+  avatar?: string;
+}
+
+export interface GameRoom {
+  code: string;
+  state: GamePhase;
+  players: Player[];
+  idealVipId: string;   // Preferred VIP (survives reconnects)
+  settings: RoomSettings;
+  createdAt: number;
+  lastActive: number;
+}
+```
+
+Do **not** use `isHost` on the Player to mean VIP. Reserve `isHost` for the display connection if tracking it at all.
+
+## 2. VIP Assignment
+
+The first player to join a room automatically becomes VIP. Store the `idealVipId` at room level so VIP survives reconnection cycles.
+
+```typescript
+class Room {
+  public players: Map<string, Player> = new Map();
+  public idealVipId: string | null = null;
+
+  addPlayer(id: string, name: string, socketId: string): Player {
+    const player: Player = {
+      id,
+      socketId,
+      name,
+      score: 0,
+      isVIP: false,
+      isConnected: true,
+    };
+    this.players.set(id, player);
+
+    // First player becomes the preferred VIP
+    if (this.players.size === 1) {
+      this.idealVipId = id;
+    }
+
+    this.assignVIP();
+    return player;
+  }
+
+  private assignVIP(): void {
+    // Clear all VIP flags
+    for (const player of this.players.values()) {
+      player.isVIP = false;
+    }
+
+    // Try ideal VIP first
+    const ideal = this.players.get(this.idealVipId ?? '');
+    if (ideal && ideal.isConnected) {
+      ideal.isVIP = true;
+      return;
+    }
+
+    // Fallback: connected player who joined earliest (lowest numeric order)
+    const connected = Array.from(this.players.values())
+      .filter(p => p.isConnected);
+    if (connected.length > 0) {
+      connected[0].isVIP = true;
+    }
+  }
+}
+```
+
+This pattern is adapted from Rocketcrab's `idealHostId` + `setHost()` approach, where the party stores a preferred host ID and reassigns on every join/leave event.
+
+## 3. VIP Responsibilities
+
+### Actions Only the VIP Can Perform
+
+| Action | When | Implementation Pattern |
+|--------|------|----------------------|
+| **Start game** | Lobby phase, min players met | `socket.on('game:start')` → check `isVIP` |
+| **Skip content** | During reveal or voting | `socket.on('content:skip')` → advance phase |
+| **Censor content** | During reveal | `socket.on('content:censor')` → hide from display |
+| **Kick player** | Any phase | `socket.on('player:kick')` → remove + optional ban |
+| **Change settings** | Lobby phase only | `socket.on('settings:update')` → validate + broadcast |
+| **End game early** | Playing phase | `socket.on('game:end')` → transition to GAME_OVER |
+| **Next round** | Between rounds | `socket.on('round:next')` → start next round |
+
+### Server-Side Validation (Mandatory)
+
+Never trust the client. Every VIP action must be validated server-side:
+
+```typescript
+const requireVIP = (socket: Socket, room: Room): boolean => {
+  const player = room.getPlayerBySocketId(socket.id);
+  if (!player?.isVIP) {
+    socket.emit('error', { code: 'NOT_VIP', message: 'Only the VIP can do that' });
+    return false;
+  }
+  return true;
+};
+
+// Usage in event handlers
+socket.on('game:start', () => {
+  const room = roomManager.getRoomBySocket(socket.id);
+  if (!room || !requireVIP(socket, room)) return;
+  if (room.players.size < room.settings.minPlayers) {
+    socket.emit('error', { code: 'MIN_PLAYERS', message: 'Not enough players' });
+    return;
+  }
+  room.startGame();
+  io.to(room.code).emit('game:started');
+});
+
+socket.on('player:kick', ({ targetId }: { targetId: string }) => {
+  const room = roomManager.getRoomBySocket(socket.id);
+  if (!room || !requireVIP(socket, room)) return;
+  room.kickPlayer(targetId);
+});
+```
+
+## 4. VIP Transfer
+
+Jackbox does not support VIP transfer. However, OSS games commonly implement it. Allow the current VIP to hand off privileges to another player.
+
+```typescript
+socket.on('vip:transfer', ({ newVipId }: { newVipId: string }) => {
+  const room = roomManager.getRoomBySocket(socket.id);
+  if (!room || !requireVIP(socket, room)) return;
+
+  const newVIP = room.players.get(newVipId);
+  if (!newVIP || !newVIP.isConnected) {
+    socket.emit('error', { code: 'INVALID_TARGET', message: 'Player not found' });
+    return;
+  }
+
+  const oldVIP = room.getVIP();
+  room.idealVipId = newVipId;
+  room.assignVIP();
+
+  io.to(room.code).emit('vip:transferred', {
+    oldVipName: oldVIP?.name,
+    newVipName: newVIP.name,
+  });
+});
+```
+
+### VIP Transfer Event Protocol
+
+| Event | Direction | Payload | Description |
+|-------|-----------|---------|-------------|
+| `vip:transfer` | Client → Server | `{ newVipId: string }` | Current VIP requests transfer |
+| `vip:transferred` | Server → All | `{ oldVipName, newVipName }` | Broadcast new VIP identity |
+| `vip:assigned` | Server → All | `{ playerId, playerName }` | Auto-assignment notification |
+
+## 5. VIP Disconnect Handling
+
+When the VIP disconnects, automatically reassign to the next available player. Use the `assignVIP()` method which falls back gracefully.
+
+```typescript
+const handleDisconnect = (socket: Socket): void => {
+  const room = roomManager.getRoomBySocket(socket.id);
+  if (!room) return;
+
+  const player = room.getPlayerBySocketId(socket.id);
+  if (!player) return;
+
+  player.isConnected = false;
+  room.lastActive = Date.now();
+
+  const wasVIP = player.isVIP;
+
+  // In lobby: remove immediately. In game: keep for reconnection
+  if (room.state === 'LOBBY') {
+    room.removePlayer(player.id);
+  }
+
+  // Reassign VIP if needed
+  if (wasVIP) {
+    room.assignVIP();
+    const newVIP = room.getVIP();
+    if (newVIP) {
+      io.to(room.code).emit('vip:assigned', {
+        playerId: newVIP.id,
+        playerName: newVIP.name,
+      });
+    }
+  }
+
+  io.to(room.code).emit('player:disconnected', { playerId: player.id });
+};
+```
+
+### Reconnection
+
+When a player reconnects with a matching session ID, update their `socketId`, set `isConnected = true`, rejoin the Socket.IO room, then call `assignVIP()`. If this player is the `idealVipId`, they will be restored as VIP automatically. Emit `reconnected` with the full room state and the player's own data.
+
+## 6. Kick and Ban System
+
+VIP can kick (temporary) or ban (IP-based, permanent for session) players.
+
+```typescript
+interface KickResult {
+  success: boolean;
+  reason?: string;
+}
+
+class Room {
+  private bannedIPs: Set<string> = new Set();
+
+  kickPlayer(targetId: string, ban = false): KickResult {
+    const target = this.players.get(targetId);
+    if (!target) return { success: false, reason: 'Player not found' };
+    if (target.isVIP) return { success: false, reason: 'Cannot kick VIP' };
+
+    if (ban && target.socketId) {
+      // Store IP for ban enforcement
+      const ip = this.getPlayerIP(target.socketId);
+      if (ip) this.bannedIPs.add(ip);
+    }
+
+    // Disconnect and remove
+    const targetSocket = io.sockets.sockets.get(target.socketId);
+    if (targetSocket) {
+      targetSocket.emit('kicked', { reason: ban ? 'banned' : 'kicked' });
+      targetSocket.leave(this.code);
+      targetSocket.disconnect(true);
+    }
+
+    this.players.delete(targetId);
+    this.assignVIP(); // In case order changed
+    return { success: true };
+  }
+
+  isIPBanned(ip: string): boolean {
+    return this.bannedIPs.has(ip);
+  }
+}
+```
+
+### Join Validation with Ban Check
+
+```typescript
+socket.on('room:join', ({ code, name }: { code: string; name: string }) => {
+  const room = roomManager.getRoom(code);
+  if (!room) return socket.emit('error', { code: 'ROOM_NOT_FOUND' });
+
+  const ip = socket.handshake.address;
+  if (room.isIPBanned(ip)) {
+    return socket.emit('error', { code: 'BANNED', message: 'You are banned from this room' });
+  }
+
+  // ... normal join logic
+});
+```
+
+## 7. Room Settings
+
+The VIP configures game settings during the lobby phase. Settings are locked once the game starts.
+
+```typescript
+interface RoomSettings {
+  maxPlayers: number;       // 2-16, default 8
+  minPlayers: number;       // 2-8, default 3
+  roundCount: number;       // 1-10, default 3
+  submitDuration: number;   // seconds, default 60
+  voteDuration: number;     // seconds, default 30
+  contentFilter: 'off' | 'moderate' | 'strict';  // default 'moderate'
+  familyFriendly: boolean;  // default false
+  allowAudience: boolean;   // default true
+  promptPack: string;       // pack ID, default 'standard'
+}
+
+const DEFAULT_SETTINGS: RoomSettings = {
+  maxPlayers: 8,
+  minPlayers: 3,
+  roundCount: 3,
+  submitDuration: 60,
+  voteDuration: 30,
+  contentFilter: 'moderate',
+  familyFriendly: false,
+  allowAudience: true,
+  promptPack: 'standard',
+};
+```
+
+### Settings Update Handler
+
+```typescript
+import { z } from 'zod';
+
+const settingsSchema = z.object({
+  maxPlayers: z.number().min(2).max(16).optional(),
+  minPlayers: z.number().min(2).max(8).optional(),
+  roundCount: z.number().min(1).max(10).optional(),
+  submitDuration: z.number().min(15).max(300).optional(),
+  voteDuration: z.number().min(10).max(120).optional(),
+  contentFilter: z.enum(['off', 'moderate', 'strict']).optional(),
+  familyFriendly: z.boolean().optional(),
+  allowAudience: z.boolean().optional(),
+  promptPack: z.string().optional(),
+});
+
+socket.on('settings:update', (data: unknown) => {
+  const room = roomManager.getRoomBySocket(socket.id);
+  if (!room || !requireVIP(socket, room)) return;
+  if (room.state !== 'LOBBY') {
+    return socket.emit('error', { code: 'GAME_IN_PROGRESS' });
+  }
+
+  const parsed = settingsSchema.safeParse(data);
+  if (!parsed.success) {
+    return socket.emit('error', { code: 'INVALID_SETTINGS' });
+  }
+
+  Object.assign(room.settings, parsed.data);
+  io.to(room.code).emit('settings:updated', room.settings);
+});
+```
+
+## 8. Bot Replacement
+
+When a player disconnects mid-game, replace them with a bot to prevent the round from stalling. Pattern adapted from Drawphone.
+
+```typescript
+interface BotPlayer extends Player {
+  isBot: true;
+  originalPlayerId: string;  // ID of the player this bot replaced
+}
+
+const BOT_NAMES = [
+  'RoboWriter', 'AutoVote', 'SillyBot', 'QuipMaster',
+  'DrawBot', 'VoteBot', 'AnswerBot', 'JokeBot',
+];
+
+class Room {
+  replaceWithBot(disconnectedId: string): BotPlayer | null {
+    const player = this.players.get(disconnectedId);
+    if (!player || this.state === 'LOBBY') return null;
+
+    const bot: BotPlayer = {
+      id: `bot-${disconnectedId}`,
+      socketId: '',
+      name: `${player.name} (Bot)`,
+      score: player.score,
+      isVIP: false,  // Bots never become VIP
+      isConnected: true,
+      isBot: true,
+      originalPlayerId: disconnectedId,
+    };
+
+    this.players.delete(disconnectedId);
+    this.players.set(bot.id, bot);
+    return bot;
+  }
+}
+```
+
+When the timer expires, iterate over bot players and auto-submit `'(No answer)'` for any that haven't submitted. This prevents the game from stalling.
+
+## 9. VIP UI Patterns
+
+### Player List with VIP Badge
+
+```tsx
+const PlayerList = ({ players }: { players: Player[] }) => (
+  <ul className="space-y-2">
+    {players.map(player => (
+      <li key={player.id} className="flex items-center gap-3 p-3 bg-white rounded-xl">
+        <span className="text-lg font-bold">{player.name}</span>
+        {player.isVIP && (
+          <span className="bg-yellow-400 text-yellow-900 text-xs font-black px-2 py-0.5 rounded-full uppercase">
+            VIP
+          </span>
+        )}
+        {!player.isConnected && (
+          <span className="text-red-400 text-sm">Disconnected</span>
+        )}
+      </li>
+    ))}
+  </ul>
+);
+```
+
+### VIP Controls on Player Phone
+
+Show a "VIP Controls" panel only to the VIP player. Include a start button and a collapsible kick list using `<details>`. Gate with `if (!isVIP) return null`. Style the panel with a distinct border color (e.g., `border-yellow-300 bg-yellow-50`) so the VIP knows they have special powers.
+
+### Host Screen VIP Indicator
+
+On the TV lobby screen, display who is VIP: `"{vip.name} is the VIP — they'll start the game"`. This tells the room who controls the game flow.
+
+## 10. Checklist
+
+Before shipping VIP functionality:
+
+| Item | Requirement |
+|------|-------------|
+| VIP assignment | First player to join becomes VIP |
+| Server validation | Every VIP action checked server-side |
+| Disconnect handling | VIP auto-reassigns on disconnect |
+| Reconnection | `idealVipId` restored on reconnect |
+| Kick/ban | VIP can remove players; IP ban prevents rejoin |
+| Settings | VIP controls room settings in lobby only |
+| UI badge | VIP clearly marked on player list |
+| Host display | TV shows who is VIP |
+| Bot replacement | Mid-game disconnects replaced with bots |
+| Transfer | Optional: VIP can hand off to another player |

--- a/skills/party-game-dev/skills.json
+++ b/skills/party-game-dev/skills.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/party-game-dev",
   "version": "1.0.0",
-  "description": "Build Jackbox-style multiplayer party games with TypeScript. Covers host-player architecture, Socket.IO networking, game state machines, room/lobby management, voting/scoring, and BDD multiplayer testing. Triggers: party game, jackbox, multiplayer game, game room, socket.io game, game state machine, voting game, drawing game, trivia game, quiplash, host screen, player controller, multiplayer testing, game server",
+  "description": "Build Jackbox-style multiplayer party games with TypeScript. Covers host-player architecture, VIP role (player with elevated control), Socket.IO networking, game state machines, room/lobby management, kick/ban system, content safety and moderation (profanity filtering, family mode, VIP censoring), voting/scoring, and BDD multiplayer testing. Triggers: party game, jackbox, multiplayer game, VIP, game VIP, room owner, kick player, game room, socket.io game, game state machine, voting game, drawing game, trivia game, quiplash, host screen, player controller, content moderation, profanity filter, family friendly, multiplayer testing, game server",
   "permissions": {
     "network": {
       "outbound": []


### PR DESCRIPTION
## Summary

Phase 2 of the party-game-dev skill improvement. Adds the 6 remaining gaps identified by Oracle analysis as new sections in existing reference files + 5 new asset templates.

### New Asset Templates (5)
- **`protocol-envelope.ts`** — Event envelope with dedup, version gating, phase guarding, client sender
- **`audio-unlock-howler.tsx`** — iOS AudioContext unlock + Howler.js preloader React provider
- **`room-timeline.ts`** — Structured room event log for post-game forensics
- **`loadtest-socketio.ts`** — Load test harness with p50/p95/p99 latency reporting
- **`prompt-pack.schema.ts`** — Prompt pack schema, validator, Fisher-Yates shuffle, CLI validator

### New Sections in Existing Reference Files (4)
- **`frontend-patterns.md`** — iOS audio unlock + asset preloading (~91 lines)
- **`deployment-and-ops.md`** — Room forensics + load testing (~68 lines)
- **`game-architecture.md`** — Crowd Play / Twitch stream integration (~54 lines)
- **`game-types-and-mechanics.md`** — Content pipeline with prompt packs (~50 lines)

### New Reference Files (from Phase 1, included in this branch)
- **`vip-and-room-authority.md`** (443 lines)
- **`content-safety-and-moderation.md`** (422 lines)

### Other Changes
- Condensed protocol hardening in `multiplayer-networking.md` (481→439 lines) — full code now lives in asset
- Updated SKILL.md asset index with all 9 asset files, compacted frontmatter (187/200 lines)
- Updated `skills.json` description with VIP and content safety triggers

### All Constraints Met
- SKILL.md: 187/200 lines
- 9/9 reference files, all 356-443 lines (max 450)
- 9 asset files, all cross-referenced
- skills.json: valid JSON