### PR TITLE
chore(vector-graphics-gen): bump version to 1.0.0 for permission escalation publish

### DIFF
--- a/skills/vector-graphics-gen/skills.json
+++ b/skills/vector-graphics-gen/skills.json
@@ -1,6 +1,6 @@
 {
   "name": "@tank/vector-graphics-gen",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "Generate vector graphics (SVG) using AI APIs. QuiverAI Arrow (#1 SVG Arena) and fal.ai Recraft V4 for native SVG, image-to-SVG conversion, prompt engineering, SVGO optimization, web integration (React, Vue, sprites, dark mode).\n\nTrigger phrases: \"generate SVG\", \"SVG icon\", \"vector illustration\", \"fal.ai\", \"recraft\", \"quiverai\", \"arrow\", \"text to SVG\", \"image to SVG\", \"vectorize\", \"vector logo\", \"icon generation\", \"SVG for web\", \"fal-ai/recraft\", \"vector pattern\", \"production SVG\"",
   "permissions": {
     "network": {


### PR DESCRIPTION
Bumps to 1.0.0 because adding api.quiver.ai to network permissions triggers Tank's permission escalation check (same pattern as #13 for frontend-craft).