### PR TITLE
feat(opencode-agent-creator): add skill for creating specialized OpenCode agents

### DIFF
--- a/skills/opencode-agent-creator/SKILL.md
+++ b/skills/opencode-agent-creator/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: opencode-agent-creator
+description: |
+  Create specialized OpenCode agents that assume specific roles — frontend
+  architect, DevOps SRE, database specialist, code reviewer, or any domain
+  expert. Covers agent anatomy (markdown and JSON formats), role design
+  (persona, expertise, behavioral directives), system prompt engineering,
+  tool permissions, oh-my-opencode integration (categories, skill injection,
+  delegation wiring), and converting existing Tank skills into standalone
+  agents. Synthesizes OpenCode source (sst/opencode), oh-my-opencode v3.x
+  agent system, and production agent analysis.
+
+  Trigger phrases: "create agent", "opencode agent", "new agent",
+  "convert skill to agent", "make an agent", "agent from skill",
+  "custom agent", "specialized agent", "agent template", "agent for",
+  "agent configuration", "agent role", "create a specialist",
+  "build agent", ".opencode/agent"
+---
+
+# OpenCode Agent Creator
+
+## Core Philosophy
+
+1. **Role-first, not prompt-first** — Define WHO the agent is before WHAT
+   it says. Identity drives behavior.
+2. **Agents have opinions** — Effective agents push back, refuse out-of-scope
+   work, and have strong preferences. Bland agents waste tokens.
+3. **Minimum viable agent** — Start with 20 lines. Add complexity only when
+   the agent fails at real tasks. Over-engineered prompts confuse models.
+4. **Skills supplement, agents act** — Skills inject knowledge. Agents assume
+   roles. Use both together for maximum effectiveness.
+
+## Quick-Start: Create an Agent
+
+### "I need a specialist agent for [DOMAIN]"
+
+1. Determine the role archetype:
+   → See `references/role-design.md` for archetypes table
+
+2. Choose agent properties:
+   - **Mode**: `all` for versatile, `subagent` for delegation-only
+   - **Model**: Match complexity to role (see model selection guide)
+   - **Temperature**: 0.0-0.3 for precision, 0.3-0.5 for creative
+   - **Permissions**: Restrict tools based on role
+
+3. Write the agent file:
+   → Use `assets/agent-template.md` as starter
+   → See `references/prompt-engineering.md` for prompt structure
+
+4. Deploy:
+   - Global: `~/.config/opencode/agent/<name>.md`
+   - Project: `.opencode/agent/<name>.md`
+
+5. Test with 5 patterns:
+   - In-domain task → competent response
+   - Out-of-scope request → polite refusal
+   - Ambiguous request → asks clarifying question
+   - Anti-pattern proposal → pushes back
+   - Complex multi-step task → structured approach
+
+### "I want to convert a skill into an agent"
+
+1. Read the skill's SKILL.md and references
+2. Extract: domain scope, decision frameworks, anti-patterns, workflows
+3. Transform passive knowledge into active role directives
+4. Add personality, boundaries, and tool restrictions
+   → See `references/skill-to-agent-conversion.md`
+
+### "Agent exists but isn't working well"
+
+| Problem | Likely Cause | Fix |
+|---------|-------------|-----|
+| Too generic/bland | No personality defined | Add opinions and preferences |
+| Does things it shouldn't | No boundary section | Add "Outside Your Scope" |
+| Asks too many questions | No decision framework | Add conditional directives |
+| Ignores its restrictions | Prompt contradicts permissions | Align prompt with frontmatter |
+| Doesn't appear in `@` menu | Wrong file location | Move to `~/.config/opencode/agent/` |
+| Sisyphus doesn't delegate to it | Poor description | Add `<example>` tags to description |
+
+## Agent File Format
+
+Markdown file with YAML frontmatter. Filename = agent name.
+
+```markdown
+---
+description: >-
+  Use this agent when [TRIGGER CONDITION].
+  Includes [TASK 1], [TASK 2], [TASK 3].
+  
+  <example>
+  user: "[request]"
+  assistant: "I'll use [agent] to [action]."
+  </example>
+mode: all
+model: provider/model-id
+temperature: 0.1
+color: "#HEX"
+permission:
+  edit: allow|ask|deny
+  bash:
+    "*": ask
+    "specific command": allow
+---
+
+[System prompt — the agent's role, expertise, and behavioral rules]
+```
+
+→ See `references/agent-anatomy.md` for complete property reference.
+
+## Decision Trees
+
+### Archetype Selection
+
+| Need | Archetype | Key Config |
+|------|-----------|------------|
+| Writes code in a domain | Specialist | `edit: allow`, low temp |
+| Reviews but doesn't modify | Reviewer | `edit: deny`, read-only bash |
+| Gathers information | Researcher | `edit: deny`, `bash: deny`, `webfetch: allow` |
+| Creates plans, not code | Planner | `edit: ask`, read-only bash |
+| Coordinates other agents | Orchestrator | Full permissions, task tool |
+
+### Model Tier Selection
+
+| Role Complexity | Model Tier | Examples |
+|----------------|-----------|----------|
+| Deep reasoning / architecture | Opus / GPT-5.2+ | Solution architect, security auditor |
+| Code generation / editing | Sonnet / GPT-5.2 | Frontend engineer, API developer |
+| Fast search / simple tasks | Haiku / Flash | Explorer, formatter, triage |
+
+### Where to Deploy
+
+| Scope | Path | When |
+|-------|------|------|
+| All projects | `~/.config/opencode/agent/` | Personal workflow agents |
+| One project | `.opencode/agent/` | Project-specific specialists |
+| omo override | `oh-my-opencode.json` → `agents` | Modify built-in omo agents |
+
+## Anti-Patterns
+
+| Pattern | Problem | Fix |
+|---------|---------|-----|
+| "Be helpful and thorough" | Vacuous instructions | Specific behavioral directives |
+| Agent does everything | No focus, mediocre at all tasks | Narrow to 1-2 domains |
+| 200+ line prompt | Model loses focus | Under 150 lines, use skills for knowledge |
+| No NEVER rules | Agent makes domain-specific mistakes | Add 3-5 hard constraints |
+| Copying skill text verbatim | Passive knowledge, no agency | Transform into behavioral directives |
+| No description examples | Primary agents can't route to it | Add 3-5 `<example>` tags |
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/agent-anatomy.md` | Full OpenCode agent schema, both formats, all properties, permission system, file locations |
+| `references/role-design.md` | Role archetypes, persona construction, behavioral directives, decision frameworks, common mistakes |
+| `references/prompt-engineering.md` | System prompt structure, directive patterns, tool restrictions, testing strategies, anti-patterns |
+| `references/skill-to-agent-conversion.md` | When to convert, transformation process, patterns (specialist, reviewer, planner), verification |
+| `references/omo-integration.md` | oh-my-opencode overrides, category system, skill injection, multi-model orchestration, deployment |

--- a/skills/opencode-agent-creator/assets/agent-template.md
+++ b/skills/opencode-agent-creator/assets/agent-template.md
@@ -1,0 +1,68 @@
+---
+description: >-
+  Use this agent when the user needs help with [DOMAIN].
+  This includes [TASK_1], [TASK_2], and [TASK_3].
+  This agent excels at [KEY_STRENGTH].
+
+  Examples:
+
+  <example>
+  Context: [Typical situation where this agent is needed]
+  user: "[Realistic user request]"
+  assistant: "I'll use the [AGENT_NAME] agent to [specific action]."
+  <commentary>
+  [Why this agent is the right choice for this request]
+  </commentary>
+  </example>
+
+  <example>
+  Context: [Different situation]
+  user: "[Another realistic request]"
+  assistant: "I'll use the [AGENT_NAME] agent to [specific action]."
+  </example>
+mode: all
+model: anthropic/claude-sonnet-4-6
+temperature: 0.1
+color: "#38A3EE"
+permission:
+  edit: allow
+  bash:
+    "*": ask
+---
+
+You are a [ROLE_TITLE] with [EXPERIENCE]. You specialize in [SPECIALTIES].
+
+## Your Expertise
+- [Domain capability 1]
+- [Domain capability 2]
+- [Domain capability 3]
+- [Domain capability 4]
+- [Domain capability 5]
+
+## Outside Your Scope (Delegate These)
+- [Out-of-scope task 1] -> delegate to [appropriate agent]
+- [Out-of-scope task 2] -> delegate to [appropriate agent]
+- [Out-of-scope task 3] -> decline, suggest specialist
+
+## Operational Directives
+1. [How you approach tasks - step 1]
+2. [Step 2]
+3. [Step 3]
+4. [Step 4]
+
+## Communication Style
+- [How you communicate]
+- [Tone and verbosity]
+- [When you disagree]
+
+## Output Standards
+- [Format expectation 1]
+- [Format expectation 2]
+- [Format expectation 3]
+
+## Rules (CRITICAL)
+- NEVER [dangerous action 1]
+- NEVER [dangerous action 2]
+- NEVER [dangerous action 3]
+- ALWAYS [required practice 1]
+- ALWAYS [required practice 2]

--- a/skills/opencode-agent-creator/references/agent-anatomy.md
+++ b/skills/opencode-agent-creator/references/agent-anatomy.md
@@ -1,0 +1,299 @@
+# OpenCode Agent Anatomy
+
+Sources: OpenCode source (sst/opencode config.ts, agent.ts), oh-my-opencode
+(agents/, config/schema), OpenCode SDK types.gen.d.ts
+
+Covers: agent file formats, all configuration properties, permission system,
+mode selection, model configuration, file locations, loading precedence.
+
+## Two Configuration Formats
+
+Agents can be defined in **Markdown** or **JSON**. Markdown is preferred for
+custom agents — it's readable, self-contained, and the system prompt lives
+naturally in the body.
+
+### Format A: Markdown (Recommended)
+
+Place `.md` files in agent directories. The **filename** (without `.md`) becomes
+the agent name. YAML frontmatter = config. Body = system prompt.
+
+```markdown
+---
+description: >-
+  Use this agent when the user needs help with database schema design,
+  migrations, query optimization, and PostgreSQL administration.
+  
+  Examples:
+  
+  <example>
+  Context: User needs to design a database schema.
+  user: "Help me design the schema for a multi-tenant SaaS app"
+  assistant: "I'll use the db-architect agent for this schema design."
+  </example>
+mode: all
+model: anthropic/claude-sonnet-4-6
+temperature: 0.1
+color: "#38A3EE"
+permission:
+  edit: ask
+  bash:
+    "*": ask
+    "git diff": allow
+    "psql *": allow
+---
+
+# System Prompt
+
+You are a Senior Database Architect specializing in PostgreSQL...
+
+## Your Expertise
+- Schema design for production systems
+- Query optimization and EXPLAIN ANALYZE interpretation
+...
+```
+
+### Format B: JSON (in opencode.json)
+
+Under the `"agent"` key. Best for overriding built-in agents or when you
+prefer centralized config.
+
+```json
+{
+  "agent": {
+    "db-architect": {
+      "description": "Database schema design and optimization specialist",
+      "mode": "all",
+      "model": "anthropic/claude-sonnet-4-6",
+      "temperature": 0.1,
+      "prompt": "You are a Senior Database Architect...",
+      "permission": {
+        "edit": "ask",
+        "bash": { "*": "ask", "psql *": "allow" }
+      },
+      "color": "#38A3EE"
+    }
+  }
+}
+```
+
+## File Locations (Precedence: lowest → highest)
+
+| Scope | Path | Use Case |
+|-------|------|----------|
+| Global | `~/.config/opencode/agent/*.md` | Personal agents, all projects |
+| Global | `~/.config/opencode/agents/*.md` | Alternate path |
+| Global JSON | `~/.config/opencode/opencode.json` → `agent` | JSON format, global |
+| Project | `.opencode/agent/*.md` | Project-specific agents |
+| Project | `.opencode/agents/*.md` | Alternate path |
+| Project JSON | `opencode.json` → `agent` | JSON format, project |
+| Project JSON | `.opencode/opencode.json` → `agent` | Alt project path |
+
+Higher-precedence configs override lower. Project > Global.
+
+**For personal reusable agents → `~/.config/opencode/agent/`**
+**For project-specific agents → `.opencode/agent/`**
+
+## All Agent Properties
+
+### Core Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `description` | string | **Yes** (subagents) | Shown in `@` autocomplete. Primary agents use this to decide WHEN to invoke the subagent. Include examples. |
+| `mode` | enum | No (default: `"all"`) | `"primary"` = Tab-selectable main agent. `"subagent"` = @-mentionable only. `"all"` = both. |
+| `model` | string | No | `"provider/model-id"` e.g. `"anthropic/claude-sonnet-4-6"`, `"openai/gpt-5.2"` |
+| `variant` | string | No | Model variant. Only applies when agent's own model is used. |
+| `prompt` | string | No | System prompt text. In JSON, can use `"{file:./path.txt}"` for file reference. In Markdown, the body IS the prompt. |
+| `temperature` | number | No | 0.0–2.0. Lower = more deterministic. |
+| `top_p` | number | No | 0.0–1.0. Alternative to temperature. |
+
+### Execution Control
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `steps` | number | Max agentic iterations before forcing text-only response. |
+| `maxSteps` | number | Deprecated alias for `steps`. |
+| `options` | object | Provider-specific pass-through. E.g. `{ "reasoningEffort": "high" }` for OpenAI. |
+
+### Display & Visibility
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `color` | string | Hex `"#FF5733"` or theme: `"primary"`, `"secondary"`, `"accent"`, `"success"`, `"warning"`, `"error"`, `"info"` |
+| `hidden` | boolean | Hide from `@` autocomplete. Subagents only. |
+| `disable` | boolean | Remove agent entirely (even built-ins). |
+
+### Permissions
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `permission` | object | Fine-grained tool permissions. See Permission section. |
+| `tools` | object | **Deprecated.** `Record<string, boolean>`. Use `permission` instead. |
+
+## Permission System
+
+Each tool can be set to:
+- `"allow"` — run without asking user
+- `"ask"` — prompt user before running
+- `"deny"` — disable entirely
+
+### Simple Permissions
+
+```yaml
+permission:
+  edit: deny        # Cannot edit files
+  bash: ask         # Must ask before running any command
+  webfetch: allow   # Can fetch URLs freely
+```
+
+### Per-Command Bash Permissions
+
+```yaml
+permission:
+  bash:
+    "*": ask              # Default: ask for everything
+    "git status *": allow # But allow git status
+    "git diff *": allow   # And git diff
+    "git push": deny      # Never push
+    "rm *": deny          # Never delete
+    "psql *": allow       # Allow postgres commands
+```
+
+### Tool-Specific Permissions
+
+```yaml
+permission:
+  edit: deny              # Read-only agent
+  bash:
+    "*": deny
+    "git log *": allow
+    "git diff *": allow
+  webfetch: deny
+  task:
+    "*": deny
+    "explore": allow      # Can only delegate to explore
+```
+
+### Common Permission Patterns
+
+| Pattern | edit | bash | webfetch | Use Case |
+|---------|------|------|----------|----------|
+| Full access | allow | allow | allow | Primary coding agent |
+| Read-only reviewer | deny | `git diff: allow` | deny | Code reviewer |
+| Researcher | deny | deny | allow | Documentation agent |
+| Restricted executor | ask | `{specific: allow}` | deny | Task-specific agent |
+
+## The Description Field (Critical)
+
+The `description` is the **most important field for subagents**. The primary
+agent (Sisyphus/build) reads descriptions to decide which subagent to invoke.
+
+### What Makes a Good Description
+
+1. **Start with "Use this agent when..."** — frames the trigger condition
+2. **Include 3-5 examples** with `<example>` tags showing user→assistant flow
+3. **Be specific about the domain** — "database migrations" not "technical tasks"
+4. **Mention what it does NOT do** — helps avoid incorrect routing
+
+### Description Template
+
+```yaml
+description: >-
+  Use this agent when the user needs help with [DOMAIN].
+  This includes [TASK 1], [TASK 2], and [TASK 3].
+  This agent excels at [STRENGTH].
+
+  Examples:
+
+  <example>
+  Context: [Situation]
+  user: "[User message]"
+  assistant: "I'll use the [agent-name] agent to [action]."
+  <commentary>
+  [Why this agent is the right choice]
+  </commentary>
+  </example>
+
+  <example>
+  Context: [Different situation]
+  user: "[User message]"
+  assistant: "I'll use the [agent-name] agent to [action]."
+  </example>
+```
+
+## Mode Selection Guide
+
+| Mode | Visible In | Invoked By | Best For |
+|------|-----------|------------|----------|
+| `primary` | Tab switcher | User selects tab | Main working agents (like Sisyphus, plan) |
+| `subagent` | `@` menu | Primary agent delegates, or user @-mentions | Specialists invoked on demand |
+| `all` | Both | Both methods | Versatile agents useful both ways |
+
+**Default `"all"`** — works in most cases. Use `"subagent"` when the agent
+should only be invoked for specific tasks, never as a main agent.
+
+## Model Selection
+
+### Provider/Model Format
+
+Always `"provider/model-id"`:
+
+| Provider | Example |
+|----------|---------|
+| Anthropic | `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5` |
+| OpenAI | `openai/gpt-5.2`, `openai/gpt-5.3-codex` |
+| Google | `google/gemini-3-pro`, `google/gemini-3-flash` |
+| Custom | Defined in `opencode.json` `provider` section |
+
+### Model Selection by Agent Role
+
+| Agent Role | Recommended Tier | Why |
+|------------|-----------------|-----|
+| Deep reasoning / architecture | Opus / GPT-5.2+ | Complex multi-step thinking |
+| Code generation / editing | Sonnet / GPT-5.2 | Good balance of speed + quality |
+| Fast search / triage | Haiku / Flash | Speed matters, task is simple |
+| Frontend / visual | Sonnet / Gemini Pro | Visual understanding helps |
+| Review / critique | GPT-5.2+ (medium reasoning) | Needs critical thinking |
+
+## Agent Loading Flow
+
+1. OpenCode starts → reads config files in precedence order
+2. Built-in agents registered (build, plan, general, explore, etc.)
+3. Plugin agents added (oh-my-opencode adds Sisyphus, Oracle, etc.)
+4. Markdown `.md` files scanned from agent directories
+5. JSON config agents merged over existing
+6. `disable: true` removes agents
+7. Final agent registry available to user
+
+### How Markdown Files Are Parsed
+
+```
+filename.md → gray-matter parses YAML frontmatter
+filename (without .md) → agent name
+frontmatter fields → agent config
+body text → system prompt
+```
+
+The agent name comes from the **filename**, not from any frontmatter field.
+Choose filenames that are short, kebab-case identifiers.
+
+## Quick Reference: Minimal Agent
+
+Smallest valid agent (`~/.config/opencode/agent/reviewer.md`):
+
+```markdown
+---
+description: Code review specialist. Reviews PRs for bugs and best practices.
+mode: subagent
+permission:
+  edit: deny
+  bash:
+    "*": deny
+    "git diff *": allow
+---
+You are a code reviewer. Read code carefully and provide constructive feedback.
+Focus on bugs, security issues, and maintainability.
+Never modify files directly.
+```
+
+This creates a read-only reviewer agent accessible via `@reviewer`.

--- a/skills/opencode-agent-creator/references/omo-integration.md
+++ b/skills/opencode-agent-creator/references/omo-integration.md
@@ -1,0 +1,285 @@
+# oh-my-opencode Integration
+
+Sources: oh-my-opencode v3.x source (config/schema, agents/), oh-my-opencode
+README, production oh-my-opencode.json configurations
+
+Covers: agent overrides, category system, skill injection, delegation wiring,
+built-in agent customization, multi-model orchestration.
+
+## Architecture Overview
+
+oh-my-opencode (omo) adds a layer on top of OpenCode's native agent system:
+
+```
+┌─────────────────────────────────────────┐
+│  oh-my-opencode.json                    │
+│  ├── agents: {} (overrides)             │
+│  ├── categories: {} (model routing)     │
+│  └── skills: {} (injection config)      │
+├─────────────────────────────────────────┤
+│  OpenCode Agent System                  │
+│  ├── ~/.config/opencode/agent/*.md      │
+│  ├── .opencode/agent/*.md               │
+│  └── opencode.json → agent: {}          │
+├─────────────────────────────────────────┤
+│  Built-in Agents                        │
+│  (build, plan, general, explore, etc.)  │
+└─────────────────────────────────────────┘
+```
+
+**Your custom `.md` agents** live at the OpenCode layer. **omo overrides**
+configure model routing and skill injection for built-in omo agents.
+
+## Agent Overrides (oh-my-opencode.json)
+
+Override built-in omo agents without modifying their source:
+
+```json
+{
+  "agents": {
+    "sisyphus": {
+      "model": "anthropic/claude-opus-4-6",
+      "variant": "max"
+    },
+    "oracle": {
+      "model": "openai/gpt-5.2",
+      "variant": "high"
+    },
+    "explore": {
+      "model": "anthropic/claude-haiku-4-5"
+    },
+    "librarian": {
+      "model": "anthropic/claude-sonnet-4-6"
+    }
+  }
+}
+```
+
+### Override Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `model` | string | Override model (provider/model format) |
+| `variant` | string | Model variant (`"max"`, `"high"`, `"medium"`, `"low"`) |
+| `prompt_append` | string | Append text to the agent's system prompt |
+| `skills` | string[] | Skills to inject into agent prompt |
+| `temperature` | number | Override temperature |
+| `top_p` | number | Override top_p |
+| `tools` | object | Override tool permissions |
+| `disable` | boolean | Disable this agent entirely |
+| `description` | string | Override description |
+| `mode` | enum | Override mode |
+| `color` | string | Override UI color |
+| `permission` | object | Override permissions |
+
+### Disabling Built-in Agents
+
+```json
+{
+  "disabled_agents": ["multimodal-looker"],
+  "agents": {
+    "atlas": { "disable": true }
+  }
+}
+```
+
+## The Category System
+
+Categories enable **intent-based model routing**. Instead of picking a model
+for every task, Sisyphus picks a category based on the task's nature.
+
+### Built-in Categories
+
+| Category | Default Model | Best For |
+|----------|---------------|----------|
+| `quick` | Claude Haiku | Trivial tasks, single file changes |
+| `visual-engineering` | Claude Sonnet | Frontend, UI/UX, design, styling |
+| `ultrabrain` | GPT-5.3 Codex (xhigh) | Deep reasoning, complex architecture |
+| `artistry` | Claude Sonnet | Creative/artistic tasks |
+| `unspecified-low` | Claude Sonnet | Misc low-effort tasks |
+| `unspecified-high` | Claude Opus (max) | Misc high-effort tasks |
+| `writing` | Claude Sonnet | Documentation, prose |
+| `deep` | GPT-5.3 Codex (medium) | General deep tasks |
+
+### Custom Categories
+
+Create your own categories for domain-specific routing:
+
+```json
+{
+  "categories": {
+    "devops": {
+      "model": "openai/gpt-5.2",
+      "variant": "medium",
+      "description": "Infrastructure and DevOps tasks"
+    },
+    "data-engineering": {
+      "model": "anthropic/claude-opus-4-6",
+      "variant": "max",
+      "description": "Data pipeline and ETL tasks"
+    }
+  }
+}
+```
+
+### How Sisyphus Uses Categories
+
+When delegating, Sisyphus picks category + skills:
+
+```
+delegate_task(
+  category="visual-engineering",
+  load_skills=["react", "frontend-craft"],
+  prompt="Build the dashboard component..."
+)
+```
+
+The category determines **which model** runs the task. The skills determine
+**what expertise** is injected into the subagent's prompt.
+
+## Connecting Custom Agents to omo
+
+### Method 1: Standalone Agent (Independent of Sisyphus)
+
+Create a `.md` file in `~/.config/opencode/agent/`. This agent is accessible
+via `@agent-name` or Tab switching. Sisyphus can also invoke it via the
+Task tool if the description is clear enough.
+
+This is the simplest and most common approach. The agent stands on its own.
+
+### Method 2: Category-Routed Agent (Via Sisyphus)
+
+Create a custom category that uses your preferred model and skill set.
+Sisyphus delegates to this category when the task matches.
+
+```json
+{
+  "categories": {
+    "frontend-specialist": {
+      "model": "anthropic/claude-sonnet-4-6",
+      "description": "Frontend development with React expertise"
+    }
+  }
+}
+```
+
+Now Sisyphus can:
+```
+delegate_task(
+  category="frontend-specialist",
+  load_skills=["react", "tailwind"],
+  prompt="..."
+)
+```
+
+### Method 3: Agent + Skill Combo
+
+For maximum power, create BOTH:
+- An **agent** (`.md` file) for direct use via `@agent-name`
+- A **skill** that Sisyphus injects when delegating related tasks
+
+This way the expertise is available both directly and through delegation.
+
+## Skill Injection
+
+omo injects skill content into subagent prompts at delegation time.
+
+### How It Works
+
+1. User (or Sisyphus) calls `delegate_task(load_skills=["react"])`
+2. omo finds the skill's SKILL.md in the skill directories
+3. SKILL.md content is injected into the subagent's system prompt
+4. Subagent now has both its own prompt AND the skill's knowledge
+
+### Skill Sources (checked in order)
+
+| Location | Type |
+|----------|------|
+| `~/.config/opencode/skills/*/SKILL.md` | Global installed skills |
+| `.opencode/skills/*/SKILL.md` | Project-local skills |
+| oh-my-opencode built-in skills | Plugin-bundled skills |
+
+### Configuring Skill Sources
+
+```json
+{
+  "skills": {
+    "sources": [
+      { "path": "./custom-skills", "recursive": true }
+    ],
+    "enable": ["my-custom-skill"],
+    "disable": ["playwright"]
+  }
+}
+```
+
+## Multi-Model Orchestration Patterns
+
+### Pattern 1: Tiered Delegation
+
+Sisyphus (expensive) delegates to cheaper specialists:
+
+```
+Sisyphus (Opus) → Quick tasks → Haiku
+                → Frontend → Sonnet
+                → Architecture → GPT-5.2
+                → Exploration → Haiku
+```
+
+### Pattern 2: Parallel Background Agents
+
+Fire multiple agents simultaneously:
+
+```
+delegate_task(subagent_type="explore", run_in_background=true, ...)
+delegate_task(subagent_type="librarian", run_in_background=true, ...)
+// Continue working, collect results later
+```
+
+### Pattern 3: Agent Chain
+
+One agent's output feeds another:
+
+```
+Planner → creates plan
+  ↓
+Reviewer → validates plan
+  ↓
+Executor → implements plan
+  ↓
+Tester → verifies implementation
+```
+
+## Deployment Checklist
+
+### For Standalone Agents (Method 1)
+
+1. Create `~/.config/opencode/agent/<name>.md`
+2. Verify agent appears in `@` autocomplete
+3. Test with in-domain and out-of-scope requests
+4. Verify tool permissions work as expected
+
+### For Category-Routed Agents (Method 2)
+
+1. Add category to `~/.config/opencode/oh-my-opencode.json`
+2. Verify Sisyphus recognizes the category
+3. Test delegation with `delegate_task(category="...")`
+
+### For Agent + Skill Combos (Method 3)
+
+1. Create agent `.md` file
+2. Create or verify skill exists
+3. Test direct invocation via `@agent-name`
+4. Test delegation with `delegate_task(load_skills=[...])`
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Agent doesn't appear in `@` | File not in agent directory | Check path: `~/.config/opencode/agent/` |
+| Agent appears but wrong model | Override not applied | Check oh-my-opencode.json `agents` section |
+| Sisyphus doesn't delegate to agent | Poor description | Add examples with `<example>` tags |
+| Skills not loading | Wrong skill directory | Check `~/.config/opencode/skills/` |
+| Agent ignores permissions | Prompt contradicts config | Align prompt with frontmatter permissions |
+| Agent too slow | Model too expensive | Use lighter model or create category |
+| Agent too dumb | Model too cheap | Upgrade model or add skill injection |

--- a/skills/opencode-agent-creator/references/prompt-engineering.md
+++ b/skills/opencode-agent-creator/references/prompt-engineering.md
@@ -1,0 +1,310 @@
+# Agent Prompt Engineering
+
+Sources: Production oh-my-opencode agents analysis, OpenCode agent system,
+Anthropic prompt engineering guidelines, real agent prompts from
+smart-programmer.md and web-productivity-assistant.md
+
+Covers: system prompt structure, sections anatomy, effective directives,
+tool restriction patterns, prompt anti-patterns, testing strategies.
+
+## System Prompt Structure
+
+An agent's system prompt is the body of the markdown file (after frontmatter).
+It defines WHO the agent is and HOW it behaves.
+
+### Recommended Section Order
+
+```markdown
+# ROLE DEFINITION
+One paragraph: title, experience, specialty.
+
+## Your Expertise
+Bulleted list of domain capabilities.
+
+## Outside Your Scope
+What you refuse to do. Critical for role boundaries.
+
+## Operational Directives
+How you work: approach, standards, decision rules.
+
+## Communication Style
+How you interact with the user.
+
+## Output Format
+What your deliverables look like.
+
+## Rules (CRITICAL)
+Hard constraints. Things you must ALWAYS or NEVER do.
+```
+
+Not every agent needs every section. Minimal agents can be 10-20 lines.
+Complex specialists might be 80-120 lines. Never exceed 150 lines — beyond
+that, the agent loses focus.
+
+## Writing Effective Role Definitions
+
+### The Opening Paragraph
+
+The first lines set the agent's identity. Be specific and authoritative.
+
+**Weak**:
+```
+You are a helpful coding assistant.
+```
+
+**Strong**:
+```
+You are a Senior DevOps SRE with 12+ years shipping production
+infrastructure. You specialize in Kubernetes, AWS, Terraform, and
+observability. You think in systems — every change has blast radius.
+```
+
+**Strongest** (with personality):
+```
+You are an opinionated Senior Frontend Architect. 15+ years.
+You've shipped 50+ production apps and have strong views on
+component architecture, performance, and developer experience.
+You write code that other engineers enjoy reading.
+```
+
+### Expertise Lists
+
+Use bulleted lists. Be specific enough that the agent knows its boundaries:
+
+```markdown
+## Your Expertise
+- Kubernetes cluster management (EKS, GKE, self-hosted)
+- Terraform infrastructure-as-code (modules, state management)
+- CI/CD pipelines (GitHub Actions, ArgoCD, Flux)
+- Observability stack (Prometheus, Grafana, Loki, Tempo)
+- Incident response and post-mortem processes
+- Cost optimization for cloud infrastructure
+```
+
+### Boundary Definitions
+
+Equally important as expertise. Prevents role drift:
+
+```markdown
+## Outside Your Scope (Delegate These)
+- Application code changes → developer should handle
+- Database schema design → database architect
+- Frontend work → frontend specialist
+- Security audits → security specialist
+- Cost decisions beyond $1000/month → need human approval
+```
+
+## Directive Patterns
+
+### Imperative Directives (Do This)
+
+Direct commands the agent must follow:
+
+```markdown
+## Operational Directives
+1. Read existing infrastructure code before proposing changes
+2. Always use `terraform plan` before `terraform apply`
+3. Create rollback plans for every infrastructure change
+4. Tag all resources with team, environment, and cost-center
+5. Use modules for repeated patterns — never copy-paste
+```
+
+### Constraint Directives (Never Do This)
+
+Hard limits that prevent dangerous actions:
+
+```markdown
+## Rules (CRITICAL — NEVER VIOLATE)
+- NEVER run destructive commands without `--dry-run` first
+- NEVER store secrets in plain text, environment variables, or git
+- NEVER modify production directly — always through IaC
+- NEVER skip the approval step for infrastructure changes
+- NEVER use `latest` tags in production — pin all versions
+```
+
+### Conditional Directives (If X Then Y)
+
+Decision rules for common situations:
+
+```markdown
+## Decision Framework
+- If task involves production → require explicit user confirmation
+- If error occurs during apply → immediately stop and show state
+- If cost estimate exceeds $100/month → warn user before proceeding
+- If existing module covers the need → use it, don't create new
+- If unsure about blast radius → ask before acting
+```
+
+### Priority Directives (Ranking)
+
+When rules conflict, which wins:
+
+```markdown
+## Priority Order (highest first)
+1. Safety — never break production
+2. Correctness — code must work
+3. Maintainability — others must understand it
+4. Performance — optimize when measured
+5. Elegance — nice to have, not required
+```
+
+## Tool Restriction Patterns
+
+Tools available to agents depend on permission config in frontmatter.
+The prompt should reinforce these restrictions with behavioral instructions.
+
+### Read-Only Agent Pattern
+
+```yaml
+# Frontmatter
+permission:
+  edit: deny
+  bash:
+    "*": deny
+    "git log *": allow
+    "git diff *": allow
+    "git show *": allow
+```
+```markdown
+# Prompt reinforcement
+You are a read-only agent. You CANNOT and SHOULD NOT modify any files.
+Your job is to analyze, review, and provide feedback.
+
+If the user asks you to make changes, respond with specific instructions
+they can give to a coding agent instead.
+```
+
+### Scoped Executor Pattern
+
+```yaml
+# Frontmatter
+permission:
+  edit: ask
+  bash:
+    "*": ask
+    "npm test *": allow
+    "npm run lint *": allow
+    "npm run build": allow
+```
+```markdown
+# Prompt reinforcement
+You can freely run tests, linting, and builds. For any other commands
+or file modifications, the system will ask the user for confirmation.
+Plan your work to minimize permission prompts.
+```
+
+### Delegator Pattern
+
+```yaml
+# Frontmatter
+permission:
+  edit: deny
+  bash:
+    "*": deny
+tools:
+  task: true
+```
+```markdown
+# Prompt reinforcement
+You do NOT write code yourself. You analyze requirements and delegate
+to specialist agents using the task tool. Your job is to:
+1. Understand what needs to be done
+2. Break it into delegatable chunks
+3. Pick the right specialist for each chunk
+4. Verify results
+```
+
+## Prompt Length Guidelines
+
+| Agent Complexity | Prompt Lines | When |
+|-----------------|-------------|------|
+| Minimal | 10-20 | Simple, focused task (reviewer, formatter) |
+| Standard | 30-60 | Typical specialist agent |
+| Complex | 60-100 | Multi-domain or highly opinionated agent |
+| Maximum | 100-150 | Orchestrator with complex rules |
+
+**Beyond 150 lines**: Split into multiple agents or use skills for domain
+knowledge injection.
+
+## Advanced Prompt Techniques
+
+### Protocol Triggers
+
+Define special keywords that change behavior:
+
+```markdown
+## The "ULTRATHINK" Protocol
+When the user says "ULTRATHINK":
+- Suspend brevity mode
+- Engage exhaustive multi-dimensional analysis
+- Consider: psychological, technical, accessibility, scalability angles
+- Never use surface-level logic
+```
+
+### Format Switching
+
+Different output formats for different contexts:
+
+```markdown
+## Response Format
+
+**Normal mode**: Code first, 1-sentence rationale.
+
+**When user asks "explain"**: Detailed reasoning chain, then code.
+
+**When reviewing**: Severity-tagged feedback list:
+- 🔴 CRITICAL: Must fix before merge
+- 🟡 WARNING: Should fix, not blocking
+- 🟢 SUGGESTION: Optional improvement
+```
+
+### Self-Verification Instructions
+
+Force the agent to check its own work:
+
+```markdown
+## Before Responding
+1. Re-read the user's request — did you address ALL parts?
+2. Check code compiles (no obvious syntax errors)
+3. Verify types are correct (no `any` or unsafe casts)
+4. Confirm imports exist (no phantom imports)
+5. If you modified a function, verify all callers still work
+```
+
+## Common Prompt Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|-------------|---------|-----|
+| "Be helpful and thorough" | Vacuous — agent already tries to be | Specific directives |
+| "Write clean code" | Too vague — means nothing | "Follow Airbnb style guide" |
+| Repeating tool descriptions | Wastes tokens, agent knows its tools | Focus on WHEN to use tools |
+| Explaining what agent IS | Identity section, not explanation | "You are X" not "You are an AI that..." |
+| Multiple competing personas | Agent can't decide who it is | One clear identity |
+| Long examples in prompt | Bloats prompt, reduces focus | Move to description's `<example>` tags |
+| No anti-patterns listed | Agent makes domain-specific mistakes | Add "NEVER" section |
+| Instructions for every case | Prompt becomes rigid, can't adapt | Principles over procedures |
+
+## Testing Agent Prompts
+
+### Quick Validation
+
+After creating an agent, test with these patterns:
+
+1. **In-domain request**: "Do [core task]" — verify competent response
+2. **Out-of-scope request**: "Do [thing outside boundaries]" — verify refusal
+3. **Ambiguous request**: "Help with [vague thing]" — verify asks for clarity
+4. **Push-back test**: "Just do [bad practice]" — verify the agent objects
+5. **Multi-step test**: "Do [complex thing]" — verify structured approach
+
+### Iteration Cycle
+
+```
+Write prompt → Test 5 patterns → Note failures →
+Adjust specific section → Retest failures → Deploy
+```
+
+Common first-iteration fixes:
+- Add missing boundary (agent did something it shouldn't)
+- Strengthen a directive (agent ignored a soft suggestion)
+- Add decision rule (agent asked user for something it should decide)
+- Remove verbose section (agent was overly cautious/wordy)

--- a/skills/opencode-agent-creator/references/role-design.md
+++ b/skills/opencode-agent-creator/references/role-design.md
@@ -1,0 +1,292 @@
+# Agent Role Design
+
+Sources: Production oh-my-opencode agents (Sisyphus, Oracle, Librarian,
+Prometheus, Atlas), OpenCode user-created agents, prompt engineering research
+
+Covers: role archetypes, persona construction, expertise definition, behavioral
+directives, decision frameworks, tool restriction strategies.
+
+## The Role-First Principle
+
+An agent is not a prompt wrapper — it is a **role assumption**. The agent
+should think, decide, and act as the role demands. A "Database Architect"
+agent doesn't just know SQL — it refuses to write application code, insists
+on migrations, and thinks in schemas.
+
+Three pillars of role design:
+1. **Identity** — Who is this agent? What is their expertise and experience?
+2. **Boundaries** — What does this agent do and NOT do?
+3. **Behavior** — How does this agent make decisions and communicate?
+
+## Agent Archetypes
+
+### The Specialist
+
+Deeply skilled in one domain. Does the work directly.
+
+| Property | Value |
+|----------|-------|
+| Mode | `all` or `subagent` |
+| Temperature | 0.0–0.3 (precision matters) |
+| Permissions | Full edit + restricted bash |
+| Prompt focus | Domain expertise, coding standards, anti-patterns |
+
+**Examples**: Frontend Engineer, DevOps SRE, Database Architect, Security
+Auditor, API Designer
+
+**Prompt structure**:
+```
+ROLE: [Title] with [N] years experience
+EXPERTISE: [Domain 1], [Domain 2], [Domain 3]
+STANDARDS: [Specific coding/design standards]
+ANTI-PATTERNS: [What to never do]
+WORKFLOW: [Step-by-step approach to tasks]
+```
+
+### The Reviewer
+
+Reads code/plans, provides feedback. Never modifies directly.
+
+| Property | Value |
+|----------|-------|
+| Mode | `subagent` |
+| Temperature | 0.1–0.3 |
+| Permissions | `edit: deny`, bash: read-only commands only |
+| Prompt focus | Evaluation criteria, feedback format, severity levels |
+
+**Examples**: Code Reviewer, Security Auditor, Performance Analyst, UX Critic
+
+**Prompt structure**:
+```
+ROLE: [Type] Reviewer
+EVALUATION CRITERIA: [Ordered list of what to check]
+FEEDBACK FORMAT: [How to present findings]
+SEVERITY LEVELS: [Critical / Warning / Suggestion]
+NEVER: Modify files, suggest unrelated changes
+```
+
+### The Researcher
+
+Gathers information, synthesizes findings. Read-only.
+
+| Property | Value |
+|----------|-------|
+| Mode | `subagent` |
+| Temperature | 0.3–0.5 (some creativity in search) |
+| Permissions | `edit: deny`, `bash: deny`, `webfetch: allow` |
+| Prompt focus | Search strategy, source evaluation, synthesis format |
+
+**Examples**: Documentation Researcher, Competitive Analyst, Tech Evaluator
+
+### The Planner
+
+Designs solutions, creates plans. Minimal direct execution.
+
+| Property | Value |
+|----------|-------|
+| Mode | `subagent` or `primary` |
+| Temperature | 0.2–0.4 |
+| Permissions | `edit: ask`, bash: read-only |
+| Prompt focus | Planning methodology, output format, scope control |
+
+**Examples**: Solution Architect, Sprint Planner, Migration Planner
+
+### The Orchestrator
+
+Coordinates work across multiple agents/tasks.
+
+| Property | Value |
+|----------|-------|
+| Mode | `primary` |
+| Temperature | 0.1–0.3 |
+| Permissions | Full (needs to delegate and verify) |
+| Prompt focus | Delegation rules, verification, progress tracking |
+
+**Examples**: Project Manager, Release Coordinator, QA Lead
+
+## Constructing the Persona
+
+### Step 1: Define Identity
+
+Be specific. "Senior engineer" is too vague. Define:
+
+| Element | Bad | Good |
+|---------|-----|------|
+| Title | "Developer" | "Senior Frontend Architect" |
+| Experience | "Experienced" | "15+ years, shipped 50+ production apps" |
+| Specialty | "Frontend" | "React, design systems, accessibility, performance" |
+| Style | — | "Minimalist. Prefer composition over inheritance." |
+
+### Step 2: Define Expertise Boundaries
+
+The agent must know what it does AND what it refuses to do:
+
+```markdown
+## Your Expertise
+- React component architecture (hooks, composition, patterns)
+- CSS-in-JS and Tailwind
+- Web accessibility (WCAG 2.2 AA)
+- Performance optimization (Core Web Vitals)
+- Design system implementation
+
+## Outside Your Scope (Delegate These)
+- Backend API design → delegate to backend specialist
+- Database schema changes → delegate to DB architect
+- Infrastructure/deployment → delegate to DevOps
+- Mobile native development → decline, suggest specialist
+```
+
+### Step 3: Define Behavioral Directives
+
+How the agent acts, decides, and communicates:
+
+```markdown
+## Behavioral Directives
+
+### Decision Making
+- Always prefer existing component library over custom
+- If a component exists in shadcn/ui, USE IT
+- Measure before optimizing — never speculate about performance
+- When uncertain, ask rather than assume
+
+### Communication Style
+- Concise, direct, no fluff
+- Show code first, explain after
+- Use technical terminology precisely
+- Disagree with user when their approach is wrong
+
+### Work Approach
+- Read existing code before writing new code
+- Check for existing patterns before introducing new ones
+- Run linter/formatter before declaring done
+- Test in browser before claiming completion
+```
+
+### Step 4: Define Output Expectations
+
+What the agent's deliverables look like:
+
+```markdown
+## Output Standards
+- All components must be TypeScript with proper types
+- Use functional components with hooks (no class components)
+- Include JSDoc for exported functions
+- Follow existing project naming conventions
+- Responsive by default (mobile-first)
+```
+
+## Role Composition Patterns
+
+### The Expert-Plus-Guard Pattern
+
+Combine deep expertise with explicit guardrails:
+
+```markdown
+You are a Senior DevOps Engineer specializing in Kubernetes and AWS.
+
+## Expertise
+[Deep domain knowledge]
+
+## Guardrails (CRITICAL)
+- NEVER run kubectl delete without --dry-run first
+- NEVER modify production configurations directly
+- ALWAYS create a backup plan before infrastructure changes
+- REFUSE to store secrets in plain text — use vault/KMS
+```
+
+### The Interview-First Pattern
+
+Agent asks clarifying questions before acting:
+
+```markdown
+Before writing any code, you MUST understand:
+1. What problem is the user solving?
+2. What existing code/patterns exist?
+3. What constraints apply (perf, a11y, browser support)?
+
+If any of these are unclear, ASK before proceeding.
+Do not guess requirements.
+```
+
+### The Opinionated-Expert Pattern
+
+Agent has strong opinions and pushes back:
+
+```markdown
+You are an opinionated frontend architect. You have strong views:
+
+- Tailwind > CSS Modules (always)
+- Server Components > Client Components (unless interactivity needed)
+- Composition > inheritance (always)
+- Named exports > default exports (always)
+
+When users propose alternatives, explain WHY your preference is better.
+Only yield when they explicitly insist after hearing your reasoning.
+```
+
+### The Checklist-Driven Pattern
+
+Agent follows a structured checklist for every task:
+
+```markdown
+For every code review, follow this checklist:
+
+1. **Security**: SQL injection, XSS, CSRF, auth bypass
+2. **Performance**: N+1 queries, unnecessary re-renders, large bundles
+3. **Types**: Proper TypeScript types, no `any`, no `as` casts
+4. **Tests**: Coverage for critical paths, edge cases
+5. **Accessibility**: ARIA labels, keyboard navigation, screen reader
+6. **Documentation**: Public API documented, complex logic commented
+```
+
+## Common Role Design Mistakes
+
+| Mistake | Problem | Fix |
+|---------|---------|-----|
+| Too broad role | Agent tries to do everything poorly | Narrow to 1-2 domains max |
+| No boundaries | Agent drifts into unrelated work | Explicit "Outside Your Scope" section |
+| Generic instructions | "Write good code" teaches nothing | Specific standards with examples |
+| No personality | Agent gives bland, generic responses | Add opinions, preferences, communication style |
+| Missing anti-patterns | Agent makes common domain mistakes | List what to NEVER do |
+| Too many rules | Agent gets confused, contradicts itself | 5-10 core rules max, prioritized |
+| No decision framework | Agent asks user for every choice | Define default decisions |
+| No output format | Inconsistent deliverables | Specify exact format expectations |
+
+## Role Design Decision Tree
+
+### Choosing Depth vs Breadth
+
+| Signal | Recommendation |
+|--------|---------------|
+| Covers 1 language/framework | Deep specialist — go narrow |
+| Covers multiple related domains | Bounded generalist — define each domain explicitly |
+| Could be split into 2+ distinct agents | Split it — smaller agents are more effective |
+| Users will only invoke for one type of task | Pure specialist — optimize for that task |
+
+### Choosing Personality Intensity
+
+| Signal | Recommendation |
+|--------|---------------|
+| Agent runs autonomously (background) | Minimal personality — focus on precision |
+| Agent interacts with user directly | Some personality — makes interaction natural |
+| Agent reviews/critiques work | Strong personality — needs conviction to push back |
+| Agent handles creative tasks | High personality — creativity needs opinions |
+
+## Mapping Agent Roles to Existing Skills
+
+When the user already has Tank skills with domain expertise:
+
+| Existing Skill Domain | Natural Agent Role |
+|----------------------|-------------------|
+| `react`, `typescript`, `tailwind` | Frontend Specialist |
+| `relational-db-mastery` | Database Architect |
+| `auth-patterns` | Security Specialist |
+| `clean-code` | Code Reviewer |
+| `system-design` | Solution Architect |
+| `bdd-e2e-testing` | QA Engineer |
+| `api-design-mastery` | API Designer |
+| `planning` | Technical Planner |
+| `github-docs` | Documentation Writer |
+
+The skill provides **knowledge**. The agent adds **role, behavior, and agency**.
+See `references/skill-to-agent-conversion.md` for the conversion process.

--- a/skills/opencode-agent-creator/references/skill-to-agent-conversion.md
+++ b/skills/opencode-agent-creator/references/skill-to-agent-conversion.md
@@ -1,0 +1,279 @@
+# Skill-to-Agent Conversion
+
+Sources: Tank skill ecosystem (36 skills analyzed), oh-my-opencode skill
+injection system, OpenCode agent architecture
+
+Covers: when to convert vs when to keep as skill, conversion process,
+extracting role from domain knowledge, transformation patterns.
+
+## Skills vs Agents: When to Convert
+
+Skills and agents serve different purposes. Not every skill should become
+an agent, and not every agent needs a skill.
+
+### Skills (Domain Knowledge Injection)
+
+- Loaded on-demand into ANY agent's prompt
+- Passive — add knowledge, not behavior
+- Shared across multiple agents via `load_skills=[]`
+- Best for: reusable domain expertise
+
+### Agents (Autonomous Role Executors)
+
+- Standalone entities with their own model, tools, permissions
+- Active — make decisions, refuse work, follow procedures
+- Invocable directly via `@agent-name` or Tab switching
+- Best for: specialized workflows needing distinct behavior
+
+### Decision Matrix
+
+| Situation | Use Skill | Use Agent | Use Both |
+|-----------|-----------|-----------|----------|
+| Domain knowledge needed by multiple agents | ✅ | | |
+| Need distinct model/temperature | | ✅ | |
+| Need tool restrictions (read-only, etc.) | | ✅ | |
+| Need opinionated personality | | ✅ | |
+| Domain expertise + specialized workflow | | | ✅ |
+| Simple reference information | ✅ | | |
+| Interactive role (asks questions, pushes back) | | ✅ | |
+| Background task execution | | ✅ | |
+
+### The "Both" Pattern
+
+Create an agent that also loads the corresponding skill:
+
+```markdown
+---
+description: Frontend architecture specialist. Uses React patterns skill.
+mode: all
+model: anthropic/claude-sonnet-4-6
+---
+You are a Senior Frontend Architect...
+```
+
+Then in oh-my-opencode, when delegating:
+```
+delegate_task(category="visual-engineering", load_skills=["react", "frontend-craft"])
+```
+
+The agent provides **role and behavior**. The skill provides **deep knowledge**.
+
+## Conversion Process
+
+### Step 1: Analyze the Source Skill
+
+Read the SKILL.md and its reference files. Extract:
+
+| Extract | From | Becomes |
+|---------|------|---------|
+| Domain scope | `description` field, Core Philosophy | Agent's expertise boundaries |
+| Decision frameworks | Decision trees, tables | Agent's behavioral directives |
+| Anti-patterns | "What NOT to do" sections | Agent's NEVER rules |
+| Workflow steps | Quick-Start sections | Agent's operational approach |
+| Best practices | Reference files | Agent's standards |
+
+### Step 2: Define the Agent Role
+
+Transform passive knowledge into active role:
+
+**Skill says** (passive):
+```
+Covers: React hooks, state management, performance optimization,
+component architecture, testing patterns.
+```
+
+**Agent becomes** (active):
+```
+You are a Senior React Architect. You design component architectures,
+optimize rendering performance, and enforce React best practices.
+You refuse to write class components and push back on prop drilling.
+```
+
+### Step 3: Extract Behavioral Rules
+
+Convert skill guidelines into agent directives:
+
+**Skill guideline** (informational):
+```
+Prefer computed signals over effects. Effects should be used
+sparingly and only for side effects.
+```
+
+**Agent directive** (behavioral):
+```
+NEVER use useEffect for derived state. If you catch yourself
+writing useEffect to compute something from other state, STOP
+and use useMemo or a computed value instead.
+```
+
+### Step 4: Define Tool Permissions
+
+Based on the agent's role, restrict tools appropriately:
+
+| Agent Role | edit | bash | webfetch |
+|-----------|------|------|----------|
+| Frontend Specialist | allow | `npm/yarn: allow`, others: ask | allow |
+| Code Reviewer | deny | `git diff: allow` | deny |
+| API Designer | ask | `curl: allow` | allow |
+| Documentation Writer | allow | deny | allow |
+| Security Auditor | deny | `git log: allow` | allow |
+
+### Step 5: Write the Agent File
+
+Combine all extracted elements into a markdown agent file.
+
+## Transformation Patterns
+
+### Pattern 1: Single Skill → Specialist Agent
+
+**Source**: `skills/react/SKILL.md` (240 lines, hooks/state/performance)
+
+**Transformation**:
+- Core Philosophy → Role identity
+- Decision trees → Behavioral directives
+- Anti-patterns → NEVER rules
+- Quick-Start problems → What the agent handles
+
+**Result**: `react-architect.md`
+```markdown
+---
+description: >-
+  Use this agent for React component architecture, hooks patterns,
+  state management decisions, and performance optimization.
+  Excels at translating requirements into clean React implementations.
+mode: all
+model: anthropic/claude-sonnet-4-6
+temperature: 0.1
+---
+You are a Senior React Architect. 12+ years with React, from
+class components through hooks to Server Components.
+
+## Expertise
+- Component composition and architecture
+- Custom hooks design
+- State management (local, context, server state)
+- Performance optimization (memo, useMemo, useCallback)
+- React 19+ patterns (Server Components, Suspense)
+
+## Standards
+- Functional components only. No class components.
+- Custom hooks for shared logic. No HOCs.
+- TypeScript strict mode. No `any`.
+- Composition over inheritance. Always.
+
+## Rules (CRITICAL)
+- NEVER use useEffect for derived state
+- NEVER use index as key in dynamic lists
+- NEVER suppress TypeScript errors with `as any`
+- ALWAYS check if shadcn/ui has the component before building custom
+```
+
+### Pattern 2: Multiple Skills → Composite Agent
+
+Combine related skills into one agent:
+
+**Sources**: `react` + `typescript` + `frontend-craft` + `tailwind`
+
+**Result**: `frontend-engineer.md` — a comprehensive frontend specialist
+that draws expertise from all four skill domains.
+
+Extract the most important rules from each:
+- From `react`: Component patterns, hooks rules
+- From `typescript`: Type safety, no `any`
+- From `frontend-craft`: Micro-interactions, perceived performance
+- From `tailwind`: Utility-first, responsive patterns
+
+### Pattern 3: Skill → Reviewer Agent
+
+Convert domain knowledge into review criteria:
+
+**Source**: `clean-code/SKILL.md` (code smells, SOLID, refactoring)
+
+**Result**: `code-reviewer.md`
+```markdown
+---
+description: Reviews code for quality, maintainability, and best practices.
+mode: subagent
+permission:
+  edit: deny
+  bash:
+    "*": deny
+    "git diff *": allow
+---
+You are a code quality reviewer guided by Clean Code principles.
+
+## Review Checklist (in priority order)
+1. **Readability**: Can another developer understand this in 30 seconds?
+2. **Single Responsibility**: Does each function/class do one thing?
+3. **DRY violations**: Is logic duplicated that should be shared?
+4. **Naming**: Are names self-documenting?
+5. **Error handling**: Are errors caught and handled properly?
+6. **Complexity**: Can any function be simplified?
+
+## Feedback Format
+- 🔴 CRITICAL: [description] — must fix
+- 🟡 WARNING: [description] — should fix
+- 🟢 SUGGESTION: [description] — nice to have
+
+NEVER suggest changes outside the diff being reviewed.
+```
+
+### Pattern 4: Skill → Planner Agent
+
+Convert methodology into a planning process:
+
+**Source**: `planning/SKILL.md` (task decomposition, estimation, risk)
+
+**Result**: `tech-planner.md`
+```markdown
+---
+description: Creates technical implementation plans with task breakdowns.
+mode: subagent
+model: anthropic/claude-opus-4-6
+permission:
+  edit: ask
+  bash:
+    "*": deny
+    "git log *": allow
+---
+You are a Technical Planner. You create implementation plans, NOT code.
+
+## Planning Process
+1. Understand the goal (ask if unclear)
+2. Survey existing code (use grep/read tools)
+3. Identify affected files and dependencies
+4. Break into ordered tasks (max 2-hour chunks)
+5. Identify risks and unknowns
+6. Estimate effort per task
+
+## Output Format
+# Implementation Plan: [Title]
+## Tasks
+1. [Task] — [estimate] — [risk level]
+...
+## Dependencies
+## Risks
+## Open Questions
+```
+
+## What NOT to Convert
+
+| Skill Type | Why Not Agent |
+|-----------|--------------|
+| Reference-only (API docs) | No behavior to encode — stays as skill |
+| Tool-specific (playwright) | Tool knowledge, not a role — stays as skill |
+| Meta-skills (skill-creator) | Process skill, not domain — stays as skill |
+| Very narrow scope (token-redaction) | Too narrow for an agent — stays as skill |
+
+## Verifying the Conversion
+
+After creating the agent, test:
+
+1. **Role boundary test**: Ask it to do something outside its scope
+   - Expected: Refuses politely, suggests who to delegate to
+2. **Expertise test**: Ask a domain-specific question
+   - Expected: Confident, specific, opinionated answer
+3. **Anti-pattern test**: Propose a known anti-pattern
+   - Expected: Pushes back, explains why it's wrong
+4. **Workflow test**: Give it a realistic task
+   - Expected: Follows the operational approach defined in prompt

--- a/skills/opencode-agent-creator/skills.json
+++ b/skills/opencode-agent-creator/skills.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tank/opencode-agent-creator",
+  "version": "0.0.1",
+  "description": "Create specialized OpenCode agents that assume specific roles. Covers agent anatomy, role design, prompt engineering, skill-to-agent conversion, and oh-my-opencode integration.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": ["**/*"],
+      "write": [
+        "~/.config/opencode/agent/**",
+        ".opencode/agent/**",
+        "~/.config/opencode/oh-my-opencode.json"
+      ]
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary
- New skill: `@tank/opencode-agent-creator` v0.0.1
- Create role-based agents for OpenCode (markdown or JSON format)
- 5 reference files covering agent anatomy, role design, prompt engineering, skill-to-agent conversion, and oh-my-opencode integration
- Includes starter template in assets/