### PR TITLE
feat(vercel): add Vercel CLI deployment and management skill

### DIFF
--- a/skills/vercel/SKILL.md
+++ b/skills/vercel/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: "@tank/vercel"
+description: |
+  Vercel deployment and project management using the CLI. Covers all CLI
+  commands (deploy, build, dev, pull, env, domains, dns, logs, promote,
+  rollback), vercel.json configuration (redirects, rewrites, headers,
+  functions, crons, images, regions), CI/CD workflows (GitHub Actions,
+  GitLab CI, preview and production pipelines), environment variable
+  management, domain and DNS setup, serverless and edge functions, and
+  troubleshooting. Synthesizes Vercel CLI docs (2026), vercel.json schema,
+  and production deployment patterns.
+
+  Trigger phrases: "vercel", "vercel deploy", "vercel cli", "vercel build",
+  "vercel dev", "vercel pull", "vercel env", "vercel domains", "vercel dns",
+  "vercel logs", "vercel promote", "vercel rollback", "vercel.json",
+  "deployment", "preview deployment", "production deployment", "CI/CD vercel",
+  "serverless function", "edge function", "cron job vercel", "vercel monorepo",
+  "vercel turborepo", "vercel domain", "vercel certificate", "deploy to vercel",
+  "vercel environment variables", "vercel preview", "vercel production"
+---
+
+# Vercel Deployment and Management
+
+Deploy, configure, and manage Vercel projects using the CLI. Covers the
+complete lifecycle from project setup through production deployment,
+monitoring, and troubleshooting.
+
+## Core Philosophy
+
+1. **Verify before acting** -- Run `vercel whoami` to confirm auth and
+   `vercel project inspect` to confirm project linking before any operation.
+2. **Pull before build** -- Always run `vercel pull` before `vercel build`
+   or `vercel dev` to sync environment variables and project settings.
+3. **Preview before production** -- Deploy to preview first, verify, then
+   promote or deploy to production. Never skip preview in CI/CD.
+4. **Use --yes in automation** -- Every interactive prompt has a flag-based
+   path. Use `--yes` and `--token` for all CI/CD commands.
+5. **Match functions to workload** -- Use Edge for auth/routing/geo (<30s,
+   global), Serverless for heavy compute (up to 800s, regional).
+
+## Quick-Start
+
+### "I want to deploy my project"
+
+| Step | Action |
+|------|--------|
+| 1 | Check auth: `vercel whoami` |
+| 2 | Link project: `vercel link` (or `vercel link --yes` in CI) |
+| 3 | Preview deploy: `vercel` |
+| 4 | Production deploy: `vercel --prod` |
+-> See `references/deployment-workflows.md` for CI/CD patterns
+
+### "I need to set up CI/CD with GitHub Actions"
+
+| Step | Action |
+|------|--------|
+| 1 | Set secrets: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` |
+| 2 | Use the 3-step pattern: pull -> build -> deploy |
+| 3 | Use `--prebuilt --archive=tgz` for faster deploys |
+-> See `references/deployment-workflows.md`
+
+### "I need to configure my project"
+
+| Step | Action |
+|------|--------|
+| 1 | Add `$schema` for autocomplete |
+| 2 | Configure redirects, rewrites, headers, functions, crons |
+| 3 | Set regions for function deployment |
+-> See `references/project-configuration.md`
+
+### "Something is broken"
+
+| Symptom | Action |
+|---------|--------|
+| Build fails | Check env vars: `vercel env ls`, test locally: `vercel build` |
+| Function timeout | Check limits, increase `maxDuration`, check Fluid compute |
+| 5xx errors | `vercel logs --status-code 5xx --since 1h` |
+| Slow function | `vercel httpstat /api/endpoint`, check cold starts |
+| Domain not working | `vercel domains inspect`, check DNS propagation |
+| Need to revert | `vercel rollback` (instant, no rebuild) |
+-> See `references/troubleshooting.md`
+
+## Project Detection
+
+Before running commands, check for existing Vercel setup:
+
+| Signal | Meaning | Next Step |
+|--------|---------|-----------|
+| `.vercel/` directory exists | Project is linked | Verify with `vercel project inspect` |
+| `vercel.json` exists | Project has config | Read and respect existing settings |
+| Neither exists | New project | Run `vercel link` to connect |
+| `vercel.json` + no `.vercel/` | Config but not linked | Run `vercel link --yes` |
+
+## Decision Trees
+
+### Deployment Method
+
+| Signal | Method | Reference |
+|--------|--------|-----------|
+| Push to Git, automatic deploys desired | Git integration (dashboard) | -- |
+| CI/CD pipeline, custom build steps | CLI: pull -> build -> deploy | `references/deployment-workflows.md` |
+| Quick manual deploy from local | `vercel` or `vercel --prod` | `references/cli-commands.md` |
+| Monorepo with Turborepo | Turbo build + `vercel deploy --prebuilt` | `references/deployment-workflows.md` |
+| Deploy without sharing source | `vercel build` + `vercel deploy --prebuilt` | `references/deployment-workflows.md` |
+
+### Function Runtime
+
+| Need | Runtime | Key Constraints |
+|------|---------|----------------|
+| Full Node.js APIs, heavy compute | Serverless (Node.js) | Regional, ~250ms cold start |
+| Ultra-low latency, global | Edge | No fs/native modules, 30s max, 1MB compressed |
+| Auth gating, redirects, geo-routing | Edge Middleware | Runs before every matched request |
+| Python, Go, Ruby | Serverless (community) | Limited runtime support |
+
+### Environment Variables
+
+| Task | Command |
+|------|---------|
+| Add variable to production | `vercel env add NAME production` |
+| Pull vars for local dev | `vercel env pull` |
+| Run command with env vars | `vercel env run -- next dev` |
+| Sync project settings + vars | `vercel pull` |
+| Override var for one deploy | `vercel deploy --env KEY=value` |
+-> See `references/environment-variables.md`
+
+## Anti-Patterns
+
+| Don't | Do Instead | Why |
+|-------|-----------|-----|
+| Deploy to production without preview | `vercel` first, then `vercel --prod` | Catch issues before users see them |
+| Use interactive prompts in CI | Add `--yes --token $TOKEN` to all commands | CI has no TTY |
+| Skip `vercel pull` before `vercel build` | Always pull first | Build needs env vars and project settings |
+| Set memory in vercel.json with Fluid | Configure in dashboard Settings | Fluid compute manages memory differently |
+| Use `has`/`missing` and test with `vercel dev` | Test conditional routes on preview deploys | Conditions don't work locally |
+| Hardcode env vars in vercel.json | Use `vercel env add` or dashboard | Env vars don't belong in config files |
+| Commit `.vercel/` directory | Add to `.gitignore` | Contains local project linking data |
+| Use `vercel deploy` for monorepo CI | Use `turbo build` + `vercel deploy --prebuilt` | Turborepo caching saves 80%+ build time |
+| Promote preview without checking env vars | Verify: promoted deploys use production env vars | Preview and production env vars differ |
+| Use serverless for auth/redirects | Use Edge middleware | Edge is global, <1ms cold start |
+
+## The 3-Step CI/CD Pattern
+
+The standard deployment pattern for all CI/CD pipelines:
+
+```bash
+vercel pull --yes --environment=production --token=$VERCEL_TOKEN
+vercel build --prod --token=$VERCEL_TOKEN
+vercel deploy --prod --prebuilt --archive=tgz --token=$VERCEL_TOKEN
+```
+
+Step 1 syncs env vars and project config. Step 2 builds locally.
+Step 3 uploads pre-built artifacts. Use `--archive=tgz` for large projects.
+
+For preview deployments, remove `--prod` from build and deploy, and use
+`--environment=preview` for pull.
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/cli-commands.md` | All CLI commands organized by category, key flags and options for each, global options, project specification precedence, usage examples |
+| `references/project-configuration.md` | Complete vercel.json schema, all configuration fields with JSON examples, framework presets, monorepo config, routing (redirects, rewrites, headers), functions, crons, images, gotchas |
+| `references/deployment-workflows.md` | CI/CD patterns (GitHub Actions, GitLab CI, Bitbucket), preview and production workflows, promote, rollback, rolling releases, monorepo deployment, deploy hooks, prebuilt deploys |
+| `references/environment-variables.md` | Per-environment management, branch-specific vars, sensitive vars, pull vs env pull, env run, system variables, limits, security best practices |
+| `references/domains-and-dns.md` | Domain lifecycle, DNS records (A, CNAME, MX, TXT, SRV, CAA), SSL certificates, wildcard domains, multi-tenant patterns, apex and www setup |
+| `references/serverless-and-edge.md` | Serverless vs edge functions, middleware, geolocation, Edge Config, cold start mitigation, streaming, Build Output API, storage integrations, firewall, feature flags |
+| `references/troubleshooting.md` | Common errors and fixes, debugging commands, plan limits by tier, cost optimization strategies, recovery procedures, cache management, vercel dev limitations |

