### PR TITLE
chore(vercel): trim skills.json description to tank 500-char limit

### DIFF
--- a/skills/vercel/skills.json
+++ b/skills/vercel/skills.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/vercel",
   "version": "1.0.0",
-  "description": "Vercel deployment and project management using the CLI. Covers all CLI commands (deploy, build, dev, pull, env, domains, dns, logs, promote, rollback), vercel.json configuration (redirects, rewrites, headers, functions, crons, images, regions), CI/CD workflows (GitHub Actions, GitLab CI, preview/production), environment variable management, domain and DNS setup, serverless and edge functions, and troubleshooting. Synthesizes Vercel CLI docs (2026), vercel.json schema, and production deployment patterns. Triggers: vercel, vercel deploy, vercel cli, vercel build, vercel dev, vercel pull, vercel env, vercel domains, vercel dns, vercel logs, vercel promote, vercel rollback, vercel.json, deployment, preview deployment, production deployment, CI/CD vercel, serverless function, edge function, cron job vercel, vercel monorepo, vercel turborepo.",
+  "description": "Vercel deployment and project management via CLI. Covers deploy, build, dev, env, domains, dns, logs, promote, rollback. vercel.json config (redirects, rewrites, headers, functions, crons, regions). CI/CD patterns (GitHub Actions, GitLab CI). Env var management, serverless/edge functions, troubleshooting. Triggers: vercel, vercel deploy, vercel cli, vercel build, vercel dev, vercel env, vercel domains, vercel.json, deployment, CI/CD vercel, serverless function, edge function, vercel monorepo.",
   "permissions": {
     "network": { "outbound": [] },
     "filesystem": { "read": ["**/*"], "write": [] },


### PR DESCRIPTION
Trim description from 830 chars to 497 chars to pass tank publish validation.