### PR TITLE
feat(vector-graphics-gen): add new skill for SVG generation from text and images

### DIFF
--- a/skills/vector-graphics-gen/SKILL.md
+++ b/skills/vector-graphics-gen/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: "@tank/vector-graphics-gen"
+description: |
+  Generate vector graphics (SVG) for websites and apps using AI APIs.
+  Primary platform: fal.ai with Recraft V3/V4 for native SVG generation,
+  plus image-to-SVG conversion via recraft/vectorize and image2svg.
+  Covers text-to-vector generation, image vectorization, prompt engineering
+  for clean vector output, SVG optimization (SVGO), and web integration
+  patterns (React, Vue, sprites, dark mode). Synthesizes fal.ai documentation,
+  Recraft AI documentation, SVGO docs, and SVG specification.
+
+  Trigger phrases: "vector graphic", "generate SVG", "SVG icon",
+  "vector illustration", "AI vector", "fal.ai", "FAL_KEY", "recraft",
+  "recraft v3", "recraft v4", "text to SVG", "image to SVG",
+  "vectorize image", "SVG generation", "vector logo", "AI illustration",
+  "icon generation", "SVG for web", "vector art API", "fal-ai/recraft",
+  "generate icon", "web illustration", "SVG background", "vector pattern",
+  "clean SVG", "production SVG", "vector_illustration", "text-to-vector"
+---
+
+# Vector Graphics Generation
+
+## Core Philosophy
+
+1. **Generate native SVG when possible.** Use Recraft V4 text-to-vector
+   for true SVG output. Fall back to raster generation + vectorization
+   only when native models cannot achieve the desired style.
+2. **Every SVG must be production-ready.** Run SVGO, verify viewBox,
+   check file size, remove embedded rasters. Never ship raw AI output.
+3. **Prompt quality determines output quality.** Specific, structured
+   prompts with style keywords and color control produce clean vectors.
+   Vague prompts produce unusable output.
+4. **Match the tool to the task.** Icons need different models, prompts,
+   and optimization than hero illustrations or logos. Select deliberately.
+5. **Cost awareness matters.** Vector generation costs 2X raster ($0.08
+   vs $0.04). Use the cheapest pipeline that meets quality requirements.
+
+## Quick-Start: Generate Vector Graphics
+
+### "I need an SVG icon"
+
+1. Set `FAL_KEY` environment variable.
+2. Call Recraft V4 text-to-vector with a specific prompt:
+   ```javascript
+   const result = await fal.subscribe("fal-ai/recraft/v4/text-to-vector", {
+     input: {
+       prompt: "minimal settings gear icon, flat design, monochrome black, centered",
+       image_size: "square_hd"
+     }
+   });
+   ```
+3. Download SVG from `result.data.images[0].url`.
+4. Optimize with SVGO: `svgo --precision 1 --multipass icon.svg`
+   -> See `references/text-to-vector-models.md` for all model options
+   -> See `references/prompt-engineering.md` for icon prompt patterns
+
+### "I need a hero illustration"
+
+1. Call Recraft V3 with `vector_illustration` style and a sub-style:
+   ```javascript
+   const result = await fal.subscribe("fal-ai/recraft/v3/text-to-image", {
+     input: {
+       prompt: "team collaboration workspace illustration, people at desks with laptops",
+       style: "vector_illustration/emotional_flat",
+       image_size: "landscape_16_9",
+       colors: [{ r: 99, g: 102, b: 241 }, { r: 249, g: 115, b: 22 }]
+     }
+   });
+   ```
+2. If raster output, vectorize: call `fal-ai/recraft/vectorize`.
+3. Optimize with SVGO.
+   -> See `references/prompt-engineering.md` for illustration prompts
+   -> See `references/image-to-svg-conversion.md` for vectorization
+
+### "I need to convert an existing image to SVG"
+
+1. Use `fal-ai/image2svg` for cheapest conversion ($0.005):
+   ```javascript
+   const result = await fal.subscribe("fal-ai/image2svg", {
+     input: { image_url: "https://example.com/logo.png" }
+   });
+   ```
+2. Or use `fal-ai/recraft/vectorize` for higher quality ($0.01).
+3. Download and optimize.
+   -> See `references/image-to-svg-conversion.md` for all options
+
+### "I need a batch of consistent assets"
+
+1. Use the `colors` parameter to enforce brand palette across all generations.
+2. Use the same model and sub-style for visual consistency.
+3. Generate in a loop, optimize each output.
+   -> See `references/use-case-recipes.md` for batch pipeline code
+
+## Decision Trees
+
+### Model Selection
+
+| Need | Model | Endpoint | Cost |
+|------|-------|----------|------|
+| True SVG from text | Recraft V4 | `fal-ai/recraft/v4/text-to-vector` | $0.08 |
+| High-res true SVG | Recraft V4 Pro | `fal-ai/recraft/v4/pro/text-to-vector` | $0.30 |
+| Vector-style raster | Recraft V3 | `fal-ai/recraft/v3/text-to-image` | $0.08 |
+| Convert image to SVG | Recraft Vectorize | `fal-ai/recraft/vectorize` | $0.01 |
+| Cheap image to SVG | Image2SVG | `fal-ai/image2svg` | $0.005 |
+
+### Pipeline Selection
+
+| Scenario | Pipeline | Total Cost |
+|----------|----------|------------|
+| Simple icon/logo | V4 text-to-vector → SVGO | $0.08 |
+| Styled illustration | V3 vector_illustration → vectorize → SVGO | $0.09 |
+| Existing image | image2svg → SVGO | $0.005 |
+| Highest quality | V4 Pro text-to-vector → SVGO | $0.30 |
+| Budget batch | V3 vector → SVGO (skip vectorize if raster OK) | $0.08 |
+
+### Vector Sub-Style Selection (Recraft V3)
+
+| Use Case | Recommended Sub-Style |
+|----------|----------------------|
+| UI icons | `line_art`, `thin`, `sharp_contrast` |
+| App icons | `roundish_flat`, `bold_stroke`, `vivid_shapes` |
+| Editorial illustrations | `editorial`, `emotional_flat`, `infographical` |
+| Logo marks | `bold_stroke`, `cutout`, `sharp_contrast` |
+| Technical diagrams | `line_circuit`, `infographical`, `thin` |
+| Artistic illustrations | `cosmics`, `mosaic`, `naivector` |
+| Print/engraving | `engraving`, `linocut`, `colored_stencil` |
+
+### SVG Type File Size Targets
+
+| SVG Type | Target Size | Max Paths |
+|----------|-------------|-----------|
+| UI icon (24px) | < 1 KB | 1-5 |
+| Feature icon (48px) | < 2 KB | 5-15 |
+| Logo | < 10 KB | 5-30 |
+| Illustration | < 30 KB | 20-100 |
+| Background pattern | < 5 KB | 5-20 |
+
+## Authentication
+
+Set the `FAL_KEY` environment variable before making API calls:
+
+```bash
+export FAL_KEY="YOUR_API_KEY"
+```
+
+Install the client: `npm install @fal-ai/client` (JS) or `pip install fal-client` (Python).
+
+-> See `references/fal-api-reference.md` for complete setup
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/fal-api-reference.md` | fal.ai authentication, client setup (JS/Python/REST), request patterns (subscribe, queue, sync), response format, file upload, error handling, downloading SVG results |
+| `references/text-to-vector-models.md` | Recraft V3/V4 text-to-vector endpoints, all parameters, complete vector sub-style catalog (22 styles), color palette control, size options, model comparison, pricing |
+| `references/image-to-svg-conversion.md` | recraft/vectorize, image2svg, star-vector endpoints, two-step pipeline, Potrace CLI, input preparation, quality comparison, limitations |
+| `references/prompt-engineering.md` | Prompt structure formula, icon/illustration/logo/pattern prompt templates, style keyword catalog, negative prompts, color control, sub-style mapping, common mistakes |
+| `references/svg-optimization.md` | AI-generated SVG issues and fixes, SVGO setup and config, manual cleanup checklist, path simplification, file size targets, accessibility, batch processing |
+| `references/svg-integration-patterns.md` | React/Vue SVG components, icon system architecture, SVG sprite sheets, CSS background SVGs, responsive SVGs, dark mode adaptation, animation basics, bundler config |
+| `references/use-case-recipes.md` | Complete end-to-end recipes: icon sets, hero illustrations, empty states, logo variations, background patterns, image-to-SVG conversion, brand-consistent assets, batch generation pipeline |

--- a/skills/vector-graphics-gen/references/fal-api-reference.md
+++ b/skills/vector-graphics-gen/references/fal-api-reference.md
@@ -1,0 +1,431 @@
+# fal.ai API Reference
+Sources: fal.ai official documentation (2025-2026), @fal-ai/client npm package
+
+## 1. Authentication
+
+Use the FAL key via environment variables or explicit client configuration.
+Prefer env vars for local development and CI; use programmatic config for
+multi-tenant services.
+
+### Environment variable
+
+```bash
+export FAL_KEY="YOUR_FAL_KEY"
+```
+
+### Programmatic config (JavaScript)
+
+```javascript
+import { fal } from "@fal-ai/client";
+
+fal.config({
+  credentials: process.env.FAL_KEY || "YOUR_FAL_KEY"
+});
+```
+
+### Programmatic config (Python)
+
+```python
+from fal_client import FalClient
+
+client = FalClient("YOUR_FAL_KEY")
+```
+
+## 2. Client Setup
+
+### JavaScript: @fal-ai/client
+
+Install the SDK, configure credentials, and call an endpoint with async
+queue handling.
+
+```bash
+npm install @fal-ai/client
+```
+
+```javascript
+import { fal } from "@fal-ai/client";
+
+fal.config({ credentials: process.env.FAL_KEY });
+
+const result = await fal.subscribe("fal-ai/recraft/v4/text-to-vector", {
+  input: {
+    prompt: "Minimal geometric badge for a coffee brand"
+  },
+  logs: true,
+  onQueueUpdate: (update) => {
+    if (update.status === "IN_PROGRESS") {
+      update.logs.map((log) => log.message).forEach(console.log);
+    }
+  }
+});
+
+console.log(result.images[0].url);
+```
+
+### Python: fal-client
+
+Install the SDK and use the client to subscribe to a model endpoint.
+
+```bash
+pip install fal-client
+```
+
+```python
+from fal_client import FalClient
+
+client = FalClient()
+
+result = client.subscribe("fal-ai/recraft/v4/text-to-vector", {
+    "prompt": "Minimal geometric badge for a coffee brand"
+})
+
+print(result["images"][0]["url"])
+```
+
+### REST: curl
+
+Use the queue endpoint for language-agnostic calls. The queue domain accepts
+direct POSTs and returns a request id you can poll for results.
+
+```bash
+curl -X POST "https://queue.fal.run/fal-ai/recraft/v4/text-to-vector" \
+  -H "Authorization: Key $FAL_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"Minimal geometric badge for a coffee brand"}'
+```
+
+## 3. Request Patterns
+
+Use queue-based async by default. Only use sync when you need a single, quick
+call and are willing to block the process. Use manual queue when you need
+explicit request ids for tracking or external orchestration.
+
+### Pattern comparison
+
+| Pattern | When to use | Pros | Cons |
+| --- | --- | --- | --- |
+| subscribe (async) | Most production workflows | Logs + progress callbacks | Slightly more code |
+| run (sync) | One-off scripts | Simple, linear | Can time out, blocks process |
+| submit/status/result | Orchestrated pipelines | Explicit request id | Multiple network round trips |
+
+### Async subscribe (recommended)
+
+#### JavaScript
+
+```javascript
+import { fal } from "@fal-ai/client";
+
+fal.config({ credentials: process.env.FAL_KEY });
+
+const result = await fal.subscribe("fal-ai/recraft/v4/text-to-vector", {
+  input: {
+    prompt: "Flat icon set: cloud, sun, rain"
+  },
+  logs: true,
+  onQueueUpdate: (update) => {
+    if (update.status === "IN_PROGRESS") {
+      update.logs.map((log) => log.message).forEach(console.log);
+    }
+  }
+});
+
+console.log(result.images.map((img) => img.url));
+```
+
+#### Python
+
+```python
+from fal_client import FalClient
+
+client = FalClient()
+
+def on_update(update):
+    if update["status"] == "IN_PROGRESS":
+        for log in update.get("logs", []):
+            print(log.get("message"))
+
+result = client.subscribe(
+    "fal-ai/recraft/v4/text-to-vector",
+    {"prompt": "Flat icon set: cloud, sun, rain"},
+    on_queue_update=on_update,
+    logs=True,
+)
+
+print([img["url"] for img in result["images"]])
+```
+
+### Sync run
+
+#### JavaScript
+
+```javascript
+import { fal } from "@fal-ai/client";
+
+fal.config({ credentials: process.env.FAL_KEY });
+
+const result = await fal.run("fal-ai/recraft/v4/text-to-vector", {
+  input: {
+    prompt: "Simple monochrome SVG logo for a bike shop"
+  }
+});
+
+console.log(result.images[0].url);
+```
+
+#### Python
+
+```python
+from fal_client import FalClient
+
+client = FalClient()
+
+result = client.run("fal-ai/recraft/v4/text-to-vector", {
+    "prompt": "Simple monochrome SVG logo for a bike shop"
+})
+
+print(result["images"][0]["url"])
+```
+
+### Manual queue (submit/status/result)
+
+#### JavaScript
+
+```javascript
+import { fal } from "@fal-ai/client";
+
+fal.config({ credentials: process.env.FAL_KEY });
+
+const { request_id } = await fal.queue.submit("fal-ai/recraft/v4/text-to-vector", {
+  input: {
+    prompt: "Minimal map pin icon with clean outline"
+  }
+});
+
+let status = await fal.queue.status("fal-ai/recraft/v4/text-to-vector", {
+  requestId: request_id
+});
+
+while (status.status !== "COMPLETED" && status.status !== "FAILED") {
+  await new Promise((r) => setTimeout(r, 1000));
+  status = await fal.queue.status("fal-ai/recraft/v4/text-to-vector", {
+    requestId: request_id
+  });
+}
+
+if (status.status === "FAILED") {
+  throw new Error(status.error || "Fal queue failed");
+}
+
+const result = await fal.queue.result("fal-ai/recraft/v4/text-to-vector", {
+  requestId: request_id
+});
+
+console.log(result.images[0].url);
+```
+
+#### curl
+
+```bash
+# Submit
+curl -X POST "https://queue.fal.run/fal-ai/recraft/v4/text-to-vector" \
+  -H "Authorization: Key $FAL_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"Minimal map pin icon with clean outline"}'
+
+# Check status
+curl -X GET "https://queue.fal.run/fal-ai/recraft/v4/text-to-vector/status/{REQUEST_ID}" \
+  -H "Authorization: Key $FAL_KEY"
+
+# Fetch result
+curl -X GET "https://queue.fal.run/fal-ai/recraft/v4/text-to-vector/result/{REQUEST_ID}" \
+  -H "Authorization: Key $FAL_KEY"
+```
+
+## 4. Response Format
+
+Expect an `images` array. For vector endpoints, each image entry points to
+an SVG file with `content_type` set to `image/svg+xml`.
+
+```json
+{
+  "images": [
+    {
+      "url": "https://storage.fal.run/outputs/abc123/image.svg",
+      "file_size": 24561,
+      "file_name": "image.svg",
+      "content_type": "image/svg+xml"
+    }
+  ]
+}
+```
+
+## 5. File Upload
+
+Use fal storage to upload local files (e.g., a raster image you want to
+vectorize) and pass the resulting URL in model input.
+
+### JavaScript upload
+
+```javascript
+import { fal } from "@fal-ai/client";
+import fs from "node:fs";
+
+fal.config({ credentials: process.env.FAL_KEY });
+
+const buffer = fs.readFileSync("./input.png");
+const file = new File([buffer], "input.png", { type: "image/png" });
+
+const url = await fal.storage.upload(file);
+
+const result = await fal.subscribe("fal-ai/recraft/vectorize", {
+  input: { image_url: url }
+});
+
+console.log(result.images[0].url);
+```
+
+### Python upload
+
+```python
+from fal_client import FalClient
+
+client = FalClient()
+
+uploaded_url = client.upload_file("./input.png")
+
+result = client.subscribe("fal-ai/recraft/vectorize", {
+    "image_url": uploaded_url
+})
+
+print(result["images"][0]["url"])
+```
+
+## 6. Error Handling
+
+Handle queue failures explicitly, and implement timeouts and retries for
+network errors or 429 responses. Fail fast on invalid inputs.
+
+### Queue statuses to handle
+
+| Status | Meaning | Action |
+| --- | --- | --- |
+| IN_QUEUE | Waiting for worker | Keep polling |
+| IN_PROGRESS | Running | Stream logs or wait |
+| COMPLETED | Success | Fetch result |
+| FAILED | Model or input error | Inspect error, do not retry blindly |
+| CANCELED | Request canceled | Treat as failure |
+| TIMEOUT | Worker exceeded limit | Retry with backoff or reduce workload |
+
+### JavaScript retry pattern
+
+```javascript
+import { fal } from "@fal-ai/client";
+
+fal.config({ credentials: process.env.FAL_KEY });
+
+async function runWithRetry(endpoint, input, maxAttempts = 3) {
+  let attempt = 0;
+  let lastError;
+
+  while (attempt < maxAttempts) {
+    attempt += 1;
+    try {
+      return await fal.run(endpoint, { input });
+    } catch (err) {
+      lastError = err;
+      const waitMs = 500 * attempt;
+      await new Promise((r) => setTimeout(r, waitMs));
+    }
+  }
+
+  throw lastError;
+}
+
+const result = await runWithRetry(
+  "fal-ai/recraft/v4/text-to-vector",
+  { prompt: "Outlined badge with clean geometry" }
+);
+
+console.log(result.images[0].url);
+```
+
+### Python timeout and retry
+
+```python
+import time
+from fal_client import FalClient
+
+client = FalClient()
+
+def run_with_retry(endpoint, payload, max_attempts=3):
+    last_error = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return client.run(endpoint, payload)
+        except Exception as err:
+            last_error = err
+            time.sleep(0.5 * attempt)
+    raise last_error
+
+result = run_with_retry(
+    "fal-ai/recraft/v4/text-to-vector",
+    {"prompt": "Outlined badge with clean geometry"}
+)
+
+print(result["images"][0]["url"])
+```
+
+## 7. Downloading SVG Results
+
+Download the SVG with a standard HTTP fetch once you have the image URL.
+Verify `content_type` if the caller needs to enforce SVG output.
+
+### JavaScript download
+
+```javascript
+import fs from "node:fs";
+
+async function downloadSvg(url, outputPath) {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Download failed: ${res.status}`);
+  }
+  const svg = await res.text();
+  fs.writeFileSync(outputPath, svg, "utf8");
+}
+
+await downloadSvg(
+  "https://storage.fal.run/outputs/abc123/image.svg",
+  "./result.svg"
+);
+```
+
+### Python download
+
+```python
+import requests
+
+def download_svg(url, path):
+    res = requests.get(url, timeout=30)
+    res.raise_for_status()
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(res.text)
+
+download_svg(
+    "https://storage.fal.run/outputs/abc123/image.svg",
+    "./result.svg"
+)
+```
+
+## 8. Common Pitfalls Table
+
+| Pitfall | Cause | Fix |
+| --- | --- | --- |
+| Using sync run for large batches | run blocks and can time out | Use subscribe or manual queue |
+| Missing credentials in CI | FAL_KEY not set in environment | Export FAL_KEY in CI secret config |
+| Treating vector-style raster as SVG | Some models return PNG | Check `content_type` and file extension |
+| Ignoring queue failures | FAILED status not handled | Stop and surface error details |
+| Hard-coding request ids | Reusing old request_id | Always capture from submit response |
+| Uploading local paths directly | API expects URLs | Upload via fal storage and pass URL |
+| Polling too aggressively | Rate limits or wasted requests | Poll every 1-2 seconds |
+| Saving SVG as binary | Using response.arrayBuffer | Use res.text() and write UTF-8 |

--- a/skills/vector-graphics-gen/references/image-to-svg-conversion.md
+++ b/skills/vector-graphics-gen/references/image-to-svg-conversion.md
@@ -1,0 +1,354 @@
+# Image-to-SVG Conversion
+Sources: fal.ai documentation (2025-2026), Recraft vectorization docs, Potrace documentation
+
+This reference covers raster-to-SVG conversion methods for existing images. It assumes fal.ai client setup is already configured elsewhere.
+
+## 1. When to Convert vs Generate Native
+
+Decision table for choosing conversion rather than native vector generation.
+
+| Situation | Convert Raster to SVG | Generate Native Vector | Why |
+| --- | --- | --- | --- |
+| You already have a raster asset (logo, scan, screenshot) | Yes | No | Preserve existing visual identity |
+| You need pixel-accurate reproduction of a bitmap | Yes | No | Vectorization can simplify or distort |
+| You need editable shapes for icon systems | Maybe | Yes | Native vectors reduce path noise |
+| Input is a photo or complex texture | Maybe | No | Results are heavy and noisy |
+| You need quick budget conversion | Yes | No | image2svg is cheapest |
+| You need highest quality conversion | Yes | No | Prefer Recraft Vectorize or StarVector |
+| You are designing new artwork | No | Yes | Avoid conversion artifacts |
+
+Guidance:
+- Convert if the asset already exists and must be preserved.
+- Generate native if you can control style, palette, and shape complexity from scratch.
+
+## 2. fal-ai/recraft/vectorize
+
+Endpoint for high quality raster-to-SVG conversion.
+
+Key constraints:
+- Input formats: PNG, JPG, WEBP
+- File size: < 5 MB
+- Resolution: < 16 MP total, max dimension 4096 px, min dimension 256 px
+- Output: SVG (`image/svg+xml`)
+- Pricing: $0.01 per image
+
+JavaScript (fal client):
+```javascript
+// Assumes fal client already configured
+const result = await fal.subscribe("fal-ai/recraft/vectorize", {
+  input: {
+    image_url: "https://example.com/assets/logo.png"
+  }
+});
+
+// result.data contains output URL(s)
+console.log(result.data);
+```
+
+REST (curl):
+```bash
+curl -X POST "https://queue.fal.run/fal-ai/recraft/vectorize" \
+  -H "Authorization: Key $FAL_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"image_url":"https://example.com/assets/logo.png"}'
+```
+
+## 3. fal-ai/image2svg
+
+Lower-cost vectorization with detail control.
+
+Key constraints:
+- Input formats: JPG, JPEG, PNG, WEBP, GIF
+- Output: SVG (`image/svg+xml`)
+- Pricing: $0.005 per image
+- Detail control: use `detail` or model-specific parameter to trade fidelity vs simplicity
+
+JavaScript (fal client):
+```javascript
+// Assumes fal client already configured
+const result = await fal.subscribe("fal-ai/image2svg", {
+  input: {
+    image_url: "https://example.com/assets/icon.png",
+    detail: 0.6
+  }
+});
+
+console.log(result.data);
+```
+
+REST (curl):
+```bash
+curl -X POST "https://queue.fal.run/fal-ai/image2svg" \
+  -H "Authorization: Key $FAL_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"image_url":"https://example.com/assets/icon.png","detail":0.6}'
+```
+
+## 4. fal-ai/star-vector
+
+AI vectorization model for complex shapes and cleaner output on illustrations.
+
+Capabilities:
+- Strong at illustration-style conversion
+- Handles multi-color shapes better than classical trace
+- Useful when Potrace yields too many jagged paths
+
+JavaScript (fal client):
+```javascript
+// Assumes fal client already configured
+const result = await fal.subscribe("fal-ai/star-vector", {
+  input: {
+    image_url: "https://example.com/assets/illustration.png"
+  }
+});
+
+console.log(result.data);
+```
+
+REST (curl):
+```bash
+curl -X POST "https://queue.fal.run/fal-ai/star-vector" \
+  -H "Authorization: Key $FAL_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"image_url":"https://example.com/assets/illustration.png"}'
+```
+
+## 5. Two-Step Pipeline: Generate Raster then Vectorize
+
+Use when you need custom style control but still want SVG output. The raster step produces a clean, flat image that vectorizes well.
+
+Runnable Node.js example (uses fal client and storage upload):
+```javascript
+import fs from "node:fs";
+import { fal } from "@fal-ai/client";
+
+// Expects FAL_KEY in the environment and fal client already configured
+
+async function generateRaster() {
+  const result = await fal.subscribe("fal-ai/recraft/v3/text-to-image", {
+    input: {
+      prompt: "minimal flat icon of a delivery truck, solid colors, no gradients",
+      style: "vector_illustration",
+      image_size: "square_hd"
+    }
+  });
+  return result.data.images[0].url;
+}
+
+async function vectorize(imageUrl) {
+  const result = await fal.subscribe("fal-ai/recraft/vectorize", {
+    input: {
+      image_url: imageUrl
+    }
+  });
+  return result.data;
+}
+
+async function main() {
+  const rasterUrl = await generateRaster();
+  const svgResult = await vectorize(rasterUrl);
+  console.log({ rasterUrl, svgResult });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+Notes:
+- The vectorization step works best when the raster has flat fills, limited colors, and crisp edges.
+- If the generated raster is too detailed, reduce complexity in the prompt before vectorizing.
+
+## 6. Local Conversion: Potrace CLI
+
+Potrace is a classic bitmap-to-vector tracer. It is deterministic and works well for black-and-white or high-contrast inputs.
+
+Install:
+```bash
+# macOS
+brew install potrace
+
+# Ubuntu
+sudo apt-get install potrace
+```
+
+Usage (basic):
+```bash
+# Convert PNG to SVG (Potrace expects a bitmap, so convert first)
+potrace input.pbm -s -o output.svg
+```
+
+Common workflow with ImageMagick:
+```bash
+# 1) Convert to grayscale
+magick input.png -colorspace Gray gray.png
+
+# 2) Increase contrast and binarize
+magick gray.png -threshold 55% bw.pbm
+
+# 3) Trace to SVG
+potrace bw.pbm -s -o output.svg
+```
+
+Useful options:
+- `-s`: SVG output
+- `-o file.svg`: Output file
+- `-t <n>`: Tolerance; higher reduces detail
+- `-a <n>`: Corner threshold; higher keeps corners sharper
+- `-O <n>`: Curve optimization; higher simplifies curves
+- `--color <hex>`: Set output fill color for single-color traces
+
+When to use Potrace:
+- Simple logos, line art, and monochrome icons
+- Need deterministic output in offline environments
+- Need clean, minimal paths with strong contrast input
+
+## 7. Input Preparation Checklist
+
+Quality of the input image strongly affects vectorization results.
+
+Preparation steps:
+- Increase contrast between foreground and background
+- Reduce noise and texture (blur or denoise, then sharpen edges)
+- Flatten gradients into solid color bands
+- Resize so the shortest side is at least 256 px
+- Avoid photos with complex lighting or high-frequency detail
+
+Practical tweaks:
+- Use a white or solid background when possible
+- Limit palette to 2-6 colors for icons or logos
+- Remove drop shadows and glows before vectorization
+
+## 8. Quality Comparison Table
+
+| Input Type | Best Tool | Why | Notes |
+| --- | --- | --- | --- |
+| Simple monochrome logo | Potrace | Minimal paths, deterministic | Requires PBM/PGM input |
+| Flat vector-style illustration | Recraft Vectorize | Handles multi-color flat fills | $0.01/image |
+| Small icon (simple shapes) | image2svg | Cheapest, acceptable detail | Reduce detail to avoid noise |
+| Hand-drawn sketch | Star Vector | Better curve interpretation | Still may need cleanup |
+| Photo or textured art | None (avoid) | Vectorization bloats paths | Consider keeping raster |
+| UI screenshot | Recraft Vectorize | Better at sharp edges | Expect heavy SVG |
+
+## 9. Limitations and Gotchas
+
+Common issues to watch:
+- File size limits: Recraft Vectorize enforces <5 MB and <16 MP
+- Color handling: Excessive colors inflate path count and file size
+- Complex textures: Convert poorly and create bloated SVGs
+- Embedded rasters: Some conversions may include image data rather than paths
+- Over-detailing: Too high detail creates many small paths, hard to edit
+- Small inputs: Under 256 px short side often produce jagged paths
+
+Mitigations:
+- Simplify before conversion (posterize, reduce colors)
+- Target flat colors and strong edges
+- Prefer higher resolution inputs for clean outlines
+- Use Potrace for monochrome art instead of AI models
+
+## 10. Troubleshooting Common Conversion Failures
+
+| Symptom | Likely Cause | Fix |
+| --- | --- | --- |
+| Photo produces thousands of paths | Too many colors and gradients | Posterize to 4-8 colors in ImageMagick before vectorizing |
+| Text not converting cleanly | Low input resolution or anti-aliasing | Upscale to at least 2x, sharpen edges, then convert |
+| Output SVG is 5+ MB | Complex input with fine detail | Reduce detail parameter (image2svg) or simplify input |
+| Jagged curves on smooth shapes | Input resolution too low | Resize to at least 512 px on shortest side before tracing |
+| Colors merge or bleed together | Low contrast between adjacent regions | Increase contrast and saturation before conversion |
+| Recraft Vectorize returns 400 error | File exceeds 5 MB or 16 MP limit | Resize and compress input; check dimensions |
+| SVG contains embedded raster data | Endpoint fell back to image embedding | Use a different endpoint; verify output content_type is `image/svg+xml` |
+| Potrace output is all black | Input was not binarized | Run threshold step with ImageMagick before Potrace |
+| Star Vector returns generic shapes | Input too abstract or low-contrast | Use Recraft Vectorize instead; provide cleaner input |
+| Paths are editable but wrong color | Potrace default is black fill | Pass `--color #RRGGBB` to set fill color |
+
+## 11. Pre-Processing Tips
+
+Apply these transformations before sending an image to any vectorization endpoint. Pre-processing is the single highest-leverage step for improving output quality.
+
+Resize to a clean working resolution:
+```bash
+# Resize so shortest side is 512 px, preserve aspect ratio
+magick input.png -resize 512x512^ -gravity Center -extent 512x512 resized.png
+```
+
+Adjust contrast to separate foreground from background:
+```bash
+# Boost contrast and saturation
+magick resized.png -modulate 100,150 -contrast-stretch 5%x5% contrast.png
+```
+
+Remove background before vectorizing (for logos on white):
+```bash
+# Flood-fill white background to transparent
+magick contrast.png -fuzz 10% -transparent white nobg.png
+```
+
+Posterize to reduce color count:
+```bash
+# Reduce to 6 color levels — good for logos and icons
+magick nobg.png -posterize 6 posterized.png
+```
+
+Sharpen edges after posterization:
+```bash
+# Unsharp mask to crisp up edges before tracing
+magick posterized.png -unsharp 0x1+1.5+0.05 sharpened.png
+```
+
+Run all steps in sequence:
+```bash
+magick input.png \
+  -resize 512x512^ -gravity Center -extent 512x512 \
+  -modulate 100,150 -contrast-stretch 5%x5% \
+  -posterize 6 \
+  -unsharp 0x1+1.5+0.05 \
+  ready-for-vectorize.png
+```
+
+## 12. Batch Conversion Pattern
+
+Convert multiple images in a pipeline using the fal client. Use `Promise.allSettled` to handle partial failures without aborting the batch.
+
+```javascript
+import { fal } from "@fal-ai/client";
+import fs from "node:fs/promises";
+
+// Expects FAL_KEY in environment and fal client configured
+
+async function vectorizeBatch(imageUrls, endpoint = "fal-ai/recraft/vectorize") {
+  const tasks = imageUrls.map((url) =>
+    fal.subscribe(endpoint, { input: { image_url: url } })
+      .then((result) => ({ url, status: "ok", data: result.data }))
+      .catch((err) => ({ url, status: "error", error: err.message }))
+  );
+
+  const results = await Promise.allSettled(tasks);
+  return results.map((r) => (r.status === "fulfilled" ? r.value : r.reason));
+}
+
+async function main() {
+  const urls = [
+    "https://example.com/logo-a.png",
+    "https://example.com/logo-b.png",
+    "https://example.com/icon-c.png"
+  ];
+
+  const results = await vectorizeBatch(urls);
+
+  for (const r of results) {
+    if (r.status === "ok") {
+      console.log("Converted:", r.url, "->", r.data);
+    } else {
+      console.error("Failed:", r.url, r.error);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+Rate limiting note: fal.ai enforces per-account concurrency limits. If batches exceed the limit, add a concurrency cap using a semaphore or process in chunks of 5-10 images at a time.

--- a/skills/vector-graphics-gen/references/prompt-engineering.md
+++ b/skills/vector-graphics-gen/references/prompt-engineering.md
@@ -1,0 +1,420 @@
+# Prompt Engineering for Vector Graphics
+
+Sources: fal.ai prompt guides, Recraft documentation, production prompt testing (2025-2026)
+
+Covers: prompt anatomy, style selection, color control, icon/logo patterns, illustration patterns, seamless patterns, negative patterns, templates, iteration strategy.
+
+## 1. Prompt Structure Formula
+
+Effective vector prompts follow a four-part anatomy. Each part is optional but order matters — specificity increases left to right.
+
+```
+[Subject] + [Style descriptor] + [Composition] + [Constraints]
+```
+
+**Subject**: What the image depicts. Be concrete. "coffee cup" beats "beverage container". Name the object, action, or concept directly.
+
+**Style descriptor**: The visual treatment. For vector work, this maps to Recraft sub-styles. Include 1-2 style words that reinforce the API parameter you are passing.
+
+**Composition**: Spatial arrangement, orientation, framing. "centered on white background", "full bleed", "isometric view", "top-down perspective".
+
+**Constraints**: What to exclude or limit. "solid colors only", "no gradients", "two colors maximum", "no text", "no shadows".
+
+### Formula in Practice
+
+| Goal | Prompt |
+|------|--------|
+| App icon | "shield with checkmark, flat design, centered on white background, solid colors only" |
+| Hero illustration | "team of people collaborating around a table, editorial illustration, balanced composition, limited palette" |
+| Logo mark | "abstract mountain peak, geometric, symmetrical, single color, minimal" |
+| Pattern | "small repeating leaves, flat botanical, seamless tile, two colors" |
+| Badge | "star burst badge with ribbon, bold stroke, centered, no gradients" |
+
+### Subject Specificity Rules
+
+- Name the primary object first: "magnifying glass" not "search concept"
+- Add one modifier for shape: "rounded magnifying glass", "angular shield"
+- Add one modifier for state: "open envelope", "locked padlock", "spinning gear"
+- Avoid metaphors: "security" is vague; "padlock with shield" is actionable
+
+---
+
+## 2. Style Control
+
+Recraft V3 exposes 22 sub-styles under `vector_illustration`. Pass the sub-style as the `style_name` parameter alongside `style: "vector_illustration"`.
+
+### Sub-Style Visual Reference
+
+| Sub-style | Visual Character | Best For |
+|-----------|-----------------|----------|
+| `bold_stroke` | Thick outlines, high contrast, comic-adjacent | App icons, badges, stickers |
+| `line_art` | Clean single-weight lines, minimal fill | Technical diagrams, icons, logos |
+| `line_circuit` | Circuit board aesthetic, geometric lines | Tech products, developer tools |
+| `thin` | Hairline strokes, delicate, editorial | Premium brands, editorial spots |
+| `roundish_flat` | Soft shapes, friendly, rounded corners | Consumer apps, onboarding illustrations |
+| `emotional_flat` | Expressive flat characters, warm palette | Marketing illustrations, hero images |
+| `editorial` | Sophisticated, magazine-quality | Long-form content, article headers |
+| `infographical` | Data-friendly, clear hierarchy | Charts, explainers, process diagrams |
+| `sharp_contrast` | High contrast, punchy, graphic | Posters, social media, announcements |
+| `vivid_shapes` | Overlapping geometric forms, colorful | Abstract backgrounds, brand visuals |
+| `segmented_colors` | Flat color blocks, stained-glass feel | Portraits, character illustrations |
+| `cutout` | Paper-cut aesthetic, layered shapes | Playful brands, children's content |
+| `colored_stencil` | Spray-paint texture, urban | Music, streetwear, event graphics |
+| `contour_pop_art` | Pop art outlines, retro | Retro campaigns, nostalgia brands |
+| `naivector` | Naive/folk art style, hand-drawn feel | Artisan brands, craft products |
+| `marker_outline` | Marker pen aesthetic, sketchy | Startup pitch decks, whiteboards |
+| `mosaic` | Tessellated shapes, geometric fill | Abstract art, decorative backgrounds |
+| `engraving` | Cross-hatch, etching aesthetic | Luxury brands, certificates |
+| `linocut` | Woodblock print texture | Artisan, organic, handmade brands |
+| `chemistry` | Scientific diagram aesthetic | EdTech, science products |
+| `cosmics` | Space, cosmic, nebula-inspired | Gaming, sci-fi, futuristic brands |
+| `depressive` | Muted, melancholic, desaturated | Mental health, introspective content |
+
+### Style Selection Decision Tree
+
+| Signal | Recommended Sub-styles |
+|--------|----------------------|
+| Icon, scales to 16px | `line_art`, `bold_stroke` |
+| Icon with personality | `roundish_flat`, `bold_stroke` |
+| Playful brand | `roundish_flat`, `emotional_flat`, `cutout` |
+| Professional brand | `editorial`, `thin`, `line_art` |
+| Technical product | `line_circuit`, `infographical`, `chemistry` |
+| Decorative / abstract | `vivid_shapes`, `mosaic`, `cosmics` |
+| Functional / UI | `line_art`, `infographical`, `bold_stroke` |
+
+### Reinforcing Style in the Prompt
+
+Mismatched prompts and sub-styles produce inconsistent results. Reinforce the sub-style with matching text:
+
+| Sub-style | Reinforce with prompt words |
+|-----------|----------------------------|
+| `bold_stroke` | "bold outlines", "high contrast", "graphic" |
+| `line_art` | "line drawing", "outline only", "minimal" |
+| `roundish_flat` | "flat design", "soft shapes", "friendly" |
+| `editorial` | "editorial illustration", "sophisticated" |
+| `infographical` | "diagram", "clear hierarchy", "labeled" |
+| `engraving` | "engraved", "etched", "detailed linework" |
+
+---
+
+## 3. Color Control
+
+The `colors` parameter accepts an array of `{r, g, b}` objects. The model treats these as a palette constraint — it will not introduce colors outside this set.
+
+```json
+{"colors": [{"r": 59, "g": 130, "b": 246}, {"r": 255, "g": 255, "b": 255}]}
+```
+
+Convert brand hex values before passing: `#3B82F6` → `{r: 59, g: 130, b: 246}`. Parse each hex pair as a base-16 integer.
+
+### Palette Strategies
+
+| Strategy | Colors Array | Use Case |
+|----------|-------------|----------|
+| Monochrome | 1 color + white | Icons, logos, stamps |
+| Two-tone | 2 brand colors | Badges, simple illustrations |
+| Brand palette | 3-5 brand colors | Marketing illustrations |
+| Neutral + accent | 2 neutrals + 1 accent | UI illustrations |
+| Full palette | 5-8 colors | Hero illustrations, complex scenes |
+
+### Color Count Guidelines
+
+- Icons: 1-2 colors. More colors reduce scalability and recognizability.
+- Logos: 1-3 colors. Match brand guidelines exactly.
+- Illustrations: 3-6 colors. Limit prevents visual noise.
+- Patterns: 2-4 colors. Seamless tiles need restraint.
+
+### Brand Color Matching
+
+Pass exact hex values converted to RGB, and name the colors in the prompt. The model responds better when text and parameter agree:
+
+```
+Prompt: "abstract wave logo mark, geometric, using only navy blue and white"
+Colors: [{r: 15, g: 23, b: 42}, {r: 255, g: 255, b: 255}]
+```
+
+The `background_color` parameter (Recraft V4) sets the canvas background separately. Use `{r: 255, g: 255, b: 255}` for white or `{r: 0, g: 0, b: 0}` for black.
+
+---
+
+## 4. Icon and Logo Generation
+
+### Icon Prompt Pattern
+
+```
+[Shape/object], [style adjective], centered, [color constraint], no text, no gradients
+```
+
+Working examples:
+- "bell notification icon, flat design, centered, single color, no gradients, no text"
+- "shopping cart with plus sign, bold stroke, centered on white, two colors maximum"
+- "circular progress indicator, thin line art, centered, monochrome"
+- "lightning bolt inside circle, sharp contrast, centered, black and white"
+
+### Logo Mark Pattern
+
+```
+[Abstract concept or object], [geometric/organic], [symmetry], [color count], no text, vector mark
+```
+
+Working examples:
+- "abstract letter A formed from two triangles, geometric, symmetrical, single color, vector logo mark"
+- "stylized fox head, minimal geometric, facing forward, two colors, no text"
+- "infinity symbol made of ribbon, smooth curves, monochrome, logo mark"
+- "mountain peak with sun rays, geometric, centered, navy and gold, no text"
+
+### Favicon, Badge, and App Icon Patterns
+
+Favicons render at 16x16 — use extreme simplicity:
+- "bold letter S, rounded, single color, ultra minimal, no serifs"
+- "checkmark inside square, bold stroke, green and white"
+
+Badges and stamps:
+- "circular badge with star burst edge, bold stroke, two colors, retro"
+- "hexagonal badge with ribbon banner, flat design, bold, three colors"
+
+App icons display on colored backgrounds. Use `background_color` to set the canvas, then design the foreground element in white or a contrasting color:
+- `background_color: {r: 99, g: 102, b: 241}` + prompt: "white rocket ship, minimal, centered, no gradients"
+
+---
+
+## 5. Illustration Generation
+
+### Hero Illustration Pattern
+
+```
+[Scene description], [style], [mood/tone], balanced composition, [color palette], no text
+```
+
+Working examples:
+- "two people shaking hands across a desk, editorial illustration, professional and warm, balanced composition, blue and cream palette"
+- "developer at laptop with floating code symbols, emotional flat, focused and energetic, dark background with bright accents"
+- "small plant growing from a coin, roundish flat, optimistic, centered, green and gold on white"
+- "team of diverse people around a circular table, editorial, collaborative, top-down view, muted warm palette"
+
+### Spot Illustration Pattern
+
+Spot illustrations are small, self-contained visuals used inline with text. They read at 200-400px.
+
+```
+[Single concept], [style], simple, [1-3 colors], no background, isolated
+```
+
+Working examples:
+- "open book with light bulb above it, line art, simple, two colors, no background"
+- "envelope with paper airplane flying out, roundish flat, playful, blue and white"
+- "shield with lock, bold stroke, simple, monochrome"
+
+### Empty State and Error Patterns
+
+Empty states — keep light and encouraging:
+- "empty inbox tray with small bird perched on edge, roundish flat, friendly, soft blue and white"
+- "magnifying glass finding nothing, emotional flat, curious not sad, light gray and blue"
+
+Error states:
+- "broken chain link, bold stroke, clear, red and gray, centered"
+- "disconnected plug with sad face, roundish flat, sympathetic, muted red and white"
+
+---
+
+## 6. Pattern and Texture Generation
+
+### Seamless Pattern Formula
+
+```
+[Motif description], seamless pattern, [density], [style], [color count], tile-ready
+```
+
+Working examples:
+- "small geometric diamonds, seamless pattern, medium density, flat design, two colors, tile-ready"
+- "repeating leaf and branch motifs, seamless botanical pattern, scattered, line art, green and cream"
+- "interlocking hexagons, seamless geometric pattern, tight grid, single color on white"
+- "repeating circuit board traces, seamless tech pattern, medium density, line art, teal on dark"
+
+### Background Texture Formula
+
+```
+[Texture type], subtle, [style], [very limited colors], low contrast, background texture
+```
+
+Working examples:
+- "subtle dot grid, minimal, single color, very low contrast, background texture"
+- "light diagonal lines, subtle, thin, single color, background"
+- "soft geometric mesh, abstract, muted, two colors, background texture"
+
+Decorative borders:
+- "ornamental corner flourishes, symmetrical, line art, single color"
+- "repeating geometric border strip, bold, two colors, horizontal band"
+
+---
+
+## 7. Negative Patterns
+
+Certain words and phrases consistently degrade vector output quality.
+
+### Words to Avoid
+
+Photorealism triggers — never include:
+- "photorealistic", "photo", "realistic", "lifelike", "3D render", "CGI"
+- "bokeh", "depth of field", "lens flare", "film grain"
+- "hyperdetailed", "8K", "cinematic", "dramatic lighting", "HDRI"
+
+Complexity triggers — avoid unless intentional:
+- "complex", "intricate", "detailed", "elaborate", "ornate"
+- "shadow", "drop shadow" — use "no shadows" explicitly
+- "gradient" — use "no gradients, solid colors only"
+- "glow", "bloom", "luminous" — introduces raster-like effects
+
+### Structural Anti-Patterns
+
+| Anti-pattern | Problem | Fix |
+|-------------|---------|-----|
+| "A beautiful illustration of..." | Filler words dilute signal | Start with the subject directly |
+| "Create a vector of..." | Instruction language confuses model | Describe the result, not the task |
+| Multiple subjects without hierarchy | Model splits attention | Name primary subject first |
+| Abstract concepts without visual anchor | "Success", "growth" | Anchor to object: "upward arrow", "sprouting plant" |
+| Contradictory style words | "photorealistic flat design" | Pick one visual language |
+| Overly long prompts (100+ words) | Model loses focus | Keep under 50 words for icons, 80 for illustrations |
+
+### Standard Negative Constraint Set
+
+Append to any vector prompt: `no gradients, no shadows, no textures, solid colors only, no text`
+
+---
+
+## 8. Prompt Templates
+
+Copy-paste templates for common use cases. Replace bracketed placeholders.
+
+All templates use `fal-ai/recraft/v3/text-to-image` unless noted. Size defaults to `square_hd`.
+
+### Template 1: App Icon (Flat)
+```
+[object name], flat design, centered on white background, solid colors only, no gradients, no shadows, no text
+```
+Sub-style: `bold_stroke` or `roundish_flat`
+
+### Template 2: App Icon (Line Art)
+```
+[object name], minimal line art, centered, single color, thin strokes, no fill, no text
+```
+Sub-style: `line_art`
+
+### Template 3: Logo Mark (True SVG)
+```
+[abstract shape or object], geometric, symmetrical, vector logo mark, [N] colors, no text, no gradients
+```
+Model: `fal-ai/recraft/v4/text-to-vector`
+
+### Template 4: Hero Illustration
+```
+[scene with people], editorial illustration, [mood] tone, balanced composition, [palette description], no text
+```
+Sub-style: `editorial` or `emotional_flat` | Size: `landscape_16_9`
+
+### Template 5: Spot Illustration
+```
+[single concept], flat design, simple, isolated on white, [1-3 colors], no background, no text
+```
+Sub-style: `roundish_flat` or `line_art`
+
+### Template 6: Seamless Pattern
+```
+[motif], seamless repeating pattern, [sparse/medium/dense], flat design, [N] colors, tile-ready, no gradients
+```
+Sub-style: `vivid_shapes` or `segmented_colors`
+
+### Template 7: Badge or Stamp
+```
+[shape type] badge, [style adjective], centered, bold, [N] colors, no text, decorative border
+```
+Sub-style: `bold_stroke` or `contour_pop_art`
+
+### Template 8: Technical Diagram
+```
+[technical concept], diagram style, clean lines, flat, [2-3 colors], no shadows, no gradients
+```
+Sub-style: `infographical` or `line_circuit` | Size: `landscape_4_3`
+
+### Template 9: Subtle Background
+```
+[pattern type], subtle background texture, low contrast, [1-2 colors], seamless, no focal point
+```
+Sub-style: `thin` or `mosaic` | Size: `landscape_16_9`
+
+### Template 10: Empty State
+```
+[empty or absent object], friendly illustration, [encouraging emotion], soft colors, centered, simple, no text
+```
+Sub-style: `roundish_flat` or `emotional_flat`
+
+### Template 11: Favicon
+```
+[single bold shape], ultra minimal, bold, [1-2 colors], no fine detail, no text
+```
+Sub-style: `bold_stroke`
+
+### Template 12: Icon Set (Single Generation)
+```
+[object 1], [object 2], [object 3] icons, flat design, consistent style, monochrome, no text, icon set
+```
+Sub-style: `line_art` | Size: `landscape_4_3`
+
+---
+
+## 9. Iteration Strategy
+
+When the first generation misses the mark, diagnose before rewriting.
+
+### Diagnosis Table
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| Wrong visual style | Sub-style mismatch | Change sub-style parameter |
+| Wrong colors | Colors parameter not set | Add `colors` array |
+| Too complex / too many paths | Prompt too vague | Add "minimal", "simple", "few shapes" |
+| Photorealistic output | Photorealism words in prompt | Remove them, add "flat design" |
+| Wrong composition | No composition constraint | Add "centered", "balanced", "full bleed" |
+| Subject not recognizable | Subject too abstract | Use more concrete noun |
+| Gradients appearing | No constraint | Add "no gradients, solid colors only" |
+| Text appearing | No constraint | Add "no text" |
+
+### Iteration Order
+
+1. Fix the sub-style if the visual language is wrong
+2. Fix the prompt subject if the object is unrecognizable
+3. Add or adjust the `colors` parameter
+4. Add negative constraints for specific failures
+5. Adjust composition words
+
+Make one change per iteration — changing multiple variables simultaneously makes it impossible to identify what improved the result.
+
+### Sub-Style Substitution Pairs
+
+| Original | Too complex | Too simple | Wrong mood |
+|----------|------------|------------|------------|
+| `bold_stroke` | → `line_art` | → `sharp_contrast` | → `roundish_flat` |
+| `roundish_flat` | → `thin` | → `bold_stroke` | → `emotional_flat` |
+| `editorial` | → `thin` | → `marker_outline` | → `emotional_flat` |
+| `line_art` | → `thin` | → `bold_stroke` | → `line_circuit` |
+| `emotional_flat` | → `roundish_flat` | → `editorial` | → `segmented_colors` |
+
+### Prompt Refinement Examples
+
+| Weak prompt | Problem | Strong prompt |
+|-------------|---------|---------------|
+| "a security icon" | Too vague | "padlock with shield overlay, flat design, centered on white, two colors, no gradients, no text" |
+| "illustration of teamwork" | Abstract concept | "three people pushing a large gear together, editorial illustration, collaborative mood, blue and gray palette" |
+| "modern logo" | No subject or constraints | "abstract letter M formed from two mountain peaks, geometric, symmetrical, navy blue, vector logo mark, no text" |
+
+### When to Switch Models
+
+| Failure | Alternative |
+|---------|------------|
+| Needs true SVG output | `fal-ai/recraft/v4/text-to-vector` |
+| Needs text in the image | `fal-ai/ideogram/v3` (superior typography) |
+| Needs highest quality | `fal-ai/recraft/v4/pro/text-to-vector` |
+| Need speed, raster acceptable | `fal-ai/nano-banana-2` then vectorize |
+
+For model parameters and endpoint details, see `references/text-to-vector-models.md`.
+For the two-step raster-to-SVG pipeline, see `references/fal-api-reference.md`.

--- a/skills/vector-graphics-gen/references/svg-integration-patterns.md
+++ b/skills/vector-graphics-gen/references/svg-integration-patterns.md
@@ -1,0 +1,380 @@
+# SVG Integration Patterns
+
+Sources: React documentation, Vite plugin ecosystem, web component patterns (2025)
+
+Covers: framework integration, sprite sheets, icon systems, dynamic theming, performance, caching.
+
+## Integration Decision Table
+
+| Method | Use When | Avoid When | Bundle Impact |
+|--------|----------|------------|---------------|
+| Inline SVG | Need JS access, dynamic props, animations | Many repeated icons, SSR-heavy apps | Increases HTML size |
+| `<img src>` | Static decorative images, CDN-hosted assets | Need color control, accessibility labels | Zero JS bundle cost |
+| CSS `background-image` | Decorative backgrounds, pseudo-elements | Need accessibility, dynamic colors | Zero JS bundle cost |
+| React/Vue component | Icon systems, reusable UI elements, theming | One-off illustrations | Adds to JS bundle |
+| Sprite sheet | 20+ icons used across app, icon libraries | Single-use illustrations | One HTTP request |
+| Data URI | Tiny icons in CSS, email templates | Files over 2KB (base64 bloat) | Inlined in CSS |
+
+Decision rule: use `<img>` for illustrations, components for icons, sprite sheets for icon libraries at scale.
+
+## React Integration
+
+### SVGR Setup with Vite
+
+```bash
+npm install --save-dev vite-plugin-svgr
+```
+
+Configure `vite.config.ts`:
+
+```typescript
+import svgr from 'vite-plugin-svgr'
+
+export default defineConfig({
+  plugins: [
+    react(),
+    svgr({
+      svgrOptions: { exportType: 'named', ref: true, svgo: false, titleProp: true },
+      include: '**/*.svg',
+    }),
+  ],
+})
+```
+
+### TypeScript Declarations
+
+Add to `src/vite-env.d.ts` to get both URL and component exports from `.svg` files:
+
+```typescript
+declare module '*.svg' {
+  import * as React from 'react'
+  export const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement> & { title?: string }>
+  const src: string
+  export default src
+}
+```
+
+### Importing and Using SVG Components
+
+```typescript
+import { ReactComponent as ArrowIcon } from './icons/arrow.svg'
+import logoUrl from './logo.svg'  // URL for <img> usage
+
+// As component
+<ArrowIcon width={16} height={16} fill="currentColor" aria-hidden="true" />
+
+// As image (URL export)
+<img src={logoUrl} alt="Company logo" width={120} height={40} />
+```
+
+### Passing Props to SVG Components
+
+AI-generated SVGs often hardcode fill colors. Override at import time:
+
+```typescript
+<StarIcon fill="#FFD700" width={24} height={24} />
+<StarIcon fill="currentColor" style={{ color: 'var(--color-accent)' }} />
+```
+
+For SVGs with multiple colored paths, use CSS custom properties (see Dynamic SVG section).
+
+## Vue Integration
+
+### vite-svg-loader Setup
+
+```bash
+npm install --save-dev vite-svg-loader
+```
+
+```typescript
+import svgLoader from 'vite-svg-loader'
+export default defineConfig({ plugins: [vue(), svgLoader({ defaultImport: 'component' })] })
+```
+
+### Using SVGs as Vue Components
+
+```vue
+<script setup lang="ts">
+import ArrowIcon from './icons/arrow.svg'   // component (defaultImport)
+import LogoUrl from './logo.svg?url'        // force URL import
+import LogoRaw from './logo.svg?raw'        // force raw string import
+
+const props = defineProps<{ size: number; color: string }>()
+</script>
+
+<template>
+  <ArrowIcon :width="props.size" :height="props.size" :fill="props.color" />
+  <img :src="LogoUrl" alt="Logo" />
+  <div v-html="LogoRaw" />  <!-- sanitize before use -->
+</template>
+```
+
+## Vanilla/HTML Integration
+
+### Inline SVG
+
+Paste SVG markup directly into HTML. Enables CSS targeting and JS manipulation:
+
+```html
+<button class="btn-icon">
+  <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+    <path d="M12 2L2 7l10 5 10-5-10-5z" fill="currentColor"/>
+  </svg>
+  Save
+</button>
+```
+
+### img Tag
+
+Best for illustrations and logos where color control is not needed:
+
+```html
+<img
+  src="/assets/hero-illustration.svg"
+  alt="Team collaborating on a project"
+  width="600" height="400"
+  loading="lazy"
+/>
+```
+
+Always include `width` and `height` to prevent layout shift (CLS).
+
+### CSS background-image
+
+For decorative icons and patterns:
+
+```css
+.icon-search {
+  width: 20px; height: 20px;
+  background: url('/icons/search.svg') no-repeat center / contain;
+}
+/* Data URI for tiny icons (under 1KB) — encode # as %23, " as ' */
+.icon-close {
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24'%3E%3Cpath d='M18 6L6 18M6 6l12 12' stroke='%23333' stroke-width='2'/%3E%3C/svg%3E");
+}
+```
+
+## Sprite Sheets
+
+### vite-plugin-svg-spritemap Setup
+
+```bash
+npm install --save-dev vite-plugin-svg-spritemap
+```
+
+```typescript
+// vite.config.ts
+import svgSpritemap from 'vite-plugin-svg-spritemap'
+
+export default defineConfig({
+  plugins: [svgSpritemap({
+    pattern: 'src/icons/*.svg',
+    filename: 'icons/sprite.svg',
+    prefix: 'icon-',
+    svgo: { plugins: [{ name: 'removeViewBox', active: false }] },
+  })],
+})
+```
+
+### Referencing Icons from the Sprite
+
+```html
+<svg width="24" height="24" aria-hidden="true"><use href="/icons/sprite.svg#icon-arrow" /></svg>
+<svg width="24" height="24" aria-label="Search"><use href="/icons/sprite.svg#icon-search" /></svg>
+```
+
+### Inline Sprite for CSS Color Control
+
+External `<use href="file.svg#id">` references cannot be styled with CSS `fill`. Inject the sprite inline to enable color overrides:
+
+```typescript
+const text = await fetch('/icons/sprite.svg').then(r => r.text())
+const div = Object.assign(document.createElement('div'), { style: 'display:none', innerHTML: text })
+document.body.insertBefore(div, document.body.firstChild)
+// Then reference as: <use href="#icon-arrow" />
+```
+
+## Icon Systems
+
+### Building a Lazy Icon Component (React)
+
+```typescript
+// src/components/Icon.tsx
+import { lazy, Suspense } from 'react'
+
+type IconName = 'arrow' | 'search' | 'close' | 'star' | 'menu'
+interface IconProps {
+  name: IconName; size?: number | string; color?: string
+  className?: string; 'aria-label'?: string; 'aria-hidden'?: boolean
+}
+
+const iconMap = {
+  arrow: lazy(() => import('../icons/arrow.svg?react')),
+  search: lazy(() => import('../icons/search.svg?react')),
+  close: lazy(() => import('../icons/close.svg?react')),
+  star: lazy(() => import('../icons/star.svg?react')),
+  menu: lazy(() => import('../icons/menu.svg?react')),
+} satisfies Record<IconName, ReturnType<typeof lazy>>
+
+export function Icon({ name, size = 24, color = 'currentColor', className, ...aria }: IconProps) {
+  const C = iconMap[name]
+  return (
+    <Suspense fallback={<span style={{ width: size, height: size, display: 'inline-block' }} />}>
+      <C width={size} height={size} fill={color} className={className} {...aria} />
+    </Suspense>
+  )
+}
+```
+
+### Icon Component Usage
+
+```tsx
+<Icon name="arrow" size={16} aria-hidden />                  // decorative
+<Icon name="search" size={20} aria-label="Search" />         // meaningful
+<Icon name="star" size={24} color="var(--color-warning)" />  // themed
+<Icon name="menu" size="1.5rem" />                           // responsive
+```
+
+## Dynamic SVG
+
+### CSS Custom Properties for Runtime Color Changes
+
+Replace hardcoded fill values in AI-generated SVGs with CSS variables:
+
+```svg
+<!-- Before -->
+<circle cx="12" cy="12" r="10" fill="#3B82F6"/>
+
+<!-- After -->
+<circle cx="12" cy="12" r="10" fill="var(--icon-bg, #3B82F6)"/>
+```
+
+Apply themes via CSS — no JavaScript re-render needed:
+
+```css
+:root          { --icon-bg: #3B82F6; --icon-fg: #FFFFFF; }
+[data-theme="dark"] { --icon-bg: #60A5FA; --icon-fg: #1E293B; }
+.btn-danger .icon   { --icon-bg: #EF4444; }
+```
+
+Switch themes with a single attribute:
+
+```typescript
+document.documentElement.setAttribute('data-theme', 'dark')
+```
+
+### Hover and Focus States
+
+```css
+/* currentColor approach — simpler, inherits from parent element */
+.btn svg { fill: currentColor; transition: color 150ms ease; }
+.btn:hover { color: var(--color-primary-hover); }
+.btn:focus-visible svg { outline: 2px solid var(--color-focus-ring); outline-offset: 2px; }
+```
+
+## Performance
+
+### Lazy Loading
+
+Use native lazy loading for `<img>` SVGs:
+
+```html
+<img src="/illustrations/hero.svg" alt="Hero" width="600" height="400"
+  loading="lazy" decoding="async" />
+```
+
+For inline SVGs below the fold, defer fetch with Intersection Observer (`rootMargin: '200px'` preloads before the element enters the viewport):
+
+```typescript
+const observer = new IntersectionObserver(([e]) => {
+  if (e.isIntersecting) {
+    fetch(src).then(r => r.text()).then(html => { container.innerHTML = html })
+    observer.disconnect()
+  }
+}, { rootMargin: '200px' })
+observer.observe(container)
+```
+
+### Code Splitting Icon Libraries
+
+```typescript
+// Avoid: imports entire icon set
+import * as Icons from '../icons'
+
+// Better: named imports (tree-shakeable with SVGR)
+import { ReactComponent as ArrowIcon } from '../icons/arrow.svg'
+
+// Best for large sets: dynamic import per name
+const { default: C } = await import(`../icons/${name}.svg?react`)
+```
+
+### SSR Considerations
+
+Inline SVG components (SVGR imports) render on the server without issues in Next.js and Remix. Avoid fetching SVG strings server-side and injecting via `dangerouslySetInnerHTML` — this causes hydration mismatches.
+
+```typescript
+// Next.js: next/image for file-based SVGs
+import Image from 'next/image'
+<Image src="/icons/logo.svg" alt="Logo" width={120} height={40} />
+
+// SVGR import — renders correctly in SSR
+import LogoIcon from './logo.svg'
+<LogoIcon width={120} height={40} />
+```
+
+### Bundle Size Reference
+
+| Approach | JS Bundle Cost | Notes |
+|----------|---------------|-------|
+| `<img src>` | 0 bytes | File fetched separately |
+| CSS background | 0 bytes (file) | Data URI adds to CSS bundle |
+| Inline SVG (static) | SVG file size | Included in HTML payload |
+| React component (SVGR) | SVG size + ~200B | In JS bundle |
+| Sprite sheet | 0 bytes | One SVG file, all icons |
+| Lazy component | 0 bytes initial | Loaded on demand |
+
+Target: icons under 1KB each, illustrations under 30KB. Audit with `vite-bundle-visualizer`.
+
+## Caching Strategy
+
+### Content-Hash Filenames
+
+Vite generates content-hashed filenames for all imported assets (`arrow.a3f9b2c1.svg`). The hash changes only when file content changes, enabling aggressive long-term caching:
+
+```
+# Hashed assets (Vite build output)
+Cache-Control: public, max-age=31536000, immutable
+
+# SVGs in public/ (no hash)
+Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+```
+
+### Service Worker Caching (Workbox)
+
+```typescript
+import { registerRoute } from 'workbox-routing'
+import { CacheFirst, StaleWhileRevalidate } from 'workbox-strategies'
+
+// Hashed assets — cache forever
+registerRoute(
+  ({ url }) => url.pathname.match(/\.[a-f0-9]{8}\.svg$/),
+  new CacheFirst({ cacheName: 'svg-hashed-v1' })
+)
+// Non-hashed SVGs — serve stale, update in background
+registerRoute(
+  ({ request }) => request.destination === 'image' && request.url.endsWith('.svg'),
+  new StaleWhileRevalidate({ cacheName: 'svg-images-v1' })
+)
+```
+
+### Preloading Critical SVGs
+
+Preload above-the-fold SVGs in `<head>` to eliminate render-blocking fetches:
+
+```html
+<link rel="preload" href="/icons/sprite.svg" as="image" type="image/svg+xml" />
+<link rel="preload" href="/illustrations/hero.svg" as="image" type="image/svg+xml" />
+```
+
+For SVG optimization before integration, see `references/svg-optimization.md`.
+For AI generation and prompting strategies, see `references/ai-generation-workflow.md`.

--- a/skills/vector-graphics-gen/references/svg-optimization.md
+++ b/skills/vector-graphics-gen/references/svg-optimization.md
@@ -1,0 +1,375 @@
+# SVG Optimization
+
+Sources: SVGO documentation, SVG specification, web performance guides (2025-2026)
+
+Covers: Cleaning AI-generated SVGs, SVGO configuration, manual cleanup patterns, file size targets, accessibility, dark mode preparation, animation preparation, and validation.
+
+## 1. AI SVG Common Problems
+
+AI image generators produce SVGs with predictable defects. Identify these before running any optimizer.
+
+| Problem | Detection | Impact |
+|---------|-----------|--------|
+| Too many paths | `grep -c '<path' file.svg` — icons >20, illustrations >200 | Slow render, large file |
+| Poor grouping | All paths at root level, no `<g>` structure | Blocks animation, no inheritance |
+| Missing viewBox | `grep viewBox file.svg` returns nothing | Cannot scale responsively |
+| Embedded rasters | `grep 'data:image/' file.svg` finds matches | Defeats vector purpose, huge size |
+| Excessive precision | Coordinates like `123.456789` | Inflated file, no visual benefit |
+| Redundant transforms | `transform="translate(0,0) scale(1,1)"` | Wasted bytes, animation confusion |
+
+**Embedded rasters** are the most critical: if `data:image/png;base64` appears, the file is not truly vector. Re-generate with explicit vector-only prompts or remove the `<image>` element.
+
+**Too many paths** for simple shapes means the generator traced a raster internally. SVGO's `mergePaths` reduces count; if still above 50 for a simple icon, redraw manually.
+
+---
+
+## 2. SVGO Configuration
+
+Save as `svgo.config.js`. This configuration targets AI-generated SVGs specifically.
+
+```javascript
+// svgo.config.js
+module.exports = {
+  multipass: true,           // Run until no further reduction — critical for AI output
+  js2svg: { pretty: false },
+  plugins: [
+    // Strip editor metadata
+    { name: 'removeDoctype' },
+    { name: 'removeXMLProcInst' },
+    { name: 'removeComments' },
+    { name: 'removeMetadata' },
+    { name: 'removeEditorsNSData' },  // Removes Sketch, Illustrator, Inkscape namespaces
+
+    // NEVER remove viewBox
+    { name: 'removeViewBox', active: false },
+
+    // Structure cleanup
+    { name: 'removeEmptyAttrs' },
+    { name: 'removeEmptyContainers' },
+    { name: 'removeUnusedNS' },
+    { name: 'removeUselessDefs' },
+    { name: 'cleanupIds', params: { minify: true } },
+
+    // Numeric precision — 1 for icons, 2 for illustrations
+    { name: 'cleanupNumericValues', params: { floatPrecision: 2 } },
+    { name: 'convertPathData', params: { floatPrecision: 2, transformPrecision: 2 } },
+
+    // Transform and attribute optimization
+    { name: 'convertTransform' },
+    { name: 'removeUselessStrokeAndFill' },
+    { name: 'convertColors', params: { shorthex: true, shortname: true } },
+    { name: 'sortAttrs' },                // Improves gzip compression
+
+    // Path and group merging
+    { name: 'mergePaths' },
+    { name: 'collapseGroups' },
+    { name: 'moveElemsAttrsToGroup' },
+    { name: 'moveGroupAttrsToElems' },
+
+    // Shape simplification
+    { name: 'convertShapeToPath' },
+    { name: 'convertEllipseToCircle' },
+    { name: 'mergePaths' },              // Second pass after shape conversion
+  ],
+};
+```
+
+### CLI Commands
+
+```bash
+# Single file
+npx svgo --config svgo.config.js input.svg -o output.svg
+
+# Batch directory
+npx svgo --config svgo.config.js -f ./raw/ -o ./optimized/
+
+# Dry run — show reduction without writing
+npx svgo --config svgo.config.js input.svg --dry-run
+```
+
+### Precision by Use Case
+
+| Use Case | floatPrecision |
+|----------|---------------|
+| Icon (16-48px) | 1 |
+| Logo / Illustration | 2 |
+| Data visualization | 3 |
+
+---
+
+## 3. Manual Cleanup Patterns
+
+Run SVGO first. Apply these patterns to problems SVGO cannot fix automatically.
+
+### Fix Missing viewBox
+
+```javascript
+function fixViewBox(svgString) {
+  if (/viewBox=/.test(svgString)) return svgString;
+
+  const w = parseFloat(svgString.match(/width="([^"]+)"/)?.[1]);
+  const h = parseFloat(svgString.match(/height="([^"]+)"/)?.[1]);
+  if (!w || !h) return svgString;
+
+  return svgString
+    .replace(/<svg/, `<svg viewBox="0 0 ${w} ${h}"`)
+    .replace(/\s+width="[^"]*"/, '')
+    .replace(/\s+height="[^"]*"/, '');
+}
+```
+
+### Remove Embedded Raster Images
+
+```javascript
+function removeEmbeddedRasters(svgString) {
+  return svgString
+    .replace(/<image[^>]*data:image\/[^>]*\/>/g, '')
+    .replace(/<image[^>]*data:image\/[\s\S]*?<\/image>/g, '');
+}
+```
+
+### Convert Inline Styles to Presentation Attributes
+
+Inline `style` attributes block CSS overrides and prevent `currentColor` inheritance.
+
+```javascript
+const PRESENTATION_PROPS = new Set([
+  'fill', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin',
+  'opacity', 'fill-opacity', 'stroke-opacity', 'fill-rule', 'clip-rule',
+]);
+
+function inlineStyleToAttrs(svgString) {
+  return svgString.replace(/style="([^"]*)"/g, (_, styleContent) => {
+    const attrs = [];
+    const remaining = [];
+    styleContent.split(';').filter(Boolean).forEach(rule => {
+      const [prop, val] = rule.split(':').map(s => s.trim());
+      if (PRESENTATION_PROPS.has(prop)) {
+        attrs.push(`${prop}="${val}"`);
+      } else {
+        remaining.push(`${prop}:${val}`);
+      }
+    });
+    return remaining.length
+      ? `${attrs.join(' ')} style="${remaining.join('; ')}"`
+      : attrs.join(' ');
+  });
+}
+```
+
+---
+
+## 4. File Size Targets
+
+These targets apply after SVGO optimization. Exceeding the max indicates structural problems.
+
+| Use Case | Target | Max | Path Count |
+|----------|--------|-----|------------|
+| UI icon (16-48px) | < 1 KB | 2 KB | 1-8 |
+| Logo (simple) | < 3 KB | 5 KB | 5-20 |
+| Logo (complex) | < 8 KB | 15 KB | 20-60 |
+| Spot illustration | < 10 KB | 20 KB | 20-80 |
+| Hero illustration | < 25 KB | 50 KB | 50-200 |
+| Animated SVG | < 15 KB | 30 KB | 10-60 |
+
+If a file exceeds the max after SVGO, diagnose in order:
+1. `grep 'data:image/' file.svg` — embedded rasters
+2. `grep -c '<path' file.svg` — excessive path count
+3. `grep -c '<defs' file.svg` — duplicate definitions
+4. Consider PNG/WebP if the design is inherently photographic
+
+---
+
+## 5. Accessibility
+
+AI-generated SVGs have no accessibility metadata. Add before deploying.
+
+### Semantic SVG
+
+```svg
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24"
+  role="img"
+  aria-labelledby="svg-title svg-desc"
+>
+  <title id="svg-title">Shopping cart</title>
+  <desc id="svg-desc">Icon showing a cart with two wheels</desc>
+  <!-- paths -->
+</svg>
+```
+
+### Decorative SVG (No Semantic Meaning)
+
+```svg
+<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+  <!-- decorative paths -->
+</svg>
+```
+
+### Programmatic Addition
+
+```javascript
+function addAccessibility(svgString, title, description, isDecorative = false) {
+  if (isDecorative) {
+    return svgString.replace('<svg', '<svg aria-hidden="true" focusable="false"');
+  }
+  const ariaAttr = description
+    ? 'role="img" aria-labelledby="svg-title svg-desc"'
+    : 'role="img" aria-labelledby="svg-title"';
+  const titleEl = `<title id="svg-title">${title}</title>`;
+  const descEl = description ? `<desc id="svg-desc">${description}</desc>` : '';
+  return svgString
+    .replace('<svg', `<svg ${ariaAttr}`)
+    .replace(/(<svg[^>]*>)/, `$1\n  ${titleEl}${descEl ? '\n  ' + descEl : ''}`);
+}
+```
+
+---
+
+## 6. Dark Mode Preparation
+
+### currentColor Technique
+
+Replace hardcoded fill/stroke values with `currentColor` to inherit the CSS `color` property. The parent element's color cascades into the SVG.
+
+```svg
+<!-- Before -->
+<path fill="#1a1a1a" d="M12 2..."/>
+
+<!-- After — inherits from CSS color property -->
+<path fill="currentColor" d="M12 2..."/>
+```
+
+```css
+.icon { color: #1a1a1a; }
+@media (prefers-color-scheme: dark) { .icon { color: #f5f5f5; } }
+```
+
+### CSS Custom Properties for Multi-Color SVGs
+
+```svg
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    :root { --c-primary: #1a1a1a; --c-accent: #3b82f6; }
+    @media (prefers-color-scheme: dark) {
+      :root { --c-primary: #f5f5f5; --c-accent: #60a5fa; }
+    }
+  </style>
+  <path fill="var(--c-primary)" d="M..."/>
+  <circle fill="var(--c-accent)" cx="24" cy="24" r="4"/>
+</svg>
+```
+
+### Approach Selection
+
+| Scenario | Approach |
+|----------|----------|
+| Single-color icon | `currentColor` |
+| Multi-color illustration | CSS custom properties |
+| SVG used as `<img>` tag | Embed `<style>` with media query inside SVG |
+| Inline SVG in HTML | Either approach works |
+
+---
+
+## 7. Animation Preparation
+
+Structure AI SVGs for animation before running SVGO. `collapseGroups` and `cleanupIds` destroy animation targets.
+
+### Preserve Animation Target IDs
+
+```javascript
+// In svgo.config.js
+{
+  name: 'cleanupIds',
+  params: {
+    minify: false,
+    preserve: ['body', 'arm-left', 'arm-right', 'wheel', 'shadow'],
+  },
+},
+```
+
+### Group Structure for Animation
+
+```svg
+<svg viewBox="0 0 200 200">
+  <g id="shadow">
+    <ellipse cx="100" cy="185" rx="40" ry="8" fill="#00000033"/>
+  </g>
+  <g id="body">
+    <path d="M..."/>
+  </g>
+  <g id="arm-left" style="transform-box: fill-box; transform-origin: center">
+    <path d="M..."/>
+  </g>
+</svg>
+```
+
+### transform-origin in SVG
+
+SVG elements use the SVG coordinate system for `transform-origin`, not the element's bounding box. Always set `transform-box: fill-box` alongside `transform-origin: center` to get expected behavior:
+
+```css
+#spinner {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: spin 1s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+```
+
+### Path Simplification for Motion
+
+CSS `offset-path` and morphing require smooth, low-node paths. Target under 12 nodes for motion paths, equal node count between morph states.
+
+```bash
+# Simplify paths with Inkscape CLI
+inkscape --actions="select-all; path-simplify; export-filename:simplified.svg; export-plain-svg" input.svg
+```
+
+---
+
+## 8. Validation
+
+### Structural Checks
+
+```bash
+# XML validity
+xmllint --noout input.svg
+
+# Check for external references (breaks CSP and sandboxed contexts)
+grep -oP '(href|src|xlink:href)="https?://[^"]*"' input.svg
+
+# Check for embedded rasters
+grep 'data:image/' input.svg
+
+# Check for script elements (security risk)
+grep '<script' input.svg
+```
+
+### Programmatic Validation
+
+```javascript
+function validateSVG(svgString) {
+  const errors = [];
+  if (!/<svg[^>]+viewBox/.test(svgString)) errors.push('Missing viewBox');
+  if (/href="https?:\/\//.test(svgString)) errors.push('External href reference');
+  if (/data:image\//.test(svgString)) errors.push('Embedded raster data');
+  if (/<script/.test(svgString)) errors.push('Script element present');
+  return { valid: errors.length === 0, errors };
+}
+```
+
+### Common Validation Failures
+
+| Failure | Cause | Fix |
+|---------|-------|-----|
+| Blank render | Missing viewBox | Add `viewBox="0 0 w h"` |
+| Broken in `<img>` | External CSS reference | Inline all styles |
+| CSP violation | External font or script | Remove or inline |
+| Screen reader silent | Missing `role` and `title` | Add accessibility attributes |
+| Animation not working | SVGO removed IDs | Preserve IDs in SVGO config |
+| Wrong colors in dark mode | Hardcoded hex values | Convert to `currentColor` or CSS variables |
+| Huge file after SVGO | Embedded raster | Remove `<image data:image>` elements |
+
+For integration into React, Vue, or build pipelines, see `references/svg-integration-patterns.md`.

--- a/skills/vector-graphics-gen/references/text-to-vector-models.md
+++ b/skills/vector-graphics-gen/references/text-to-vector-models.md
@@ -1,0 +1,442 @@
+# Text-to-Vector Models
+
+Sources: fal.ai documentation (2025-2026), Recraft API docs, model benchmarks
+
+Covers: All text-to-vector and vector-style image endpoints on fal.ai — Recraft V4, V4 Pro, V3 — with complete parameter references, model comparison, code examples, and the two-step raster-to-SVG pipeline.
+
+## Model Overview
+
+Three primary paths to vector output via fal.ai:
+
+1. **Native SVG** — Recraft V4 and V4 Pro produce true SVG files directly from text
+2. **Vector-style raster** — Recraft V3 with `vector_illustration` style produces raster images optimized for vectorization
+3. **Two-step pipeline** — Generate with V3 vector style, then convert to SVG via `fal-ai/recraft/vectorize`
+
+For image-to-SVG conversion endpoints, see `references/image-to-svg-conversion.md`.
+
+## Model Comparison Table
+
+| Model | Endpoint | Output Format | Price | Quality | Speed | Best For |
+|-------|----------|---------------|-------|---------|-------|----------|
+| Recraft V4 | `fal-ai/recraft/v4/text-to-vector` | True SVG | $0.08/image | High | Medium | Logos, icons, brand assets |
+| Recraft V4 Pro | `fal-ai/recraft/v4/pro/text-to-vector` | True SVG | $0.30/image | Highest | Slow | Production assets, complex illustrations |
+| Recraft V3 | `fal-ai/recraft/v3/text-to-image` | Raster PNG | $0.08/image (vector style) | High | Fast | Vector-style illustrations, two-step pipeline |
+| Recraft V3 (raster) | `fal-ai/recraft/v3/text-to-image` | Raster PNG | $0.04/image | High | Fast | Non-vector styles, photorealistic |
+
+**Default choice**: Recraft V4 for direct SVG output. Use V4 Pro when quality is critical and cost is secondary. Use V3 + vectorize pipeline when you need fine-grained style control from V3's 22 sub-styles.
+
+---
+
+## Recraft V4 Text-to-Vector
+
+**Endpoint**: `fal-ai/recraft/v4/text-to-vector`
+**Output**: True SVG (`content_type: "image/svg+xml"`)
+**Price**: $0.08/image
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `prompt` | string | Yes | — | Text description of the desired vector graphic |
+| `image_size` | string or object | No | `square_hd` | Output dimensions (see size options below) |
+| `colors` | array | No | — | Brand palette as array of `{r, g, b}` objects |
+| `background_color` | object | No | — | Background fill as `{r, g, b}` |
+| `enable_safety_checker` | boolean | No | `true` | Enable content safety filtering |
+
+### Image Size Options
+
+| Value | Dimensions | Use Case |
+|-------|-----------|----------|
+| `square` | 512×512 | Icons, avatars |
+| `square_hd` | 1024×1024 | Logos, general use (default) |
+| `portrait_4_3` | 768×1024 | Tall illustrations |
+| `portrait_16_9` | 576×1024 | Mobile-oriented |
+| `landscape_4_3` | 1024×768 | Wide illustrations |
+| `landscape_16_9` | 1024×576 | Banner graphics |
+| `{width, height}` | Custom | Specify exact pixel dimensions |
+
+### Response Format
+
+```json
+{
+  "images": [
+    {
+      "url": "https://fal.media/files/...",
+      "file_size": 24680,
+      "file_name": "image.svg",
+      "content_type": "image/svg+xml"
+    }
+  ]
+}
+```
+
+### JavaScript Example
+
+```javascript
+import { fal } from "@fal-ai/client";
+
+const result = await fal.subscribe("fal-ai/recraft/v4/text-to-vector", {
+  input: {
+    prompt: "A minimalist mountain logo with clean geometric shapes",
+    image_size: "square_hd",
+    colors: [
+      { r: 59, g: 130, b: 246 },
+      { r: 30, g: 64, b: 175 }
+    ],
+    background_color: { r: 255, g: 255, b: 255 }
+  },
+  logs: true,
+  onQueueUpdate: (update) => {
+    if (update.status === "IN_PROGRESS") {
+      update.logs.map((log) => log.message).forEach(console.log);
+    }
+  },
+});
+
+const svgUrl = result.data.images[0].url;
+// Download SVG
+const response = await fetch(svgUrl);
+const svgContent = await response.text();
+```
+
+### Python Example
+
+```python
+import fal_client
+
+result = fal_client.subscribe(
+    "fal-ai/recraft/v4/text-to-vector",
+    arguments={
+        "prompt": "A minimalist mountain logo with clean geometric shapes",
+        "image_size": "square_hd",
+        "colors": [
+            {"r": 59, "g": 130, "b": 246},
+            {"r": 30, "g": 64, "b": 175}
+        ],
+        "background_color": {"r": 255, "g": 255, "b": 255}
+    }
+)
+
+svg_url = result["images"][0]["url"]
+```
+
+---
+
+## Recraft V4 Pro Text-to-Vector
+
+**Endpoint**: `fal-ai/recraft/v4/pro/text-to-vector`
+**Output**: True SVG (`content_type: "image/svg+xml"`)
+**Price**: $0.30/image
+
+The Pro variant uses an enhanced model with higher fidelity output, more complex path structures, and better adherence to detailed prompts. Use when the standard V4 output lacks sufficient detail or when the asset will be used at large scale.
+
+Parameters are identical to Recraft V4 — replace the endpoint string with `fal-ai/recraft/v4/pro/text-to-vector`. All `prompt`, `image_size`, `colors`, `background_color`, and `enable_safety_checker` parameters apply unchanged.
+
+### When to Use V4 Pro vs V4
+
+| Scenario | Use |
+|----------|-----|
+| Prototyping, iteration, batch generation | V4 ($0.08) |
+| Final production asset, client deliverable | V4 Pro ($0.30) |
+| Complex illustration with fine detail | V4 Pro |
+| Simple icon or logo | V4 |
+| Budget-constrained project | V4 |
+| Quality is the only constraint | V4 Pro |
+
+---
+
+## Recraft V3 Text-to-Image (Vector Style)
+
+**Endpoint**: `fal-ai/recraft/v3/text-to-image`
+**Output**: Raster PNG (NOT true SVG)
+**Price**: $0.04/image (raster styles), $0.08/image (vector_illustration style)
+
+V3 produces raster images but with 22 vector-optimized sub-styles that produce clean, flat artwork ideal for downstream vectorization. Use V3 when you need a specific illustration style not available in V4, or as the first step in the two-step pipeline.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `prompt` | string | Yes | — | Text description |
+| `style` | string | No | `realistic_image` | Top-level style category |
+| `style_id` | string | No | — | Sub-style within the category |
+| `image_size` | string or object | No | `square_hd` | Output dimensions |
+| `colors` | array | No | — | Brand palette as array of `{r, g, b}` objects |
+| `enable_safety_checker` | boolean | No | `true` | Enable content safety filtering |
+
+### Top-Level Style Values
+
+| Value | Description | Price |
+|-------|-------------|-------|
+| `realistic_image` | Photorealistic output | $0.04 |
+| `digital_illustration` | Digital art, painterly | $0.04 |
+| `vector_illustration` | Flat, clean, vector-optimized | $0.08 |
+
+Set `style: "vector_illustration"` to access all 22 vector sub-styles.
+
+### Vector Illustration Sub-Styles (22 Total)
+
+Set `style_id` to one of these values when `style` is `"vector_illustration"`:
+
+| Sub-style | Visual Character | Best For |
+|-----------|-----------------|----------|
+| `bold_stroke` | Thick outlines, high contrast | Stickers, badges, bold branding |
+| `chemistry` | Technical diagram aesthetic | Scientific, educational content |
+| `colored_sticker` | Bright fills with outline | Sticker packs, emoji-style assets |
+| `contour` | Outline-focused, minimal fill | Line art, coloring book style |
+| `cosmetics` | Soft, elegant, beauty-adjacent | Beauty brands, lifestyle |
+| `cutout` | Paper-cut layered look | Collage, editorial illustration |
+| `engraving` | Cross-hatch, etched texture | Vintage, premium, certificates |
+| `editorial` | Clean, publication-ready | Magazine, news, infographics |
+| `ethnic` | Cultural pattern motifs | Decorative, cultural content |
+| `line_art` | Pure line drawing, no fill | Sketches, technical illustration |
+| `line_circuit` | Circuit board line patterns | Tech, electronics, data |
+| `linocut` | Woodblock print texture | Artisan, handmade aesthetic |
+| `marker` | Marker pen strokes | Casual, hand-drawn feel |
+| `mosaic` | Tile/fragment composition | Decorative, abstract |
+| `naiveart` | Childlike, folk art style | Playful, approachable brands |
+| `outline` | Simple outline shapes | Icons, UI elements |
+| `outline_details` | Outline with interior detail lines | Detailed icons, technical |
+| `paper_cut_style` | Layered paper silhouettes | Craft aesthetic, depth |
+| `pointilism` | Dot-based texture | Artistic, textured illustration |
+| `pop_art` | Bold color, halftone influence | Retro, vibrant branding |
+| `psychedelic` | Swirling, surreal patterns | Music, festival, creative |
+| `seamless_pattern` | Tileable repeat pattern | Backgrounds, textiles, packaging |
+| `thin` | Hairline strokes, delicate | Elegant, minimal, luxury |
+| `watercolor` | Soft washes, organic edges | Lifestyle, organic brands |
+
+### JavaScript Example
+
+```javascript
+import { fal } from "@fal-ai/client";
+
+const result = await fal.subscribe("fal-ai/recraft/v3/text-to-image", {
+  input: {
+    prompt: "A coffee cup with steam rising, flat design",
+    style: "vector_illustration",
+    style_id: "bold_stroke",
+    image_size: "square_hd",
+    colors: [
+      { r: 120, g: 53, b: 15 },
+      { r: 254, g: 243, b: 199 }
+    ]
+  },
+  logs: true,
+  onQueueUpdate: (update) => {
+    if (update.status === "IN_PROGRESS") {
+      update.logs.map((log) => log.message).forEach(console.log);
+    }
+  },
+});
+
+const imageUrl = result.data.images[0].url;
+// This is a raster PNG — pass to vectorize endpoint to get SVG
+```
+
+### Python Example
+
+```python
+import fal_client
+
+result = fal_client.subscribe(
+    "fal-ai/recraft/v3/text-to-image",
+    arguments={
+        "prompt": "A coffee cup with steam rising, flat design",
+        "style": "vector_illustration",
+        "style_id": "bold_stroke",
+        "image_size": "square_hd",
+        "colors": [
+            {"r": 120, "g": 53, "b": 15},
+            {"r": 254, "g": 243, "b": 199}
+        ]
+    }
+)
+
+image_url = result["images"][0]["url"]
+```
+
+---
+
+## Two-Step Pipeline: V3 Vector Style + Vectorize
+
+Use this pipeline when you need a specific V3 sub-style (e.g., `engraving`, `linocut`, `seamless_pattern`) and require true SVG output. Total cost: $0.08 (V3) + $0.01 (vectorize) = $0.09/image.
+
+### When to Use the Pipeline vs Direct V4
+
+| Scenario | Approach |
+|----------|----------|
+| Need a specific V3 sub-style (e.g., linocut, engraving) | V3 + vectorize |
+| Need true SVG, style doesn't matter | V4 direct ($0.08) |
+| Need highest quality SVG | V4 Pro direct ($0.30) |
+| Need seamless/tileable pattern as SVG | V3 seamless_pattern + vectorize |
+| Iterating on style before committing to SVG | V3 raster first, vectorize when satisfied |
+
+### Step 1: Generate Raster with V3 Vector Style
+
+```javascript
+import { fal } from "@fal-ai/client";
+
+// Step 1: Generate vector-style raster
+const rasterResult = await fal.subscribe("fal-ai/recraft/v3/text-to-image", {
+  input: {
+    prompt: "A vintage compass rose, engraving style",
+    style: "vector_illustration",
+    style_id: "engraving",
+    image_size: "square_hd"
+  }
+});
+
+const rasterUrl = rasterResult.data.images[0].url;
+console.log("Raster generated:", rasterUrl);
+```
+
+### Step 2: Vectorize the Raster
+
+```javascript
+// Step 2: Convert raster to SVG
+const svgResult = await fal.subscribe("fal-ai/recraft/vectorize", {
+  input: {
+    image_url: rasterUrl
+  }
+});
+
+const svgUrl = svgResult.data.image.url;
+console.log("SVG generated:", svgUrl);
+
+// Download SVG content
+const response = await fetch(svgUrl);
+const svgContent = await response.text();
+```
+
+### Complete Pipeline (Python)
+
+```python
+import fal_client
+import requests
+
+def generate_vector_svg(prompt: str, style_id: str, colors: list = None) -> str:
+    """
+    Two-step pipeline: V3 vector style → vectorize → SVG string.
+    Returns SVG content as string.
+    """
+    # Step 1: Generate vector-style raster
+    raster_args = {
+        "prompt": prompt,
+        "style": "vector_illustration",
+        "style_id": style_id,
+        "image_size": "square_hd"
+    }
+    if colors:
+        raster_args["colors"] = colors
+
+    raster_result = fal_client.subscribe(
+        "fal-ai/recraft/v3/text-to-image",
+        arguments=raster_args
+    )
+    raster_url = raster_result["images"][0]["url"]
+
+    # Step 2: Vectorize
+    svg_result = fal_client.subscribe(
+        "fal-ai/recraft/vectorize",
+        arguments={"image_url": raster_url}
+    )
+    svg_url = svg_result["image"]["url"]
+
+    # Download and return SVG content
+    response = requests.get(svg_url)
+    return response.text
+
+# Usage
+svg = generate_vector_svg(
+    prompt="A vintage compass rose",
+    style_id="engraving",
+    colors=[{"r": 30, "g": 30, "b": 30}]
+)
+with open("compass.svg", "w") as f:
+    f.write(svg)
+```
+
+---
+
+## Colors Parameter Reference
+
+All three endpoints accept a `colors` array to constrain the model's palette to brand colors. Pass up to 5 colors for best results.
+
+```javascript
+// Single brand color
+colors: [{ r: 59, g: 130, b: 246 }]
+
+// Full brand palette
+colors: [
+  { r: 59, g: 130, b: 246 },   // primary blue
+  { r: 30, g: 64, b: 175 },    // dark blue
+  { r: 255, g: 255, b: 255 },  // white
+  { r: 15, g: 23, b: 42 }      // near-black
+]
+```
+
+Convert hex to RGB for the API:
+
+```javascript
+function hexToRgb(hex) {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return result ? {
+    r: parseInt(result[1], 16),
+    g: parseInt(result[2], 16),
+    b: parseInt(result[3], 16)
+  } : null;
+}
+
+// Usage
+const brandColors = ["#3b82f6", "#1e40af", "#ffffff"].map(hexToRgb);
+```
+
+---
+
+## Model Selection Guide
+
+### By Output Requirement
+
+| You need... | Use |
+|-------------|-----|
+| True SVG file, standard quality | `fal-ai/recraft/v4/text-to-vector` |
+| True SVG file, maximum quality | `fal-ai/recraft/v4/pro/text-to-vector` |
+| Raster with vector aesthetic | `fal-ai/recraft/v3/text-to-image` + `vector_illustration` |
+| SVG with specific illustration style | V3 + `fal-ai/recraft/vectorize` pipeline |
+
+### By Budget
+
+| Budget per asset | Approach |
+|-----------------|----------|
+| Under $0.05 | V3 raster only ($0.04), no SVG |
+| $0.08-0.09 | V4 direct SVG or V3 + vectorize pipeline |
+| $0.30 | V4 Pro for highest quality SVG |
+
+### By Style Need
+
+| Style | Endpoint | style_id |
+|-------|----------|----------|
+| Clean logo/icon | V4 direct | — |
+| Vintage/etched | V3 + vectorize | `engraving` or `linocut` |
+| Sticker/badge | V3 + vectorize | `bold_stroke` or `colored_sticker` |
+| Seamless pattern | V3 + vectorize | `seamless_pattern` |
+| Technical diagram | V3 + vectorize | `line_circuit` or `chemistry` |
+| Minimal line art | V3 + vectorize | `line_art` or `thin` |
+| Pop/retro | V3 + vectorize | `pop_art` |
+| Watercolor-style | V3 + vectorize | `watercolor` |
+
+---
+
+## Error Handling
+
+| HTTP Status | Cause | Action |
+|-------------|-------|--------|
+| 401 | Invalid or missing FAL_KEY | Check `FAL_KEY` env var or `fal.config({credentials})` |
+| 422 | Invalid parameter type or value | Check `style_id` spelling, `colors` format `{r,g,b}`, `image_size` value |
+| 429 | Rate limit exceeded | Implement exponential backoff; use queue pattern for batch jobs |
+| 500 | Model inference failure | Retry once; if persistent, simplify prompt or switch endpoint |
+
+Wrap `fal.subscribe()` calls in try/catch and inspect `error.status` and `error.body` for validation details. The `422` body typically names the offending field.
+
+For fal.ai client setup, authentication, and queue management patterns, see `references/fal-api-reference.md`.
+For prompt engineering strategies specific to vector output, see `references/prompt-engineering.md`.

--- a/skills/vector-graphics-gen/references/use-case-recipes.md
+++ b/skills/vector-graphics-gen/references/use-case-recipes.md
@@ -1,0 +1,436 @@
+# Use Case Recipes
+
+Sources: fal.ai documentation, production implementations (2025-2026)
+
+Covers: complete end-to-end code for common vector graphics tasks. Copy and adapt directly.
+
+## Shared Setup
+
+All recipes use this boilerplate. Install: `npm install @fal-ai/client svgo`.
+
+```javascript
+import { fal } from "@fal-ai/client";
+import { optimize } from "svgo";
+import fs from "fs/promises";
+
+fal.config({ credentials: process.env.FAL_KEY });
+
+const svgoConfig = {
+  multipass: true,
+  plugins: [
+    { name: "preset-default", params: { overrides: { removeViewBox: false } } },
+    { name: "convertPathData", params: { floatPrecision: 1 } },
+  ],
+};
+
+async function fetchSvg(url) {
+  const text = await fetch(url).then((r) => r.text());
+  return optimize(text, svgoConfig).data;
+}
+```
+
+**Two-step pipeline** (Recraft V3 — raster-style, then vectorize):
+`fal-ai/recraft/v3/text-to-image` → `fal-ai/recraft/vectorize`
+
+**One-step pipeline** (Recraft V4 — native SVG):
+`fal-ai/recraft/v4/text-to-vector`
+
+---
+
+## Recipe 1: App Icon Set
+
+Generate a single icon at multiple sizes with PNG fallbacks for all platforms.
+
+**Model**: `fal-ai/recraft/v4/text-to-vector` — true SVG, scales to any size.
+**Extra dep**: `npm install sharp`
+
+```javascript
+import sharp from "sharp";
+
+async function generateAppIconSet(appName, description, brandColor) {
+  const result = await fal.subscribe("fal-ai/recraft/v4/text-to-vector", {
+    input: {
+      prompt: `App icon for ${appName}: ${description}. Flat design, single centered symbol, minimal geometric shapes, solid colors only, white background, no text, no gradients`,
+      image_size: "square_hd",
+      colors: [brandColor],
+      background_color: { r: 255, g: 255, b: 255 },
+    },
+    logs: true,
+    onQueueUpdate: (u) => u.status === "IN_PROGRESS" && u.logs.forEach((l) => console.log(l.message)),
+  });
+
+  const svg = await fetchSvg(result.data.images[0].url);
+  const outDir = `./icons/${appName.toLowerCase()}`;
+  await fs.mkdir(outDir, { recursive: true });
+  await fs.writeFile(`${outDir}/icon.svg`, svg);
+
+  for (const size of [16, 32, 64, 128, 512]) {
+    await sharp(Buffer.from(svg)).resize(size, size).png().toFile(`${outDir}/icon-${size}.png`);
+  }
+}
+
+await generateAppIconSet("Taskflow", "checkmark inside a circle", { r: 99, g: 102, b: 241 });
+```
+
+**Integration**: Use `icon.svg` inline for crisp rendering at any size. Use `icon-512.png` for app store submissions, `icon-32.png` for favicons.
+
+---
+
+## Recipe 2: Logo Generation with Variants
+
+Generate a brand logo and produce four standard variants: full lockup, icon-only, monochrome, reversed.
+
+**Model**: `fal-ai/recraft/v4/text-to-vector` — color palette control, true SVG.
+
+```javascript
+async function generateLogoVariants({ name, tagline, primaryColor, secondaryColor }) {
+  const [fullResult, iconResult] = await Promise.all([
+    fal.subscribe("fal-ai/recraft/v4/text-to-vector", {
+      input: {
+        prompt: `Professional logo for "${name}" — ${tagline}. Symbol left, company name right. Clean vector, flat, minimal, 2 colors, white background`,
+        image_size: { width: 800, height: 300 },
+        colors: [primaryColor, secondaryColor],
+        background_color: { r: 255, g: 255, b: 255 },
+      },
+      logs: false,
+    }),
+    fal.subscribe("fal-ai/recraft/v4/text-to-vector", {
+      input: {
+        prompt: `Logo symbol only for "${name}" — ${tagline}. No text, centered symbol, flat vector, white background`,
+        image_size: "square_hd",
+        colors: [primaryColor],
+        background_color: { r: 255, g: 255, b: 255 },
+      },
+      logs: false,
+    }),
+  ]);
+
+  const outDir = `./logos/${name.toLowerCase().replace(/\s+/g, "-")}`;
+  await fs.mkdir(outDir, { recursive: true });
+
+  const fullSvg = await fetchSvg(fullResult.data.images[0].url);
+  const iconSvg = await fetchSvg(iconResult.data.images[0].url);
+
+  await fs.writeFile(`${outDir}/logo-full.svg`, fullSvg);
+  await fs.writeFile(`${outDir}/logo-icon.svg`, iconSvg);
+  await fs.writeFile(`${outDir}/logo-mono.svg`, iconSvg.replace(/fill="[^"]*"/g, 'fill="#1a1a1a"'));
+  await fs.writeFile(`${outDir}/logo-reversed.svg`, iconSvg.replace(/fill="[^"]*"/g, 'fill="white"'));
+}
+
+await generateLogoVariants({
+  name: "Meridian", tagline: "navigation software",
+  primaryColor: { r: 14, g: 165, b: 233 }, secondaryColor: { r: 15, g: 23, b: 42 },
+});
+```
+
+**Integration**: Use `logo-full.svg` in the site header. Use `logo-icon.svg` for favicons. Apply `logo-reversed.svg` on dark backgrounds.
+
+---
+
+## Recipe 3: Hero Illustration
+
+Generate a large illustration for a landing page hero, optimized for web delivery.
+
+**Model**: `fal-ai/recraft/v3/text-to-image` with `style: "vector_illustration"`, `substyle: "emotional_flat"`. Follow with vectorize step.
+
+```javascript
+async function generateHeroIllustration(concept, palette) {
+  const rasterResult = await fal.subscribe("fal-ai/recraft/v3/text-to-image", {
+    input: {
+      prompt: `${concept}. Flat vector illustration, editorial style, bold shapes, limited color palette, no text, no gradients, clean composition`,
+      style: "vector_illustration",
+      substyle: "emotional_flat",
+      image_size: "landscape_16_9",
+      colors: palette,
+    },
+    logs: true,
+    onQueueUpdate: (u) => u.status === "IN_PROGRESS" && u.logs.forEach((l) => console.log(l.message)),
+  });
+
+  const vectorResult = await fal.subscribe("fal-ai/recraft/vectorize", {
+    input: { image_url: rasterResult.data.images[0].url },
+    logs: false,
+  });
+
+  const svg = await fetchSvg(vectorResult.data.images[0].url);
+  await fs.writeFile("./hero-illustration.svg", svg);
+  console.log(`SVG: ${(svg.length / 1024).toFixed(1)}KB`);
+}
+
+await generateHeroIllustration(
+  "Team collaborating around a glowing dashboard, modern office, diverse people",
+  [{ r: 99, g: 102, b: 241 }, { r: 236, g: 72, b: 153 }, { r: 248, g: 250, b: 252 }]
+);
+```
+
+**Integration**:
+
+```html
+<img src="/hero-illustration.svg" alt="Team collaborating" width="1200" height="675"
+     loading="eager" fetchpriority="high" />
+```
+
+---
+
+## Recipe 4: Icon Library with Sprite Sheet and React Component
+
+Batch-generate a consistent icon set, merge into a sprite, and expose as a typed React component.
+
+**Model**: `fal-ai/recraft/v4/text-to-vector` — consistent style across batch.
+
+```javascript
+const ICONS = [
+  { id: "home", prompt: "house outline, minimal" },
+  { id: "search", prompt: "magnifying glass, minimal" },
+  { id: "settings", prompt: "gear/cog wheel, 8 teeth" },
+  { id: "user", prompt: "person silhouette, head and shoulders" },
+  { id: "bell", prompt: "notification bell, minimal" },
+  { id: "mail", prompt: "envelope, closed, minimal" },
+  { id: "chart", prompt: "bar chart, 3 ascending bars" },
+  { id: "lock", prompt: "padlock, closed, minimal" },
+  { id: "star", prompt: "5-point star, minimal" },
+  { id: "trash", prompt: "trash can with lid, minimal" },
+];
+
+async function generateIconLibrary(brandColor) {
+  const iconData = [];
+  for (let i = 0; i < ICONS.length; i += 5) {
+    const batch = ICONS.slice(i, i + 5);
+    const results = await Promise.all(
+      batch.map((icon) =>
+        fal.subscribe("fal-ai/recraft/v4/text-to-vector", {
+          input: {
+            prompt: `Icon: ${icon.prompt}. 24x24 grid, centered, flat vector, line art, stroke only, white background`,
+            image_size: "square_hd",
+            colors: [brandColor],
+          },
+          logs: false,
+        })
+      )
+    );
+    for (let j = 0; j < batch.length; j++) {
+      const svg = await fetchSvg(results[j].data.images[0].url);
+      const inner = svg.replace(/<\?xml[^>]*\?>/, "").replace(/<svg[^>]*>/, "").replace(/<\/svg>/, "").trim();
+      iconData.push({ id: batch[j].id, inner });
+    }
+  }
+
+  await fs.mkdir("./icons", { recursive: true });
+
+  const symbols = iconData
+    .map(({ id, inner }) => `  <symbol id="icon-${id}" viewBox="0 0 24 24">\n    ${inner}\n  </symbol>`)
+    .join("\n");
+  await fs.writeFile("./icons/sprite.svg",
+    `<svg xmlns="http://www.w3.org/2000/svg" style="display:none">\n${symbols}\n</svg>`
+  );
+
+  const iconIds = iconData.map((i) => `"${i.id}"`).join(" | ");
+  await fs.writeFile("./icons/Icon.tsx",
+`import React from "react";
+type IconId = ${iconIds};
+interface IconProps { name: IconId; size?: number; className?: string; "aria-label"?: string; }
+export function Icon({ name, size = 24, className, "aria-label": label }: IconProps) {
+  return (
+    <svg width={size} height={size} className={className} aria-label={label} aria-hidden={!label}>
+      <use href={\`/icons/sprite.svg#icon-\${name}\`} />
+    </svg>
+  );
+}`);
+}
+
+await generateIconLibrary({ r: 99, g: 102, b: 241 });
+```
+
+**Integration**: Include `sprite.svg` once at the page root, then use `<Icon name="home" size={20} />` anywhere.
+
+---
+
+## Recipe 5: Seamless Tileable Pattern
+
+Generate a pattern tile and output as a CSS background.
+
+**Model**: `fal-ai/recraft/v3/text-to-image` with `style: "vector_illustration"`, `substyle: "segmented_colors"`.
+
+```javascript
+async function generateSeamlessPattern(theme, colors) {
+  const rasterResult = await fal.subscribe("fal-ai/recraft/v3/text-to-image", {
+    input: {
+      prompt: `Seamless repeating pattern: ${theme}. Flat vector, geometric, elements near edges for seamless tiling, no central focal point, white background`,
+      style: "vector_illustration",
+      substyle: "segmented_colors",
+      image_size: "square_hd",
+      colors,
+    },
+    logs: false,
+  });
+
+  const vectorResult = await fal.subscribe("fal-ai/recraft/vectorize", {
+    input: { image_url: rasterResult.data.images[0].url },
+    logs: false,
+  });
+
+  const svg = await fetchSvg(vectorResult.data.images[0].url);
+  await fs.writeFile("./pattern-tile.svg", svg);
+
+  const dataUri = `data:image/svg+xml,${encodeURIComponent(svg)}`;
+  await fs.writeFile("./pattern.css",
+    `.pattern-bg { background-image: url("${dataUri}"); background-repeat: repeat; background-size: 200px 200px; }`
+  );
+}
+
+await generateSeamlessPattern("small leaves and botanical elements", [
+  { r: 34, g: 197, b: 94 }, { r: 240, g: 253, b: 244 },
+]);
+```
+
+**Integration**: Apply `.pattern-bg` to any container. Adjust `background-size` to control tile density.
+
+---
+
+## Recipe 6: Photo to Clean Vector
+
+Convert an existing photo or screenshot to an optimized SVG.
+
+**Model**: `fal-ai/image2svg` ($0.005) for simple images; `fal-ai/recraft/vectorize` ($0.01) for higher fidelity.
+
+```javascript
+async function photoToVector(inputPath, outputPath, highFidelity = false) {
+  const imageBuffer = await fs.readFile(inputPath);
+  const ext = inputPath.split(".").pop().toLowerCase();
+  const file = new File([imageBuffer], `input.${ext}`, { type: ext === "png" ? "image/png" : "image/jpeg" });
+  const uploadedUrl = await fal.storage.upload(file);
+
+  const endpoint = highFidelity ? "fal-ai/recraft/vectorize" : "fal-ai/image2svg";
+  const result = await fal.subscribe(endpoint, {
+    input: { image_url: uploadedUrl },
+    logs: true,
+    onQueueUpdate: (u) => u.status === "IN_PROGRESS" && u.logs.forEach((l) => console.log(l.message)),
+  });
+
+  const svg = await fetchSvg(result.data.images[0].url);
+  await fs.writeFile(outputPath, svg);
+  console.log(`${(imageBuffer.length / 1024).toFixed(1)}KB → ${(svg.length / 1024).toFixed(1)}KB SVG`);
+}
+
+await photoToVector("./logo-photo.png", "./logo-vector.svg", true);
+```
+
+**Note**: If the output SVG exceeds 50KB, the source image is too complex for clean vectorization. Regenerate from a prompt with `fal-ai/recraft/v4/text-to-vector` instead.
+
+---
+
+## Recipe 7: Badge and Sticker Set
+
+Generate a matching set of gamification badges with consistent visual style.
+
+**Model**: `fal-ai/recraft/v3/text-to-image` with `style: "vector_illustration"`, `substyle: "bold_stroke"`.
+
+```javascript
+const BADGES = [
+  { id: "beginner", symbol: "seedling sprout", color: { r: 34, g: 197, b: 94 } },
+  { id: "explorer", symbol: "compass rose", color: { r: 59, g: 130, b: 246 } },
+  { id: "builder", symbol: "hammer and wrench crossed", color: { r: 245, g: 158, b: 11 } },
+  { id: "expert", symbol: "lightning bolt", color: { r: 168, g: 85, b: 247 } },
+  { id: "master", symbol: "crown with gems", color: { r: 239, g: 68, b: 68 } },
+];
+
+async function generateBadgeSet() {
+  const outDir = "./badges";
+  await fs.mkdir(outDir, { recursive: true });
+
+  const rasterResults = await Promise.all(
+    BADGES.map((b) =>
+      fal.subscribe("fal-ai/recraft/v3/text-to-image", {
+        input: {
+          prompt: `Achievement badge: ${b.symbol}. Circular badge shape, bold stroke outline, flat vector, centered symbol, no text, white background`,
+          style: "vector_illustration",
+          substyle: "bold_stroke",
+          image_size: "square_hd",
+          colors: [b.color, { r: 255, g: 255, b: 255 }],
+        },
+        logs: false,
+      }).then((r) => ({ badge: b, url: r.data.images[0].url }))
+    )
+  );
+
+  for (const { badge, url } of rasterResults) {
+    const vectorResult = await fal.subscribe("fal-ai/recraft/vectorize", {
+      input: { image_url: url }, logs: false,
+    });
+    const svg = await fetchSvg(vectorResult.data.images[0].url);
+    await fs.writeFile(`${outDir}/${badge.id}.svg`, svg);
+  }
+}
+
+await generateBadgeSet();
+```
+
+**Integration**:
+
+```jsx
+function AchievementBadge({ id, label, earned }) {
+  return (
+    <div className={`badge ${earned ? "earned" : "locked"}`}>
+      <img src={`/badges/${id}.svg`} alt={label} width={64} height={64} />
+      <span>{label}</span>
+    </div>
+  );
+}
+```
+
+---
+
+## Recipe 8: Decorative Dividers and Ornamental Elements
+
+Generate section dividers and wave separators for landing pages.
+
+**Model**: `fal-ai/recraft/v3/text-to-image` with `style: "vector_illustration"`, `substyle: "thin"`.
+
+```javascript
+const DIVIDERS = [
+  { id: "wave", prompt: "Smooth wave divider, single continuous wave path, horizontal" },
+  { id: "zigzag", prompt: "Zigzag border, sharp geometric teeth, horizontal strip" },
+  { id: "floral", prompt: "Ornamental floral divider, symmetrical botanical motif, centered, horizontal" },
+];
+
+async function generateDividerSet(accentColor) {
+  const outDir = "./dividers";
+  await fs.mkdir(outDir, { recursive: true });
+
+  for (const divider of DIVIDERS) {
+    const rasterResult = await fal.subscribe("fal-ai/recraft/v3/text-to-image", {
+      input: {
+        prompt: `${divider.prompt}. Flat vector, no gradients, white background`,
+        style: "vector_illustration",
+        substyle: "thin",
+        image_size: "landscape_16_9",
+        colors: [accentColor, { r: 255, g: 255, b: 255 }],
+      },
+      logs: false,
+    });
+
+    const vectorResult = await fal.subscribe("fal-ai/image2svg", {
+      input: { image_url: rasterResult.data.images[0].url }, logs: false,
+    });
+
+    const svg = await fetchSvg(vectorResult.data.images[0].url);
+    await fs.writeFile(`${outDir}/${divider.id}.svg`, svg);
+  }
+}
+
+await generateDividerSet({ r: 99, g: 102, b: 241 });
+```
+
+**Integration**:
+
+```html
+<section class="hero">...</section>
+<div style="width:100%; overflow:hidden; line-height:0;">
+  <img src="/dividers/wave.svg" alt="" aria-hidden="true" style="display:block; width:100%;" />
+</div>
+<section class="features">...</section>
+```
+
+---
+
+For prompt engineering patterns that improve output quality across all recipes, see `references/prompt-engineering.md`. For SVGO configuration details, see `references/svg-optimization.md`. For model selection guidance, see `references/fal-api-reference.md`.

--- a/skills/vector-graphics-gen/skills.json
+++ b/skills/vector-graphics-gen/skills.json
@@ -1,0 +1,16 @@
+{
+  "name": "@tank/vector-graphics-gen",
+  "version": "0.0.1",
+  "description": "Generate vector graphics (SVG) for websites and apps using AI APIs. Primary platform: fal.ai with Recraft V3/V4 for native SVG generation, plus image-to-SVG conversion. Covers text-to-vector generation, image vectorization, prompt engineering for clean vector output, SVG optimization (SVGO), and web integration patterns (React, Vue, sprites, dark mode). Synthesizes fal.ai documentation, Recraft AI documentation, SVGO docs, and SVG specification.\n\nTrigger phrases: \"vector graphic\", \"generate SVG\", \"SVG icon\", \"vector illustration\", \"AI vector\", \"fal.ai\", \"FAL_KEY\", \"recraft\", \"recraft v3\", \"recraft v4\", \"text to SVG\", \"image to SVG\", \"vectorize image\", \"SVG generation\", \"vector logo\", \"AI illustration\", \"icon generation\", \"SVG for web\", \"vector art API\", \"fal-ai/recraft\", \"generate icon\", \"web illustration\", \"SVG background\", \"vector pattern\", \"clean SVG\", \"production SVG\", \"vector_illustration\", \"text-to-vector\"",
+  "permissions": {
+    "network": {
+      "outbound": ["fal.ai", "queue.fal.run", "fal.run", "v3.fal.media", "fal.media"]
+    },
+    "filesystem": {
+      "read": ["**/*"],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

- Adds `@tank/vector-graphics-gen` skill (v0.0.1) for generating vector graphics (SVG) using AI APIs
- Primary platform: fal.ai with Recraft V3/V4 for native SVG generation, plus image-to-SVG conversion
- Includes 7 reference files covering API usage, models, prompt engineering, optimization, integration, and recipes

## Files

- `SKILL.md` — Core skill instructions (160 lines)
- `skills.json` — Package manifest with fal.ai network permissions
- `references/fal-api-reference.md` — fal.ai client setup, auth, request patterns
- `references/text-to-vector-models.md` — All Recraft V3/V4 endpoints and parameters
- `references/image-to-svg-conversion.md` — Raster-to-SVG conversion methods
- `references/prompt-engineering.md` — Prompt patterns for icons, logos, illustrations
- `references/svg-optimization.md` — SVGO config, AI SVG cleanup, accessibility
- `references/svg-integration-patterns.md` — React/Vue components, sprites, dark mode
- `references/use-case-recipes.md` — End-to-end code recipes for common use cases