### PR TITLE
chore(frontend-craft): bump version to 1.0.0 for permission escalation publish

### DIFF
--- a/skills/frontend-craft/skills.json
+++ b/skills/frontend-craft/skills.json
@@ -1,6 +1,6 @@
 {
   "name": "@tank/frontend-craft",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "description": "Frontend craft for polished, delightful apps. Micro-interactions, perceived performance, premium components, visual polish, state choreography, shadcn registry search (8K+ components, 34+ registries, group/tag filtering). Triggers: animation, skeleton, optimistic update, framer motion, command palette, data table, toast, sonner, cmdk, shadcn, aceternity, 21st.dev, react bits, UI polish, premium feel, parallax, text effect, hero section, bento grid, sparkles, marketing blocks.",
   "permissions": {
     "network": { "outbound": ["ui.shadcn.com", "shadcn.com"] },


### PR DESCRIPTION
## Summary
- Bump version from 0.0.6 to 1.0.0 (major) to pass Tank's permission escalation check
- v0.0.1 had no subprocess/network/write permissions; v1.0.0 adds all three (required for registry search scripts)
- Already published to Tank: `@tank/frontend-craft@1.0.0`