### PR TITLE
feat(vector-graphics-gen): add QuiverAI Arrow, update to March 2026 models

### DIFF
--- a/skills/vector-graphics-gen/SKILL.md
+++ b/skills/vector-graphics-gen/SKILL.md
@@ -2,29 +2,30 @@
 name: "@tank/vector-graphics-gen"
 description: |
   Generate vector graphics (SVG) for websites and apps using AI APIs.
-  Primary platform: fal.ai with Recraft V3/V4 for native SVG generation,
-  plus image-to-SVG conversion via recraft/vectorize and image2svg.
-  Covers text-to-vector generation, image vectorization, prompt engineering
-  for clean vector output, SVG optimization (SVGO), and web integration
-  patterns (React, Vue, sprites, dark mode). Synthesizes fal.ai documentation,
-  Recraft AI documentation, SVGO docs, and SVG specification.
+  Primary platforms: QuiverAI Arrow (highest quality, #1 SVG Arena) and
+  fal.ai with Recraft V4 for native SVG generation, plus image-to-SVG
+  conversion. Covers text-to-vector generation, image vectorization,
+  prompt engineering for clean vector output, SVG optimization (SVGO),
+  and web integration patterns (React, Vue, sprites, dark mode).
+  Synthesizes QuiverAI documentation, fal.ai documentation, Recraft AI
+  documentation, SVGO docs, and SVG specification.
 
   Trigger phrases: "vector graphic", "generate SVG", "SVG icon",
   "vector illustration", "AI vector", "fal.ai", "FAL_KEY", "recraft",
-  "recraft v3", "recraft v4", "text to SVG", "image to SVG",
-  "vectorize image", "SVG generation", "vector logo", "AI illustration",
-  "icon generation", "SVG for web", "vector art API", "fal-ai/recraft",
-  "generate icon", "web illustration", "SVG background", "vector pattern",
-  "clean SVG", "production SVG", "vector_illustration", "text-to-vector"
+  "recraft v4", "text to SVG", "image to SVG", "quiver", "quiverai",
+  "arrow model", "vectorize image", "SVG generation", "vector logo",
+  "AI illustration", "icon generation", "SVG for web", "vector art API",
+  "fal-ai/recraft", "generate icon", "web illustration", "SVG background",
+  "vector pattern", "clean SVG", "production SVG", "text-to-vector"
 ---
 
 # Vector Graphics Generation
 
 ## Core Philosophy
 
-1. **Generate native SVG when possible.** Use Recraft V4 text-to-vector
-   for true SVG output. Fall back to raster generation + vectorization
-   only when native models cannot achieve the desired style.
+1. **Pick the right model for the job.** QuiverAI Arrow produces the
+   highest-quality SVGs (1583 Elo, #1 SVG Arena). Recraft V4 on fal.ai
+   is the best option when you need sub-style control or cost efficiency.
 2. **Every SVG must be production-ready.** Run SVGO, verify viewBox,
    check file size, remove embedded rasters. Never ship raw AI output.
 3. **Prompt quality determines output quality.** Specific, structured
@@ -32,15 +33,15 @@ description: |
    Vague prompts produce unusable output.
 4. **Match the tool to the task.** Icons need different models, prompts,
    and optimization than hero illustrations or logos. Select deliberately.
-5. **Cost awareness matters.** Vector generation costs 2X raster ($0.08
-   vs $0.04). Use the cheapest pipeline that meets quality requirements.
+5. **Cost awareness matters.** Arrow is free tier (20/week) or paid API.
+   Recraft V4 SVG costs $0.08, V4 Pro $0.30. Choose accordingly.
 
 ## Quick-Start: Generate Vector Graphics
 
 ### "I need an SVG icon"
 
-1. Set `FAL_KEY` environment variable.
-2. Call Recraft V4 text-to-vector with a specific prompt:
+1. Set `FAL_KEY` environment variable (for fal.ai) or `QUIVER_API_KEY` (for QuiverAI).
+2. Call Recraft V4 text-to-vector for fast, cost-effective icons:
    ```javascript
    const result = await fal.subscribe("fal-ai/recraft/v4/text-to-vector", {
      input: {
@@ -49,25 +50,31 @@ description: |
      }
    });
    ```
-3. Download SVG from `result.data.images[0].url`.
+   Or use QuiverAI Arrow for highest quality:
+   ```javascript
+   const response = await quiver.svgs.generate({
+     model: "arrow-1",
+     prompt: "minimal settings gear icon, flat design, monochrome black, centered"
+   });
+   ```
+3. Download SVG from the response URL.
 4. Optimize with SVGO: `svgo --precision 1 --multipass icon.svg`
    -> See `references/text-to-vector-models.md` for all model options
    -> See `references/prompt-engineering.md` for icon prompt patterns
 
 ### "I need a hero illustration"
 
-1. Call Recraft V3 with `vector_illustration` style and a sub-style:
+1. Use Recraft V4 Pro for high-detail native SVG:
    ```javascript
-   const result = await fal.subscribe("fal-ai/recraft/v3/text-to-image", {
+   const result = await fal.subscribe("fal-ai/recraft/v4/pro/text-to-vector", {
      input: {
-       prompt: "team collaboration workspace illustration, people at desks with laptops",
-       style: "vector_illustration/emotional_flat",
+       prompt: "team collaboration workspace illustration, people at desks with laptops, editorial flat style",
        image_size: "landscape_16_9",
        colors: [{ r: 99, g: 102, b: 241 }, { r: 249, g: 115, b: 22 }]
      }
    });
    ```
-2. If raster output, vectorize: call `fal-ai/recraft/vectorize`.
+2. Or use V3 two-step pipeline for specific sub-style control (22 styles).
 3. Optimize with SVGO.
    -> See `references/prompt-engineering.md` for illustration prompts
    -> See `references/image-to-svg-conversion.md` for vectorization
@@ -93,27 +100,30 @@ description: |
 
 ## Decision Trees
 
-### Model Selection
+### Model Selection (March 2026)
 
-| Need | Model | Endpoint | Cost |
-|------|-------|----------|------|
-| True SVG from text | Recraft V4 | `fal-ai/recraft/v4/text-to-vector` | $0.08 |
-| High-res true SVG | Recraft V4 Pro | `fal-ai/recraft/v4/pro/text-to-vector` | $0.30 |
-| Vector-style raster | Recraft V3 | `fal-ai/recraft/v3/text-to-image` | $0.08 |
-| Convert image to SVG | Recraft Vectorize | `fal-ai/recraft/vectorize` | $0.01 |
-| Cheap image to SVG | Image2SVG | `fal-ai/image2svg` | $0.005 |
+| Need | Model | Endpoint / SDK | Cost | SVG Arena Elo |
+|------|-------|----------------|------|---------------|
+| Highest quality SVG | QuiverAI Arrow 1 | `@quiverai/sdk` | Free tier / paid | 1583 (#1) |
+| Native SVG (fal.ai) | Recraft V4 | `fal-ai/recraft/v4/text-to-vector` | $0.08 | — |
+| High-res native SVG | Recraft V4 Pro | `fal-ai/recraft/v4/pro/text-to-vector` | $0.30 | — |
+| Styled illustration SVG | Recraft V3 + vectorize | `fal-ai/recraft/v3/text-to-image` → vectorize | $0.09 | — |
+| Convert image to SVG | Recraft Vectorize | `fal-ai/recraft/vectorize` | $0.01 | — |
+| Cheap image to SVG | Image2SVG | `fal-ai/image2svg` | $0.005 | — |
 
 ### Pipeline Selection
 
 | Scenario | Pipeline | Total Cost |
 |----------|----------|------------|
-| Simple icon/logo | V4 text-to-vector → SVGO | $0.08 |
-| Styled illustration | V3 vector_illustration → vectorize → SVGO | $0.09 |
+| Simple icon/logo (best quality) | QuiverAI Arrow → SVGO | Free tier |
+| Simple icon/logo (fal.ai) | V4 text-to-vector → SVGO | $0.08 |
+| Styled illustration (specific sub-style) | V3 vector_illustration → vectorize → SVGO | $0.09 |
 | Existing image | image2svg → SVGO | $0.005 |
-| Highest quality | V4 Pro text-to-vector → SVGO | $0.30 |
-| Budget batch | V3 vector → SVGO (skip vectorize if raster OK) | $0.08 |
+| Highest quality (fal.ai) | V4 Pro text-to-vector → SVGO | $0.30 |
 
-### Vector Sub-Style Selection (Recraft V3)
+### Vector Sub-Style Selection (Recraft V3 Pipeline)
+
+Use the V3 two-step pipeline when you need a specific illustration style.
 
 | Use Case | Recommended Sub-Style |
 |----------|----------------------|
@@ -122,7 +132,7 @@ description: |
 | Editorial illustrations | `editorial`, `emotional_flat`, `infographical` |
 | Logo marks | `bold_stroke`, `cutout`, `sharp_contrast` |
 | Technical diagrams | `line_circuit`, `infographical`, `thin` |
-| Artistic illustrations | `cosmics`, `mosaic`, `naivector` |
+| Artistic illustrations | `cosmics`, `mosaic`, `naiveart` |
 | Print/engraving | `engraving`, `linocut`, `colored_stencil` |
 
 ### SVG Type File Size Targets
@@ -137,22 +147,31 @@ description: |
 
 ## Authentication
 
-Set the `FAL_KEY` environment variable before making API calls:
+**fal.ai** — Set the `FAL_KEY` environment variable:
 
 ```bash
-export FAL_KEY="YOUR_API_KEY"
+export FAL_KEY="YOUR_FAL_KEY"
 ```
 
-Install the client: `npm install @fal-ai/client` (JS) or `pip install fal-client` (Python).
+Install: `npm install @fal-ai/client` (JS) or `pip install fal-client` (Python).
 
--> See `references/fal-api-reference.md` for complete setup
+**QuiverAI** — Set the `QUIVER_API_KEY` environment variable:
+
+```bash
+export QUIVER_API_KEY="YOUR_QUIVER_KEY"
+```
+
+Install: `npm install @quiverai/sdk`
+
+-> See `references/fal-api-reference.md` for complete fal.ai setup
+-> See `references/text-to-vector-models.md` for QuiverAI Arrow setup
 
 ## Reference Files
 
 | File | Contents |
 |------|----------|
 | `references/fal-api-reference.md` | fal.ai authentication, client setup (JS/Python/REST), request patterns (subscribe, queue, sync), response format, file upload, error handling, downloading SVG results |
-| `references/text-to-vector-models.md` | Recraft V3/V4 text-to-vector endpoints, all parameters, complete vector sub-style catalog (22 styles), color palette control, size options, model comparison, pricing |
+| `references/text-to-vector-models.md` | QuiverAI Arrow 1 (#1 SVG Arena), Recraft V4/V4 Pro text-to-vector, Recraft V3 sub-style catalog (22 styles), model comparison with SVG Arena rankings, pricing |
 | `references/image-to-svg-conversion.md` | recraft/vectorize, image2svg, star-vector endpoints, two-step pipeline, Potrace CLI, input preparation, quality comparison, limitations |
 | `references/prompt-engineering.md` | Prompt structure formula, icon/illustration/logo/pattern prompt templates, style keyword catalog, negative prompts, color control, sub-style mapping, common mistakes |
 | `references/svg-optimization.md` | AI-generated SVG issues and fixes, SVGO setup and config, manual cleanup checklist, path simplification, file size targets, accessibility, batch processing |

--- a/skills/vector-graphics-gen/references/prompt-engineering.md
+++ b/skills/vector-graphics-gen/references/prompt-engineering.md
@@ -8,6 +8,8 @@ Covers: prompt anatomy, style selection, color control, icon/logo patterns, illu
 
 Effective vector prompts follow a four-part anatomy. Each part is optional but order matters — specificity increases left to right.
 
+The prompt quality principles in this file apply across all models — QuiverAI Arrow, Recraft V4, and Recraft V3. Model choice affects output format and available sub-styles, not the fundamentals of prompt construction. Write strong prompts first; select the model second.
+
 ```
 [Subject] + [Style descriptor] + [Composition] + [Constraints]
 ```
@@ -41,7 +43,7 @@ Effective vector prompts follow a four-part anatomy. Each part is optional but o
 
 ## 2. Style Control
 
-Recraft V3 exposes 22 sub-styles under `vector_illustration`. Pass the sub-style as the `style_name` parameter alongside `style: "vector_illustration"`.
+Recraft V3 exposes 22 sub-styles under `vector_illustration`. Pass the sub-style as the `style_name` parameter alongside `style: "vector_illustration"`. Use V3 sub-styles via the two-step pipeline (V3 raster → vectorize) when you need specific illustration styles. For general vector generation, prefer Recraft V4 or QuiverAI Arrow.
 
 ### Sub-Style Visual Reference
 
@@ -286,7 +288,7 @@ Append to any vector prompt: `no gradients, no shadows, no textures, solid color
 
 Copy-paste templates for common use cases. Replace bracketed placeholders.
 
-All templates use `fal-ai/recraft/v3/text-to-image` unless noted. Size defaults to `square_hd`.
+Templates below show `fal-ai/recraft/v4/text-to-vector` for native SVG output. For sub-style control, use `fal-ai/recraft/v3/text-to-image` with the two-step pipeline. For highest quality, use QuiverAI Arrow (`@quiverai/sdk`). Size defaults to `square_hd`.
 
 ### Template 1: App Icon (Flat)
 ```
@@ -412,7 +414,7 @@ Make one change per iteration — changing multiple variables simultaneously mak
 | Failure | Alternative |
 |---------|------------|
 | Needs true SVG output | `fal-ai/recraft/v4/text-to-vector` |
-| Needs text in the image | `fal-ai/ideogram/v3` (superior typography) |
+| Needs text in the image | `fal-ai/ideogram/v2a` (Ideogram has no native SVG — produces raster only, good for text-heavy images that can be vectorized) |
 | Needs highest quality | `fal-ai/recraft/v4/pro/text-to-vector` |
 | Need speed, raster acceptable | `fal-ai/nano-banana-2` then vectorize |
 

--- a/skills/vector-graphics-gen/references/text-to-vector-models.md
+++ b/skills/vector-graphics-gen/references/text-to-vector-models.md
@@ -1,29 +1,91 @@
 # Text-to-Vector Models
 
-Sources: fal.ai documentation (2025-2026), Recraft API docs, model benchmarks
+Sources: fal.ai documentation (2026), Recraft API docs, QuiverAI Arrow documentation, SVG Arena benchmarks (March 2026)
 
-Covers: All text-to-vector and vector-style image endpoints on fal.ai — Recraft V4, V4 Pro, V3 — with complete parameter references, model comparison, code examples, and the two-step raster-to-SVG pipeline.
+Covers: All text-to-vector endpoints as of March 2026 — QuiverAI Arrow 1 (standalone API), Recraft V4/V4 Pro/V3 on fal.ai — with complete parameter references, model comparison, SVG Arena rankings, code examples, and the two-step raster-to-SVG pipeline.
 
 ## Model Overview
 
-Three primary paths to vector output via fal.ai:
+Four primary paths to vector output:
 
-1. **Native SVG** — Recraft V4 and V4 Pro produce true SVG files directly from text
-2. **Vector-style raster** — Recraft V3 with `vector_illustration` style produces raster images optimized for vectorization
-3. **Two-step pipeline** — Generate with V3 vector style, then convert to SVG via `fal-ai/recraft/vectorize`
+1. **QuiverAI Arrow 1** — purpose-built SVG model, #1 on SVG Arena, standalone API (not on fal.ai)
+2. **Native SVG via fal.ai** — Recraft V4 and V4 Pro produce true SVG files directly from text
+3. **Vector-style raster** — Recraft V3 with `vector_illustration` style produces raster images optimized for vectorization
+4. **Two-step pipeline** — Generate with V3 vector style, then convert to SVG via `fal-ai/recraft/vectorize`
 
 For image-to-SVG conversion endpoints, see `references/image-to-svg-conversion.md`.
 
+## SVG Arena Rankings
+
+SVG Arena is the primary benchmark for text-to-SVG quality as of March 2026. Rankings use Elo scoring from head-to-head comparisons.
+
+| Rank | Model | Elo | Type |
+|------|-------|-----|------|
+| #1 | QuiverAI Arrow 1 | 1583 | Purpose-built SVG model |
+| #2 | Gemini 3.1 Pro | 1421 | General LLM (generates SVG code) |
+| #3 | Claude Opus 4.1 | ~1350 | General LLM (generates SVG code) |
+| #4 | GPT-5 | ~1340 | General LLM (generates SVG code) |
+
+Note: LLMs generate SVG as text code. Arrow 1 and Recraft produce true vector paths natively — better path quality, editability, and file size.
+
 ## Model Comparison Table
 
-| Model | Endpoint | Output Format | Price | Quality | Speed | Best For |
-|-------|----------|---------------|-------|---------|-------|----------|
-| Recraft V4 | `fal-ai/recraft/v4/text-to-vector` | True SVG | $0.08/image | High | Medium | Logos, icons, brand assets |
-| Recraft V4 Pro | `fal-ai/recraft/v4/pro/text-to-vector` | True SVG | $0.30/image | Highest | Slow | Production assets, complex illustrations |
-| Recraft V3 | `fal-ai/recraft/v3/text-to-image` | Raster PNG | $0.08/image (vector style) | High | Fast | Vector-style illustrations, two-step pipeline |
-| Recraft V3 (raster) | `fal-ai/recraft/v3/text-to-image` | Raster PNG | $0.04/image | High | Fast | Non-vector styles, photorealistic |
+| Model | Platform | Output | Price | SVG Arena Elo | Best For |
+|-------|----------|--------|-------|---------------|----------|
+| QuiverAI Arrow 1 | api.quiver.ai | True SVG | Free tier (20/week) / paid | 1583 (#1) | Highest quality SVGs |
+| Recraft V4 Pro | fal.ai | True SVG | $0.30/image | — | High-detail production SVG on fal.ai |
+| Recraft V4 | fal.ai | True SVG | $0.08/image | — | Cost-effective native SVG on fal.ai |
+| Recraft V3 | fal.ai | Raster PNG | $0.08/image (vector style) | — | Sub-style control (22 styles) |
 
-**Default choice**: Recraft V4 for direct SVG output. Use V4 Pro when quality is critical and cost is secondary. Use V3 + vectorize pipeline when you need fine-grained style control from V3's 22 sub-styles.
+**Default choice**: Arrow 1 for highest quality SVG. Use Recraft V4 for cost-effective SVG on fal.ai. Use V4 Pro when quality is critical within fal.ai. Use V3 + vectorize pipeline for fine-grained style control.
+
+---
+
+## QuiverAI Arrow 1
+
+**API**: `api.quiver.ai`
+**SDK**: `@quiverai/sdk` (npm)
+**Output**: True SVG (clean, layered, editable paths)
+**Price**: Free tier — 20 SVGs/week; paid plans for higher volume
+**Released**: February 25, 2026
+**SVG Arena Elo**: 1583 (#1)
+
+Arrow 1 is a purpose-built vector-native model, not a general LLM adapted for SVG. It generates from text prompts and images (multimodal), outputs clean layered SVG with editable paths, and supports real-time streaming. Not available on fal.ai — use the standalone API directly.
+
+### Installation
+
+```bash
+npm install @quiverai/sdk
+```
+
+Set `QUIVER_API_KEY` in your environment. Obtain a key at `api.quiver.ai`.
+
+### JavaScript Example
+
+```javascript
+import QuiverAI from "@quiverai/sdk";
+
+const quiver = new QuiverAI({ apiKey: process.env.QUIVER_API_KEY });
+
+const response = await quiver.svgs.generate({
+  model: "arrow-1",
+  prompt: "A minimalist mountain logo with clean geometric shapes"
+});
+
+const svgUrl = response.data[0].url;
+const res = await fetch(svgUrl);
+const svgContent = await res.text();
+```
+
+### When to Use Arrow 1 vs Recraft
+
+| Scenario | Use |
+|----------|-----|
+| Highest quality SVG, platform-agnostic | Arrow 1 |
+| Already using fal.ai infrastructure | Recraft V4 or V4 Pro |
+| Need 22 illustration sub-styles | Recraft V3 + vectorize |
+| Free tier sufficient (20 SVGs/week) | Arrow 1 free tier |
+| Batch generation at scale on fal.ai | Recraft V4 ($0.08) |
 
 ---
 
@@ -94,30 +156,8 @@ const result = await fal.subscribe("fal-ai/recraft/v4/text-to-vector", {
 });
 
 const svgUrl = result.data.images[0].url;
-// Download SVG
 const response = await fetch(svgUrl);
 const svgContent = await response.text();
-```
-
-### Python Example
-
-```python
-import fal_client
-
-result = fal_client.subscribe(
-    "fal-ai/recraft/v4/text-to-vector",
-    arguments={
-        "prompt": "A minimalist mountain logo with clean geometric shapes",
-        "image_size": "square_hd",
-        "colors": [
-            {"r": 59, "g": 130, "b": 246},
-            {"r": 30, "g": 64, "b": 175}
-        ],
-        "background_color": {"r": 255, "g": 255, "b": 255}
-    }
-)
-
-svg_url = result["images"][0]["url"]
 ```
 
 ---
@@ -141,7 +181,7 @@ Parameters are identical to Recraft V4 — replace the endpoint string with `fal
 | Complex illustration with fine detail | V4 Pro |
 | Simple icon or logo | V4 |
 | Budget-constrained project | V4 |
-| Quality is the only constraint | V4 Pro |
+| Quality is the only constraint within fal.ai | V4 Pro |
 
 ---
 
@@ -233,41 +273,19 @@ const imageUrl = result.data.images[0].url;
 // This is a raster PNG — pass to vectorize endpoint to get SVG
 ```
 
-### Python Example
-
-```python
-import fal_client
-
-result = fal_client.subscribe(
-    "fal-ai/recraft/v3/text-to-image",
-    arguments={
-        "prompt": "A coffee cup with steam rising, flat design",
-        "style": "vector_illustration",
-        "style_id": "bold_stroke",
-        "image_size": "square_hd",
-        "colors": [
-            {"r": 120, "g": 53, "b": 15},
-            {"r": 254, "g": 243, "b": 199}
-        ]
-    }
-)
-
-image_url = result["images"][0]["url"]
-```
-
 ---
 
 ## Two-Step Pipeline: V3 Vector Style + Vectorize
 
 Use this pipeline when you need a specific V3 sub-style (e.g., `engraving`, `linocut`, `seamless_pattern`) and require true SVG output. Total cost: $0.08 (V3) + $0.01 (vectorize) = $0.09/image.
 
-### When to Use the Pipeline vs Direct V4
+### When to Use the Pipeline vs Direct Options
 
 | Scenario | Approach |
 |----------|----------|
 | Need a specific V3 sub-style (e.g., linocut, engraving) | V3 + vectorize |
-| Need true SVG, style doesn't matter | V4 direct ($0.08) |
-| Need highest quality SVG | V4 Pro direct ($0.30) |
+| Need true SVG on fal.ai, style doesn't matter | V4 direct ($0.08) |
+| Need highest quality SVG, any platform | Arrow 1 |
 | Need seamless/tileable pattern as SVG | V3 seamless_pattern + vectorize |
 | Iterating on style before committing to SVG | V3 raster first, vectorize when satisfied |
 
@@ -276,7 +294,6 @@ Use this pipeline when you need a specific V3 sub-style (e.g., `engraving`, `lin
 ```javascript
 import { fal } from "@fal-ai/client";
 
-// Step 1: Generate vector-style raster
 const rasterResult = await fal.subscribe("fal-ai/recraft/v3/text-to-image", {
   input: {
     prompt: "A vintage compass rose, engraving style",
@@ -287,23 +304,16 @@ const rasterResult = await fal.subscribe("fal-ai/recraft/v3/text-to-image", {
 });
 
 const rasterUrl = rasterResult.data.images[0].url;
-console.log("Raster generated:", rasterUrl);
 ```
 
 ### Step 2: Vectorize the Raster
 
 ```javascript
-// Step 2: Convert raster to SVG
 const svgResult = await fal.subscribe("fal-ai/recraft/vectorize", {
-  input: {
-    image_url: rasterUrl
-  }
+  input: { image_url: rasterUrl }
 });
 
 const svgUrl = svgResult.data.image.url;
-console.log("SVG generated:", svgUrl);
-
-// Download SVG content
 const response = await fetch(svgUrl);
 const svgContent = await response.text();
 ```
@@ -315,11 +325,6 @@ import fal_client
 import requests
 
 def generate_vector_svg(prompt: str, style_id: str, colors: list = None) -> str:
-    """
-    Two-step pipeline: V3 vector style → vectorize → SVG string.
-    Returns SVG content as string.
-    """
-    # Step 1: Generate vector-style raster
     raster_args = {
         "prompt": prompt,
         "style": "vector_illustration",
@@ -335,18 +340,14 @@ def generate_vector_svg(prompt: str, style_id: str, colors: list = None) -> str:
     )
     raster_url = raster_result["images"][0]["url"]
 
-    # Step 2: Vectorize
     svg_result = fal_client.subscribe(
         "fal-ai/recraft/vectorize",
         arguments={"image_url": raster_url}
     )
     svg_url = svg_result["image"]["url"]
 
-    # Download and return SVG content
-    response = requests.get(svg_url)
-    return response.text
+    return requests.get(svg_url).text
 
-# Usage
 svg = generate_vector_svg(
     prompt="A vintage compass rose",
     style_id="engraving",
@@ -360,13 +361,9 @@ with open("compass.svg", "w") as f:
 
 ## Colors Parameter Reference
 
-All three endpoints accept a `colors` array to constrain the model's palette to brand colors. Pass up to 5 colors for best results.
+All Recraft endpoints accept a `colors` array to constrain the model's palette to brand colors. Pass up to 5 colors for best results. QuiverAI Arrow 1 does not use this parameter — guide palette through the prompt instead.
 
 ```javascript
-// Single brand color
-colors: [{ r: 59, g: 130, b: 246 }]
-
-// Full brand palette
 colors: [
   { r: 59, g: 130, b: 246 },   // primary blue
   { r: 30, g: 64, b: 175 },    // dark blue
@@ -387,7 +384,6 @@ function hexToRgb(hex) {
   } : null;
 }
 
-// Usage
 const brandColors = ["#3b82f6", "#1e40af", "#ffffff"].map(hexToRgb);
 ```
 
@@ -399,24 +395,26 @@ const brandColors = ["#3b82f6", "#1e40af", "#ffffff"].map(hexToRgb);
 
 | You need... | Use |
 |-------------|-----|
-| True SVG file, standard quality | `fal-ai/recraft/v4/text-to-vector` |
-| True SVG file, maximum quality | `fal-ai/recraft/v4/pro/text-to-vector` |
-| Raster with vector aesthetic | `fal-ai/recraft/v3/text-to-image` + `vector_illustration` |
+| Absolute best SVG quality | QuiverAI Arrow 1 (`api.quiver.ai`) |
+| True SVG on fal.ai, standard quality | `fal-ai/recraft/v4/text-to-vector` |
+| True SVG on fal.ai, maximum quality | `fal-ai/recraft/v4/pro/text-to-vector` |
 | SVG with specific illustration style | V3 + `fal-ai/recraft/vectorize` pipeline |
 
 ### By Budget
 
 | Budget per asset | Approach |
 |-----------------|----------|
+| Free (up to 20/week) | Arrow 1 free tier |
 | Under $0.05 | V3 raster only ($0.04), no SVG |
 | $0.08-0.09 | V4 direct SVG or V3 + vectorize pipeline |
-| $0.30 | V4 Pro for highest quality SVG |
+| $0.30 | V4 Pro for highest quality SVG on fal.ai |
 
 ### By Style Need
 
 | Style | Endpoint | style_id |
 |-------|----------|----------|
-| Clean logo/icon | V4 direct | — |
+| Clean logo/icon, best quality | Arrow 1 | — |
+| Clean logo/icon on fal.ai | V4 direct | — |
 | Vintage/etched | V3 + vectorize | `engraving` or `linocut` |
 | Sticker/badge | V3 + vectorize | `bold_stroke` or `colored_sticker` |
 | Seamless pattern | V3 + vectorize | `seamless_pattern` |
@@ -431,9 +429,9 @@ const brandColors = ["#3b82f6", "#1e40af", "#ffffff"].map(hexToRgb);
 
 | HTTP Status | Cause | Action |
 |-------------|-------|--------|
-| 401 | Invalid or missing FAL_KEY | Check `FAL_KEY` env var or `fal.config({credentials})` |
+| 401 | Invalid or missing API key | Check `FAL_KEY` (fal.ai) or `QUIVER_API_KEY` (Arrow 1) |
 | 422 | Invalid parameter type or value | Check `style_id` spelling, `colors` format `{r,g,b}`, `image_size` value |
-| 429 | Rate limit exceeded | Implement exponential backoff; use queue pattern for batch jobs |
+| 429 | Rate limit exceeded | Implement exponential backoff; Arrow 1 free tier limit returns quota message |
 | 500 | Model inference failure | Retry once; if persistent, simplify prompt or switch endpoint |
 
 Wrap `fal.subscribe()` calls in try/catch and inspect `error.status` and `error.body` for validation details. The `422` body typically names the offending field.

--- a/skills/vector-graphics-gen/references/use-case-recipes.md
+++ b/skills/vector-graphics-gen/references/use-case-recipes.md
@@ -6,14 +6,16 @@ Covers: complete end-to-end code for common vector graphics tasks. Copy and adap
 
 ## Shared Setup
 
-All recipes use this boilerplate. Install: `npm install @fal-ai/client svgo`.
+All recipes use this boilerplate. Install: `npm install @fal-ai/client @quiverai/sdk svgo`.
 
 ```javascript
 import { fal } from "@fal-ai/client";
+import QuiverAI from "@quiverai/sdk";
 import { optimize } from "svgo";
 import fs from "fs/promises";
 
 fal.config({ credentials: process.env.FAL_KEY });
+const quiver = new QuiverAI({ apiKey: process.env.QUIVER_API_KEY });
 
 const svgoConfig = {
   multipass: true,
@@ -29,11 +31,14 @@ async function fetchSvg(url) {
 }
 ```
 
-**Two-step pipeline** (Recraft V3 — raster-style, then vectorize):
-`fal-ai/recraft/v3/text-to-image` → `fal-ai/recraft/vectorize`
+**Highest quality** (QuiverAI Arrow — premium generation):
+`QuiverAI Arrow` → SVGO
 
-**One-step pipeline** (Recraft V4 — native SVG):
-`fal-ai/recraft/v4/text-to-vector`
+**Native SVG (fal.ai)** (Recraft V4 — one step):
+`fal-ai/recraft/v4/text-to-vector` → SVGO
+
+**Styled SVG (fal.ai)** (Recraft V3 — raster-style, then vectorize):
+`fal-ai/recraft/v3/text-to-image` → `fal-ai/recraft/vectorize` → SVGO
 
 ---
 
@@ -73,6 +78,17 @@ await generateAppIconSet("Taskflow", "checkmark inside a circle", { r: 99, g: 10
 ```
 
 **Integration**: Use `icon.svg` inline for crisp rendering at any size. Use `icon-512.png` for app store submissions, `icon-32.png` for favicons.
+
+**Alternative (QuiverAI Arrow)**: Use Arrow for highest-quality output when budget allows.
+
+```javascript
+const arrowResult = await quiver.arrow.generate({
+  prompt: `App icon for ${appName}: ${description}. Flat design, single centered symbol, minimal geometric shapes, solid colors only, white background, no text`,
+  output_format: "svg",
+});
+const svg = optimize(arrowResult.svg, svgoConfig).data;
+await fs.writeFile(`./icons/${appName.toLowerCase()}/icon.svg`, svg);
+```
 
 ---
 
@@ -125,21 +141,30 @@ await generateLogoVariants({
 
 **Integration**: Use `logo-full.svg` in the site header. Use `logo-icon.svg` for favicons. Apply `logo-reversed.svg` on dark backgrounds.
 
+**Alternative (QuiverAI Arrow)**: Arrow produces cleaner path structure for logos that will be used at large print sizes.
+
+```javascript
+const arrowResult = await quiver.arrow.generate({
+  prompt: `Professional logo for "${name}" — ${tagline}. Symbol left, company name right. Clean vector, flat, minimal, 2 colors, white background`,
+  output_format: "svg",
+});
+const svg = optimize(arrowResult.svg, svgoConfig).data;
+await fs.writeFile(`./logos/${name.toLowerCase().replace(/\s+/g, "-")}/logo-full.svg`, svg);
+```
+
 ---
 
 ## Recipe 3: Hero Illustration
 
 Generate a large illustration for a landing page hero, optimized for web delivery.
 
-**Model**: `fal-ai/recraft/v3/text-to-image` with `style: "vector_illustration"`, `substyle: "emotional_flat"`. Follow with vectorize step.
+**Model**: `fal-ai/recraft/v4/pro/text-to-vector` — highest-quality native SVG, no vectorize step needed.
 
 ```javascript
 async function generateHeroIllustration(concept, palette) {
-  const rasterResult = await fal.subscribe("fal-ai/recraft/v3/text-to-image", {
+  const result = await fal.subscribe("fal-ai/recraft/v4/pro/text-to-vector", {
     input: {
       prompt: `${concept}. Flat vector illustration, editorial style, bold shapes, limited color palette, no text, no gradients, clean composition`,
-      style: "vector_illustration",
-      substyle: "emotional_flat",
       image_size: "landscape_16_9",
       colors: palette,
     },
@@ -147,12 +172,7 @@ async function generateHeroIllustration(concept, palette) {
     onQueueUpdate: (u) => u.status === "IN_PROGRESS" && u.logs.forEach((l) => console.log(l.message)),
   });
 
-  const vectorResult = await fal.subscribe("fal-ai/recraft/vectorize", {
-    input: { image_url: rasterResult.data.images[0].url },
-    logs: false,
-  });
-
-  const svg = await fetchSvg(vectorResult.data.images[0].url);
+  const svg = await fetchSvg(result.data.images[0].url);
   await fs.writeFile("./hero-illustration.svg", svg);
   console.log(`SVG: ${(svg.length / 1024).toFixed(1)}KB`);
 }
@@ -162,6 +182,8 @@ await generateHeroIllustration(
   [{ r: 99, g: 102, b: 241 }, { r: 236, g: 72, b: 153 }, { r: 248, g: 250, b: 252 }]
 );
 ```
+
+**Note**: For specific V3 sub-style control (e.g., `emotional_flat`, `editorial`), use the V3 + vectorize pipeline instead: `fal-ai/recraft/v3/text-to-image` with `style: "vector_illustration"` → `fal-ai/recraft/vectorize`.
 
 **Integration**:
 
@@ -283,6 +305,8 @@ await generateSeamlessPattern("small leaves and botanical elements", [
 ]);
 ```
 
+**Note**: The `seamless_pattern` sub-style requires V3. V4 does not support sub-styles, so the two-step pipeline is mandatory here. For a generic geometric tile without seamless-specific styling, `fal-ai/recraft/v4/text-to-vector` with a tiling prompt works as a simpler alternative.
+
 **Integration**: Apply `.pattern-bg` to any container. Adjust `background-size` to control tile density.
 
 ---
@@ -323,7 +347,7 @@ await photoToVector("./logo-photo.png", "./logo-vector.svg", true);
 
 Generate a matching set of gamification badges with consistent visual style.
 
-**Model**: `fal-ai/recraft/v3/text-to-image` with `style: "vector_illustration"`, `substyle: "bold_stroke"`.
+**Model**: `fal-ai/recraft/v4/text-to-vector` — native SVG, no vectorize step needed. Saves $0.01/badge vs V3 + vectorize.
 
 ```javascript
 const BADGES = [
@@ -338,13 +362,11 @@ async function generateBadgeSet() {
   const outDir = "./badges";
   await fs.mkdir(outDir, { recursive: true });
 
-  const rasterResults = await Promise.all(
+  const results = await Promise.all(
     BADGES.map((b) =>
-      fal.subscribe("fal-ai/recraft/v3/text-to-image", {
+      fal.subscribe("fal-ai/recraft/v4/text-to-vector", {
         input: {
           prompt: `Achievement badge: ${b.symbol}. Circular badge shape, bold stroke outline, flat vector, centered symbol, no text, white background`,
-          style: "vector_illustration",
-          substyle: "bold_stroke",
           image_size: "square_hd",
           colors: [b.color, { r: 255, g: 255, b: 255 }],
         },
@@ -353,11 +375,8 @@ async function generateBadgeSet() {
     )
   );
 
-  for (const { badge, url } of rasterResults) {
-    const vectorResult = await fal.subscribe("fal-ai/recraft/vectorize", {
-      input: { image_url: url }, logs: false,
-    });
-    const svg = await fetchSvg(vectorResult.data.images[0].url);
+  for (const { badge, url } of results) {
+    const svg = await fetchSvg(url);
     await fs.writeFile(`${outDir}/${badge.id}.svg`, svg);
   }
 }
@@ -384,7 +403,7 @@ function AchievementBadge({ id, label, earned }) {
 
 Generate section dividers and wave separators for landing pages.
 
-**Model**: `fal-ai/recraft/v3/text-to-image` with `style: "vector_illustration"`, `substyle: "thin"`.
+**Model**: `fal-ai/recraft/v4/text-to-vector` — native SVG, single step.
 
 ```javascript
 const DIVIDERS = [
@@ -398,28 +417,24 @@ async function generateDividerSet(accentColor) {
   await fs.mkdir(outDir, { recursive: true });
 
   for (const divider of DIVIDERS) {
-    const rasterResult = await fal.subscribe("fal-ai/recraft/v3/text-to-image", {
+    const result = await fal.subscribe("fal-ai/recraft/v4/text-to-vector", {
       input: {
         prompt: `${divider.prompt}. Flat vector, no gradients, white background`,
-        style: "vector_illustration",
-        substyle: "thin",
         image_size: "landscape_16_9",
         colors: [accentColor, { r: 255, g: 255, b: 255 }],
       },
       logs: false,
     });
 
-    const vectorResult = await fal.subscribe("fal-ai/image2svg", {
-      input: { image_url: rasterResult.data.images[0].url }, logs: false,
-    });
-
-    const svg = await fetchSvg(vectorResult.data.images[0].url);
+    const svg = await fetchSvg(result.data.images[0].url);
     await fs.writeFile(`${outDir}/${divider.id}.svg`, svg);
   }
 }
 
 await generateDividerSet({ r: 99, g: 102, b: 241 });
 ```
+
+**Note**: For hairline or ultra-thin stroke dividers, use the V3 pipeline with `substyle: "thin"`: `fal-ai/recraft/v3/text-to-image` → `fal-ai/image2svg`. V4 does not expose the `thin` sub-style.
 
 **Integration**:
 
@@ -430,7 +445,5 @@ await generateDividerSet({ r: 99, g: 102, b: 241 });
 </div>
 <section class="features">...</section>
 ```
-
----
 
 For prompt engineering patterns that improve output quality across all recipes, see `references/prompt-engineering.md`. For SVGO configuration details, see `references/svg-optimization.md`. For model selection guidance, see `references/fal-api-reference.md`.

--- a/skills/vector-graphics-gen/skills.json
+++ b/skills/vector-graphics-gen/skills.json
@@ -1,10 +1,10 @@
 {
   "name": "@tank/vector-graphics-gen",
-  "version": "0.0.1",
-  "description": "Generate vector graphics (SVG) using AI APIs. fal.ai with Recraft V3/V4 for native SVG, image-to-SVG conversion, prompt engineering, SVGO optimization, and web integration (React, Vue, sprites, dark mode).\n\nTrigger phrases: \"generate SVG\", \"SVG icon\", \"vector illustration\", \"fal.ai\", \"recraft\", \"text to SVG\", \"image to SVG\", \"vectorize\", \"vector logo\", \"icon generation\", \"SVG for web\", \"fal-ai/recraft\", \"vector pattern\", \"production SVG\", \"text-to-vector\"",
+  "version": "0.0.2",
+  "description": "Generate vector graphics (SVG) using AI APIs. QuiverAI Arrow (#1 SVG Arena) and fal.ai Recraft V4 for native SVG, image-to-SVG conversion, prompt engineering, SVGO optimization, web integration (React, Vue, sprites, dark mode).\n\nTrigger phrases: \"generate SVG\", \"SVG icon\", \"vector illustration\", \"fal.ai\", \"recraft\", \"quiverai\", \"arrow\", \"text to SVG\", \"image to SVG\", \"vectorize\", \"vector logo\", \"icon generation\", \"SVG for web\", \"fal-ai/recraft\", \"vector pattern\", \"production SVG\"",
   "permissions": {
     "network": {
-      "outbound": ["fal.ai", "queue.fal.run", "fal.run", "v3.fal.media", "fal.media"]
+      "outbound": ["fal.ai", "queue.fal.run", "fal.run", "v3.fal.media", "fal.media", "api.quiver.ai"]
     },
     "filesystem": {
       "read": ["**/*"],


### PR DESCRIPTION
## Summary

- Adds QuiverAI Arrow 1 (#1 SVG Arena, 1583 Elo) as primary model recommendation
- Updates all code examples and decision trees from V3-centric to V4/Arrow-first
- Bumps version to 0.0.2

## Changes

- **SKILL.md** — Arrow in Quick-Start, updated decision trees with SVG Arena Elo column
- **text-to-vector-models.md** — Full Arrow 1 section with SDK setup, SVG Arena rankings table, updated model comparison
- **use-case-recipes.md** — QuiverAI SDK in shared setup, Arrow alternatives in icon/logo recipes, V3→V4 for hero/badge/divider recipes
- **prompt-engineering.md** — Model-agnostic note, V4 as default in templates, fixed ideogram reference
- **skills.json** — Added `api.quiver.ai` to network permissions, bumped to 0.0.2