--- a/skills/vercel/references/cli-commands.md
+++ b/skills/vercel/references/cli-commands.md
@@ -1,0 +1,340 @@
+# CLI Commands Reference
+
+Sources: Vercel CLI documentation (2026), vercel/vercel AGENTS.md
+
+Covers: All CLI commands organized by category, key flags, global options,
+project specification, and usage patterns.
+
+## Core Commands
+
+### deploy (default command)
+
+Deploy project to Vercel. Runs as default when no subcommand is given.
+
+```bash
+vercel                              # Preview deployment
+vercel --prod                       # Production deployment
+vercel deploy --prebuilt            # Deploy pre-built output
+vercel deploy --prebuilt --archive=tgz  # Compress for large projects
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--prod` | | Deploy to production |
+| `--prebuilt` | | Deploy output from `vercel build` |
+| `--archive=tgz` | | Compress upload (faster for many files) |
+| `--env KEY=value` | `-e` | Runtime environment variable |
+| `--build-env KEY=value` | `-b` | Build-time environment variable |
+| `--skip-domain` | | Skip auto-domain assignment |
+| `--force` | `-f` | Force new build (ignore cache) |
+| `--with-cache` | | Keep cache when using `--force` |
+| `--logs` | `-l` | Print build logs |
+| `--meta KEY=value` | `-m` | Deployment metadata |
+| `--target=staging` | | Deploy to custom environment |
+| `--no-wait` | | Return immediately (don't wait) |
+| `--yes` | `-y` | Skip interactive prompts |
+
+**Output**: stdout contains deployment URL. stderr contains errors (exit code != 0).
+
+### build
+
+Build project locally using Vercel's build pipeline. Output goes to `.vercel/output/`.
+
+```bash
+vercel build                        # Build with preview env vars
+vercel build --prod                 # Build with production env vars
+vercel build --target=staging       # Build for custom environment
+vercel build --yes                  # Auto-pull env vars if missing
+```
+
+Run `vercel pull` first to sync env vars and project settings.
+
+### dev
+
+Start local development server replicating Vercel's environment.
+
+```bash
+vercel dev                          # Start dev server
+vercel dev --listen 5005            # Custom port
+vercel dev --yes                    # Skip setup questions
+```
+
+Run `vercel pull` first. Prefer framework-native dev commands (e.g., `next dev`)
+when they provide equivalent functionality.
+
+### pull
+
+Sync environment variables and project settings to `.vercel/` directory.
+
+```bash
+vercel pull                         # Pull development vars
+vercel pull --environment=preview   # Pull preview vars
+vercel pull --environment=production  # Pull production vars
+vercel pull --environment=preview --git-branch=feature  # Branch-specific
+vercel pull --yes                   # Skip prompts
+```
+
+Output stored in `.vercel/.env.$target.local`. Always run before `vercel build` or `vercel dev`.
+
+### link
+
+Connect local directory to a Vercel project. Creates `.vercel/` directory.
+
+```bash
+vercel link                         # Interactive linking
+vercel link --yes                   # Use defaults
+vercel link --yes --project foo     # Link to specific project
+vercel link --repo                  # Link all projects in monorepo
+```
+
+### logs
+
+View and filter request logs or stream runtime logs.
+
+```bash
+vercel logs                         # Last 24h, current project
+vercel logs --follow                # Live stream
+```
+
+| Filter | Flag | Example |
+|--------|------|---------|
+| Environment | `--environment` | `--environment production` |
+| Log level | `--level` | `--level error --level warning` |
+| Status code | `--status-code` | `--status-code 5xx` |
+| Source | `--source` | `--source edge-function` |
+| Full-text search | `--query` / `-q` | `--query "timeout"` |
+| Time range | `--since` / `--until` | `--since 1h --until 30m` |
+| Branch | `--branch` / `-b` | `--branch feature-x` |
+| Request ID | `--request-id` | `--request-id req_xxx` |
+| JSON output | `--json` / `-j` | Pipe to `jq` |
+| Expand messages | `--expand` / `-x` | Full log content |
+| Max entries | `--limit` / `-n` | `--limit 50` |
+
+Sources: `serverless`, `edge-function`, `edge-middleware`, `static`.
+
+### inspect
+
+Retrieve deployment details.
+
+```bash
+vercel inspect [deployment-url]
+vercel inspect [deployment-url] --logs   # Include build logs
+vercel inspect [deployment-url] --wait   # Wait for completion
+```
+
+## Environment Variable Commands
+
+```bash
+vercel env add [name] [env] [branch]       # Add variable
+vercel env update [name] [env]             # Update variable
+vercel env rm [name] [env]                 # Remove variable
+vercel env ls [env] [branch]              # List variables
+vercel env pull [file]                     # Export to file (default: .env.local)
+vercel env run -- <command>                # Run command with vars loaded
+```
+
+| Flag | Description |
+|------|-------------|
+| `--sensitive` | Mark variable as hidden in dashboard |
+| `--force` | Overwrite without confirmation |
+| `-e, --environment` | Target environment |
+| `--git-branch` | Target Git branch |
+
+See `references/environment-variables.md` for workflows.
+
+## Domain and DNS Commands
+
+### domains
+
+```bash
+vercel domains ls                          # List domains
+vercel domains inspect [domain]            # Domain details
+vercel domains add [domain] [project]      # Add to project
+vercel domains add [domain] [project] --force  # Force add
+vercel domains rm [domain]                 # Remove domain
+vercel domains buy [domain]                # Purchase domain
+vercel domains move [domain] [scope]       # Move to another team
+vercel domains transfer-in [domain]        # Transfer domain in
+```
+
+### dns
+
+```bash
+vercel dns ls                              # List records
+vercel dns add [domain] [name] [type] [value]  # Add record
+vercel dns rm [record-id]                  # Remove record
+vercel dns import [domain] [zonefile]      # Import zonefile
+```
+
+Record types: `A`, `AAAA`, `CNAME`, `TXT`, `MX` (with priority), `SRV` (priority weight port target), `CAA`.
+
+### alias
+
+```bash
+vercel alias set [deployment-url] [custom-domain]
+vercel alias rm [custom-domain]
+vercel alias ls
+```
+
+### certs
+
+```bash
+vercel certs ls                            # List certificates
+vercel certs issue [domain]                # Issue certificate
+vercel certs issue [domain] --challenge-only  # Show DNS challenges
+vercel certs rm [cert-id]                  # Remove certificate
+```
+
+## Deployment Lifecycle Commands
+
+### promote
+
+Promote a deployment to production.
+
+```bash
+vercel promote [deployment-url]
+vercel promote [deployment-url] --timeout=5m
+vercel promote status [project]
+```
+
+Warning: promoting preview deployments switches env vars to production values.
+
+### rollback
+
+Roll back production to a previous deployment. Instant, no rebuild.
+
+```bash
+vercel rollback                            # Previous deployment (all plans)
+vercel rollback [deployment-url]           # Specific deployment (Pro/Enterprise)
+vercel rollback status
+```
+
+### redeploy
+
+Rebuild and redeploy an existing deployment.
+
+```bash
+vercel redeploy [deployment-url]
+```
+
+### rolling-release
+
+Configure gradual traffic rollout.
+
+```bash
+vercel rolling-release configure --cfg='{"enabled":true,"stages":[...]}'
+vercel rolling-release start --dpl=[deployment-id]
+vercel rolling-release approve --dpl=[deployment-id]
+vercel rolling-release complete --dpl=[deployment-id]
+vercel rolling-release fetch
+```
+
+### list
+
+```bash
+vercel list                                # Current project deployments
+vercel list [project-name]                 # Specific project
+```
+
+### remove
+
+```bash
+vercel remove [deployment-url]             # Remove deployment
+vercel remove [project-name]               # Remove all deployments
+```
+
+## Project and Team Commands
+
+```bash
+vercel project ls                          # List projects
+vercel project ls --json                   # JSON output
+vercel project ls --update-required        # Projects needing Node.js update
+vercel project add                         # Create project
+vercel project inspect                     # Inspect linked project
+vercel project rm                          # Remove project
+
+vercel teams list                          # List teams
+vercel teams add                           # Create team
+vercel teams invite [email]                # Invite member
+vercel switch                              # Switch team (interactive)
+vercel switch [team-slug]                  # Switch to specific team
+
+vercel target list                         # List custom environments
+```
+
+## Storage and Cache Commands
+
+```bash
+vercel blob list                           # List blobs
+vercel blob put [file]                     # Upload file
+vercel blob get [url]                      # Download blob
+vercel blob del [url]                      # Delete blob
+vercel blob copy [from] [to]              # Copy blob
+
+vercel cache purge                         # Purge all cache
+vercel cache purge --type cdn              # CDN cache only
+vercel cache purge --type data             # Data cache only
+vercel cache invalidate --tag foo          # Invalidate by tag
+```
+
+## Integration Commands
+
+```bash
+vercel integration add [name]              # Add marketplace integration
+vercel integration list                    # List integrations
+vercel integration remove [name]           # Remove integration
+vercel integration discover               # Browse available integrations
+vercel install [name]                      # Alias for integration add
+```
+
+## Utility Commands
+
+```bash
+vercel whoami                              # Current user
+vercel login                               # Email login
+vercel login --github                      # GitHub login
+vercel logout                              # Logout
+vercel open                                # Open project in dashboard
+vercel init [template]                     # Initialize from template
+vercel bisect                              # Binary search deployments for issues
+vercel curl [path]                         # HTTP request with protection bypass
+vercel httpstat [path]                     # HTTP timing statistics
+vercel git connect                         # Connect Git provider
+vercel git disconnect                      # Disconnect Git provider
+vercel webhooks list                       # List webhooks
+vercel webhooks create [url] --event [event]  # Create webhook
+vercel telemetry status                    # Check telemetry
+```
+
+## Global Options
+
+Available for all commands:
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--token [token]` | `-t` | Authorization token |
+| `--scope [slug]` | `-S` | Execute from specific scope |
+| `--project [name-or-id]` | | Specify project |
+| `--team [slug-or-id]` | `-T` | Specify team |
+| `--cwd [path]` | | Working directory |
+| `--debug` | `-d` | Verbose output |
+| `--no-color` | | Disable color and emoji |
+| `--yes` | `-y` | Skip interactive prompts |
+| `--global-config [path]` | `-Q` | Global config directory |
+| `--local-config [path]` | `-A` | Path to vercel.json |
+
+## Project Specification Precedence
+
+1. `--project` flag (highest priority)
+2. `VERCEL_PROJECT_ID` environment variable
+3. `.vercel/project.json` from project linking (lowest priority)
+
+## CI/CD Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `VERCEL_TOKEN` | Authentication token (create at vercel.com/account/tokens) |
+| `VERCEL_ORG_ID` | Organization/team ID |
+| `VERCEL_PROJECT_ID` | Project ID |
+
+Set these as CI secrets. Use `--token $VERCEL_TOKEN` on every command in CI.

--- a/skills/vercel/references/deployment-workflows.md
+++ b/skills/vercel/references/deployment-workflows.md
@@ -1,0 +1,313 @@
+# Deployment Workflows
+
+Sources: Vercel CLI docs (2026), production GitHub repos (midday-ai, ChatGPTNextWeb, polarsource/polar)
+
+Covers: CI/CD patterns, preview and production workflows, promote, rollback,
+rolling releases, monorepo deployment, deploy hooks, and prebuilt deploys.
+
+## The 3-Step Pattern
+
+Every CI/CD pipeline follows the same core sequence:
+
+```bash
+vercel pull --yes --environment=production --token=$VERCEL_TOKEN
+vercel build --prod --token=$VERCEL_TOKEN
+vercel deploy --prod --prebuilt --archive=tgz --token=$VERCEL_TOKEN
+```
+
+**Step 1 (pull)**: Syncs environment variables and project settings to `.vercel/`.
+**Step 2 (build)**: Builds using Vercel's pipeline. Output goes to `.vercel/output/`.
+**Step 3 (deploy)**: Uploads pre-built artifacts. `--archive=tgz` compresses for speed.
+
+For preview deployments, remove `--prod` from build and deploy, use
+`--environment=preview` for pull.
+
+## GitHub Actions
+
+### Production Deployment
+
+```yaml
+name: Deploy Production
+on:
+  push:
+    branches: [main]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Vercel CLI
+        run: npm install -g vercel
+      - name: Pull, Build, Deploy
+        run: |
+          vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+          vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+          vercel deploy --prod --prebuilt --archive=tgz --token=${{ secrets.VERCEL_TOKEN }}
+```
+
+### Preview Deployment
+
+```yaml
+name: Deploy Preview
+on:
+  pull_request:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Vercel CLI
+        run: npm install -g vercel
+      - name: Pull, Build, Deploy
+        id: deploy
+        run: |
+          vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+          vercel build --token=${{ secrets.VERCEL_TOKEN }}
+          url=$(vercel deploy --prebuilt --archive=tgz --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$url" >> $GITHUB_OUTPUT
+      - name: Comment PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Preview: ${{ steps.deploy.outputs.url }}`
+            })
+```
+
+### Required Secrets
+
+| Secret | Where to Find |
+|--------|---------------|
+| `VERCEL_TOKEN` | vercel.com/account/tokens |
+| `VERCEL_ORG_ID` | `.vercel/project.json` after `vercel link` |
+| `VERCEL_PROJECT_ID` | `.vercel/project.json` after `vercel link` |
+
+## GitLab CI
+
+```yaml
+deploy_preview:
+  stage: deploy
+  except:
+    - main
+  script:
+    - npm install -g vercel
+    - vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
+    - vercel build --token=$VERCEL_TOKEN
+    - vercel deploy --prebuilt --token=$VERCEL_TOKEN
+
+deploy_production:
+  stage: deploy
+  only:
+    - main
+  script:
+    - npm install -g vercel
+    - vercel pull --yes --environment=production --token=$VERCEL_TOKEN
+    - vercel build --prod --token=$VERCEL_TOKEN
+    - vercel deploy --prod --prebuilt --token=$VERCEL_TOKEN
+```
+
+## Bitbucket Pipelines
+
+```yaml
+pipelines:
+  branches:
+    main:
+      - step:
+          script:
+            - npm install -g vercel
+            - vercel pull --yes --environment=production --token=$VERCEL_TOKEN
+            - vercel build --prod --token=$VERCEL_TOKEN
+            - vercel deploy --prod --prebuilt --token=$VERCEL_TOKEN
+    feature/*:
+      - step:
+          script:
+            - npm install -g vercel
+            - vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
+            - vercel build --token=$VERCEL_TOKEN
+            - vercel deploy --prebuilt --token=$VERCEL_TOKEN
+```
+
+## Staged Production Deployment
+
+Deploy a production build without assigning it to the production domain.
+Test first, then alias.
+
+```bash
+DEPLOYMENT_URL=$(vercel deploy --prod --skip-domain --token=$VERCEL_TOKEN)
+# Run smoke tests against $DEPLOYMENT_URL...
+vercel alias set $DEPLOYMENT_URL production-domain.com --token=$VERCEL_TOKEN
+```
+
+## Promote from Preview
+
+Promote a preview deployment to production without rebuilding.
+
+```bash
+vercel promote [deployment-url]
+vercel promote status                    # Check progress
+```
+
+**Warning**: Promoted deployments use production environment variables, not
+preview variables. If preview and production env vars differ, behavior may change.
+
+## Rollback
+
+Instantly revert production to a previous deployment. No rebuild required.
+
+```bash
+vercel rollback                          # Previous deployment (all plans)
+vercel rollback [deployment-url]         # Specific deployment (Pro/Enterprise)
+vercel rollback status                   # Check status
+```
+
+Undo a rollback with `vercel promote [deployment-url]`.
+
+Hobby plan: can only roll back to the immediately previous deployment.
+Pro/Enterprise: can roll back to any previous deployment.
+
+## Rolling Releases
+
+Gradually roll traffic to a new deployment in stages.
+
+```bash
+vercel rolling-release configure --cfg='{
+  "enabled": true,
+  "advancementType": "automatic",
+  "stages": [
+    {"targetPercentage": 10, "duration": 5},
+    {"targetPercentage": 50, "duration": 10},
+    {"targetPercentage": 100}
+  ]
+}'
+```
+
+Deploy triggers rolling release automatically:
+
+```bash
+vercel deploy --prod                     # Starts at 10%
+vercel rolling-release fetch             # Monitor rollout
+vercel rolling-release approve --dpl=... # Manual advancement (if manual mode)
+```
+
+## Redeploy
+
+Rebuild an existing deployment with fresh dependencies and env vars.
+
+```bash
+vercel redeploy [deployment-url]
+```
+
+Use when: retrying failed builds, applying updated dependencies, refreshing env vars.
+
+## Deploy Hooks
+
+Trigger deployments via HTTP POST without pushing code.
+
+Create hooks in Project Settings -> Git -> Deploy Hooks.
+Each hook is tied to a specific branch.
+
+```bash
+curl -X POST https://api.vercel.com/v1/integrations/deploy/prj_xxx/yyy
+```
+
+Use cases: CMS content changes, scheduled deployments, external triggers.
+
+## Webhooks
+
+Listen to deployment events:
+
+| Event | Description |
+|-------|-------------|
+| `deployment.created` | Deployment started |
+| `deployment.succeeded` | Build and deploy completed |
+| `deployment.failed` | Deployment failed |
+| `deployment.ready` | Deployment is live |
+| `deployment.canceled` | Deployment was canceled |
+
+Configure in Project Settings -> Webhooks.
+
+## Monorepo Deployment
+
+### Turborepo + Vercel
+
+```bash
+export TURBO_TOKEN=$VERCEL_TOKEN
+export TURBO_TEAM=$VERCEL_ORG_ID
+turbo build --filter=web
+vercel deploy --prebuilt --token=$VERCEL_TOKEN
+```
+
+Remote caching is automatic on Vercel. Achieves 80-95% cache hit rates.
+
+### Per-App Configuration
+
+Each app in a monorepo is a separate Vercel project:
+
+```json
+{
+  "buildCommand": "pnpm --filter=web build",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "outputDirectory": "apps/web/.next"
+}
+```
+
+Link each app separately:
+
+```bash
+cd apps/web && vercel link --yes --project web-app
+cd apps/api && vercel link --yes --project api-app
+```
+
+Or link the entire repo: `vercel link --repo`.
+
+### Nx Monorepo
+
+Add `runtimeCacheInputs` to prevent stale env var caching:
+
+```json
+{ "runtimeCacheInputs": ["echo $MY_VERCEL_ENV"] }
+```
+
+## Prebuilt Deployment
+
+Build without sharing source code with Vercel.
+
+```bash
+vercel build --prod
+vercel deploy --prod --prebuilt
+```
+
+**Limitations**:
+- No Skew Protection (no deployment ID at build time)
+- Missing system environment variables (VERCEL_URL, etc.) during build
+- Git metadata not available
+
+Prefer Git-based deployments when Skew Protection or system env vars are needed.
+
+## Deployment Metadata
+
+Tag deployments with custom metadata for tracking:
+
+```bash
+vercel deploy --meta commit=$GITHUB_SHA --meta author=$GITHUB_ACTOR
+```
+
+Query metadata via `vercel inspect` or the REST API.
+
+## Zero-Downtime Deployment
+
+All Vercel deployments are atomic:
+1. New deployment builds in isolation.
+2. Once ready, traffic switches instantly.
+3. Old deployment remains available for rollback.
+
+No configuration needed. Downtime is not possible during normal deployments.

--- a/skills/vercel/references/domains-and-dns.md
+++ b/skills/vercel/references/domains-and-dns.md
@@ -1,0 +1,294 @@
+# Domains and DNS
+
+Sources: Vercel CLI docs (2026), Vercel domain management documentation
+
+Covers: Domain lifecycle, DNS records, SSL certificates, wildcard domains,
+multi-tenant patterns, and domain operations via CLI.
+
+## Domain Lifecycle
+
+1. **Add** domain to project: `vercel domains add`
+2. **Configure** DNS records: `vercel dns add` or external DNS provider
+3. **Verify** configuration: `vercel domains inspect`
+4. **Certificate** issued automatically by Vercel (Let's Encrypt)
+5. **Active**: domain serves traffic from the project
+
+## Domain Commands
+
+### List Domains
+
+```bash
+vercel domains ls
+vercel domains ls --limit 100
+vercel domains ls --next 1584722256178   # Pagination token
+```
+
+### Inspect Domain
+
+```bash
+vercel domains inspect example.com
+```
+
+Shows: DNS configuration status, certificate status, project assignment,
+nameserver configuration.
+
+### Add Domain to Project
+
+```bash
+vercel domains add example.com my-project
+vercel domains add example.com my-project --force  # Override existing assignment
+```
+
+A domain can only be assigned to one project at a time. Use `--force` to
+reassign from another project.
+
+### Remove Domain
+
+```bash
+vercel domains rm example.com
+vercel domains rm example.com --yes      # Skip confirmation
+```
+
+### Purchase Domain
+
+```bash
+vercel domains buy example.com
+```
+
+Purchased domains are automatically configured with Vercel nameservers.
+
+### Move Domain
+
+Transfer domain to another team or personal account:
+
+```bash
+vercel domains move example.com target-team-slug
+```
+
+### Transfer Domain In
+
+Transfer domain registration from another registrar:
+
+```bash
+vercel domains transfer-in example.com
+```
+
+Requires authorization code from current registrar. Domain must be unlocked.
+
+## DNS Record Management
+
+### List Records
+
+```bash
+vercel dns ls
+vercel dns ls --limit 100
+```
+
+### Add Records
+
+```bash
+# A record (IPv4)
+vercel dns add example.com www A 192.0.2.1
+vercel dns add example.com '@' A 76.76.21.21     # Apex domain
+
+# AAAA record (IPv6)
+vercel dns add example.com www AAAA 2001:0db8::1
+
+# CNAME record
+vercel dns add example.com www CNAME cname.vercel-dns.com
+vercel dns add example.com blog CNAME myblog.example.com
+
+# TXT record
+vercel dns add example.com '@' TXT "v=spf1 include:_spf.example.com ~all"
+
+# MX record (with priority)
+vercel dns add example.com '@' MX mail.example.com 10
+
+# SRV record (priority weight port target)
+vercel dns add example.com _sip SRV 10 60 5060 sip.example.com
+
+# CAA record
+vercel dns add example.com '@' CAA '0 issue "letsencrypt.org"'
+```
+
+### Remove Records
+
+```bash
+vercel dns rm rec_abc123def456
+```
+
+Find record IDs with `vercel dns ls`.
+
+### Import Zonefile
+
+```bash
+vercel dns import example.com ./zonefile.txt
+```
+
+DNS changes can take up to 24 hours to propagate.
+
+## Common Domain Setups
+
+### Apex Domain (example.com)
+
+```bash
+# Add domain to project
+vercel domains add example.com my-project
+
+# If using Vercel nameservers: automatic
+# If using external DNS: add A record
+vercel dns add example.com '@' A 76.76.21.21
+```
+
+### WWW Subdomain (www.example.com)
+
+```bash
+vercel domains add www.example.com my-project
+
+# If using external DNS: add CNAME
+vercel dns add example.com www CNAME cname.vercel-dns.com
+```
+
+### Apex + WWW with Redirect
+
+Add both domains. Configure one as primary and redirect the other:
+
+```json
+{
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "www.example.com" }],
+      "destination": "https://example.com/:path*",
+      "permanent": true
+    }
+  ]
+}
+```
+
+### Custom Subdomain (blog.example.com)
+
+```bash
+vercel domains add blog.example.com my-blog-project
+vercel dns add example.com blog CNAME cname.vercel-dns.com
+```
+
+### Wildcard Domain (*.example.com)
+
+Requires Vercel nameservers:
+
+1. Add wildcard domain: `vercel domains add "*.example.com" my-project`
+2. Add apex domain: `vercel domains add example.com my-project`
+3. Point nameservers to Vercel:
+   - `ns1.vercel-dns.com`
+   - `ns2.vercel-dns.com`
+
+Any subdomain (`tenant1.example.com`, `app.example.com`) automatically
+resolves with a valid SSL certificate.
+
+Cannot use wildcard domains with external DNS providers.
+
+## Vercel Nameservers vs External DNS
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| Vercel nameservers | Wildcard support, automatic config, fastest propagation | Must move all DNS to Vercel |
+| External DNS | Keep existing DNS provider, granular control | Manual record setup, no wildcard, slower propagation |
+
+**Use Vercel nameservers when**: wildcard domains needed, new domain, or
+willing to migrate all DNS.
+
+**Use external DNS when**: other services share the domain, corporate DNS
+policies, or only adding specific subdomains.
+
+## SSL/TLS Certificates
+
+Vercel automatically provisions and renews certificates via Let's Encrypt.
+
+### Automatic Management
+
+No action needed. Certificates are issued when a domain is added and
+verified. Renewal happens automatically before expiration.
+
+### Manual Certificate Operations
+
+```bash
+vercel certs ls                          # List all certificates
+vercel certs issue example.com           # Issue certificate manually
+vercel certs issue example.com www.example.com  # Multi-domain cert
+vercel certs issue example.com --challenge-only  # Show DNS challenges
+vercel certs rm cert_abc123              # Remove certificate
+```
+
+Use `--challenge-only` to see required DNS records without issuing.
+
+## Multi-Tenant Domain Patterns
+
+For platforms serving multiple tenants on custom domains:
+
+### Programmatic Domain Management
+
+Use the Vercel SDK to add/remove domains dynamically:
+
+```typescript
+import { VercelCore as Vercel } from "@vercel/sdk/core.js";
+import { projectsAddProjectDomain } from "@vercel/sdk/funcs/projectsAddProjectDomain.js";
+
+const vercel = new Vercel({ bearerToken: process.env.VERCEL_TOKEN });
+
+await projectsAddProjectDomain(vercel, {
+  idOrName: "my-multi-tenant-app",
+  teamId: process.env.VERCEL_TEAM_ID,
+  requestBody: { name: "tenant.example.com" },
+});
+```
+
+### Tenant Domain Setup Flow
+
+1. Tenant provides their custom domain in your app.
+2. Your backend calls Vercel API to add the domain.
+3. Show tenant the required DNS records (CNAME to `cname.vercel-dns.com`).
+4. Poll domain verification status until confirmed.
+5. SSL certificate is auto-provisioned.
+
+### Wildcard for Subdomains
+
+For subdomain-based multi-tenancy (`tenant1.myapp.com`):
+
+1. Configure wildcard domain on Vercel.
+2. Read subdomain in middleware or server component.
+3. Route to tenant-specific content.
+
+```typescript
+// middleware.ts
+export function middleware(request: NextRequest) {
+  const hostname = request.headers.get("host") || "";
+  const subdomain = hostname.split(".")[0];
+  // Route based on subdomain
+}
+```
+
+## Custom Aliases
+
+Assign custom URLs to specific deployments:
+
+```bash
+vercel alias set [deployment-url] custom.example.com
+vercel alias rm custom.example.com
+vercel alias ls
+```
+
+Use cases: preview environments with stable URLs, staging aliases,
+customer-facing demo URLs.
+
+## DNS Record Type Guide
+
+| Need | Record Type | Example |
+|------|-------------|---------|
+| Point domain to Vercel (apex) | A | `@ A 76.76.21.21` |
+| Point subdomain to Vercel | CNAME | `www CNAME cname.vercel-dns.com` |
+| Email routing | MX | `@ MX mail.example.com 10` |
+| Domain verification | TXT | `@ TXT "verify=abc123"` |
+| SPF for email | TXT | `@ TXT "v=spf1 include:..."` |
+| Certificate authority auth | CAA | `@ CAA '0 issue "letsencrypt.org"'` |
+| Service discovery | SRV | `_sip SRV 10 60 5060 sip.example.com` |

--- a/skills/vercel/references/environment-variables.md
+++ b/skills/vercel/references/environment-variables.md
@@ -1,0 +1,300 @@
+# Environment Variables
+
+Sources: Vercel CLI docs (2026), Vercel environment variable documentation
+
+Covers: Per-environment management, branch-specific variables, sensitive
+variables, pull and run workflows, system variables, and limits.
+
+## Three Default Environments
+
+| Environment | When Applied | Typical Use |
+|-------------|-------------|-------------|
+| Development | `vercel dev`, `vercel env pull` | Local development |
+| Preview | Non-production branches, PR deploys | Staging, testing |
+| Production | Production branch (usually `main`) | Live site |
+
+Variables set for one environment do not leak to others.
+
+## Custom Environments
+
+Pro: 1 custom environment per project. Enterprise: 12.
+
+Create via dashboard (Project Settings -> Environments) or API. Custom
+environments can track specific branches and have their own domains.
+
+Deploy to a custom environment:
+
+```bash
+vercel deploy --target=staging
+vercel pull --environment=staging
+vercel build --target=staging
+```
+
+## CLI Operations
+
+### Add Variables
+
+```bash
+vercel env add                           # Interactive (all environments)
+vercel env add API_KEY                   # Add to all environments
+vercel env add API_KEY production        # Add to production only
+vercel env add API_KEY preview feature-x # Add to preview, feature-x branch
+vercel env add API_KEY --sensitive       # Hidden in dashboard
+vercel env add DB_URL production < secret.txt  # From file
+echo "value" | vercel env add TOKEN production # From stdin
+```
+
+### Update Variables
+
+```bash
+vercel env update API_KEY                # Update across all environments
+vercel env update API_KEY production     # Update production only
+vercel env update API_KEY --sensitive    # Mark as sensitive
+cat ~/.npmrc | vercel env update NPM_RC preview  # From stdin
+```
+
+### Remove Variables
+
+```bash
+vercel env rm API_KEY production         # Remove from production
+vercel env rm API_KEY --yes              # Skip confirmation
+```
+
+### List Variables
+
+```bash
+vercel env ls                            # All environments
+vercel env ls production                 # Production only
+vercel env ls preview feature-x          # Preview, specific branch
+```
+
+## Pull to File
+
+Export environment variables to a local file.
+
+```bash
+vercel env pull                          # -> .env.local (development vars)
+vercel env pull .env.production          # Custom filename
+vercel env pull --environment=preview    # Preview vars
+vercel env pull --environment=production # Production vars
+vercel env pull --environment=preview --git-branch=feature  # Branch-specific
+vercel env pull --yes                    # Overwrite without prompt
+```
+
+## Run with Variables
+
+Execute a command with environment variables loaded in memory.
+
+```bash
+vercel env run -- next dev               # Development vars
+vercel env run -e preview -- npm test    # Preview vars
+vercel env run -e production -- next build  # Production vars
+vercel env run -e preview --git-branch feature-x -- next dev  # Branch-specific
+```
+
+Variables are loaded into the process environment, not written to disk.
+
+## Pull vs Env Pull
+
+| Command | Output | Use When |
+|---------|--------|----------|
+| `vercel pull` | `.vercel/.env.$target.local` + project settings | Before `vercel build` or `vercel dev` |
+| `vercel env pull` | `.env.local` (or custom file) | Need vars in specific file format |
+| `vercel env run` | In-memory only | Run one-off commands with vars |
+
+In CI/CD, use `vercel pull` before `vercel build`. For local development,
+`vercel env pull` or `vercel dev` (which pulls automatically).
+
+## Runtime Injection
+
+Override or add variables for a single deployment:
+
+```bash
+vercel deploy --env KEY=value --env KEY2=value2
+vercel deploy --build-env KEY=value      # Build-time only
+```
+
+`--env` overrides dashboard values for that specific deployment.
+`--build-env` is available only during the build step.
+
+## System Environment Variables
+
+Automatically available in every deployment:
+
+| Variable | Example | Description |
+|----------|---------|-------------|
+| `VERCEL_ENV` | `production` | Current environment (`production`, `preview`, `development`) |
+| `VERCEL_URL` | `my-app-abc.vercel.app` | Deployment URL (no protocol) |
+| `VERCEL_BRANCH_URL` | `my-app-git-main.vercel.app` | Branch-based URL |
+| `VERCEL_PROJECT_PRODUCTION_URL` | `my-app.vercel.app` | Production URL |
+| `VERCEL_GIT_COMMIT_SHA` | `abc123` | Git commit SHA |
+| `VERCEL_GIT_COMMIT_MESSAGE` | `fix: typo` | Commit message |
+| `VERCEL_GIT_COMMIT_AUTHOR_LOGIN` | `username` | Commit author |
+| `VERCEL_GIT_REPO_SLUG` | `my-repo` | Repository name |
+| `VERCEL_GIT_REPO_OWNER` | `my-org` | Repository owner |
+| `VERCEL_GIT_PROVIDER` | `github` | Git provider |
+| `VERCEL_TARGET_ENV` | `staging` | Custom environment name (if applicable) |
+
+Not available during prebuilt deployments (`vercel deploy --prebuilt`).
+
+## Branch-Specific Variables
+
+Override preview variables for specific Git branches:
+
+```bash
+# Default preview value
+vercel env add API_URL preview
+# Enter: https://staging-api.example.com
+
+# Override for feature-x branch
+vercel env add API_URL preview feature-x
+# Enter: https://feature-x-api.example.com
+```
+
+All preview deployments use the default value except `feature-x`, which
+uses its own override.
+
+## Sensitive Variables
+
+Mark variables as sensitive to hide values in the dashboard:
+
+```bash
+vercel env add API_SECRET --sensitive
+vercel env update API_SECRET --sensitive
+```
+
+Sensitive variables:
+- Hidden in dashboard UI (shown as `***`)
+- Still available at runtime in functions
+- Cannot be read back via CLI or API
+- Can only be overwritten, not viewed
+
+## Limits
+
+| Limit | Value |
+|-------|-------|
+| Total size per deployment | 64 KB (all variables combined) |
+| Per variable (Edge Functions/Middleware) | 5 KB |
+| Variable name | Alphanumeric + underscores |
+| Custom environments (Pro) | 1 per project |
+| Custom environments (Enterprise) | 12 per project |
+
+## Integration Variables
+
+Marketplace integrations (Neon, Upstash, Vercel Blob) automatically add
+environment variables to the project. These appear in the dashboard under
+the integration's section and are available in all environments by default.
+
+```bash
+# Pull integration variables along with project vars
+vercel env pull
+```
+
+## Security Best Practices
+
+1. **Never commit .env files** to Git. Add `.env*` and `.vercel/` to `.gitignore`.
+2. **Use --sensitive** for API keys, database URLs, and tokens.
+3. **Rotate credentials** regularly. Update via `vercel env update`.
+4. **Use CI secrets** (GitHub Secrets, GitLab CI variables) for `VERCEL_TOKEN`.
+5. **Separate by environment**. Production database URLs should never appear in preview.
+6. **Audit variables** periodically with `vercel env ls`.
+7. **Use Edge Config** instead of env vars for large configuration data (>5KB).
+8. **Never pass secrets via CLI flags**. Use `--env` for non-sensitive overrides only.
+
+## Local Development Workflow
+
+```bash
+# Initial setup
+vercel link --yes
+vercel env pull                          # Creates .env.local
+
+# Daily development
+vercel dev                               # Loads vars automatically
+# or
+vercel env run -- next dev               # Loads vars into process
+```
+
+## CI/CD Workflow
+
+```bash
+# Set as CI secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID
+vercel pull --yes --environment=production --token=$VERCEL_TOKEN
+vercel build --prod --token=$VERCEL_TOKEN
+vercel deploy --prod --prebuilt --token=$VERCEL_TOKEN
+```
+
+All environment variables are synced in the `pull` step. No need to
+pass `--env` flags unless overriding specific values.
+
+## Env Var Naming Conventions
+
+| Prefix | Meaning | Behavior |
+|--------|---------|----------|
+| `NEXT_PUBLIC_` | Exposed to browser (Next.js) | Inlined at build time, visible in client JS |
+| `NUXT_PUBLIC_` | Exposed to browser (Nuxt) | Available in client bundle |
+| `VITE_` | Exposed to browser (Vite) | Replaced at build time |
+| No prefix | Server-only | Available only in serverless/edge functions |
+
+**Warning**: Variables with public prefixes are embedded in the JavaScript bundle.
+Never put secrets in `NEXT_PUBLIC_`, `NUXT_PUBLIC_`, or `VITE_` prefixed variables.
+
+## Common Patterns
+
+### Database URL per Environment
+
+```bash
+vercel env add DATABASE_URL development
+# Enter: postgresql://localhost:5432/mydb
+
+vercel env add DATABASE_URL preview
+# Enter: postgresql://staging-host:5432/mydb
+
+vercel env add DATABASE_URL production --sensitive
+# Enter: postgresql://prod-host:5432/mydb
+```
+
+### Feature Flags via Env Vars
+
+```bash
+vercel env add FEATURE_NEW_UI preview    # Enable in preview
+# Enter: true
+
+vercel env add FEATURE_NEW_UI production # Disable in production
+# Enter: false
+```
+
+### Third-Party API Keys
+
+```bash
+vercel env add STRIPE_SECRET_KEY production --sensitive
+vercel env add STRIPE_PUBLISHABLE_KEY production
+# Publishable keys are public, so --sensitive is not needed
+
+vercel env add STRIPE_SECRET_KEY preview --sensitive
+# Use test mode key for preview
+```
+
+### Vercel Integration Variables
+
+When adding marketplace integrations (Neon, Upstash, Vercel Blob), variables
+are added automatically. Check which variables were added:
+
+```bash
+vercel env ls production | grep -i "neon\|upstash\|blob"
+```
+
+Common auto-added variables:
+- `DATABASE_URL`, `DATABASE_URL_UNPOOLED` (Neon)
+- `KV_REST_API_URL`, `KV_REST_API_TOKEN` (Upstash)
+- `BLOB_READ_WRITE_TOKEN` (Vercel Blob)
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Var not available in function | Wrong environment selected | Check `vercel env ls production` |
+| Var empty after deploy | Not synced before build | Run `vercel pull` before `vercel build` |
+| `NEXT_PUBLIC_` var undefined | Not available at build time | Rebuild after adding variable |
+| Edge function can't read var | Variable > 5KB | Use Edge Config for large values |
+| Var visible in client bundle | Using `NEXT_PUBLIC_` prefix | Remove prefix for server-only vars |
+| Different value in preview vs prod | Intentional per-env separation | Check with `vercel env ls` per env |

--- a/skills/vercel/references/project-configuration.md
+++ b/skills/vercel/references/project-configuration.md
@@ -1,0 +1,313 @@
+# Project Configuration
+
+Sources: Vercel project configuration docs (2026), vercel.json schema
+
+Covers: Complete vercel.json schema, all configuration fields, framework
+presets, monorepo configuration, and common gotchas.
+
+## Schema Autocomplete
+
+Always include for IDE validation and autocomplete:
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json"
+}
+```
+
+## Build Settings
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `buildCommand` | `string\|null` | Override build command. `null` skips build. |
+| `devCommand` | `string\|null` | Override local dev command. |
+| `installCommand` | `string\|null` | Override install command. `""` skips install. |
+| `outputDirectory` | `string\|null` | Build output directory (default: framework-specific). |
+| `framework` | `string\|null` | Override framework detection. `null` for "Other". |
+| `bunVersion` | `"1.x"` | Use Bun runtime instead of Node.js. |
+| `ignoreCommand` | `string\|null` | Skip builds conditionally. Exit 0 = skip, 1 = build. |
+| `public` | `boolean` | Make source and logs publicly accessible. |
+| `fluid` | `boolean\|null` | Enable Fluid compute (default for new projects since April 2025). |
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm build",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "outputDirectory": "dist",
+  "framework": "nextjs"
+}
+```
+
+## URL Handling
+
+| Field | Type | Default | Effect |
+|-------|------|---------|--------|
+| `cleanUrls` | `boolean` | `false` | Remove `.html` extensions. `about.html` becomes `/about`. |
+| `trailingSlash` | `boolean` | `undefined` | `true`: `/about` -> `/about/`. `false`: `/about/` -> `/about`. |
+
+## Redirects
+
+```json
+{
+  "redirects": [
+    { "source": "/old", "destination": "/new", "permanent": true },
+    { "source": "/blog/:path*", "destination": "/news/:path*" },
+    { "source": "/post/:path(\\d{1,})", "destination": "/news/:path*" }
+  ]
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `source` | `string` | Path pattern (excludes querystring). |
+| `destination` | `string` | Target path or external URL. |
+| `permanent` | `boolean` | `true` = 308, `false` = 307. Default: `true`. |
+| `statusCode` | `number` | Explicit status (301/302/303/307/308). Overrides `permanent`. |
+| `has` | `Array` | Match when property is present. |
+| `missing` | `Array` | Match when property is absent. |
+
+**Conditional redirects** (geo-routing example):
+
+```json
+{
+  "redirects": [
+    {
+      "source": "/:path((?!uk/).*)",
+      "has": [{ "type": "header", "key": "x-vercel-ip-country", "value": "GB" }],
+      "destination": "/uk/:path*",
+      "permanent": false
+    }
+  ]
+}
+```
+
+**has/missing object types**: `"header"`, `"cookie"`, `"host"`, `"query"`.
+
+Limit: 2,048 redirects per array. Use `bulkRedirectsPath` for more.
+
+## Bulk Redirects
+
+```json
+{ "bulkRedirectsPath": "./redirects.csv" }
+```
+
+Supports CSV, JSON, JSONL files. Can point to a folder. Fields: `source`,
+`destination`, `permanent`, `statusCode`, `caseSensitive`, `preserveQueryParams`.
+
+CSV boolean shorthand: `t` (true) or `f` (false).
+
+Does not work with `vercel dev`. No wildcard matching.
+
+## Rewrites
+
+Route requests without changing the visible URL.
+
+```json
+{
+  "rewrites": [
+    { "source": "/about", "destination": "/about-our-company.html" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}
+```
+
+**External rewrites** (reverse proxy):
+
+```json
+{
+  "rewrites": [
+    { "source": "/api/:path*", "destination": "https://api.example.com/:path*" }
+  ]
+}
+```
+
+**Cache external rewrites**: Add `x-vercel-enable-rewrite-caching` header, then
+control TTL with `CDN-Cache-Control: max-age=60`. Include `Vercel-Cache-Tag`
+for cache purging.
+
+For same-application rewrites, prefer framework-native routing (Next.js
+`next.config.js`, SvelteKit, Astro). Use vercel.json rewrites only for
+external rewrites or frameworks without native routing.
+
+## Headers
+
+```json
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
+      ]
+    }
+  ]
+}
+```
+
+Supports `has`/`missing` conditions (same syntax as redirects).
+
+**Separate client and CDN caching**:
+
+```json
+{
+  "headers": [
+    {
+      "source": "/api/data",
+      "headers": [
+        { "key": "Cache-Control", "value": "private, max-age=0" },
+        { "key": "CDN-Cache-Control", "value": "public, s-maxage=3600" }
+      ]
+    }
+  ]
+}
+```
+
+## Functions
+
+Configure serverless function behavior per glob pattern.
+
+```json
+{
+  "functions": {
+    "api/heavy.ts": {
+      "maxDuration": 60,
+      "runtime": "nodejs20.x",
+      "includeFiles": "data/**",
+      "excludeFiles": "**/*.test.ts",
+      "regions": ["sfo1"],
+      "functionFailoverRegions": ["iad1"],
+      "supportsCancellation": true
+    },
+    "api/*.ts": {
+      "maxDuration": 30
+    }
+  }
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `maxDuration` | `number` | Max execution time in seconds (up to plan limit). |
+| `memory` | `number` | Memory in MB. Cannot set with Fluid compute (use dashboard). |
+| `runtime` | `string` | Runtime identifier (e.g., `"nodejs20.x"`, `"vercel-php@0.5.2"`). |
+| `includeFiles` | `string` | Glob for files to include in bundle. |
+| `excludeFiles` | `string` | Glob for files to exclude from bundle. |
+| `regions` | `Array` | Override project-level regions. |
+| `functionFailoverRegions` | `Array` | Failover regions (Enterprise only). |
+| `supportsCancellation` | `boolean` | Enable request cancellation (Node.js only). |
+
+Glob pattern order matters -- more specific patterns first.
+
+## Regions
+
+```json
+{
+  "regions": ["iad1", "sfo1"],
+  "functionFailoverRegions": ["cle1"]
+}
+```
+
+Default: `["iad1"]`. Pro: up to 3 regions. Enterprise: unlimited.
+
+Common regions: `iad1` (Washington DC), `sfo1` (San Francisco), `cdg1` (Paris),
+`lhr1` (London), `fra1` (Frankfurt), `sin1` (Singapore), `hnd1` (Tokyo),
+`syd1` (Sydney), `gru1` (Sao Paulo).
+
+## Crons
+
+```json
+{
+  "crons": [
+    { "path": "/api/cleanup", "schedule": "0 0 * * *" },
+    { "path": "/api/hourly", "schedule": "0 * * * *" }
+  ]
+}
+```
+
+Schedule format: `minute hour day-of-month month day-of-week` (UTC).
+Max 100 jobs. Hobby: daily minimum. Pro: per-minute.
+
+Cannot use both day-of-month and day-of-week (one must be `*`).
+Cannot use named days/months (`MON`, `JAN`). Use numbers only.
+
+Cron requests include `vercel-cron/1.0` user agent. Secure with
+`CRON_SECRET` env var and authorization header check.
+
+## Images
+
+```json
+{
+  "images": {
+    "sizes": [640, 750, 828, 1080, 1200],
+    "remotePatterns": [
+      { "protocol": "https", "hostname": "example.com", "pathname": "/images/**" }
+    ],
+    "minimumCacheTTL": 60,
+    "formats": ["image/webp"],
+    "dangerouslyAllowSVG": false
+  }
+}
+```
+
+`sizes` is required. Image optimization URL: `/_vercel/image?url={src}&w=640&q=75`
+(or `/_next/image` for Next.js). Redeploying does not invalidate image cache.
+
+## Framework-Specific Notes
+
+**Next.js**: Use `outputFileTracingIncludes`/`outputFileTracingExcludes` in
+`next.config.js` instead of `includeFiles`/`excludeFiles` in vercel.json.
+Prefer `next.config.js` for redirects, rewrites, and headers.
+
+**Framework-specific maxDuration**:
+
+```typescript
+// Next.js App Router
+export const maxDuration = 30;
+
+// Next.js Pages Router
+export const config = { maxDuration: 30 };
+```
+
+SvelteKit, Astro, Nuxt: configure in adapter options or framework config.
+
+## Monorepo Configuration
+
+Root-level `vercel.json` applies to all projects. Project-level config overrides root.
+
+```
+monorepo/
+├── vercel.json              # Shared config (headers, regions)
+├── apps/
+│   ├── web/
+│   │   └── vercel.json      # Project-specific overrides
+│   └── api/
+│       └── vercel.json
+```
+
+Each app is a separate Vercel project. Use `buildCommand` with package filter:
+
+```json
+{
+  "buildCommand": "pnpm --filter=web build",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "outputDirectory": "apps/web/dist"
+}
+```
+
+## Gotchas
+
+| Issue | Cause | Workaround |
+|-------|-------|------------|
+| `has`/`missing` conditions return wrong results locally | Not supported in `vercel dev` | Test on preview deployments |
+| cleanUrls returns 404 with `vercel dev` + Next.js | Local dev limitation | Test on preview deployments |
+| Bulk redirects not working locally | Not supported in `vercel dev` | Test on preview deployments |
+| Memory setting ignored | Fluid compute enabled | Set memory in dashboard Settings |
+| `includeFiles` ignored in Next.js | Not supported | Use `outputFileTracingIncludes` |
+| Glob pattern matches wrong function | Order-dependent | Put specific patterns before general |
+| Edge function env var too large | 5KB per-variable limit | Use Edge Config for large values |
+| now.json still being used | Deprecated | Migrate to vercel.json before March 31, 2026 |

--- a/skills/vercel/references/serverless-and-edge.md
+++ b/skills/vercel/references/serverless-and-edge.md
@@ -1,0 +1,333 @@
+# Serverless and Edge Functions
+
+Sources: Vercel CLI docs (2026), Vercel functions documentation
+
+Covers: Serverless functions, edge functions, middleware, cold start mitigation,
+streaming, Build Output API, storage, and advanced platform features.
+
+## Serverless vs Edge Decision
+
+| Need | Use Serverless | Use Edge |
+|------|---------------|----------|
+| Full Node.js APIs (fs, child_process) | Yes | No |
+| Heavy compute (>30s) | Yes (up to 800s) | No (30s max) |
+| Database queries, external APIs | Yes | Possible (Web fetch only) |
+| Auth gating, redirects | No | Yes (middleware) |
+| Geo-routing, A/B testing | No | Yes |
+| Ultra-low latency (<10ms) | No (~250ms cold start) | Yes (~1ms cold start) |
+| Global distribution | Regional | Automatic (200+ locations) |
+| Native modules, C++ addons | Yes | No |
+| Python, Go, Ruby runtime | Yes | No |
+
+## Serverless Functions
+
+### File-Based Routing
+
+Files in `api/` become serverless endpoints. Next.js uses `app/api/`.
+
+```
+api/
+├── hello.ts          # /api/hello
+├── users/
+│   └── [id].ts       # /api/users/:id
+└── data.ts           # /api/data
+```
+
+### Supported Runtimes
+
+| Runtime | Identifier | Notes |
+|---------|-----------|-------|
+| Node.js 20 | `nodejs20.x` | Default, full API access |
+| Node.js 18 | `nodejs18.x` | Supported |
+| Python 3.9/3.11 | `python3.9`, `python3.11` | Community runtime |
+| Go | `go1.x` | Community runtime |
+| Ruby 3.2 | `ruby3.2` | Community runtime |
+| PHP | `vercel-php@0.5.2` | Community runtime |
+| Bun | Set `bunVersion: "1.x"` | Uses Bun instead of Node.js |
+
+### Runtime Configuration
+
+```typescript
+// Next.js App Router
+export const runtime = 'nodejs';    // or 'edge'
+export const maxDuration = 60;
+
+export async function GET(request: Request) {
+  return new Response('Hello');
+}
+```
+
+### Memory and Duration Limits
+
+**With Fluid Compute** (default since April 2025):
+
+| Plan | Memory | Default Duration | Max Duration |
+|------|--------|-----------------|-------------|
+| Hobby | 2 GB / 1 vCPU (fixed) | 300s | 300s |
+| Pro | Standard: 2 GB / 1 vCPU | 300s | 800s |
+| Pro | Performance: 4 GB / 2 vCPU | 300s | 800s |
+| Enterprise | Custom | 300s | 800s |
+
+Memory is configured in the dashboard (Settings -> Functions), not in vercel.json.
+
+**Without Fluid Compute** (legacy):
+
+| Plan | Memory Range | Default Duration | Max Duration |
+|------|-------------|-----------------|-------------|
+| Hobby | 1024 MB | 10s | 60s |
+| Pro | 128-3009 MB | 15s | 300s |
+| Enterprise | 128-3009 MB | 15s | 900s |
+
+### Cold Start Mitigation
+
+1. **Use Edge runtime** for lightweight operations (auth, routing). ~1ms vs ~250ms.
+2. **Minimize dependencies**. Import only what you need:
+   ```typescript
+   // Bad: imports entire lodash
+   import _ from 'lodash';
+   // Good: imports single function
+   import debounce from 'lodash/debounce';
+   ```
+3. **Top-level initialization**. Connections and clients persist across invocations:
+   ```typescript
+   import { db } from './db';  // Initialized once, reused
+   export async function GET() {
+     return Response.json(await db.query('SELECT 1'));
+   }
+   ```
+4. **Connection pooling** for databases. Use serverless-compatible pools.
+5. **Lazy load** heavy dependencies only when needed.
+
+## Edge Functions
+
+### Characteristics
+
+- V8 isolates (not Node.js). ~1ms cold start.
+- Global deployment (200+ edge locations).
+- Max execution: 30 seconds.
+- Max compressed size: 1 MB. Max response: 4 MB.
+- Auto-scales to 30,000 (Hobby/Pro) or 100,000+ (Enterprise).
+
+### Available APIs
+
+**Yes**: `fetch`, `Request`, `Response`, `Headers`, `URL`, `URLSearchParams`,
+`ReadableStream`, `WritableStream`, `TextEncoder`, `TextDecoder`,
+`crypto.subtle`, `Blob`, `File`, `FormData`, `setTimeout`, `setInterval`.
+
+**No**: `fs`, `path`, `child_process`, `net`, `dgram`, `os`, `eval`,
+`new Function()`, native modules, synchronous crypto.
+
+### Edge Function Example
+
+```typescript
+export const config = { runtime: 'edge' };
+
+export default async function handler(request: Request) {
+  const country = request.headers.get('x-vercel-ip-country');
+  return new Response(`Hello from ${country}`, {
+    headers: { 'content-type': 'text/plain' },
+  });
+}
+```
+
+## Middleware
+
+Runs on the Edge runtime before requests reach functions or pages.
+Place `middleware.ts` at the project root.
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  if (!request.cookies.get('auth')) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/admin/:path*'],
+};
+```
+
+### Geolocation
+
+```typescript
+export function middleware(request: NextRequest) {
+  const { country, city, region, latitude, longitude } = request.geo || {};
+  const ip = request.ip;
+  // Route based on location
+}
+```
+
+### A/B Testing
+
+```typescript
+export function middleware(request: NextRequest) {
+  const variant = Math.random() < 0.5 ? 'A' : 'B';
+  const response = NextResponse.next();
+  response.cookies.set('ab-variant', variant);
+  if (variant === 'A') {
+    return NextResponse.rewrite(new URL('/home-v2', request.url));
+  }
+  return response;
+}
+```
+
+## Edge Config
+
+Global low-latency data store. Reads in <1ms. Use for runtime configuration
+that changes without redeployment.
+
+```typescript
+import { get } from '@vercel/edge-config';
+
+export async function middleware(request: NextRequest) {
+  const maintenance = await get('maintenance_mode');
+  if (maintenance) {
+    return new Response('Site under maintenance', { status: 503 });
+  }
+  return NextResponse.next();
+}
+```
+
+Use cases: feature flags, maintenance mode, A/B test rules, dynamic redirects.
+
+## Streaming Responses
+
+```typescript
+export async function GET() {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    async start(controller) {
+      for (let i = 0; i < 10; i++) {
+        controller.enqueue(encoder.encode(`data: chunk ${i}\n\n`));
+        await new Promise(r => setTimeout(r, 100));
+      }
+      controller.close();
+    }
+  });
+  return new Response(stream, {
+    headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+  });
+}
+```
+
+## Build Output API
+
+Framework adapters emit this directory structure for deployment:
+
+```
+.vercel/output/
+├── config.json              # Routes, images, crons, overrides
+├── static/                  # CDN-served files
+│   ├── index.html
+│   └── assets/
+└── functions/               # Serverless and edge functions
+    └── api/hello.func/
+        ├── .vc-config.json  # Runtime, handler, memory, duration
+        └── index.js
+```
+
+`.vc-config.json` example:
+```json
+{
+  "runtime": "nodejs20.x",
+  "handler": "index.js",
+  "launcherType": "Nodejs",
+  "maxDuration": 60
+}
+```
+
+`vercel build` generates this structure. `vercel deploy --prebuilt` uploads it.
+
+## Storage Integrations
+
+| Service | Type | Setup |
+|---------|------|-------|
+| Vercel Blob | Object storage | `vercel integration add vercel-blob` |
+| Upstash Redis | Key-value store | `vercel integration add upstash-redis` |
+| Neon | PostgreSQL | `vercel integration add neon` |
+| Edge Config | Low-latency config | `vercel edge-config create` |
+
+```bash
+# CLI blob operations
+vercel blob put ./image.png --pathname images/logo.png
+vercel blob list --prefix images/
+vercel blob del images/old.png
+```
+
+Integrations auto-add environment variables (connection strings, tokens).
+
+## Observability
+
+**Speed Insights**: Real user performance metrics.
+```tsx
+import { SpeedInsights } from '@vercel/speed-insights/next';
+// Add <SpeedInsights /> to layout
+```
+
+**Web Analytics**: Privacy-friendly page view tracking.
+```tsx
+import { Analytics } from '@vercel/analytics/react';
+// Add <Analytics /> to layout
+```
+
+**Custom Events**:
+```typescript
+import { track } from '@vercel/analytics';
+track('purchase', { product: 'Premium', value: 99 });
+```
+
+## Firewall and Security
+
+- **DDoS protection**: Automatic for all plans. No configuration needed.
+- **WAF custom rules**: Pro/Enterprise. Configure in dashboard Firewall settings.
+- **IP blocking**: Hobby: 10, Pro: 25, Enterprise: 100 rules.
+- **Attack Challenge Mode**: CAPTCHA for all traffic during active attacks.
+- **Skew Protection**: Prevents version mismatches during deployments. Automatic in Next.js 14+.
+- **Deployment Protection Bypass**: Use `x-vercel-protection-bypass` header with
+  `VERCEL_AUTOMATION_BYPASS_SECRET` env var for CI/CD access to protected deploys.
+
+## Cron Jobs
+
+Schedule functions to run periodically. Configure in vercel.json `crons` array.
+
+| Plan | Min Interval | Precision | Max Jobs |
+|------|-------------|-----------|----------|
+| Hobby | Daily | +/- 59 minutes | 100 |
+| Pro | Per-minute | Per-minute | 100 |
+| Enterprise | Per-minute | Per-minute | 100 |
+
+Secure cron endpoints with `CRON_SECRET` env var:
+
+```typescript
+export async function GET(request: Request) {
+  if (request.headers.get('authorization') !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  await performTask();
+  return Response.json({ success: true });
+}
+```
+
+## Feature Flags
+
+```bash
+npm install @vercel/flags
+```
+
+```typescript
+import { flag } from '@vercel/flags/next';
+
+export const showNewUI = flag({
+  key: 'show-new-ui',
+  decide: () => false,
+  description: 'Enable redesigned dashboard',
+});
+
+// In component
+const enabled = await showNewUI();
+```
+
+$30 per 1M flag requests. Configure targeting rules in Vercel dashboard.

--- a/skills/vercel/references/troubleshooting.md
+++ b/skills/vercel/references/troubleshooting.md
@@ -1,0 +1,251 @@
+# Troubleshooting and Optimization
+
+Sources: Vercel CLI docs (2026), Vercel support documentation, production deployment patterns
+
+Covers: Common errors and fixes, debugging commands, plan limits, cost
+optimization strategies, recovery procedures, and vercel dev limitations.
+
+## Diagnostic Commands
+
+| Task | Command |
+|------|---------|
+| Check auth | `vercel whoami` |
+| Check project linking | `vercel project inspect` |
+| View build logs | `vercel inspect [deployment-url] --logs` |
+| View runtime logs | `vercel logs --environment production` |
+| Filter error logs | `vercel logs --level error --since 1h` |
+| Filter by status code | `vercel logs --status-code 5xx --since 1h` |
+| Stream live logs | `vercel logs --follow` |
+| HTTP timing analysis | `vercel httpstat /api/endpoint` |
+| Inspect deployment | `vercel inspect [deployment-url]` |
+| Check env vars | `vercel env ls production` |
+| Test build locally | `vercel build` |
+| Purge CDN cache | `vercel cache purge --type cdn` |
+| Purge data cache | `vercel cache purge --type data` |
+| Invalidate cache tag | `vercel cache invalidate --tag foo` |
+
+## Build Failures
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Missing environment variable | Variable not set for build environment | `vercel env ls production`, add missing vars |
+| Command not found | Wrong build command or missing dependency | Check `buildCommand` in vercel.json or dashboard |
+| Out of memory during build | Build process exceeds memory | Optimize build, reduce concurrent processes |
+| Build timeout | Build exceeds time limit | Optimize build steps, use caching (Turborepo) |
+| Module not found | Dependency not installed | Check `installCommand`, verify package.json |
+| TypeScript errors | Type errors in production build | Fix types, don't use `skipLibCheck` as workaround |
+| `now.json` deprecated | Using legacy config file | Rename to `vercel.json` (deadline: March 31, 2026) |
+
+### Debug Build Locally
+
+```bash
+vercel env pull --environment=production  # Get production vars
+vercel build --prod                       # Reproduce build locally
+```
+
+If local build succeeds but remote fails, check for missing env vars
+or system dependencies.
+
+## Function Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| FUNCTION_INVOCATION_TIMEOUT | Execution exceeds maxDuration | Increase `maxDuration`, optimize code, check DB queries |
+| FUNCTION_INVOCATION_FAILED | Unhandled exception | Check logs: `vercel logs --level error` |
+| FUNCTION_PAYLOAD_TOO_LARGE | Request/response body too large | Reduce payload size, use streaming |
+| EDGE_FUNCTION_INVOCATION_TIMEOUT | Edge function exceeds 30s | Move to serverless, or optimize |
+| FUNCTION_RATE_LIMIT | Too many concurrent invocations | Check concurrency limits for plan |
+| NO_RESPONSE_FROM_FUNCTION | Function didn't return a response | Ensure all code paths return Response |
+| FUNCTION_BOOT_TIMEOUT | Cold start too slow | Reduce bundle size, use Edge for lightweight ops |
+
+### Debug Slow Functions
+
+```bash
+# Measure response time
+vercel httpstat /api/slow-endpoint
+
+# Check function logs
+vercel logs --source serverless --query "slow-endpoint" --since 1h
+
+# Check for timeout patterns
+vercel logs --level error --query "timeout" --since 24h
+```
+
+## Edge Function Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Size limit exceeded | Bundle > 1MB compressed | Remove heavy deps, use serverless instead |
+| Node.js API not available | Using fs, child_process, etc. | Use Web APIs or switch to serverless |
+| Env var too large | Variable > 5KB | Use Edge Config for large values |
+| Dynamic import failed | Not supported well in Edge | Use static imports |
+
+## Domain and DNS Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Domain not verified | DNS not configured | `vercel domains inspect`, add required records |
+| Certificate pending | DNS propagation incomplete | Wait up to 24h, verify DNS records |
+| Domain in use | Assigned to another project | Use `--force` flag or remove from other project |
+| CNAME conflict at apex | Apex domains can't use CNAME | Use A record (76.76.21.21) for apex |
+| Wildcard not working | Not using Vercel nameservers | Migrate to ns1/ns2.vercel-dns.com |
+
+## vercel dev Limitations
+
+These features do not work locally with `vercel dev`:
+
+| Feature | Limitation | Workaround |
+|---------|-----------|------------|
+| `has`/`missing` conditions | Not evaluated | Test on preview deployments |
+| `cleanUrls` with Next.js | Returns 404 locally | Test on preview deployments |
+| Bulk redirects | Not processed | Test on preview deployments |
+| Edge Config | No local emulation | Use mock values in development |
+| Image optimization | Limited local support | Test on preview deployments |
+| Cron jobs | Not triggered locally | Call endpoints manually |
+| Deployment protection | Not applicable | N/A |
+
+## Plan Limits Reference
+
+### Function Execution
+
+| Metric | Hobby | Pro | Enterprise |
+|--------|-------|-----|-----------|
+| Max duration (Fluid) | 300s | 800s | 800s |
+| Max duration (legacy) | 60s | 300s | 900s |
+| Memory | 2 GB fixed | 2 or 4 GB | Custom |
+| Included GB-hours | 100 | 1,000 | Custom |
+| Included invocations | 100K | 1M | Custom |
+| Concurrency | Auto | Auto (30K) | Auto (100K+) |
+| Edge cold start | ~1ms | ~1ms | ~1ms |
+| Serverless cold start | ~250ms | ~250ms | ~250ms |
+
+### Bandwidth and Builds
+
+| Metric | Hobby | Pro | Enterprise |
+|--------|-------|-----|-----------|
+| Bandwidth | 100 GB/mo | 1 TB/mo | Custom |
+| Bandwidth overage | N/A | $0.15/GB | Custom |
+| Build minutes | 100/mo | 6,000/mo | Custom |
+| Build overage | N/A | $0.50/100min | Custom |
+| Deployments/day | 100 | 6,000 | Custom |
+| Team members | 1 | Unlimited | Unlimited |
+
+### Configuration Limits
+
+| Limit | Value |
+|-------|-------|
+| Redirects per array | 2,048 |
+| Env var total size | 64 KB per deployment |
+| Env var (Edge) | 5 KB per variable |
+| Cron jobs | 100 per project |
+| Regions (Pro) | 3 |
+| Custom environments (Pro) | 1 |
+| Custom environments (Enterprise) | 12 |
+| Firewall IP rules (Pro) | 25 |
+| Function size (compressed) | 250 MB serverless, 1 MB edge |
+
+## Cost Optimization
+
+### Bandwidth
+
+1. **Image optimization**: Use `next/image` or `/_vercel/image` API.
+2. **CDN caching**: Set `Cache-Control: public, s-maxage=3600, stale-while-revalidate=30`.
+3. **Compression**: Automatic (gzip/brotli). Verify with `Content-Encoding` header.
+4. **Code splitting**: Reduce initial bundle size. Dynamic imports for heavy modules.
+
+### Function Invocations
+
+1. **Static generation** over SSR where possible (`export const dynamic = 'force-static'`).
+2. **Edge caching**: Cache API responses at the CDN layer.
+3. **Batch operations**: Combine multiple API calls into one function.
+4. **Client-side fetch**: For non-critical, personalized content.
+
+### Build Minutes
+
+1. **Turborepo remote caching**: 80-95% cache hit rate. Set `TURBO_TOKEN` and `TURBO_TEAM`.
+2. **Incremental builds**: Only rebuild changed packages in monorepo.
+3. **Skip unnecessary builds**: Use `ignoreCommand` in vercel.json.
+4. **Frozen lockfile**: `pnpm install --frozen-lockfile` prevents resolution overhead.
+
+### Spend Management (Pro)
+
+Configure in dashboard Settings -> Billing -> Spend Management:
+- Set monthly spending limits per resource type.
+- Configure alert thresholds (email notifications).
+- Enable auto-pause at spending cap.
+
+## Recovery Procedures
+
+### Production Down
+
+```bash
+# 1. Confirm the issue
+vercel logs --environment production --status-code 5xx --since 30m
+
+# 2. Roll back immediately
+vercel rollback
+
+# 3. Verify recovery
+vercel logs --environment production --status-code 5xx --since 5m
+
+# 4. Investigate the bad deployment
+vercel list --prod
+vercel inspect [bad-deployment-url] --logs
+```
+
+### Build Broken
+
+```bash
+# 1. Check env vars
+vercel env ls production
+
+# 2. Test build locally
+vercel env pull --environment=production
+vercel build --prod
+
+# 3. Check dependencies
+vercel inspect [failed-deployment] --logs
+```
+
+### Slow Functions
+
+```bash
+# 1. Identify slow endpoints
+vercel httpstat /api/suspect-endpoint
+
+# 2. Check for cold starts (first request after idle)
+vercel logs --source serverless --since 1h --json | jq 'select(.duration > 5000)'
+
+# 3. Optimize
+# - Reduce bundle size (check includeFiles/excludeFiles)
+# - Use Edge runtime for lightweight operations
+# - Add connection pooling for databases
+# - Enable Fluid compute (default for new projects)
+```
+
+### Cache Issues
+
+```bash
+# Purge everything
+vercel cache purge
+
+# Purge specific cache type
+vercel cache purge --type cdn
+vercel cache purge --type data
+
+# Invalidate by tag
+vercel cache invalidate --tag products
+```
+
+## Prebuilt Deployment Gotchas
+
+When using `vercel build` + `vercel deploy --prebuilt`:
+
+| Missing Feature | Reason | Workaround |
+|----------------|--------|------------|
+| Skew Protection | No deployment ID at build time | Use Git-based deployments |
+| `VERCEL_URL` | System vars not available | Hardcode or use build-time vars |
+| `VERCEL_GIT_*` vars | Git metadata not available | Pass via `--build-env` |
+| Deployment metadata | Not auto-populated | Use `--meta` flag manually |
+
+Prefer Git-based deployments when these features are needed.

--- a/skills/vercel/skills.json
+++ b/skills/vercel/skills.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tank/vercel",
+  "version": "1.0.0",
+  "description": "Vercel deployment and project management using the CLI. Covers all CLI commands (deploy, build, dev, pull, env, domains, dns, logs, promote, rollback), vercel.json configuration (redirects, rewrites, headers, functions, crons, images, regions), CI/CD workflows (GitHub Actions, GitLab CI, preview/production), environment variable management, domain and DNS setup, serverless and edge functions, and troubleshooting. Synthesizes Vercel CLI docs (2026), vercel.json schema, and production deployment patterns. Triggers: vercel, vercel deploy, vercel cli, vercel build, vercel dev, vercel pull, vercel env, vercel domains, vercel dns, vercel logs, vercel promote, vercel rollback, vercel.json, deployment, preview deployment, production deployment, CI/CD vercel, serverless function, edge function, cron job vercel, vercel monorepo, vercel turborepo.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

- Add `@tank/vercel` skill covering the full Vercel CLI lifecycle
- 7 reference files (2,144 lines total) with no content overlap
- SKILL.md entry point (167 lines) with decision trees, anti-patterns, and quick-start guides

## Coverage

- **CLI Commands**: All 30+ commands (deploy, build, dev, pull, env, domains, dns, logs, promote, rollback, etc.) with flags and usage patterns
- **Project Configuration**: Complete vercel.json schema (redirects, rewrites, headers, functions, crons, images, regions, bulk redirects)
- **Deployment Workflows**: CI/CD patterns (GitHub Actions, GitLab CI, Bitbucket), preview/production, promote, rollback, rolling releases, monorepo (Turborepo/Nx)
- **Environment Variables**: Per-environment management, branch-specific vars, sensitive vars, pull/run workflows, system vars, limits
- **Domains and DNS**: Domain lifecycle, all DNS record types, SSL certificates, wildcard domains, multi-tenant patterns
- **Serverless and Edge**: Functions, edge runtime, middleware, cold start mitigation, streaming, Build Output API, storage integrations, firewall, feature flags
- **Troubleshooting**: Common errors with fix tables, debugging commands, plan limits by tier, cost optimization, recovery procedures

## Sources

Vercel CLI docs (2026), vercel.json schema, vercel/vercel AGENTS.md, production GitHub repos