### PR TITLE
chore(frontend-craft): trim skills.json description to tank 500-char limit

### DIFF
--- a/skills/frontend-craft/skills.json
+++ b/skills/frontend-craft/skills.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/frontend-craft",
   "version": "0.0.6",
-  "description": "Frontend craft for apps that feel fast, polished, and delightful. Micro-interactions, perceived performance, premium components, visual polish, state choreography, component architecture (shadcn/ui, Radix, CVA), and shadcn registry discovery (Aceternity UI, 21st.dev, React Bits, Fancy Components, Shadcn Space, and more). Triggers: micro-interaction, animation, skeleton, optimistic update, framer motion, command palette, data table, toast, sonner, cmdk, shadcn, aceternity, shadcn space, shadcnspace, 21st.dev, react bits, reactbits, fancy components, fancycomponents, UI polish, premium feel, page transition, form UX, 3d card, parallax, text effect, animated background, hero section, spotlight, bento grid, typewriter, sparkles, dashboard blocks, marketing blocks, physics animation, variable font, letter swap, gravity effect, neumorphism, animated button, animated component.",
+  "description": "Frontend craft for polished, delightful apps. Micro-interactions, perceived performance, premium components, visual polish, state choreography, shadcn registry search (8K+ components, 34+ registries, group/tag filtering). Triggers: animation, skeleton, optimistic update, framer motion, command palette, data table, toast, sonner, cmdk, shadcn, aceternity, 21st.dev, react bits, UI polish, premium feel, parallax, text effect, hero section, bento grid, sparkles, marketing blocks.",
   "permissions": {
     "network": { "outbound": ["ui.shadcn.com", "shadcn.com"] },
     "filesystem": { "read": ["**/*"], "write": ["scripts/.cache/**"] },


### PR DESCRIPTION
## Summary
- Trim `skills.json` description from 883 to 480 chars to pass Tank's 500-char limit
- Required for `tank publish` to succeed