### PR TITLE
feat(rust-discord-bot): add Rust Discord bot skill covering serenity, poise, and twilight

### DIFF
--- a/skills/rust-discord-bot/SKILL.md
+++ b/skills/rust-discord-bot/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: "@tank/rust-discord-bot"
+description: |
+  Build high-performance Discord bots in Rust using serenity, poise, and
+  twilight. Covers framework selection (serenity vs poise vs twilight),
+  project scaffolding (workspace, Cargo.toml, feature flags), slash commands
+  and prefix commands (poise macros, parameters, autocomplete, cooldowns,
+  subcommands), message components (buttons, select menus, modals), embeds,
+  gateway intents and event handling, state management and database
+  integration (sqlx, DashMap, moka caching), voice and audio (Songbird),
+  performance optimization (tokio tuning, sharding, zero-copy, Cargo release
+  profiles), and deployment (Docker, systemd, tracing). Synthesizes
+  serenity-rs v0.12.5 docs, poise v0.6.1 docs, twilight-rs v0.17.1 docs,
+  Discord API reference (2026), and production patterns from Discord-TTS,
+  robbb, Bathbot, and rustbot.
+
+  Trigger phrases: "discord bot rust", "rust discord", "serenity-rs",
+  "serenity bot", "poise discord", "poise command", "twilight discord",
+  "twilight-rs", "discord bot", "rust bot", "slash command rust",
+  "discord gateway", "discord intents", "songbird voice", "discord music bot",
+  "discord interaction rust", "discord embed rust", "discord button rust",
+  "discord modal rust", "discord select menu", "poise framework",
+  "serenity event handler", "discord sharding rust", "discord sqlx",
+  "discord deployment rust", "discord bot docker", "discord bot systemd"
+---
+
+# Rust Discord Bot Development
+
+Build Discord bots in Rust for maximum performance and reliability. The
+ecosystem centers on three libraries: **serenity** (API wrapper), **poise**
+(command framework), and **twilight** (modular low-level). Most bots use
+poise + serenity.
+
+## Core Philosophy
+
+1. **Poise is the default** — Use poise + serenity for all new bots. Only
+   drop to raw serenity for custom interaction flows. Only use twilight for
+   large-scale multi-service architectures.
+2. **Slash commands first** — Prefer slash commands over prefix commands.
+   Prefix commands require the privileged MESSAGE_CONTENT intent.
+3. **Server owns state** — Shared state lives in the `Data` struct, accessed
+   via `ctx.data()`. Use `DashMap` for concurrent collections, `sqlx` for
+   persistence, `moka` for TTL caching.
+4. **Async everything** — Never block the tokio runtime. Use `spawn_blocking`
+   for CPU-heavy work. Use `Semaphore` to bound concurrent tasks.
+5. **Intents are permissions** — Only request gateway intents the bot needs.
+   Privileged intents (GUILD_MEMBERS, MESSAGE_CONTENT, PRESENCES) require
+   Discord verification at 100+ guilds.
+
+## Quick-Start
+
+### "I want to build a Discord bot from scratch"
+
+| Step | Action | Reference |
+|------|--------|-----------|
+| 1 | Choose framework (poise recommended) | `references/framework-selection.md` |
+| 2 | Scaffold project (Cargo.toml, main.rs, .env) | `references/project-setup.md` |
+| 3 | Define commands with `#[poise::command]` | `references/commands-and-interactions.md` |
+| 4 | Configure gateway intents | `references/event-handling.md` |
+| 5 | Add database and shared state | `references/state-and-data.md` |
+| 6 | Optimize for production | `references/performance-and-concurrency.md` |
+| 7 | Deploy with Docker or systemd | `references/deployment-and-ops.md` |
+
+### "I need to add a slash command"
+
+| Step | Action |
+|------|--------|
+| 1 | Write `async fn` with `#[poise::command(slash_command)]` |
+| 2 | Add parameters as typed function arguments |
+| 3 | Register in `commands: vec![my_command()]` |
+| 4 | Commands auto-register on startup via `register_globally` |
+-> See `references/commands-and-interactions.md`
+
+### "I want to add voice/music support"
+
+| Step | Action |
+|------|--------|
+| 1 | Add `songbird` and `symphonia` to Cargo.toml |
+| 2 | Enable `GUILD_VOICE_STATES` intent |
+| 3 | Register Songbird with `.register_songbird()` |
+| 4 | Join channel, play audio with `handler.enqueue_input()` |
+-> See `references/voice-and-audio.md`
+
+### "I need buttons, select menus, or modals"
+
+| Step | Action |
+|------|--------|
+| 1 | Build components with `CreateButton`, `CreateSelectMenu`, or `CreateModal` |
+| 2 | Send with `ctx.send()` including `.components()` |
+| 3 | Await interaction with `.await_component_interaction()` |
+| 4 | Respond within 3 seconds (or defer) |
+-> See `references/commands-and-interactions.md`
+
+## Decision Trees
+
+### Framework Selection
+
+| Signal | Use |
+|--------|-----|
+| New bot, want to ship fast | Poise + Serenity |
+| Custom interaction flows, webhook-only | Raw Serenity |
+| 10,000+ guilds, microservice architecture | Twilight |
+| Voice/music bot | Poise + Serenity + Songbird |
+
+### Database Selection
+
+| Scale | Use |
+|-------|-----|
+| Prototype / small bot (<100 guilds) | SQLite via sqlx |
+| Production / growing bot | PostgreSQL via sqlx |
+| No persistence needed | In-memory only (DashMap) |
+
+### Intent Selection
+
+| Feature | Required Intents |
+|---------|-----------------|
+| Slash commands only | `GatewayIntents::empty()` |
+| Basic guild events | `GatewayIntents::non_privileged()` |
+| Prefix commands | + `MESSAGE_CONTENT` (privileged) |
+| Welcome messages | + `GUILD_MEMBERS` (privileged) |
+| Voice bot | + `GUILD_VOICE_STATES` |
+| Status tracking | + `GUILD_PRESENCES` (privileged) |
+
+## Anti-Patterns
+
+| Don't | Do Instead | Why |
+|-------|-----------|-----|
+| Use standard framework | Use poise | Standard framework deprecated in v0.12.1 |
+| Request `GatewayIntents::all()` | Request only needed intents | Fails verification at 100+ guilds |
+| Block the tokio runtime | Use `spawn_blocking` | Freezes all event processing |
+| Clone strings unnecessarily | Borrow `&str` | Allocations hurt throughput |
+| Use `Arc<RwLock<HashMap>>` | Use `DashMap` | 3-5x faster for concurrent access |
+| Skip error handling in on_error | Handle all FrameworkError variants | Silent failures in production |
+| Register guild commands in prod | Use `register_globally` | Guild commands are for development |
+| Ignore rate limits | Let serenity handle them | Bot gets banned by Discord |
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/framework-selection.md` | Serenity vs Poise vs Twilight decision matrix, Cargo.toml configs, feature flags, crate ecosystem, companion crates |
+| `references/project-setup.md` | Directory structure (simple and workspace), main.rs bootstrapping, command registration, configuration, .env handling |
+| `references/commands-and-interactions.md` | Poise command macros, slash/prefix/context menu commands, parameter types, autocomplete, subcommands, permission checks, embeds, buttons, select menus, modals |
+| `references/event-handling.md` | Gateway intents (standard and privileged), poise event handler, FullEvent variants, raw serenity EventHandler, presence/activity, component interaction handling |
+| `references/state-and-data.md` | Data struct pattern, database integration (sqlx, PostgreSQL, SQLite), migrations, DashMap, moka caching, serenity cache, TypeMap, background tasks |
+| `references/performance-and-concurrency.md` | Tokio runtime tuning, memory optimization, sharding, concurrency patterns (Semaphore, channels, select), Cargo release profiles, SIMD JSON, gateway compression |
+| `references/voice-and-audio.md` | Songbird setup, join/leave voice, audio playback (files, URLs, yt-dlp), queue management, voice events, volume control, voice receive |
+| `references/deployment-and-ops.md` | Docker multi-stage builds, systemd services, structured logging (tracing), error handling strategies, graceful shutdown, cross-compilation, CI/CD, monitoring |

--- a/skills/rust-discord-bot/references/commands-and-interactions.md
+++ b/skills/rust-discord-bot/references/commands-and-interactions.md
@@ -1,0 +1,380 @@
+# Commands and Interactions
+
+Sources: poise v0.6.1 docs, serenity v0.12.5 interaction examples, Discord API reference (2026)
+
+Covers: poise command macros, slash commands, prefix commands, context menus,
+parameter types, autocomplete, cooldowns, permission checks, message components
+(buttons, select menus, modals), embeds.
+
+## Poise Command Definition
+
+Every command is an `async fn` annotated with `#[poise::command(...)]`. The
+function signature defines the command's parameters automatically.
+
+### Basic Command
+
+```rust
+/// Responds with "Pong!" and gateway latency
+#[poise::command(slash_command, prefix_command)]
+async fn ping(ctx: Context<'_>) -> Result<(), Error> {
+    let latency = ctx.ping().await;
+    ctx.say(format!("Pong! Latency: {:.0?}", latency)).await?;
+    Ok(())
+}
+```
+
+The doc comment becomes the command description in Discord's UI.
+
+### Command Attributes
+
+| Attribute | Purpose | Example |
+|-----------|---------|---------|
+| `slash_command` | Enable as slash command | Always include |
+| `prefix_command` | Enable as prefix command | Include if prefix needed |
+| `context_menu_command` | Right-click menu command | `= "User Info"` |
+| `guild_only` | Restrict to servers | Moderation commands |
+| `dm_only` | Restrict to DMs | Private commands |
+| `nsfw_only` | Restrict to NSFW channels | Adult content |
+| `owners_only` | Restrict to bot owners | Admin/debug commands |
+| `required_permissions` | User must have permissions | `= "MANAGE_MESSAGES"` |
+| `required_bot_permissions` | Bot must have permissions | `= "BAN_MEMBERS"` |
+| `track_edits` | Update response on message edit | Prefix commands |
+| `rename` | Override command name | `= "my-command"` |
+| `aliases` | Prefix command aliases | `("b", "prohibit")` |
+| `subcommands` | Nested commands | `("add", "remove", "list")` |
+| `check` | Custom check function | `= "is_moderator"` |
+| `global_cooldown` | Seconds between uses (global) | `= 5` |
+| `user_cooldown` | Seconds between uses per user | `= 10` |
+| `guild_cooldown` | Seconds between uses per guild | `= 3` |
+| `channel_cooldown` | Seconds per channel | `= 2` |
+| `member_cooldown` | Seconds per member | `= 5` |
+| `ephemeral` | Response visible only to invoker | Sensitive data |
+
+## Parameter Types
+
+Poise parses parameters from Rust types. Each parameter becomes a slash command
+option or a prefix command argument.
+
+### Supported Types
+
+| Rust Type | Discord Option | Notes |
+|-----------|---------------|-------|
+| `String` | String | Free text |
+| `i32`, `i64`, `u32`, `u64` | Integer | Min/max supported |
+| `f32`, `f64` | Number | Min/max supported |
+| `bool` | Boolean | True/false toggle |
+| `serenity::User` | User | User picker |
+| `serenity::Member` | User | Guild member (guild_only) |
+| `serenity::Role` | Role | Role picker |
+| `serenity::GuildChannel` | Channel | Channel picker |
+| `serenity::Message` | String | Message link/ID (prefix only) |
+| `serenity::Attachment` | Attachment | File upload |
+| `Option<T>` | (any, optional) | Makes parameter optional |
+| `Vec<T>` | (variadic) | Prefix only, collects remaining |
+
+### Parameter Attributes
+
+```rust
+#[poise::command(slash_command, prefix_command)]
+async fn example(
+    ctx: Context<'_>,
+    #[description = "The target user"]
+    user: serenity::User,
+    #[description = "Amount to give"]
+    #[min = 1]
+    #[max = 1000]
+    amount: i32,
+    #[description = "Reason for action"]
+    #[rest]  // Consumes rest of message (prefix only)
+    reason: Option<String>,
+    #[description = "Target channel"]
+    #[channel_types("Text", "News")]
+    channel: Option<serenity::GuildChannel>,
+) -> Result<(), Error> {
+    // ...
+    Ok(())
+}
+```
+
+### Choice Parameters
+
+```rust
+#[derive(Debug, poise::ChoiceParameter)]
+pub enum TimeUnit {
+    #[name = "Seconds"]
+    Seconds,
+    #[name = "Minutes"]
+    Minutes,
+    #[name = "Hours"]
+    Hours,
+    #[name = "Days"]
+    Days,
+}
+
+#[poise::command(slash_command)]
+async fn remind(
+    ctx: Context<'_>,
+    #[description = "Time amount"] amount: u32,
+    #[description = "Time unit"] unit: TimeUnit,
+    #[description = "Reminder text"] text: String,
+) -> Result<(), Error> {
+    // unit is strongly typed
+    Ok(())
+}
+```
+
+## Autocomplete
+
+Provide dynamic suggestions as the user types.
+
+```rust
+async fn autocomplete_city(
+    _ctx: Context<'_>,
+    partial: &str,
+) -> impl Iterator<Item = String> {
+    let cities = ["New York", "London", "Tokyo", "Paris", "Berlin"];
+    cities.iter()
+        .filter(move |c| c.to_lowercase().contains(&partial.to_lowercase()))
+        .map(|c| c.to_string())
+}
+
+#[poise::command(slash_command)]
+async fn weather(
+    ctx: Context<'_>,
+    #[description = "City name"]
+    #[autocomplete = "autocomplete_city"]
+    city: String,
+) -> Result<(), Error> {
+    ctx.say(format!("Weather in {city}: Sunny")).await?;
+    Ok(())
+}
+```
+
+Autocomplete functions can return `Iterator`, `Stream`, `Vec<String>`,
+or `Vec<serenity::AutocompleteChoice>` for custom display labels.
+
+## Subcommands
+
+```rust
+/// Settings management
+#[poise::command(slash_command, prefix_command, subcommands("get", "set"))]
+async fn settings(ctx: Context<'_>) -> Result<(), Error> {
+    ctx.say("Use `/settings get` or `/settings set`").await?;
+    Ok(())
+}
+
+/// Get a setting value
+#[poise::command(slash_command, prefix_command)]
+async fn get(
+    ctx: Context<'_>,
+    #[description = "Setting key"] key: String,
+) -> Result<(), Error> {
+    // lookup key
+    Ok(())
+}
+
+/// Set a setting value
+#[poise::command(slash_command, prefix_command)]
+async fn set(
+    ctx: Context<'_>,
+    #[description = "Setting key"] key: String,
+    #[description = "New value"] value: String,
+) -> Result<(), Error> {
+    // update key
+    Ok(())
+}
+```
+
+Register only the parent: `commands: vec![settings()]`. Subcommands register
+automatically. Slash commands cannot invoke the parent directly — only
+subcommands. Prefix commands can invoke either.
+
+## Custom Permission Checks
+
+```rust
+async fn is_moderator(ctx: Context<'_>) -> Result<bool, Error> {
+    let guild_id = ctx.guild_id().ok_or("Must be in a guild")?;
+    let member = ctx.author_member().await.ok_or("Not a member")?;
+    let permissions = member.permissions(ctx)?;
+    Ok(permissions.contains(serenity::Permissions::MANAGE_MESSAGES))
+}
+
+#[poise::command(slash_command, check = "is_moderator")]
+async fn purge(
+    ctx: Context<'_>,
+    #[description = "Number of messages"] count: u32,
+) -> Result<(), Error> {
+    // Only runs if is_moderator returns true
+    Ok(())
+}
+```
+
+## Context Menu Commands
+
+```rust
+/// Get info about a user (right-click → Apps → User Info)
+#[poise::command(context_menu_command = "User Info")]
+async fn user_info(
+    ctx: Context<'_>,
+    user: serenity::User,
+) -> Result<(), Error> {
+    let response = format!(
+        "**{}**\nID: {}\nCreated: {}",
+        user.name, user.id, user.created_at()
+    );
+    ctx.say(response).await?;
+    Ok(())
+}
+
+/// Report a message (right-click → Apps → Report)
+#[poise::command(context_menu_command = "Report Message")]
+async fn report_message(
+    ctx: Context<'_>,
+    msg: serenity::Message,
+) -> Result<(), Error> {
+    ctx.say("Message reported to moderators.").await?;
+    Ok(())
+}
+```
+
+## Embeds
+
+```rust
+use serenity::builder::{CreateEmbed, CreateEmbedFooter, CreateEmbedAuthor};
+
+#[poise::command(slash_command)]
+async fn info(ctx: Context<'_>) -> Result<(), Error> {
+    let embed = CreateEmbed::new()
+        .title("Bot Information")
+        .description("A high-performance Discord bot written in Rust")
+        .color(0x5865F2)
+        .field("Language", "Rust", true)
+        .field("Framework", "Poise + Serenity", true)
+        .field("Uptime", format_uptime(ctx.data()), false)
+        .thumbnail(ctx.cache().current_user().face())
+        .footer(CreateEmbedFooter::new("Built with ❤️"))
+        .timestamp(serenity::Timestamp::now());
+
+    ctx.send(poise::CreateReply::default().embed(embed)).await?;
+    Ok(())
+}
+```
+
+**Embed limits**: Title 256 chars, description 4096 chars, 25 fields max,
+field name 256 chars, field value 1024 chars, footer 2048 chars, total 6000
+chars across all fields.
+
+## Message Components
+
+### Buttons
+
+```rust
+use serenity::builder::{CreateButton, CreateMessage, CreateActionRow};
+
+#[poise::command(slash_command)]
+async fn confirm(ctx: Context<'_>) -> Result<(), Error> {
+    let reply = ctx.send(
+        poise::CreateReply::default()
+            .content("Are you sure?")
+            .components(vec![CreateActionRow::Buttons(vec![
+                CreateButton::new("confirm_yes")
+                    .label("Yes")
+                    .style(serenity::ButtonStyle::Success),
+                CreateButton::new("confirm_no")
+                    .label("No")
+                    .style(serenity::ButtonStyle::Danger),
+            ])])
+    ).await?;
+
+    // Wait for button click (60 second timeout)
+    let interaction = reply.message().await?
+        .await_component_interaction(ctx.serenity_context().shard.clone())
+        .timeout(std::time::Duration::from_secs(60))
+        .await;
+
+    if let Some(interaction) = interaction {
+        let choice = &interaction.data.custom_id;
+        interaction.create_response(
+            ctx,
+            serenity::CreateInteractionResponse::UpdateMessage(
+                serenity::CreateInteractionResponseMessage::new()
+                    .content(format!("You chose: {choice}"))
+                    .components(vec![])  // Remove buttons
+            ),
+        ).await?;
+    }
+    Ok(())
+}
+```
+
+### Select Menus
+
+```rust
+use serenity::builder::{CreateSelectMenu, CreateSelectMenuKind, CreateSelectMenuOption};
+
+let menu = CreateSelectMenu::new(
+    "role_select",
+    CreateSelectMenuKind::String {
+        options: vec![
+            CreateSelectMenuOption::new("Rust", "rust").emoji('🦀'),
+            CreateSelectMenuOption::new("Python", "python").emoji('🐍'),
+            CreateSelectMenuOption::new("Go", "go").emoji('🐹'),
+        ],
+    },
+).placeholder("Pick your language");
+```
+
+### Modals
+
+```rust
+use serenity::builder::{CreateModal, CreateInputText, CreateActionRow};
+
+#[poise::command(slash_command)]
+async fn feedback(ctx: poise::ApplicationContext<'_, Data, Error>) -> Result<(), Error> {
+    let modal = CreateModal::new("feedback_modal", "Send Feedback")
+        .components(vec![
+            CreateActionRow::InputText(
+                CreateInputText::new(
+                    serenity::InputTextStyle::Short,
+                    "Subject",
+                    "feedback_subject",
+                ).placeholder("Brief subject")
+            ),
+            CreateActionRow::InputText(
+                CreateInputText::new(
+                    serenity::InputTextStyle::Paragraph,
+                    "Details",
+                    "feedback_details",
+                ).placeholder("Describe your feedback...")
+                 .required(true)
+            ),
+        ]);
+
+    ctx.interaction.create_response(
+        ctx,
+        serenity::CreateInteractionResponse::Modal(modal),
+    ).await?;
+
+    // Handle modal submit in event_handler via FullEvent::InteractionCreate
+    Ok(())
+}
+```
+
+Modals can only be shown from application command or component interactions.
+Handle the modal submission in the `event_handler`, matching on
+`FullEvent::InteractionCreate` with `InteractionType::Modal`.
+
+## Help Command
+
+Poise provides built-in help commands:
+
+```rust
+commands: vec![
+    poise::builtins::help(),        // Simple text-based help
+    poise::builtins::pretty_help(), // Embed-based help
+    // ... your commands
+]
+```
+
+The help commands automatically use doc comments and parameter descriptions
+from your command definitions. No manual help text needed.

