### PR TITLE
fix(frontend-craft): add .venv to .tankignore for tank publish

### DIFF
--- a/skills/frontend-craft/.tankignore
+++ b/skills/frontend-craft/.tankignore
@@ -1,5 +1,6 @@
 scripts/.cache/
 .bdd/
+.venv/
 pyrightconfig.json
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
## Summary
- Add `.venv/` to `.tankignore` to prevent symlink error during `tank publish`