--- a/skills/rust-discord-bot/references/deployment-and-ops.md
+++ b/skills/rust-discord-bot/references/deployment-and-ops.md
@@ -1,0 +1,438 @@
+# Deployment and Operations
+
+Sources: production bot deployment patterns (2026), Docker best practices, systemd docs, tracing crate docs
+
+Covers: Docker multi-stage builds, systemd services, structured logging with
+tracing, error handling strategies, CI/CD, graceful shutdown, monitoring.
+
+## Docker Deployment
+
+### Multi-Stage Build (Recommended)
+
+```dockerfile
+# Stage 1: Build
+FROM rust:1.84-slim AS builder
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    pkg-config libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Cache dependencies
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo "fn main() {}" > src/main.rs
+RUN cargo build --release
+RUN rm -rf src
+
+# Build application
+COPY . .
+RUN cargo build --release
+
+# Stage 2: Runtime
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y \
+    ca-certificates libssl3 yt-dlp \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/my-bot /usr/local/bin/
+
+# Non-root user
+RUN useradd -m -u 1000 botuser
+USER botuser
+
+ENV RUST_LOG=my_bot=info,serenity=warn
+CMD ["my-bot"]
+```
+
+### Minimal Alpine Build (Smaller Image)
+
+```dockerfile
+FROM rust:1.84-alpine AS builder
+RUN apk add --no-cache musl-dev openssl-dev pkgconfig
+WORKDIR /app
+COPY . .
+RUN cargo build --release --target x86_64-unknown-linux-musl
+
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/my-bot /usr/local/bin/
+RUN adduser -D -u 1000 botuser
+USER botuser
+CMD ["my-bot"]
+```
+
+### Docker Compose
+
+```yaml
+version: "3.8"
+services:
+  bot:
+    build: .
+    restart: unless-stopped
+    environment:
+      - DISCORD_TOKEN=${DISCORD_TOKEN}
+      - DATABASE_URL=postgresql://bot:password@db:5432/botdb
+      - RUST_LOG=my_bot=info,serenity=warn
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: bot
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: botdb
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U bot"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:
+```
+
+## systemd Service
+
+### Service File
+
+```ini
+# /etc/systemd/system/discord-bot.service
+[Unit]
+Description=Discord Bot
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=botuser
+Group=botuser
+WorkingDirectory=/opt/discord-bot
+EnvironmentFile=/opt/discord-bot/.env
+ExecStart=/opt/discord-bot/my-bot
+Restart=always
+RestartSec=10
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=discord-bot
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/opt/discord-bot/data
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Management Commands
+
+```bash
+sudo systemctl enable discord-bot    # Enable on boot
+sudo systemctl start discord-bot     # Start
+sudo systemctl stop discord-bot      # Stop
+sudo systemctl restart discord-bot   # Restart
+sudo systemctl status discord-bot    # Status
+journalctl -u discord-bot -f         # Live logs
+journalctl -u discord-bot --since "1 hour ago"  # Recent logs
+```
+
+## Structured Logging with tracing
+
+### Basic Setup
+
+```rust
+use tracing_subscriber::{fmt, EnvFilter};
+
+fn init_tracing() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::from_default_env()
+                .add_directive("my_bot=debug".parse().unwrap())
+                .add_directive("serenity=info".parse().unwrap())
+                .add_directive("sqlx=warn".parse().unwrap())
+                .add_directive("h2=warn".parse().unwrap())
+        )
+        .with_target(true)
+        .with_thread_ids(false)
+        .init();
+}
+```
+
+### JSON Logging (Production)
+
+```rust
+fn init_json_logging() {
+    tracing_subscriber::fmt()
+        .json()
+        .with_current_span(true)
+        .with_target(true)
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+}
+```
+
+### Structured Fields in Commands
+
+```rust
+use tracing::{info, warn, error, instrument};
+
+#[instrument(skip(ctx), fields(
+    user_id = %ctx.author().id,
+    guild_id = ?ctx.guild_id(),
+    command = "ban"
+))]
+async fn ban_command(ctx: Context<'_>, user: serenity::User, reason: String) -> Result<(), Error> {
+    info!(target_user = %user.id, %reason, "Executing ban");
+
+    match execute_ban(ctx, &user, &reason).await {
+        Ok(_) => {
+            info!("Ban successful");
+            ctx.say(format!("Banned {} for: {}", user.name, reason)).await?;
+        }
+        Err(e) => {
+            error!(error = %e, "Ban failed");
+            ctx.say("Failed to ban user.").await?;
+        }
+    }
+
+    Ok(())
+}
+```
+
+### Log Level Guidelines
+
+| Level | Use For | Example |
+|-------|---------|---------|
+| `error!` | Failures that need attention | Database down, API errors |
+| `warn!` | Recoverable issues | Rate limited, missing permissions |
+| `info!` | Normal operations | Command executed, bot started |
+| `debug!` | Development details | Cache hit/miss, query params |
+| `trace!` | Verbose internals | Event payload, raw data |
+
+## Error Handling Strategies
+
+### Poise Error Handler
+
+```rust
+async fn on_error(error: poise::FrameworkError<'_, Data, Error>) -> Result<(), Error> {
+    match error {
+        poise::FrameworkError::Command { error, ctx, .. } => {
+            tracing::error!("Command error: {:?}", error);
+            let _ = ctx.say("An error occurred. Please try again.").await;
+        }
+        poise::FrameworkError::ArgumentParse { error, ctx, .. } => {
+            let _ = ctx.say(format!("Invalid argument: {error}")).await;
+        }
+        poise::FrameworkError::CommandCheckFailed { error, ctx, .. } => {
+            if let Some(error) = error {
+                let _ = ctx.say(format!("Check failed: {error}")).await;
+            }
+        }
+        poise::FrameworkError::CooldownHit { remaining_cooldown, ctx, .. } => {
+            let _ = ctx.say(format!(
+                "Please wait {:.1} seconds before using this command again.",
+                remaining_cooldown.as_secs_f32()
+            )).await;
+        }
+        poise::FrameworkError::MissingBotPermissions { missing_permissions, ctx, .. } => {
+            let _ = ctx.say(format!(
+                "I need these permissions: {}",
+                missing_permissions
+            )).await;
+        }
+        poise::FrameworkError::MissingUserPermissions { missing_permissions, ctx, .. } => {
+            if let Some(perms) = missing_permissions {
+                let _ = ctx.say(format!("You need: {perms}")).await;
+            }
+        }
+        other => {
+            if let Err(e) = poise::builtins::on_error(other).await {
+                tracing::error!("Fallback error handler failed: {:?}", e);
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+### Custom Error Types
+
+```rust
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum BotError {
+    #[error("Discord API error: {0}")]
+    Serenity(#[from] serenity::Error),
+
+    #[error("Database error: {0}")]
+    Database(#[from] sqlx::Error),
+
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("User {0} not found")]
+    UserNotFound(String),
+
+    #[error("Insufficient permissions")]
+    InsufficientPermissions,
+
+    #[error("Rate limited, retry after {0} seconds")]
+    RateLimited(u64),
+}
+```
+
+## Graceful Shutdown
+
+```rust
+// In main, after client is built:
+let shard_manager = client.shard_manager.clone();
+let pool = data.pool.clone();
+
+tokio::spawn(async move {
+    tokio::signal::ctrl_c().await.unwrap();
+    tracing::info!("Received shutdown signal");
+
+    // Stop accepting new gateway events
+    shard_manager.shutdown_all().await;
+
+    // Close database connections
+    pool.close().await;
+
+    tracing::info!("Shutdown complete");
+});
+
+client.start().await?;
+```
+
+## Cross-Compilation
+
+Build for Linux from macOS or Windows:
+
+```bash
+# Install target
+rustup target add x86_64-unknown-linux-musl
+
+# Build static binary
+cargo build --release --target x86_64-unknown-linux-musl
+
+# Using cross (handles toolchain setup)
+cargo install cross
+cross build --release --target x86_64-unknown-linux-gnu
+```
+
+## CI/CD (GitHub Actions)
+
+```yaml
+name: Build and Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Test
+        run: cargo test
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: discord-bot
+          path: target/release/my-bot
+```
+
+## Health Monitoring
+
+### Uptime Tracking
+
+```rust
+pub struct Data {
+    pub start_time: std::time::Instant,
+    pub commands_executed: std::sync::atomic::AtomicU64,
+    pub errors_count: std::sync::atomic::AtomicU64,
+}
+
+#[poise::command(slash_command)]
+async fn status(ctx: Context<'_>) -> Result<(), Error> {
+    let data = ctx.data();
+    let uptime = data.start_time.elapsed();
+    let commands = data.commands_executed.load(Ordering::Relaxed);
+    let errors = data.errors_count.load(Ordering::Relaxed);
+
+    let embed = serenity::CreateEmbed::new()
+        .title("Bot Status")
+        .field("Uptime", format_duration(uptime), true)
+        .field("Commands", commands.to_string(), true)
+        .field("Errors", errors.to_string(), true)
+        .field("Guilds", ctx.cache().guilds().len().to_string(), true)
+        .color(0x57F287);
+
+    ctx.send(poise::CreateReply::default().embed(embed)).await?;
+    Ok(())
+}
+```
+
+### Shard Health
+
+```rust
+#[poise::command(slash_command, owners_only)]
+async fn shards(ctx: Context<'_>) -> Result<(), Error> {
+    let manager = ctx.framework().shard_manager();
+    let runners = manager.runners.lock().await;
+
+    let mut status = String::new();
+    for (id, runner) in runners.iter() {
+        status.push_str(&format!(
+            "Shard {}: {:?} (latency: {:?})\n",
+            id, runner.stage, runner.latency
+        ));
+    }
+
+    ctx.say(format!("```\n{status}```")).await?;
+    Ok(())
+}
+```
+
+## Environment Variable Checklist
+
+| Variable | Required | Example |
+|----------|----------|---------|
+| `DISCORD_TOKEN` | Yes | `Bot MTk...` |
+| `DATABASE_URL` | If using DB | `postgresql://user:pass@host/db` |
+| `RUST_LOG` | Recommended | `my_bot=info,serenity=warn` |
+| `GUILD_ID` | Dev only | `123456789` (for guild command registration) |
+
+## Production Checklist
+
+- [ ] Use `non_privileged()` intents, add only what is needed
+- [ ] Register commands globally (not per-guild) for production
+- [ ] Enable structured logging (JSON for production)
+- [ ] Implement graceful shutdown (SIGTERM handling)
+- [ ] Set up database migrations
+- [ ] Configure rate limiting for custom features
+- [ ] Set Cargo release profile optimizations
+- [ ] Run as non-root user (Docker/systemd)
+- [ ] Monitor shard health
+- [ ] Handle all poise error variants
+- [ ] Strip debug symbols in release builds
+- [ ] Set up CI/CD pipeline

--- a/skills/rust-discord-bot/references/event-handling.md
+++ b/skills/rust-discord-bot/references/event-handling.md
@@ -1,0 +1,298 @@
+# Event Handling and Gateway Intents
+
+Sources: serenity-rs v0.12.5 gateway docs, Discord API gateway reference (2026), production bot patterns
+
+Covers: gateway intents configuration, privileged intents, event handler patterns,
+FullEvent variants, message processing, reaction handling, member events.
+
+## Gateway Intents
+
+Intents control which events the bot receives from Discord's gateway. Configure
+them at client creation — events not covered by selected intents are silently
+dropped.
+
+### Intent Configuration
+
+```rust
+use serenity::model::gateway::GatewayIntents;
+
+// Minimal (slash commands only — no message content needed)
+let intents = GatewayIntents::empty();
+
+// Standard non-privileged (recommended starting point)
+let intents = GatewayIntents::non_privileged();
+
+// With message content (prefix commands — requires privileged intent)
+let intents = GatewayIntents::non_privileged()
+    | GatewayIntents::MESSAGE_CONTENT;
+
+// Voice bot
+let intents = GatewayIntents::non_privileged()
+    | GatewayIntents::GUILD_VOICE_STATES;
+
+// Moderation bot (member tracking)
+let intents = GatewayIntents::non_privileged()
+    | GatewayIntents::GUILD_MEMBERS;
+```
+
+### Intent Reference
+
+| Intent | Privileged? | Events Enabled |
+|--------|------------|----------------|
+| `GUILDS` | No | Guild create/update/delete, channel/role changes |
+| `GUILD_MEMBERS` | **Yes** | Member add/remove/update |
+| `GUILD_MODERATION` | No | Ban add/remove, audit log |
+| `GUILD_EMOJIS_AND_STICKERS` | No | Emoji/sticker updates |
+| `GUILD_INTEGRATIONS` | No | Integration updates |
+| `GUILD_WEBHOOKS` | No | Webhook updates |
+| `GUILD_INVITES` | No | Invite create/delete |
+| `GUILD_VOICE_STATES` | No | Voice state updates (required for Songbird) |
+| `GUILD_PRESENCES` | **Yes** | Online/offline/activity status |
+| `GUILD_MESSAGES` | No | Message create/update/delete in guilds |
+| `GUILD_MESSAGE_REACTIONS` | No | Reaction add/remove in guilds |
+| `GUILD_MESSAGE_TYPING` | No | Typing indicators |
+| `DIRECT_MESSAGES` | No | DM message events |
+| `DIRECT_MESSAGE_REACTIONS` | No | DM reaction events |
+| `MESSAGE_CONTENT` | **Yes** | Access to message content, embeds, attachments |
+| `GUILD_SCHEDULED_EVENTS` | No | Scheduled event CRUD |
+| `AUTO_MODERATION_CONFIG` | No | AutoMod rule changes |
+| `AUTO_MODERATION_EXECUTION` | No | AutoMod actions taken |
+| `GUILD_MESSAGE_POLLS` | No | Poll create/vote events |
+
+### Privileged Intents
+
+Three intents require explicit enablement in the Discord Developer Portal:
+
+1. **GUILD_MEMBERS** — Member join/leave/update events. Needed for welcome
+   messages, member tracking, role management.
+2. **GUILD_PRESENCES** — User online status and activity. Rarely needed.
+3. **MESSAGE_CONTENT** — Access to message text. Required for prefix commands.
+   Without it, `msg.content` is empty for bot messages in guilds.
+
+**Verification requirement**: Bots in 100+ guilds must be verified by Discord
+to use privileged intents. Justification required for each intent.
+
+**Recommendation**: Use slash commands to avoid MESSAGE_CONTENT. Only request
+GUILD_MEMBERS if the bot needs member event tracking.
+
+## Poise Event Handler
+
+Poise provides a single event handler function that receives all gateway events
+not handled by the command framework.
+
+### Setup
+
+```rust
+let framework = poise::Framework::builder()
+    .options(poise::FrameworkOptions {
+        commands: vec![/* ... */],
+        event_handler: |ctx, event, framework, data| {
+            Box::pin(event_handler(ctx, event, framework, data))
+        },
+        ..Default::default()
+    })
+    // ...
+```
+
+### Event Handler Function
+
+```rust
+async fn event_handler(
+    ctx: &serenity::Context,
+    event: &serenity::FullEvent,
+    _framework: poise::FrameworkContext<'_, Data, Error>,
+    data: &Data,
+) -> Result<(), Error> {
+    match event {
+        serenity::FullEvent::Ready { data_about_bot } => {
+            tracing::info!("Connected as {}", data_about_bot.user.name);
+        }
+
+        serenity::FullEvent::Message { new_message } => {
+            // Non-command message processing
+            if new_message.author.bot {
+                return Ok(());  // Ignore bot messages
+            }
+            handle_message(ctx, new_message, data).await?;
+        }
+
+        serenity::FullEvent::GuildMemberAddition { new_member } => {
+            send_welcome(ctx, new_member, data).await?;
+        }
+
+        serenity::FullEvent::GuildMemberRemoval { guild_id, user, .. } => {
+            log_member_leave(ctx, *guild_id, user, data).await?;
+        }
+
+        serenity::FullEvent::ReactionAdd { add_reaction } => {
+            handle_reaction(ctx, add_reaction, data).await?;
+        }
+
+        serenity::FullEvent::InteractionCreate { interaction } => {
+            // Handle modal submissions and non-command interactions
+            if let serenity::Interaction::Modal(modal) = interaction {
+                handle_modal_submit(ctx, modal, data).await?;
+            }
+        }
+
+        serenity::FullEvent::VoiceStateUpdate { old, new } => {
+            handle_voice_update(ctx, old.as_ref(), new, data).await?;
+        }
+
+        _ => {}  // Ignore unhandled events
+    }
+    Ok(())
+}
+```
+
+### Common FullEvent Variants
+
+| Event | Trigger | Common Use |
+|-------|---------|------------|
+| `Ready` | Bot connected | Log startup, set activity |
+| `Resume` | Reconnected after disconnect | Log reconnection |
+| `Message` | Message created | Auto-moderation, keyword tracking |
+| `MessageUpdate` | Message edited | Edit logging |
+| `MessageDelete` | Message deleted | Delete logging |
+| `ReactionAdd` | Reaction added | Reaction roles, polls |
+| `ReactionRemove` | Reaction removed | Undo reaction roles |
+| `GuildMemberAddition` | Member joined | Welcome messages, auto-roles |
+| `GuildMemberRemoval` | Member left/kicked | Leave logging |
+| `GuildMemberUpdate` | Role/nick changed | Role tracking |
+| `GuildCreate` | Bot joins guild | Setup, logging |
+| `GuildDelete` | Bot leaves guild | Cleanup |
+| `InteractionCreate` | Any interaction | Modal submits, custom components |
+| `VoiceStateUpdate` | Voice state changed | Voice tracking, auto-disconnect |
+| `PresenceUpdate` | Status changed | Activity tracking (privileged) |
+| `ChannelCreate/Update/Delete` | Channel modified | Channel logging |
+| `GuildBanAddition/Removal` | Ban added/removed | Moderation logging |
+
+## Raw Serenity Event Handler
+
+Without poise, implement the `EventHandler` trait directly:
+
+```rust
+struct Handler;
+
+#[serenity::async_trait]
+impl serenity::EventHandler for Handler {
+    async fn message(&self, ctx: serenity::Context, msg: serenity::Message) {
+        if msg.content == "!ping" {
+            if let Err(e) = msg.channel_id.say(&ctx.http, "Pong!").await {
+                tracing::error!("Failed to send message: {:?}", e);
+            }
+        }
+    }
+
+    async fn ready(&self, _ctx: serenity::Context, ready: serenity::Ready) {
+        tracing::info!("{} is connected!", ready.user.name);
+    }
+
+    async fn interaction_create(
+        &self,
+        ctx: serenity::Context,
+        interaction: serenity::Interaction,
+    ) {
+        if let serenity::Interaction::Command(command) = interaction {
+            let content = match command.data.name.as_str() {
+                "ping" => "Pong!".to_string(),
+                _ => "Unknown command".to_string(),
+            };
+
+            let data = serenity::CreateInteractionResponseMessage::new()
+                .content(content);
+            let builder = serenity::CreateInteractionResponse::Message(data);
+            if let Err(e) = command.create_response(&ctx.http, builder).await {
+                tracing::error!("Interaction response failed: {:?}", e);
+            }
+        }
+    }
+}
+
+// Usage
+let client = serenity::ClientBuilder::new(token, intents)
+    .event_handler(Handler)
+    .await?;
+```
+
+## Setting Bot Activity/Presence
+
+```rust
+serenity::FullEvent::Ready { data_about_bot } => {
+    let activity = serenity::ActivityData::watching("for /help");
+    ctx.set_activity(Some(activity));
+
+    // Other activity types:
+    // ActivityData::playing("with Rust")
+    // ActivityData::listening("music")
+    // ActivityData::competing("a tournament")
+    // ActivityData::custom("Custom status text")
+}
+```
+
+## Handling Component Interactions in Events
+
+When components (buttons, selects) are used outside poise commands — for
+example in welcome messages or persistent menus — handle them in the
+event handler:
+
+```rust
+serenity::FullEvent::InteractionCreate { interaction } => {
+    if let serenity::Interaction::Component(component) = interaction {
+        match component.data.custom_id.as_str() {
+            "role_select" => {
+                // Handle role selection
+                let values = match &component.data.kind {
+                    serenity::ComponentInteractionDataKind::StringSelect { values } => values,
+                    _ => return Ok(()),
+                };
+                // Process selected values
+                component.create_response(
+                    ctx,
+                    serenity::CreateInteractionResponse::Message(
+                        serenity::CreateInteractionResponseMessage::new()
+                            .content("Roles updated!")
+                            .ephemeral(true)
+                    ),
+                ).await?;
+            }
+            "verify_button" => {
+                // Handle verification button
+            }
+            _ => {}
+        }
+    }
+}
+```
+
+## Interaction Response Types
+
+When responding to any interaction (command, component, modal):
+
+| Response Type | When to Use |
+|--------------|-------------|
+| `Message` | Send a new message |
+| `DeferredMessage` | Need >3 seconds to respond, edit later |
+| `UpdateMessage` | Edit the message the component was on |
+| `DeferredUpdateMessage` | Defer component update, edit later |
+| `Modal` | Show a modal form (cannot respond to modal with modal) |
+
+**Critical**: Respond within 3 seconds or the interaction fails. Use
+`DeferredMessage` for long operations, then follow up with
+`interaction.edit_response()`.
+
+```rust
+// Defer for long operations
+command.create_response(
+    ctx,
+    serenity::CreateInteractionResponse::Defer(
+        serenity::CreateInteractionResponseMessage::new()
+    ),
+).await?;
+
+// Later, edit the deferred response
+command.edit_response(
+    ctx,
+    serenity::EditInteractionResponse::new().content("Done!")
+).await?;
+```

--- a/skills/rust-discord-bot/references/framework-selection.md
+++ b/skills/rust-discord-bot/references/framework-selection.md
@@ -1,0 +1,252 @@
+# Framework Selection
+
+Sources: serenity-rs v0.12.5 docs, poise v0.6.1 docs, twilight-rs v0.17.1 docs, production bot analysis (2026)
+
+Covers: choosing between serenity, poise, and twilight; Cargo.toml configuration;
+feature flags; crate ecosystem; migration paths.
+
+## The Three Frameworks
+
+Rust has three major Discord library ecosystems. They are not interchangeable —
+each serves a different audience and architecture style.
+
+### Serenity (Low-Level Foundation)
+
+Full-featured Discord API wrapper. Provides event handlers, caching, HTTP
+client, and gateway management. Most bots build on serenity indirectly
+through poise.
+
+- **Version**: v0.12.5 (December 2025, last planned 0.12.x release)
+- **GitHub**: serenity-rs/serenity (5.4k stars)
+- **Runtime**: tokio multi-thread
+- **TLS**: rustls (default) or native-tls
+
+Use raw serenity only when poise's abstractions get in the way — custom
+interaction flows, webhook-only bots, or non-command-driven architectures.
+
+### Poise (Command Framework on Serenity)
+
+Opinionated command framework built on serenity. Recommended for all new bots.
+
+- **Version**: v0.6.1 (January 2024)
+- **Requires**: serenity 0.12.5
+- **MSRV**: Rust 1.74.0
+
+Key features over raw serenity:
+- Single function defines both slash and prefix commands
+- Automatic argument parsing from Rust types
+- Edit tracking (bot response updates when user edits message)
+- Built-in help generation, cooldowns, permission checks
+- Centralized error handling
+
+### Twilight (Modular Low-Level)
+
+Modular crate ecosystem for experienced Rust developers who need fine-grained
+control. Each component (gateway, HTTP, cache, models) is a separate crate.
+
+- **Version**: v0.17.1 (December 2025)
+- **GitHub**: twilight-rs/twilight (813 stars)
+- **MSRV**: Rust 1.89
+
+Use twilight for:
+- Multi-service architectures (gateway clusters, HTTP proxies)
+- Bots serving thousands of guilds with custom infrastructure
+- Interaction-only bots (no gateway needed via webhook mode)
+- When you need to cache only specific resource types
+
+## Decision Matrix
+
+| Factor | Poise + Serenity | Raw Serenity | Twilight |
+|--------|------------------|--------------|----------|
+| Learning curve | Low | Medium | High |
+| Time to first bot | Minutes | Hours | Days |
+| Command framework | Built-in | Manual dispatch | Build your own |
+| Architectural freedom | Medium | High | Maximum |
+| Memory footprint | Medium | Medium | Low (configurable) |
+| Bundle size | ~15-25 MB | ~15-25 MB | ~10-20 MB |
+| Sharding complexity | Handled | Handled | Manual (flexible) |
+| Multi-process deploy | Possible | Possible | Designed for it |
+| Community/examples | Large | Large | Small |
+| Production bots | ~80% of Rust bots | ~5% | ~15% |
+| Best for | Most bots | Custom interaction flows | Large-scale infra |
+
+### Quick Decision
+
+```
+Do you need custom gateway/HTTP infrastructure?
+  YES → Twilight
+  NO →
+    Do you want command framework with slash + prefix support?
+      YES → Poise + Serenity (recommended default)
+      NO → Raw Serenity
+```
+
+## Cargo.toml Configuration
+
+### Poise + Serenity (Recommended)
+
+```toml
+[dependencies]
+poise = "0.6"
+serenity = { version = "0.12", features = [
+    "builder",
+    "cache",
+    "client",
+    "collector",
+    "framework",
+    "gateway",
+    "http",
+    "model",
+    "utils",
+    "rustls_backend",
+] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
+```
+
+### Minimal Serenity (No Poise)
+
+```toml
+[dependencies]
+serenity = { version = "0.12", default-features = false, features = [
+    "client",
+    "gateway",
+    "model",
+    "http",
+    "rustls_backend",
+] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+```
+
+### Twilight
+
+```toml
+[dependencies]
+twilight-gateway = { version = "0.16", features = ["rustls-webpki-roots", "zstd"] }
+twilight-http = { version = "0.16", features = ["rustls-webpki-roots"] }
+twilight-model = "0.16"
+twilight-cache-inmemory = "0.16"
+twilight-standby = "0.16"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
+```
+
+## Serenity Feature Flags
+
+| Feature | Purpose | Default? |
+|---------|---------|----------|
+| `builder` | Builder structs for HTTP requests | Yes |
+| `cache` | In-memory event-driven cache | Yes |
+| `client` | High-level client wrapper | Yes |
+| `collector` | Await interactions without event handlers | No |
+| `framework` | Framework trait (needed for poise) | Yes |
+| `gateway` | WebSocket gateway connection | Yes |
+| `http` | REST API client | Yes |
+| `model` | Discord model types with helper methods | Yes |
+| `utils` | Utility functions | Yes |
+| `voice` | Voice state tracking (for Songbird) | No |
+| `temp_cache` | TTL-based temporary message cache (mini-moka) | No |
+| `simd_json` | SIMD-accelerated JSON parsing | No |
+| `rustls_backend` | Rustls TLS (default, recommended) | Yes |
+| `native_tls_backend` | Native TLS (mutually exclusive with rustls) | No |
+| `unstable_discord_api` | Unstable Discord API features | No |
+
+### Recommended Feature Sets
+
+**Standard bot**:
+```toml
+features = ["builder", "cache", "client", "collector", "framework",
+            "gateway", "http", "model", "utils", "rustls_backend"]
+```
+
+**Voice bot** (add to standard):
+```toml
+features = ["voice"]  # Plus songbird dependency
+```
+
+**Minimal memory**:
+```toml
+default-features = false
+features = ["client", "gateway", "model", "http", "rustls_backend"]
+```
+
+**High throughput**:
+```toml
+features = ["simd_json", "temp_cache"]  # Add to standard set
+```
+
+## Twilight Crate Ecosystem
+
+| Crate | Purpose | When to Include |
+|-------|---------|-----------------|
+| `twilight-model` | Discord data structures | Always |
+| `twilight-gateway` | WebSocket gateway | Event-driven bots |
+| `twilight-http` | REST API client | Always |
+| `twilight-cache-inmemory` | In-process cache | When caching needed |
+| `twilight-standby` | Wait for specific events | Reaction menus, confirmations |
+| `twilight-gateway-queue` | Shard identify ratelimiting | Multi-process sharding |
+| `twilight-http-ratelimiting` | HTTP ratelimit tracking | API proxies |
+| `twilight-validate` | Request validation | Custom request building |
+| `twilight-util` | Utilities and builders | Message/embed building |
+
+## Common Companion Crates
+
+These crates appear in 90%+ of production Rust Discord bots regardless of
+framework choice:
+
+```toml
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Error handling (pick one combo)
+anyhow = "1"           # Application errors (simple)
+thiserror = "2"        # Library error types (typed)
+
+# Logging
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# HTTP client (external APIs)
+reqwest = { version = "0.12", features = ["rustls-tls", "json"] }
+
+# Database (pick one)
+sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls", "macros"] }
+# OR for SQLite:
+sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio-rustls", "macros"] }
+
+# Concurrency
+dashmap = "6"          # Lock-free concurrent HashMap
+parking_lot = "0.12"   # Faster Mutex/RwLock than std
+
+# Caching
+mini-moka = "0.10"     # TTL-based in-memory cache
+
+# Configuration
+toml = "0.8"           # Config file parsing
+dotenvy = "0.15"       # .env file loading
+```
+
+## Migration Notes
+
+### Standard Framework → Poise
+
+Serenity's built-in standard framework was deprecated in v0.12.1. Migrate
+prefix commands to poise. Poise commands can serve both slash and prefix
+simultaneously with `#[poise::command(slash_command, prefix_command)]`.
+
+### Serenity v0.12 → v0.13
+
+v0.13 is in development on the `next` branch. Expect breaking changes to
+builder APIs and interaction handling. Pin to `0.12` for stability.
+
+### Discriminators Removed
+
+Discord removed discriminators (the `#1234` suffix). Use `User::global_name`
+or `User::display_name` instead of `User::tag()`. The `Member::distinct`
+method is deprecated.
+
+### Gateway Intents Changes
+
+Discord enforces privileged intents for `MESSAGE_CONTENT`, `GUILD_MEMBERS`,
+and `GUILD_PRESENCES`. Enable these in the Developer Portal first, then in
+code. Without `MESSAGE_CONTENT`, prefix commands cannot read message text —
+this is why slash commands are the recommended default.

--- a/skills/rust-discord-bot/references/performance-and-concurrency.md
+++ b/skills/rust-discord-bot/references/performance-and-concurrency.md
@@ -1,0 +1,390 @@
+# Performance and Concurrency
+
+Sources: tokio runtime docs, serenity sharding, Rust Performance Book, production bot benchmarks (2026)
+
+Covers: tokio runtime tuning, memory optimization, sharding, concurrency
+patterns, rate limiting, Cargo release profiles, binary size optimization.
+
+## Tokio Runtime Configuration
+
+### Default (Recommended for Most Bots)
+
+```rust
+#[tokio::main]
+async fn main() {
+    // Uses multi-thread runtime with num_cpus worker threads
+}
+```
+
+### Explicit Configuration
+
+```rust
+#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+async fn main() {
+    // 4 worker threads — good for most Discord bots
+}
+```
+
+### Custom Runtime (Advanced)
+
+```rust
+fn main() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .thread_name("discord-worker")
+        .thread_stack_size(3 * 1024 * 1024)  // 3 MB stack
+        .enable_all()
+        .build()
+        .unwrap();
+
+    runtime.block_on(async {
+        // bot startup...
+    });
+}
+```
+
+### Worker Thread Guidelines
+
+| Bot Size | Guilds | Workers | Rationale |
+|----------|--------|---------|-----------|
+| Small | <100 | 2 | I/O-bound, minimal CPU |
+| Medium | 100-2,500 | 4 | Default is fine |
+| Large | 2,500-10,000 | 4-8 | More shards need more threads |
+| Very large | 10,000+ | 8-16 | Consider multi-process instead |
+
+Discord bots are I/O-bound. More worker threads do not help unless the bot
+performs CPU-intensive work (image processing, ML inference).
+
+### Blocking Operations
+
+Never block the tokio runtime. Use `spawn_blocking` for CPU-heavy or
+synchronous operations:
+
+```rust
+// ❌ BAD: blocks a worker thread
+let result = expensive_computation();
+
+// ✅ GOOD: runs on blocking thread pool
+let result = tokio::task::spawn_blocking(|| {
+    expensive_computation()
+}).await?;
+```
+
+Common blocking operations in Discord bots:
+- Image generation/manipulation
+- Audio encoding/decoding
+- Diesel database queries (Diesel is synchronous)
+- File I/O with large files
+- Cryptographic operations
+
+## Memory Optimization
+
+### String Allocation Patterns
+
+```rust
+// ❌ BAD: unnecessary allocation
+fn format_user(user: &User) -> String {
+    let name = user.name.clone();  // Clones the string
+    format!("User: {}", name)
+}
+
+// ✅ GOOD: borrow instead of clone
+fn format_user(user: &User) -> String {
+    format!("User: {}", user.name)  // Borrows &str
+}
+
+// ❌ BAD: allocates Vec<String>
+let parts: Vec<String> = input.split(' ')
+    .map(|s| s.to_string())
+    .collect();
+
+// ✅ GOOD: zero-copy slices
+let parts: Vec<&str> = input.split(' ').collect();
+```
+
+### Arc for Shared Data
+
+`Arc::clone()` is cheap — it increments a reference counter, not the data.
+Dereference has zero overhead compared to `&T`.
+
+```rust
+let config = Arc::new(load_config()?);
+
+// Cheap clone for spawned tasks
+let config_clone = Arc::clone(&config);
+tokio::spawn(async move {
+    use_config(&config_clone).await;
+});
+```
+
+### Cache Memory Management
+
+```rust
+// Limit serenity's message cache
+let settings = serenity::cache::Settings::default()
+    .max_messages(50);  // Per channel
+
+// Disable cache entirely for minimal memory
+// In Cargo.toml: default-features = false, omit "cache"
+
+// Moka cache with capacity limit
+let cache = Cache::builder()
+    .max_capacity(10_000)  // Hard cap on entries
+    .time_to_live(Duration::from_secs(300))  // Auto-expire
+    .build();
+```
+
+## Sharding
+
+Discord requires sharding for bots in 2,500+ guilds. Each shard handles a
+subset of guilds via separate gateway connections.
+
+### Automatic Sharding
+
+```rust
+// Discord recommends shard count
+client.start_autosharded().await?;
+```
+
+### Manual Shard Count
+
+```rust
+// Fixed shard count
+client.start_shards(4).await?;
+```
+
+### Distributed Sharding (Multi-Process)
+
+Run different shard ranges on different machines:
+
+```rust
+// Process 1: shards 0-1 of 4 total
+client.start_shard_range([0, 1], 4).await?;
+
+// Process 2: shards 2-3 of 4 total
+client.start_shard_range([2, 3], 4).await?;
+```
+
+### Shard Monitoring
+
+```rust
+let manager = client.shard_manager.clone();
+
+tokio::spawn(async move {
+    loop {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        let runners = manager.runners.lock().await;
+        for (id, runner) in runners.iter() {
+            tracing::info!(
+                "Shard {} — latency: {:?}, stage: {:?}",
+                id, runner.latency, runner.stage
+            );
+        }
+    }
+});
+```
+
+### Shard Selection Formula
+
+Discord assigns guilds to shards:
+
+```
+shard_id = (guild_id >> 22) % total_shards
+```
+
+## Concurrency Patterns
+
+### Bounded Task Spawning
+
+Prevent unbounded memory growth from spawning too many tasks:
+
+```rust
+use tokio::sync::Semaphore;
+
+let semaphore = Arc::new(Semaphore::new(10));  // Max 10 concurrent
+
+for item in items {
+    let permit = semaphore.clone().acquire_owned().await?;
+    tokio::spawn(async move {
+        process_item(item).await;
+        drop(permit);  // Release slot
+    });
+}
+```
+
+### Channel-Based Task Queue
+
+```rust
+use tokio::sync::mpsc;
+
+let (tx, mut rx) = mpsc::channel::<ModAction>(100);
+
+// Producer (event handler)
+tx.send(ModAction::Ban { user_id, reason }).await?;
+
+// Consumer (background task)
+tokio::spawn(async move {
+    while let Some(action) = rx.recv().await {
+        match action {
+            ModAction::Ban { user_id, reason } => {
+                execute_ban(user_id, &reason).await;
+            }
+            ModAction::Mute { user_id, duration } => {
+                execute_mute(user_id, duration).await;
+            }
+        }
+    }
+});
+```
+
+### Select for Multiple Futures
+
+```rust
+tokio::select! {
+    msg = rx.recv() => {
+        if let Some(msg) = msg {
+            handle_message(msg).await;
+        }
+    }
+    _ = tokio::time::sleep(Duration::from_secs(60)) => {
+        // Timeout — no messages for 60 seconds
+        cleanup().await;
+    }
+    _ = tokio::signal::ctrl_c() => {
+        // Shutdown signal
+        break;
+    }
+}
+```
+
+## Rate Limit Handling
+
+Serenity handles Discord API rate limits automatically. The HTTP client tracks
+per-route buckets and delays requests when limits are hit.
+
+### Disabling Rate Limiter (API Proxies)
+
+```rust
+let http = serenity::HttpBuilder::new(token)
+    .ratelimiter_disabled(true)  // For API proxy setups
+    .build();
+```
+
+### Custom Rate Limiting for Bot Features
+
+```rust
+use dashmap::DashMap;
+use std::time::{Duration, Instant};
+
+struct RateLimiter {
+    limits: DashMap<(UserId, &'static str), Instant>,
+}
+
+impl RateLimiter {
+    fn check(&self, user_id: UserId, command: &'static str, cooldown: Duration) -> bool {
+        let key = (user_id, command);
+        if let Some(last) = self.limits.get(&key) {
+            if last.elapsed() < cooldown {
+                return false;  // Rate limited
+            }
+        }
+        self.limits.insert(key, Instant::now());
+        true
+    }
+}
+```
+
+## Cargo Release Profile
+
+### Maximum Performance
+
+```toml
+[profile.release]
+opt-level = 3        # Maximum optimization
+lto = "fat"          # Full link-time optimization
+codegen-units = 1    # Single codegen unit (better optimization)
+strip = true         # Strip debug symbols
+panic = "abort"      # No unwinding (smaller binary)
+```
+
+**Trade-off**: Build time increases 3-5x. Use for final deployment builds.
+
+### Balanced (Faster Builds)
+
+```toml
+[profile.release]
+opt-level = 3
+lto = "thin"         # Faster LTO
+codegen-units = 16   # Faster parallel codegen
+strip = true
+```
+
+### Minimum Binary Size
+
+```toml
+[profile.release]
+opt-level = "z"      # Optimize for size
+lto = true
+codegen-units = 1
+strip = true
+panic = "abort"
+```
+
+### Development Optimization
+
+Speed up dev builds by optimizing dependencies but not your code:
+
+```toml
+# Optimize deps even in debug mode
+[profile.dev.package."*"]
+opt-level = 2
+
+# Faster linker
+# .cargo/config.toml
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+```
+
+## SIMD JSON Parsing
+
+Enable SIMD-accelerated JSON parsing for high-throughput bots:
+
+```toml
+serenity = { version = "0.12", features = ["simd_json"] }
+```
+
+Provides measurable improvement for bots processing thousands of events per
+second. Requires a CPU with SSE2/AVX2 support (all modern x86 CPUs).
+
+## Gateway Compression
+
+Reduce bandwidth by enabling gateway compression:
+
+```toml
+# Zstandard (default in twilight, faster decompression)
+serenity = { version = "0.12", features = ["zstd_compression"] }
+
+# Zlib (traditional, wider support)
+serenity = { version = "0.12", features = ["zlib_compression"] }
+```
+
+For twilight:
+```toml
+twilight-gateway = { version = "0.16", features = ["zstd"] }  # Default
+```
+
+## Performance Checklist
+
+| Area | Action |
+|------|--------|
+| Runtime | Use multi-thread with 2-4 workers |
+| Blocking | `spawn_blocking` for CPU work |
+| Strings | Borrow `&str` instead of cloning `String` |
+| Shared state | `Arc` for data, `DashMap` for concurrent maps |
+| Cache | Set `max_messages`, use moka with TTL |
+| Sharding | Enable at 2,000+ guilds |
+| Tasks | Bound concurrency with `Semaphore` |
+| Release | `lto = "fat"`, `codegen-units = 1`, `strip = true` |
+| JSON | Enable `simd_json` for high throughput |
+| Gateway | Enable compression (`zstd`) |

--- a/skills/rust-discord-bot/references/project-setup.md
+++ b/skills/rust-discord-bot/references/project-setup.md
@@ -1,0 +1,398 @@
+# Project Setup and Structure
+
+Sources: serenity-rs examples, poise quickstart, Discord-TTS Bot, robbb, Bathbot architecture analysis
+
+Covers: directory layout, workspace configuration, main.rs bootstrapping, configuration
+management, environment variables, .env handling.
+
+## Project Structure Patterns
+
+### Simple Bot (Single Crate)
+
+For bots with fewer than 20 commands and no complex state:
+
+```
+my-bot/
+├── Cargo.toml
+├── .env                    # Secrets (DISCORD_TOKEN, DATABASE_URL)
+├── .gitignore
+├── src/
+│   ├── main.rs             # Entry point, framework setup
+│   ├── commands/
+│   │   ├── mod.rs           # Re-exports all commands
+│   │   ├── general.rs       # ping, help, about
+│   │   ├── moderation.rs    # ban, kick, mute
+│   │   └── fun.rs           # Custom commands
+│   └── events.rs            # Non-command event handling
+└── migrations/              # SQL migrations (if using database)
+    └── 001_initial.sql
+```
+
+### Production Bot (Workspace)
+
+For bots with 20+ commands, database, voice, or background tasks. Split into
+crates for faster incremental compilation and cleaner architecture:
+
+```
+my-bot/
+├── Cargo.toml               # Workspace root
+├── .env
+├── config.toml              # Non-secret configuration
+├── bot/                     # Main binary
+│   ├── Cargo.toml
+│   └── src/
+│       └── main.rs
+├── bot_core/                # Shared types, database, errors
+│   ├── Cargo.toml
+│   └── src/
+│       ├── lib.rs
+│       ├── data.rs           # Data struct (shared state)
+│       ├── database.rs       # Database layer
+│       ├── errors.rs         # Error types
+│       └── config.rs         # Configuration loading
+├── bot_commands/             # Command definitions
+│   ├── Cargo.toml
+│   └── src/
+│       ├── lib.rs            # pub fn commands() -> Vec<Command>
+│       ├── general.rs
+│       ├── moderation.rs
+│       └── settings/
+│           ├── mod.rs
+│           └── prefix.rs
+├── bot_events/               # Event handlers
+│   ├── Cargo.toml
+│   └── src/
+│       ├── lib.rs
+│       └── handlers.rs
+└── migrations/
+    ├── 001_initial.sql
+    └── 002_add_settings.sql
+```
+
+### Workspace Cargo.toml
+
+```toml
+[workspace]
+members = ["bot", "bot_core", "bot_commands", "bot_events"]
+resolver = "2"
+
+[workspace.dependencies]
+serenity = { version = "0.12", features = [
+    "builder", "cache", "client", "collector", "framework",
+    "gateway", "http", "model", "utils", "rustls_backend",
+] }
+poise = "0.6"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
+sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls", "macros"] }
+serde = { version = "1", features = ["derive"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+anyhow = "1"
+```
+
+Each member crate references workspace dependencies:
+
+```toml
+# bot_commands/Cargo.toml
+[package]
+name = "bot_commands"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serenity = { workspace = true }
+poise = { workspace = true }
+bot_core = { path = "../bot_core" }
+```
+
+## Main.rs Bootstrapping
+
+### Poise Quickstart (Minimal)
+
+```rust
+use poise::serenity_prelude as serenity;
+
+struct Data {}
+type Error = Box<dyn std::error::Error + Send + Sync>;
+type Context<'a> = poise::Context<'a, Data, Error>;
+
+/// Responds with "Pong!"
+#[poise::command(slash_command, prefix_command)]
+async fn ping(ctx: Context<'_>) -> Result<(), Error> {
+    ctx.say("Pong!").await?;
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    let token = std::env::var("DISCORD_TOKEN").expect("missing DISCORD_TOKEN");
+    let intents = serenity::GatewayIntents::non_privileged();
+
+    let framework = poise::Framework::builder()
+        .options(poise::FrameworkOptions {
+            commands: vec![ping()],
+            ..Default::default()
+        })
+        .setup(|ctx, _ready, framework| {
+            Box::pin(async move {
+                poise::builtins::register_globally(ctx, &framework.options().commands).await?;
+                Ok(Data {})
+            })
+        })
+        .build();
+
+    let client = serenity::ClientBuilder::new(token, intents)
+        .framework(framework)
+        .await;
+
+    client.unwrap().start().await.unwrap();
+}
+```
+
+### Production Main.rs
+
+```rust
+use std::sync::Arc;
+use poise::serenity_prelude as serenity;
+use tracing_subscriber::{fmt, EnvFilter};
+
+mod commands;
+mod events;
+
+pub struct Data {
+    pub pool: sqlx::PgPool,
+    pub reqwest: reqwest::Client,
+    pub start_time: std::time::Instant,
+}
+
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
+pub type Context<'a> = poise::Context<'a, Data, Error>;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Load .env
+    dotenvy::dotenv().ok();
+
+    // Initialize tracing
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::from_default_env()
+                .add_directive("my_bot=debug".parse()?)
+                .add_directive("serenity=info".parse()?)
+        )
+        .init();
+
+    // Database
+    let database_url = std::env::var("DATABASE_URL")?;
+    let pool = sqlx::PgPool::connect(&database_url).await?;
+    sqlx::migrate!("./migrations").run(&pool).await?;
+
+    // Discord token and intents
+    let token = std::env::var("DISCORD_TOKEN")?;
+    let intents = serenity::GatewayIntents::non_privileged()
+        | serenity::GatewayIntents::MESSAGE_CONTENT;
+
+    // Framework
+    let framework = poise::Framework::builder()
+        .options(poise::FrameworkOptions {
+            commands: commands::all(),
+            event_handler: |ctx, event, framework, data| {
+                Box::pin(events::handler(ctx, event, framework, data))
+            },
+            on_error: |error| {
+                Box::pin(async move {
+                    if let Err(e) = on_error(error).await {
+                        tracing::error!("Error handler failed: {:?}", e);
+                    }
+                })
+            },
+            prefix_options: poise::PrefixFrameworkOptions {
+                prefix: Some("!".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .setup(|ctx, _ready, framework| {
+            Box::pin(async move {
+                poise::builtins::register_globally(
+                    ctx,
+                    &framework.options().commands,
+                ).await?;
+                tracing::info!("Bot is ready!");
+                Ok(Data {
+                    pool,
+                    reqwest: reqwest::Client::new(),
+                    start_time: std::time::Instant::now(),
+                })
+            })
+        })
+        .build();
+
+    let mut client = serenity::ClientBuilder::new(token, intents)
+        .framework(framework)
+        .await?;
+
+    // Graceful shutdown on Ctrl+C
+    let shard_manager = client.shard_manager.clone();
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.unwrap();
+        tracing::info!("Shutting down...");
+        shard_manager.shutdown_all().await;
+    });
+
+    client.start().await?;
+    Ok(())
+}
+
+async fn on_error(error: poise::FrameworkError<'_, Data, Error>) -> Result<(), Error> {
+    match error {
+        poise::FrameworkError::Command { error, ctx, .. } => {
+            tracing::error!("Command error: {:?}", error);
+            ctx.say("An error occurred while executing this command.").await?;
+        }
+        poise::FrameworkError::ArgumentParse { error, ctx, .. } => {
+            ctx.say(format!("Invalid argument: {}", error)).await?;
+        }
+        other => poise::builtins::on_error(other).await?,
+    }
+    Ok(())
+}
+```
+
+## Command Registration
+
+### Guild Commands (Instant, for Development)
+
+```rust
+.setup(|ctx, _ready, framework| {
+    Box::pin(async move {
+        let guild_id = serenity::GuildId::new(123456789); // Your test server
+        poise::builtins::register_in_guild(
+            ctx,
+            &framework.options().commands,
+            guild_id,
+        ).await?;
+        Ok(Data {})
+    })
+})
+```
+
+### Global Commands (Up to 1 Hour Propagation, for Production)
+
+```rust
+poise::builtins::register_globally(ctx, &framework.options().commands).await?;
+```
+
+### Command Collection Pattern
+
+```rust
+// commands/mod.rs
+mod general;
+mod moderation;
+mod fun;
+
+pub fn all() -> Vec<poise::Command<crate::Data, crate::Error>> {
+    vec![
+        general::ping(),
+        general::about(),
+        general::help(),
+        moderation::ban(),
+        moderation::kick(),
+        moderation::mute(),
+        fun::roll(),
+        fun::quote(),
+    ]
+}
+```
+
+## Configuration Management
+
+### Environment Variables (.env)
+
+```bash
+# .env (never commit this file)
+DISCORD_TOKEN=Bot MTk...
+DATABASE_URL=postgresql://user:pass@localhost/botdb
+RUST_LOG=my_bot=debug,serenity=info
+```
+
+### TOML Configuration File
+
+```toml
+# config.toml (safe to commit, no secrets)
+[bot]
+prefix = "!"
+default_color = 0x5865F2  # Discord blurple
+
+[features]
+voice_enabled = true
+max_queue_size = 50
+
+[limits]
+max_embed_fields = 25
+cooldown_seconds = 5
+```
+
+```rust
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    pub bot: BotConfig,
+    pub features: FeaturesConfig,
+    pub limits: LimitsConfig,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BotConfig {
+    pub prefix: String,
+    pub default_color: u32,
+}
+
+pub fn load_config() -> anyhow::Result<Config> {
+    let content = std::fs::read_to_string("config.toml")?;
+    Ok(toml::from_str(&content)?)
+}
+```
+
+### Docker vs Self-Host Configuration
+
+Production bots often use separate config files per environment:
+
+```
+config/
+├── config.docker.toml
+├── config.selfhost.toml
+└── config.dev.toml
+```
+
+Select at runtime:
+
+```rust
+let config_path = std::env::var("CONFIG_PATH")
+    .unwrap_or_else(|_| "config/config.dev.toml".to_string());
+let config = load_config(&config_path)?;
+```
+
+## .gitignore
+
+```gitignore
+/target
+.env
+*.db
+*.sqlite
+config/config.dev.toml
+```
+
+## Type Aliases Convention
+
+Every poise bot defines these three types at the crate root:
+
+```rust
+pub struct Data { /* shared state */ }
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
+pub type Context<'a> = poise::Context<'a, Data, Error>;
+```
+
+All commands use `Context<'_>` and return `Result<(), Error>`. This convention
+is universal across the poise ecosystem — follow it exactly.

--- a/skills/rust-discord-bot/references/state-and-data.md
+++ b/skills/rust-discord-bot/references/state-and-data.md
@@ -1,0 +1,410 @@
+# State Management and Database Integration
+
+Sources: poise data patterns, serenity TypeMap, Discord-TTS Bot, robbb, sqlx docs, DashMap/moka crate docs
+
+Covers: Data struct pattern, shared state, database integration with sqlx,
+connection pooling, migrations, concurrent collections, caching strategies.
+
+## The Data Struct Pattern
+
+Every poise bot shares state across commands through a user-defined `Data`
+struct. This is the central state container for the entire bot.
+
+### Basic Data Struct
+
+```rust
+pub struct Data {
+    pub pool: sqlx::PgPool,
+    pub reqwest: reqwest::Client,
+    pub start_time: std::time::Instant,
+}
+```
+
+### Production Data Struct
+
+```rust
+use dashmap::DashMap;
+use mini_moka::sync::Cache;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+pub struct Data {
+    // Database
+    pub pool: sqlx::PgPool,
+
+    // HTTP clients
+    pub reqwest: reqwest::Client,
+
+    // Concurrent state (no lock needed)
+    pub guild_prefixes: DashMap<serenity::GuildId, String>,
+    pub cooldowns: DashMap<serenity::UserId, std::time::Instant>,
+
+    // TTL-based cache
+    pub user_cache: Cache<serenity::UserId, CachedUser>,
+
+    // Rarely-updated shared state
+    pub config: Arc<RwLock<BotConfig>>,
+
+    // Metrics
+    pub start_time: std::time::Instant,
+    pub commands_executed: std::sync::atomic::AtomicU64,
+}
+```
+
+### Accessing Data in Commands
+
+```rust
+#[poise::command(slash_command)]
+async fn stats(ctx: Context<'_>) -> Result<(), Error> {
+    let data = ctx.data();
+    let uptime = data.start_time.elapsed();
+    let commands = data.commands_executed.load(std::sync::atomic::Ordering::Relaxed);
+    ctx.say(format!("Uptime: {:.0?}, Commands: {}", uptime, commands)).await?;
+    Ok(())
+}
+```
+
+### Initialization
+
+```rust
+.setup(|ctx, _ready, framework| {
+    Box::pin(async move {
+        poise::builtins::register_globally(ctx, &framework.options().commands).await?;
+
+        let pool = sqlx::PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
+        sqlx::migrate!("./migrations").run(&pool).await?;
+
+        Ok(Data {
+            pool,
+            reqwest: reqwest::Client::new(),
+            guild_prefixes: DashMap::new(),
+            cooldowns: DashMap::new(),
+            user_cache: Cache::builder()
+                .time_to_live(std::time::Duration::from_secs(300))
+                .max_capacity(10_000)
+                .build(),
+            config: Arc::new(RwLock::new(BotConfig::load()?)),
+            start_time: std::time::Instant::now(),
+            commands_executed: std::sync::atomic::AtomicU64::new(0),
+        })
+    })
+})
+```
+
+## Database Integration with sqlx
+
+### Connection Pool Setup
+
+```rust
+use sqlx::postgres::PgPoolOptions;
+
+let pool = PgPoolOptions::new()
+    .max_connections(20)     // 10-20 for most Discord bots
+    .min_connections(5)      // Keep warm connections
+    .acquire_timeout(std::time::Duration::from_secs(5))
+    .idle_timeout(std::time::Duration::from_secs(600))
+    .max_lifetime(std::time::Duration::from_secs(1800))
+    .connect(&database_url)
+    .await?;
+```
+
+### SQLite Alternative
+
+```toml
+sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio-rustls", "macros"] }
+```
+
+```rust
+let pool = sqlx::SqlitePool::connect("sqlite:bot.db").await?;
+```
+
+### Compile-Time Checked Queries
+
+sqlx validates queries against the database at compile time:
+
+```rust
+#[derive(sqlx::FromRow)]
+struct GuildConfig {
+    guild_id: i64,
+    prefix: String,
+    welcome_channel: Option<i64>,
+    log_channel: Option<i64>,
+}
+
+async fn get_guild_config(
+    pool: &sqlx::PgPool,
+    guild_id: i64,
+) -> Result<Option<GuildConfig>, sqlx::Error> {
+    sqlx::query_as!(
+        GuildConfig,
+        "SELECT guild_id, prefix, welcome_channel, log_channel
+         FROM guild_configs WHERE guild_id = $1",
+        guild_id
+    )
+    .fetch_optional(pool)
+    .await
+}
+
+async fn upsert_guild_prefix(
+    pool: &sqlx::PgPool,
+    guild_id: i64,
+    prefix: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        "INSERT INTO guild_configs (guild_id, prefix)
+         VALUES ($1, $2)
+         ON CONFLICT (guild_id) DO UPDATE SET prefix = $2",
+        guild_id,
+        prefix
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+```
+
+### Migrations
+
+```bash
+# Create migration
+sqlx migrate add initial_schema
+
+# migrations/001_initial_schema.sql
+CREATE TABLE guild_configs (
+    guild_id BIGINT PRIMARY KEY,
+    prefix VARCHAR(10) NOT NULL DEFAULT '!',
+    welcome_channel BIGINT,
+    log_channel BIGINT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE user_data (
+    user_id BIGINT PRIMARY KEY,
+    xp INTEGER NOT NULL DEFAULT 0,
+    level INTEGER NOT NULL DEFAULT 1,
+    last_message TIMESTAMPTZ
+);
+
+CREATE TABLE warnings (
+    id SERIAL PRIMARY KEY,
+    guild_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    moderator_id BIGINT NOT NULL,
+    reason TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_warnings_guild_user ON warnings(guild_id, user_id);
+```
+
+Run migrations in code:
+
+```rust
+sqlx::migrate!("./migrations").run(&pool).await?;
+```
+
+### Transaction Pattern
+
+```rust
+async fn transfer_xp(
+    pool: &sqlx::PgPool,
+    from: i64,
+    to: i64,
+    amount: i32,
+) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    sqlx::query!("UPDATE user_data SET xp = xp - $1 WHERE user_id = $2", amount, from)
+        .execute(&mut *tx).await?;
+    sqlx::query!("UPDATE user_data SET xp = xp + $1 WHERE user_id = $2", amount, to)
+        .execute(&mut *tx).await?;
+
+    tx.commit().await?;
+    Ok(())
+}
+```
+
+## Concurrent Collections
+
+### DashMap (Lock-Free Concurrent HashMap)
+
+3-5x faster than `Arc<RwLock<HashMap>>` for concurrent workloads.
+
+```rust
+use dashmap::DashMap;
+
+let prefixes: DashMap<GuildId, String> = DashMap::new();
+
+// Insert
+prefixes.insert(guild_id, "!".to_string());
+
+// Read (returns Ref guard, not clone)
+if let Some(prefix) = prefixes.get(&guild_id) {
+    println!("Prefix: {}", prefix.value());
+}
+
+// Atomic update
+prefixes.entry(guild_id)
+    .and_modify(|p| *p = "?".to_string())
+    .or_insert_with(|| "!".to_string());
+
+// Remove
+prefixes.remove(&guild_id);
+```
+
+### When to Use Each Collection
+
+| Collection | Use Case |
+|-----------|----------|
+| `DashMap<K, V>` | Frequent concurrent reads/writes, per-guild/user state |
+| `Arc<RwLock<T>>` | Read-heavy, rarely updated config or global state |
+| `Arc<Mutex<T>>` | Write-heavy or simple exclusive access |
+| `AtomicU64` | Counters, flags |
+| `tokio::sync::mpsc` | Message passing between tasks |
+| `tokio::sync::broadcast` | Event bus (multiple consumers) |
+
+## Caching with mini-moka
+
+TTL-based in-memory cache. Entries auto-expire, preventing memory leaks.
+
+```rust
+use mini_moka::sync::Cache;
+use std::time::Duration;
+
+let cache: Cache<UserId, UserProfile> = Cache::builder()
+    .max_capacity(10_000)
+    .time_to_live(Duration::from_secs(300))    // Expire after 5 min
+    .time_to_idle(Duration::from_secs(120))    // Expire if unused for 2 min
+    .build();
+
+// Cache-aside pattern
+async fn get_profile(
+    data: &Data,
+    user_id: UserId,
+) -> Result<UserProfile, Error> {
+    // Check cache
+    if let Some(profile) = data.user_cache.get(&user_id) {
+        return Ok(profile);
+    }
+
+    // Cache miss — fetch from DB
+    let profile = sqlx::query_as!(
+        UserProfile,
+        "SELECT * FROM user_profiles WHERE user_id = $1",
+        user_id.get() as i64
+    )
+    .fetch_one(&data.pool)
+    .await?;
+
+    // Store in cache
+    data.user_cache.insert(user_id, profile.clone());
+    Ok(profile)
+}
+```
+
+## Serenity Cache
+
+Serenity maintains an in-memory cache of Discord state (guilds, channels,
+members, roles) populated from gateway events.
+
+```rust
+// Access cached guild
+if let Some(guild) = ctx.cache().guild(guild_id) {
+    println!("Guild: {} ({} members)", guild.name, guild.member_count);
+}
+
+// Access cached channel
+if let Some(channel) = ctx.cache().channel(channel_id) {
+    println!("Channel: {}", channel.name);
+}
+
+// Current user
+let me = ctx.cache().current_user().clone();
+
+// Cache settings (limit memory)
+use serenity::cache::Settings as CacheSettings;
+
+let settings = CacheSettings::default()
+    .max_messages(100);  // Cap message cache
+
+let client = serenity::ClientBuilder::new(token, intents)
+    .cache_settings(settings)
+    .await?;
+```
+
+### Cache vs HTTP
+
+| Operation | Use Cache | Use HTTP |
+|-----------|-----------|----------|
+| Guild/channel/role info | Frequently accessed, OK if slightly stale | Need guaranteed-fresh data |
+| Permission calculations | Cache provides member/role data | — |
+| Member list | If GUILD_MEMBERS intent enabled | Large guilds, paginated |
+| Message history | Only if temp_cache enabled, limited | Full history needed |
+| Creating/modifying resources | — | Always (mutations require HTTP) |
+
+## Serenity TypeMap (Raw Serenity)
+
+For raw serenity (without poise), use TypeMap for shared state:
+
+```rust
+use serenity::prelude::TypeMapKey;
+
+struct DatabasePool;
+impl TypeMapKey for DatabasePool {
+    type Value = sqlx::PgPool;
+}
+
+// Store in client setup
+let client = Client::builder(token, intents)
+    .type_map_insert::<DatabasePool>(pool)
+    .await?;
+
+// Access in event handler
+async fn message(&self, ctx: Context, msg: Message) {
+    let data = ctx.data.read().await;
+    let pool = data.get::<DatabasePool>().unwrap();
+    // use pool...
+}
+```
+
+With poise, prefer the Data struct — it is type-safe and avoids runtime
+downcast errors.
+
+## Background Tasks
+
+For periodic operations (cache cleanup, status rotation, scheduled unmutes):
+
+```rust
+// In setup, spawn background tasks
+.setup(|ctx, _ready, framework| {
+    Box::pin(async move {
+        let data = Data { /* ... */ };
+
+        // Status rotation
+        let ctx_clone = ctx.clone();
+        tokio::spawn(async move {
+            let statuses = [
+                serenity::ActivityData::watching("for /help"),
+                serenity::ActivityData::playing("with Rust"),
+            ];
+            let mut i = 0;
+            loop {
+                ctx_clone.set_activity(Some(statuses[i % statuses.len()].clone()));
+                i += 1;
+                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            }
+        });
+
+        // Database cleanup
+        let pool = data.pool.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+                let _ = sqlx::query!("DELETE FROM temp_data WHERE expires_at < NOW()")
+                    .execute(&pool).await;
+            }
+        });
+
+        Ok(data)
+    })
+})
+```

--- a/skills/rust-discord-bot/references/voice-and-audio.md
+++ b/skills/rust-discord-bot/references/voice-and-audio.md
@@ -1,0 +1,381 @@
+# Voice and Audio
+
+Sources: Songbird v0.4 docs, serenity voice examples, Discord voice gateway API (2026)
+
+Covers: Songbird setup, joining/leaving voice channels, audio playback, queue
+management, voice events, audio sources, voice receive.
+
+## Songbird Overview
+
+Serenity does not handle voice connections directly. Use **Songbird** — the
+official voice library for the serenity ecosystem.
+
+Songbird provides:
+- Voice channel join/leave
+- Audio playback (files, URLs, streams)
+- Queue management
+- Voice event hooks (speaking, silence, disconnect)
+- Audio receive (speech-to-text, recording)
+
+## Setup
+
+### Dependencies
+
+```toml
+[dependencies]
+serenity = { version = "0.12", features = ["voice", "client", "gateway", "cache"] }
+songbird = "0.4"
+symphonia = { version = "0.5", features = ["mp3", "ogg", "wav", "aac"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
+```
+
+The `voice` feature in serenity enables voice state tracking. Symphonia provides
+audio codec support.
+
+### Required Intent
+
+```rust
+let intents = GatewayIntents::non_privileged()
+    | GatewayIntents::GUILD_VOICE_STATES;  // MANDATORY for voice
+```
+
+Without `GUILD_VOICE_STATES`, the bot cannot detect voice channel membership
+or join voice channels.
+
+### Registration
+
+```rust
+use songbird::SerenityInit;
+
+let client = serenity::ClientBuilder::new(token, intents)
+    .framework(framework)
+    .register_songbird()  // Register voice manager
+    .await?;
+```
+
+For poise, store the Songbird manager in your Data struct:
+
+```rust
+pub struct Data {
+    pub songbird: std::sync::Arc<songbird::Songbird>,
+    // ...
+}
+
+// In setup:
+.setup(|ctx, _ready, framework| {
+    Box::pin(async move {
+        let songbird = songbird::Songbird::serenity();
+        Ok(Data {
+            songbird,
+            // ...
+        })
+    })
+})
+
+// Register with client builder:
+let client = serenity::ClientBuilder::new(token, intents)
+    .framework(framework)
+    .voice_manager::<songbird::Songbird>(data.songbird.clone())
+    .await?;
+```
+
+## Joining and Leaving Voice Channels
+
+### Join
+
+```rust
+#[poise::command(slash_command, guild_only)]
+async fn join(ctx: Context<'_>) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap();
+
+    // Get the user's current voice channel
+    let channel_id = {
+        let guild = ctx.guild().unwrap();
+        guild.voice_states
+            .get(&ctx.author().id)
+            .and_then(|vs| vs.channel_id)
+    };
+
+    let channel_id = match channel_id {
+        Some(id) => id,
+        None => {
+            ctx.say("You must be in a voice channel.").await?;
+            return Ok(());
+        }
+    };
+
+    let manager = songbird::get(ctx.serenity_context()).await.unwrap();
+    let (handler_lock, result) = manager.join(guild_id, channel_id).await;
+
+    if result.is_ok() {
+        ctx.say(format!("Joined <#{}>", channel_id)).await?;
+    } else {
+        ctx.say("Failed to join voice channel.").await?;
+    }
+
+    Ok(())
+}
+```
+
+### Leave
+
+```rust
+#[poise::command(slash_command, guild_only)]
+async fn leave(ctx: Context<'_>) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap();
+    let manager = songbird::get(ctx.serenity_context()).await.unwrap();
+
+    if manager.get(guild_id).is_some() {
+        manager.remove(guild_id).await?;
+        ctx.say("Left voice channel.").await?;
+    } else {
+        ctx.say("Not in a voice channel.").await?;
+    }
+
+    Ok(())
+}
+```
+
+## Audio Playback
+
+### Play a Local File
+
+```rust
+#[poise::command(slash_command, guild_only)]
+async fn play_file(ctx: Context<'_>) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap();
+    let manager = songbird::get(ctx.serenity_context()).await.unwrap();
+
+    if let Some(handler_lock) = manager.get(guild_id) {
+        let mut handler = handler_lock.lock().await;
+
+        let source = songbird::input::File::new("audio/notification.mp3");
+        let track_handle = handler.play_input(source.into());
+
+        ctx.say("Playing audio!").await?;
+    } else {
+        ctx.say("Not in a voice channel. Use /join first.").await?;
+    }
+
+    Ok(())
+}
+```
+
+### Play from URL (YouTube/HTTP)
+
+For URL-based playback, use `yt-dlp` or `youtube-dl` as a source:
+
+```rust
+use songbird::input::YoutubeDl;
+
+#[poise::command(slash_command, guild_only)]
+async fn play(
+    ctx: Context<'_>,
+    #[description = "URL to play"] url: String,
+) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap();
+    let manager = songbird::get(ctx.serenity_context()).await.unwrap();
+
+    if let Some(handler_lock) = manager.get(guild_id) {
+        let mut handler = handler_lock.lock().await;
+
+        // Requires yt-dlp installed on system
+        let source = YoutubeDl::new(
+            ctx.data().reqwest.clone(),
+            url,
+        );
+        handler.enqueue_input(source.into()).await;
+
+        let queue_len = handler.queue().len();
+        ctx.say(format!("Added to queue (position {})", queue_len)).await?;
+    }
+
+    Ok(())
+}
+```
+
+**Prerequisite**: Install `yt-dlp` on the host system:
+```bash
+# Ubuntu/Debian
+sudo apt install yt-dlp
+
+# macOS
+brew install yt-dlp
+
+# Or via pip
+pip install yt-dlp
+```
+
+### Queue Management
+
+```rust
+#[poise::command(slash_command, guild_only)]
+async fn skip(ctx: Context<'_>) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap();
+    let manager = songbird::get(ctx.serenity_context()).await.unwrap();
+
+    if let Some(handler_lock) = manager.get(guild_id) {
+        let handler = handler_lock.lock().await;
+        let queue = handler.queue();
+        let _ = queue.skip();
+        ctx.say("Skipped current track.").await?;
+    }
+    Ok(())
+}
+
+#[poise::command(slash_command, guild_only)]
+async fn stop(ctx: Context<'_>) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap();
+    let manager = songbird::get(ctx.serenity_context()).await.unwrap();
+
+    if let Some(handler_lock) = manager.get(guild_id) {
+        let handler = handler_lock.lock().await;
+        handler.queue().stop();
+        ctx.say("Stopped playback and cleared queue.").await?;
+    }
+    Ok(())
+}
+
+#[poise::command(slash_command, guild_only)]
+async fn pause(ctx: Context<'_>) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap();
+    let manager = songbird::get(ctx.serenity_context()).await.unwrap();
+
+    if let Some(handler_lock) = manager.get(guild_id) {
+        let handler = handler_lock.lock().await;
+        let _ = handler.queue().pause();
+        ctx.say("Paused.").await?;
+    }
+    Ok(())
+}
+
+#[poise::command(slash_command, guild_only)]
+async fn resume(ctx: Context<'_>) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap();
+    let manager = songbird::get(ctx.serenity_context()).await.unwrap();
+
+    if let Some(handler_lock) = manager.get(guild_id) {
+        let handler = handler_lock.lock().await;
+        let _ = handler.queue().resume();
+        ctx.say("Resumed.").await?;
+    }
+    Ok(())
+}
+```
+
+## Voice Events
+
+### Track End / Error Events
+
+```rust
+use songbird::{Event, EventContext, EventHandler as VoiceEventHandler, TrackEvent};
+
+struct TrackEndNotifier {
+    channel_id: serenity::ChannelId,
+    http: std::sync::Arc<serenity::Http>,
+}
+
+#[serenity::async_trait]
+impl VoiceEventHandler for TrackEndNotifier {
+    async fn act(&self, ctx: &EventContext<'_>) -> Option<Event> {
+        if let EventContext::Track(track_list) = ctx {
+            self.channel_id
+                .say(&self.http, "Track finished playing.")
+                .await
+                .ok();
+        }
+        None
+    }
+}
+
+// Register in handler
+let mut handler = handler_lock.lock().await;
+handler.add_global_event(
+    Event::Track(TrackEvent::End),
+    TrackEndNotifier {
+        channel_id: ctx.channel_id(),
+        http: ctx.serenity_context().http.clone(),
+    },
+);
+```
+
+### Auto-Disconnect on Empty Channel
+
+```rust
+struct EmptyChannelHandler {
+    guild_id: serenity::GuildId,
+    manager: std::sync::Arc<songbird::Songbird>,
+}
+
+#[serenity::async_trait]
+impl VoiceEventHandler for EmptyChannelHandler {
+    async fn act(&self, _ctx: &EventContext<'_>) -> Option<Event> {
+        // Check if bot is alone in the channel
+        // If so, disconnect after a delay
+        let _ = self.manager.remove(self.guild_id).await;
+        None
+    }
+}
+```
+
+## Audio Encoding Requirements
+
+Discord voice uses:
+- **Codec**: Opus
+- **Sample rate**: 48 kHz
+- **Channels**: 2 (stereo)
+- **Frame size**: 20 ms (960 samples)
+
+Songbird handles encoding automatically. Symphonia handles decoding from
+common formats (MP3, OGG, WAV, AAC, FLAC).
+
+## Volume Control
+
+```rust
+// Set volume on current track (0.0 to 2.0)
+if let Some(track) = handler.queue().current() {
+    track.set_volume(0.5)?;  // 50% volume
+}
+```
+
+## Voice Receive (Advanced)
+
+Songbird can receive audio from voice channels for recording or
+speech-to-text:
+
+```rust
+use songbird::{CoreEvent, EventContext, EventHandler as VoiceEventHandler};
+
+struct VoiceReceiver;
+
+#[serenity::async_trait]
+impl VoiceEventHandler for VoiceReceiver {
+    async fn act(&self, ctx: &EventContext<'_>) -> Option<songbird::Event> {
+        if let EventContext::SpeakingStateUpdate(speaking) = ctx {
+            tracing::info!(
+                "User {} {} speaking",
+                speaking.ssrc,
+                if speaking.speaking { "started" } else { "stopped" }
+            );
+        }
+        None
+    }
+}
+
+// Register
+handler.add_global_event(
+    songbird::Event::Core(CoreEvent::SpeakingStateUpdate),
+    VoiceReceiver,
+);
+```
+
+## Common Voice Bot Anti-Patterns
+
+| Don't | Do Instead | Why |
+|-------|-----------|-----|
+| Forget `GUILD_VOICE_STATES` intent | Always include it | Bot cannot join voice without it |
+| Block handler lock | Release lock quickly | Other operations wait |
+| Ignore empty channels | Auto-disconnect after timeout | Wastes resources |
+| Play without checking queue | Use `enqueue_input` | Prevents overlapping audio |
+| Hardcode `yt-dlp` path | Use `which` or config | Portability |
+| Skip error handling on join | Check `result.is_ok()` | May lack permissions |

--- a/skills/rust-discord-bot/skills.json
+++ b/skills/rust-discord-bot/skills.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tank/rust-discord-bot",
+  "version": "1.0.0",
+  "description": "Build high-performance Discord bots in Rust with serenity, poise, and twilight. Covers framework selection, slash/prefix commands, components, intents, event handling, state management, voice/audio (Songbird), performance, and deployment. Triggers: discord bot rust, serenity-rs, poise discord, twilight-rs, slash command rust, discord gateway, songbird voice, discord music bot, discord embed, discord button, poise framework, serenity event, discord sharding, discord sqlx",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

- Add new Tank skill `@tank/rust-discord-bot` for building high-performance Discord bots in Rust
- Covers the full Rust Discord ecosystem: **serenity** (API wrapper), **poise** (command framework), **twilight** (modular low-level)
- 8 reference files (3,106 lines total) covering framework selection, project setup, commands/interactions, event handling, state/data, performance, voice/audio, and deployment

## Skill Contents

| File | Lines | Coverage |
|------|-------|----------|
| `SKILL.md` | 148 | Entry point, decision trees, anti-patterns |
| `framework-selection.md` | 252 | Serenity vs Poise vs Twilight, Cargo.toml, crate ecosystem |
| `project-setup.md` | 398 | Directory structure, main.rs bootstrap, config |
| `commands-and-interactions.md` | 380 | Poise macros, slash/prefix/context, components |
| `event-handling.md` | 298 | Intents, FullEvent variants, event handler |
| `state-and-data.md` | 410 | Data struct, sqlx, DashMap, caching, background tasks |
| `performance-and-concurrency.md` | 390 | Tokio tuning, sharding, zero-copy, Cargo profiles |
| `voice-and-audio.md` | 381 | Songbird, playback, queues, voice events |
| `deployment-and-ops.md` | 438 | Docker, systemd, tracing, error handling, CI/CD |

## Validation

- `tank publish --dry-run` passes (88.2 KB, 10 files, 27.5 KB compressed)
- All reference files within 250-450 line target range
- No frontmatter in reference files, all start with `# Title` + `Sources:`