### PR TITLE
feat(web-analytics-consent): add privacy-compliant analytics and cookie consent skill

### DIFF
--- a/skills/web-analytics-consent/SKILL.md
+++ b/skills/web-analytics-consent/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: "@tank/web-analytics-consent"
+description: "Privacy-compliant web analytics and cookie consent implementation. Covers
+tool selection (PostHog, GA4, Plausible, Umami, Clarity), cookie consent banners
+(vanilla-cookieconsent v3, GDPR/CCPA compliance), consent-gated script loading,
+Google Consent Mode v2, funnel analysis, session recordings, heatmaps, Next.js
+integration patterns, and opt-in/opt-out architecture with free-tier pricing
+comparison.\n\nTrigger phrases: \"analytics\", \"cookie consent\", \"GDPR\",
+\"cookie banner\", \"PostHog\", \"Google Analytics\", \"GA4\", \"Plausible\",
+\"Umami\", \"Microsoft Clarity\", \"session recording\", \"heatmap\",
+\"consent mode\", \"privacy compliance\", \"CCPA\", \"cookieconsent\",
+\"funnel analysis\", \"event tracking\", \"opt-in\", \"opt-out\""
+triggers:
+- analytics
+- cookie consent
+- GDPR
+- cookie banner
+- PostHog
+- Google Analytics
+- GA4
+- Plausible
+- Umami
+- Microsoft Clarity
+- session recording
+- heatmap
+- consent mode
+- privacy compliance
+- CCPA
+- cookieconsent
+- funnel analysis
+- event tracking
+- opt-in
+- opt-out
+- vanilla-cookieconsent
+- consent-gated
+- ePrivacy
+---
+
+# Core Philosophy
+
+- Consent-first architecture: no analytics script loads until the user makes a choice.
+- Two valid paths: cookieless tools need no banner; cookie-based tools need full opt-in.
+- Privacy is a product feature, not a legal checkbox.
+- Free tiers are generous enough for most startups; know the exact numbers before choosing.
+
+# Consent Architecture Decision Tree
+
+```
+Does the tool set cookies or access device storage?
+|-- NO (Plausible, Fathom, Umami, Vercel Analytics)
+|   --> No consent banner needed
+|   --> Add to privacy policy, honor opt-out requests
+|   --> Load script unconditionally
+|
+|-- YES (GA4, PostHog default, Clarity, Hotjar)
+    --> Consent banner REQUIRED before loading
+    --> Default all consent signals to 'denied'
+    --> Load scripts ONLY after explicit opt-in
+    |
+    |-- Using Google advertising products?
+    |   --> Implement Consent Mode v2 (mandatory since March 2024)
+    |   --> Include ad_user_data and ad_personalization signals
+    |
+    |-- Using session recordings?
+        --> ALWAYS requires explicit consent regardless of tool
+```
+
+# Tool Selection Quick Reference
+
+| Tool | Type | Cookies | Free Tier | Banner Required |
+| --- | --- | --- | --- | --- |
+| Plausible | Traffic analytics | None | No free tier (paid hosted) | No |
+| Umami | Traffic analytics | None | Self-host free | No |
+| Vercel Analytics | Traffic analytics | None | Free (Vercel projects) | No |
+| PostHog | Product analytics | Optional | 1M events, 5K recordings/mo | Depends on config |
+| GA4 | Marketing analytics | Yes | Free (with limits) | Yes |
+| Clarity | Session replay | Yes | Free unlimited | Yes |
+
+# Workflow
+
+1. **Choose analytics path**: Cookieless-only or cookie-based. See `references/tool-selection.md`.
+2. **If cookie-based**: Set up consent banner with vanilla-cookieconsent v3. See `references/vanilla-cookieconsent.md`.
+3. **Configure consent architecture**: Map consent categories to scripts. See `references/consent-architecture.md`.
+4. **If using Google products**: Implement Consent Mode v2. See `references/google-consent-mode.md`.
+5. **Integrate analytics tool**: PostHog with consent gating. See `references/posthog-integration.md`.
+6. **Set up advanced features**: Funnels, session recordings, heatmaps. See `references/funnels-sessions-heatmaps.md`.
+
+# Common Patterns
+
+## Cookieless Path (No Banner Needed)
+
+```tsx
+// app/layout.tsx — Plausible loads unconditionally
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <head>
+        <script defer data-domain="yourdomain.com"
+          src="https://plausible.io/js/script.js" />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+## Cookie-Based Path (Banner Required)
+
+```tsx
+// instrumentation-client.ts — PostHog waits for consent
+import posthog from 'posthog-js';
+
+posthog.init('phc_YOUR_KEY', {
+  api_host: '/ingest',             // reverse proxy
+  persistence: 'memory',           // no cookies until consent
+  disable_session_recording: true, // no recording until consent
+  loaded: (ph) => ph.opt_out_capturing(),
+});
+```
+
+```tsx
+// components/CookieConsent.tsx — consent gates PostHog
+'use client';
+import { useEffect } from 'react';
+import posthog from 'posthog-js';
+import * as CookieConsent from 'vanilla-cookieconsent';
+import 'vanilla-cookieconsent/dist/cookieconsent.css';
+
+export function CookieBanner() {
+  useEffect(() => {
+    CookieConsent.run({
+      categories: {
+        necessary: { enabled: true, readOnly: true },
+        analytics: {
+          autoClear: { cookies: [{ name: /^ph_/ }] },
+        },
+      },
+      onConsent: () => {
+        if (CookieConsent.acceptedCategory('analytics')) {
+          posthog.opt_in_capturing();
+        }
+      },
+      onChange: ({ changedCategories }) => {
+        if (changedCategories.includes('analytics')) {
+          CookieConsent.acceptedCategory('analytics')
+            ? posthog.opt_in_capturing()
+            : posthog.opt_out_capturing();
+        }
+      },
+      language: { default: 'en', translations: { en: { /* ... */ } } },
+    });
+  }, []);
+  return null;
+}
+```
+
+# Anti-Patterns
+
+| Anti-Pattern | Replace With |
+| --- | --- |
+| Loading GA4 before consent in EU | Block with Consent Mode defaults set to 'denied' |
+| Pre-checking analytics toggle | All non-necessary categories disabled by default |
+| No "Reject All" button | Equal-weight Accept All / Reject All buttons |
+| Using PostHog with cookies but no banner | Use `persistence: 'memory'` or add consent banner |
+| Ignoring ad_user_data / ad_personalization signals | Include all four Consent Mode v2 signals |
+| Session recordings without consent | Always gate recordings behind explicit opt-in |
+| Cookie wall (blocking site until consent) | Site must be accessible without giving consent |
+
+# Quality Checklist
+
+- Consent defaults to denied for all non-necessary categories.
+- "Reject All" button has equal visual weight to "Accept All".
+- Scripts with cookies only load after explicit opt-in.
+- Consent withdrawal mechanism exists (preferences widget/link).
+- Google Consent Mode v2 defaults set before GTM/GA4 loads.
+- Session recordings gated behind consent.
+- Privacy policy linked from consent banner.
+- Cookie descriptions in plain language.
+- Consent stored with timestamp and ID for audit trail.
+
+# Reference Files
+
+- `references/tool-selection.md` — Analytics tool comparison, pricing, and selection guide
+- `references/consent-architecture.md` — GDPR/CCPA legal framework and consent patterns
+- `references/vanilla-cookieconsent.md` — Cookie consent banner setup and configuration
+- `references/posthog-integration.md` — PostHog with Next.js and consent gating
+- `references/google-consent-mode.md` — Consent Mode v2, GA4, GTM, and Clarity
+- `references/funnels-sessions-heatmaps.md` — Event taxonomy, funnels, recordings, and heatmaps

--- a/skills/web-analytics-consent/references/consent-architecture.md
+++ b/skills/web-analytics-consent/references/consent-architecture.md
@@ -1,0 +1,287 @@
+# Consent Architecture and Legal Framework
+
+Sources: GDPR (Regulation 2016/679), ePrivacy Directive (2002/58/EC as amended 2009), CCPA (Cal. Civ. Code 1798.100+), EDPB Guidelines 05/2020 on consent, EDPB Guidelines 2/2019 on legitimate interest, CNIL enforcement decisions 2022-2024, EU Digital Omnibus Proposal COM(2025)87, ICO Cookie Guidance 2023, Plausible Analytics documentation, PostHog documentation.
+
+---
+
+## The Dual Regulatory Framework
+
+Web analytics sits at the intersection of two distinct legal regimes. Conflating them produces incorrect compliance strategies.
+
+**ePrivacy Directive (2002/58/EC)** governs access to and storage of information on a user's device. Article 5(3) states that storing or accessing information on terminal equipment requires the user's prior informed consent, unless the operation is strictly necessary to provide a service explicitly requested by the user. This directive applies regardless of whether the data is personal. A cookie containing only a random session token still triggers Article 5(3).
+
+**GDPR (Regulation 2016/679)** governs the processing of personal data. It applies once data is collected and linked to an identifiable individual. Analytics that produce personal data — IP addresses, persistent identifiers, behavioral profiles — require a lawful basis under Article 6.
+
+The practical consequence: a single analytics implementation may require compliance with both regimes simultaneously. A cookie that stores a user ID triggers ePrivacy consent for the storage act and GDPR lawful basis for the subsequent processing of that identifier as personal data.
+
+### When Each Regime Applies
+
+| Trigger | Applicable Law | Default Position |
+|---|---|---|
+| Setting a cookie (any content) | ePrivacy Directive | Consent required unless strictly necessary |
+| Reading localStorage or IndexedDB | ePrivacy Directive | Consent required unless strictly necessary |
+| Processing an IP address | GDPR | Lawful basis required |
+| Building a behavioral profile | GDPR | Consent required (Article 6(1)(a)) |
+| Aggregated, non-identifiable statistics | Neither (if truly anonymous) | No consent required |
+| Fingerprinting without storage | GDPR if identifiable | Lawful basis required |
+
+---
+
+## GDPR Consent Requirements
+
+When consent is the chosen lawful basis under Article 6(1)(a), it must satisfy all five conditions simultaneously. Failure on any single condition invalidates the consent.
+
+### The Five Conditions
+
+**Freely given.** The user must have a genuine choice. Consent is not freely given when refusal results in denial of service, when consent is bundled with terms of service, or when the consent interface makes rejection significantly harder than acceptance. The CNIL fined Google 150 million EUR and Facebook 60 million EUR in 2022 specifically because their interfaces provided a single-click "Accept all" button while requiring multiple steps to reject. Regulators treat asymmetric UI as coercion.
+
+**Specific.** Consent must be obtained separately for each distinct purpose. A single checkbox covering "analytics and marketing" is invalid. Users must be able to consent to analytics without consenting to advertising, and vice versa.
+
+**Informed.** The user must understand what they are consenting to before giving consent. This requires identifying the controller, naming third-party processors, describing the purpose, and stating the retention period. Vague language such as "improve your experience" does not satisfy this requirement.
+
+**Unambiguous.** Consent requires a clear affirmative act. Pre-ticked checkboxes, continued browsing, and scrolling do not constitute consent. The user must take a deliberate action — clicking a button, toggling a switch — that unambiguously signals agreement.
+
+**Withdrawable.** Withdrawing consent must be as easy as giving it. If consent was given via a single click, withdrawal must also be achievable via a single click. Consent management platforms must provide a persistent mechanism — typically a footer link or floating button — that reopens the preference center at any time.
+
+### Consent Records
+
+Maintain a record of each consent event containing: timestamp, user identifier (session-level, not persistent), consent version, purposes accepted, purposes rejected, and the UI state presented. This record must be producible on regulatory request. Store consent records for the duration of the consent plus any applicable statute of limitations (typically three years in EU jurisdictions).
+
+---
+
+## What Counts as Strictly Necessary
+
+The ePrivacy exemption for "strictly necessary" operations is narrow. Apply it only when the technical operation is essential to deliver a service the user has explicitly requested. Interpret "explicitly requested" as an active user-initiated action, not passive site visit.
+
+### Necessary Without Consent
+
+- Session cookies that maintain login state across page requests
+- Shopping cart cookies that persist item selections during a session
+- Load balancer cookies that route requests to the correct server
+- Security cookies that prevent cross-site request forgery
+- Cookies that store the user's consent preferences (the consent cookie itself)
+- Language preference cookies set in direct response to a user's language selection
+
+### Not Necessary — Consent Required
+
+- Analytics cookies that track page views, sessions, or user journeys
+- A/B testing cookies that assign users to experiment variants
+- Heatmap and session recording scripts that capture interaction data
+- Advertising cookies that build interest profiles
+- Social media tracking pixels embedded by third parties
+- Performance monitoring that identifies individual users across sessions
+
+The test is not whether the business finds the data useful, but whether the service would fail to function without the specific storage operation. Analytics data improves the service; it does not enable the service to function.
+
+---
+
+## Legitimate Interest for Analytics
+
+Article 6(1)(f) permits processing where the controller has a legitimate interest that is not overridden by the data subject's interests or fundamental rights. The EDPB has clarified the scope of this basis for analytics contexts.
+
+### The Three-Part Test
+
+Apply all three parts. Failure at any stage means legitimate interest is unavailable.
+
+**Part 1 — Purpose test.** The interest must be legitimate: lawful, clearly articulated, and real rather than speculative. Basic reach measurement — understanding how many people visit a site and which pages are popular — qualifies. Building behavioral profiles for advertising does not. The EDPB has explicitly rejected legitimate interest as a basis for behavioral advertising.
+
+**Part 2 — Necessity test.** The processing must be necessary to achieve the purpose. If the same insight can be obtained with less privacy-invasive means, the more invasive approach fails this test. Aggregate page view counts do not require persistent user identifiers. If cookieless analytics achieves the same measurement goal, cookie-based analytics cannot claim necessity.
+
+**Part 3 — Balancing test.** The controller's interest must not be overridden by the data subject's reasonable expectations. Consider: the nature of the data, the relationship between controller and subject, the likely impact on the subject, and whether the subject would reasonably expect this processing. Users visiting a website do not reasonably expect to be tracked across sessions for analytics purposes without notice.
+
+### When Legitimate Interest Applies to Analytics
+
+Legitimate interest may support basic, aggregated, cookieless analytics where:
+- No persistent identifier is stored on the device
+- IP addresses are not retained beyond the processing moment
+- Data is aggregated before storage
+- No cross-site tracking occurs
+- The user can reasonably anticipate that site operators measure traffic
+
+### When Legitimate Interest Does Not Apply
+
+- Any analytics that sets cookies or writes to localStorage
+- Session replay and heatmap tools that capture individual interactions
+- Analytics that link behavior across multiple sessions
+- Any analytics shared with or sold to third parties
+- Behavioral advertising, regardless of how it is labeled
+
+---
+
+## GDPR vs CCPA: Structural Differences
+
+The two regimes reflect fundamentally different regulatory philosophies. Building a single consent flow that satisfies both requires understanding where they diverge.
+
+| Dimension | GDPR (EU/EEA) | CCPA (California) |
+|---|---|---|
+| Default position | No processing without lawful basis | Processing permitted by default |
+| Model | Opt-in | Opt-out |
+| Consent for analytics | Required (unless cookieless + LI) | Not required; opt-out right applies |
+| Right to opt out | N/A (must opt in) | Right to opt out of sale/sharing |
+| Applicability threshold | Any processing of EU residents' data | >$25M revenue, OR 100K+ consumers, OR 50%+ revenue from data sales |
+| Sensitive data | Explicit consent required | Opt-in required for sensitive categories |
+| Enforcement | Data protection authorities, up to 4% global turnover | California AG, private right of action for data breaches |
+| Consent record requirement | Yes, demonstrable | No formal record requirement |
+| Right to withdraw | Must be as easy as giving consent | Right to opt back in after opting out |
+
+### Practical Implications for Analytics
+
+Under GDPR, analytics cookies require prior consent from EU visitors. The site must not fire analytics scripts until consent is recorded. Under CCPA, analytics processing may begin immediately; the obligation is to honor opt-out requests and to disclose data sharing in a privacy policy.
+
+For sites with global audiences, implement GDPR-compliant opt-in consent for EU/EEA visitors and CCPA-compliant opt-out mechanisms for California residents. Geolocation-based consent logic is acceptable and common. Use the visitor's IP address to determine jurisdiction at page load, before any tracking fires.
+
+CCPA's "sale or sharing" definition is broad. Passing analytics data to Google Analytics constitutes "sharing" under CCPA if Google uses that data for cross-context behavioral advertising. Google's default GA4 configuration does this. Enable Google's "Restricted Data Processing" mode for California visitors to avoid CCPA sale/sharing obligations.
+
+---
+
+## Consent Categories
+
+Structure consent into four standard categories. This taxonomy aligns with IAB TCF 2.2 purposes and is recognized by major regulators.
+
+| Category | Description | Consent Required | Examples |
+|---|---|---|---|
+| Necessary | Operations essential to service delivery | No | Session cookies, CSRF tokens, consent storage |
+| Analytics | Measurement of site usage and performance | Yes (GDPR); opt-out (CCPA) | GA4, PostHog, Plausible with cookies |
+| Functionality | Enhanced features beyond core service | Yes | Language preferences beyond session, saved preferences |
+| Marketing | Advertising, retargeting, behavioral profiling | Yes | Meta Pixel, Google Ads, LinkedIn Insight Tag |
+
+Do not create subcategories that obscure the nature of processing. Regulators have penalized consent interfaces that use euphemistic category names to make marketing consent appear more benign than it is.
+
+Present categories in a layered interface: a first layer with category-level toggles and a second layer with per-vendor detail. The IAB TCF 2.2 standard provides a vendor list and purpose taxonomy that satisfies this requirement for participating vendors.
+
+---
+
+## Cookieless Analytics: Legal Basis Without Consent
+
+Several analytics tools are designed to operate without setting cookies or writing to persistent storage. These tools can, in some jurisdictions and configurations, rely on legitimate interest rather than consent.
+
+### How Cookieless Identification Works
+
+Plausible Analytics, Fathom Analytics, and Umami use a daily rotating hash to distinguish unique visitors without persistent identifiers. The hash is computed from the visitor's IP address, User-Agent string, and the site's domain. The hash changes every 24 hours and is never stored — not in a cookie, not in localStorage, not in a database. The same visitor on consecutive days produces different hashes. This approach counts unique visitors within a day without tracking individuals across days or across sites.
+
+Because no information is stored on or read from the user's device, Article 5(3) of the ePrivacy Directive does not apply. Because the hash is not retained and cannot be used to identify an individual, GDPR's definition of personal data is not engaged (subject to the caveat below regarding IP addresses).
+
+### The ePrivacy Caveat for Client-Side Storage
+
+The ePrivacy exemption applies only when no storage or access occurs on the user's device. This includes:
+
+- Cookies (all types, all durations)
+- localStorage
+- sessionStorage
+- IndexedDB
+- Cache API
+- Service Worker storage
+- Web SQL (deprecated but still covered)
+
+A tool that avoids cookies but writes analytics data to localStorage is not cookieless in the legal sense. It still triggers Article 5(3) and requires consent. Verify each tool's actual storage behavior, not its marketing claims.
+
+### PostHog Memory Persistence
+
+PostHog supports `persistence: 'memory'` configuration, which prevents the SDK from writing to cookies or localStorage. In this mode, the distinct ID is held only in JavaScript memory and lost on page reload. This configuration avoids ePrivacy obligations for the storage act.
+
+However, memory persistence alone does not eliminate all consent requirements. If PostHog's `identify()` method is called with a user ID, that creates a personal data processing event requiring a lawful basis. Session replay captures keystrokes, clicks, and page content — this is personal data processing that requires consent regardless of persistence configuration. Evaluate each PostHog feature independently.
+
+### Cookieless Tools and Legitimate Interest
+
+For tools that genuinely avoid device storage and do not retain identifiable data, legitimate interest is a plausible basis in many EU jurisdictions. The analysis must still pass the three-part test. Document the assessment. Note that some EU data protection authorities — particularly the Austrian DSB and the French CNIL — have taken the position that IP addresses are always personal data and that any analytics involving IP addresses requires consent or pseudonymization before processing.
+
+The safest approach: use server-side IP anonymization (truncate the last octet before any processing or storage) and document this in the legitimate interest assessment.
+
+---
+
+## Data Retention Requirements
+
+Retention periods must be disclosed in the privacy notice and enforced technically. Storing data beyond the disclosed retention period is a GDPR violation independent of the lawful basis used to collect it.
+
+| Tool | Default Retention | Configurable | Notes |
+|---|---|---|---|
+| Google Analytics 4 | 2 months (events), 14 months (user data) | Yes, up to 14 months for events | Configure in Admin > Data Settings > Data Retention |
+| PostHog Cloud | 1 year | Yes, on paid plans | Self-hosted: unlimited, operator responsibility |
+| Microsoft Clarity | 13 months | No | Rolling 13-month window, not configurable |
+| Plausible Analytics | Unlimited aggregate | N/A | No individual-level data retained |
+| Fathom Analytics | Unlimited aggregate | N/A | No individual-level data retained |
+| Umami | Operator-defined | Yes | Self-hosted; configure database retention policy |
+
+Set retention periods to the minimum necessary for the stated purpose. If analytics data is used for monthly reporting, 14 months of retention is defensible. If used only for real-time dashboards, 30 days may be the maximum justifiable period.
+
+Include retention periods in the consent notice presented to users. "We retain analytics data for 14 months" is a required disclosure, not optional detail.
+
+---
+
+## EU Digital Omnibus Proposal
+
+The European Commission published the EU Digital Omnibus proposal in November 2025 (COM(2025)87). This proposal would amend the ePrivacy Directive and is not yet law. Do not treat it as current compliance guidance.
+
+### Proposed Changes Relevant to Analytics
+
+**Aggregated audience measurement exemption.** The proposal would exempt analytics that produce only aggregated, non-identifiable statistics from the ePrivacy consent requirement. If enacted, this would allow basic traffic measurement without a consent banner, provided the data is genuinely aggregated and no individual-level data is retained.
+
+**Browser-level privacy signal recognition.** The proposal would require websites to respect browser-level privacy signals, including the Global Privacy Control (GPC) header. Sites would be legally obligated to treat a GPC signal as an opt-out from non-necessary processing, without requiring the user to interact with a consent banner.
+
+**Anticipated Timeline.** The proposal must pass through the European Parliament and Council. Based on typical legislative timelines for ePrivacy amendments, implementation is not expected before 2027-2028. Member states would then have a transposition period. Plan current implementations for existing law; monitor the proposal's progress for future architecture decisions.
+
+Do not implement the proposed exemptions as if they are current law. Regulators enforce existing law, not proposed amendments.
+
+---
+
+## Enforcement Landscape
+
+Cookie-specific fines exceeded 100 million EUR across EU jurisdictions in 2024. Enforcement has concentrated on three violation patterns:
+
+**Asymmetric consent interfaces.** Interfaces where accepting all cookies requires one click but rejecting requires multiple steps or navigation to a separate page. The CNIL's Google and Facebook decisions established that this pattern constitutes coercion, invalidating the resulting consent.
+
+**Pre-ticked boxes and implied consent.** Consent interfaces that pre-select analytics or marketing categories, or that treat continued browsing as consent. Both practices have been found invalid by multiple DPAs.
+
+**Consent walls.** Requiring consent to analytics as a condition of accessing content. The EDPB's Guidelines 05/2020 state that consent is not freely given when refusal results in denial of service, unless the controller offers an equivalent service without tracking.
+
+The ICO, CNIL, and German DPAs have all issued guidance stating that "reject all" must be available at the same level of prominence as "accept all." Implement a three-button first layer: "Accept All," "Reject All," and "Manage Preferences."
+
+---
+
+## GDPR Compliance Checklist
+
+Use this checklist before deploying any analytics implementation. Each item maps to a specific legal requirement.
+
+### Legal Basis
+
+- [ ] Identify the lawful basis for each analytics tool and each processing purpose
+- [ ] Document the legitimate interest assessment if relying on Article 6(1)(f)
+- [ ] Confirm that behavioral advertising does not rely on legitimate interest
+- [ ] Verify that consent is the basis for all cookie-based analytics for EU visitors
+
+### Consent Interface
+
+- [ ] "Accept All" and "Reject All" are available at the same prominence on the first layer
+- [ ] Pre-ticked boxes are not used for any non-necessary category
+- [ ] Consent is not bundled with terms of service acceptance
+- [ ] The interface does not deny service to users who reject non-necessary cookies
+- [ ] Each consent category is described in plain language identifying the purpose and processors
+
+### Technical Implementation
+
+- [ ] No analytics scripts fire before consent is recorded for EU visitors
+- [ ] Consent state is stored and respected across sessions
+- [ ] Withdrawal mechanism is accessible at all times (footer link or floating button)
+- [ ] Withdrawal is as easy as giving consent (single interaction)
+- [ ] Consent records are stored with timestamp, version, and accepted/rejected purposes
+
+### Data Minimization and Retention
+
+- [ ] IP addresses are anonymized before storage (last octet truncated at minimum)
+- [ ] Retention periods are configured to the minimum necessary in each tool
+- [ ] Retention periods are disclosed in the privacy notice
+- [ ] Data deletion requests can be fulfilled within 30 days
+
+### Third-Party Processors
+
+- [ ] Data processing agreements are in place with all analytics vendors
+- [ ] Third-party vendors are named in the consent notice
+- [ ] Data transfers outside the EEA have a valid transfer mechanism (SCCs, adequacy decision)
+- [ ] Google Analytics Restricted Data Processing is enabled for CCPA jurisdictions
+
+### Documentation
+
+- [ ] Privacy notice describes all analytics processing, purposes, and retention periods
+- [ ] Legitimate interest assessments are documented and dated
+- [ ] Consent records are retained for the duration of consent plus three years
+- [ ] DPA registration is current if required in the relevant jurisdiction

--- a/skills/web-analytics-consent/references/funnels-sessions-heatmaps.md
+++ b/skills/web-analytics-consent/references/funnels-sessions-heatmaps.md
@@ -1,0 +1,321 @@
+# Funnels, Session Recordings, and Heatmaps
+
+Sources: PostHog documentation (posthog.com/docs), Microsoft Clarity documentation (clarity.microsoft.com), Google Analytics 4 documentation (support.google.com/analytics), Plausible Analytics documentation (plausible.io/docs), Mixpanel Event Naming Guide (mixpanel.com/blog/event-naming-best-practices), Amplitude Data Taxonomy Guide (amplitude.com/blog/data-taxonomy), IAPP Privacy Tech Vendor Report 2024, Web Analytics Association Standards 2023.
+
+---
+
+## Event Naming Taxonomy
+
+Consistent event naming is the foundation of reliable funnel analysis. Inconsistent names produce broken funnels, duplicate metrics, and dashboards that contradict each other. Establish a taxonomy before instrumentation begins and enforce it through code review.
+
+### Object-Action Framework
+
+Name every event as `object_action` in snake_case with a past-tense verb. The object is the noun (what was acted on), the action is what happened. This produces names that read as completed facts, which matches how analytics tools store and query them.
+
+Structure: `{object}_{action}` or `{context}_{object}_{action}` for disambiguation.
+
+Rules:
+- Use snake_case throughout. Never camelCase, PascalCase, or kebab-case.
+- Use past-tense verbs: `submitted`, `clicked`, `viewed`, `completed`, `failed`.
+- Put the noun first so events sort together in autocomplete and dashboards.
+- Keep names under 40 characters. Longer names indicate the event is too specific.
+- Never embed property values in the event name. Use properties for that.
+
+### Event Naming Examples
+
+| Bad Name | Problem | Good Name |
+|---|---|---|
+| `click` | No object, no context | `signup_button_clicked` |
+| `formSubmit` | camelCase, present tense | `signup_form_submitted` |
+| `user_signed_up_with_google` | Value embedded in name | `signup_completed` + `{method: "google"}` |
+| `pageView` | camelCase | `page_viewed` |
+| `addToCart` | camelCase, present tense | `product_added_to_cart` |
+| `ERROR` | Uppercase, no context | `payment_failed` |
+| `step1_completed` | Brittle, breaks on reorder | `onboarding_profile_completed` |
+| `btn_click_header_nav_logo` | Too granular, no value | `logo_clicked` |
+| `purchase` | Ambiguous (initiated or completed?) | `order_completed` |
+| `video_play_button_clicked_homepage` | Context in name, not property | `video_played` + `{location: "homepage"}` |
+
+### Property Conventions
+
+Attach context as properties, not as name variants. Every event should carry a consistent set of base properties automatically (user ID, session ID, timestamp, URL, referrer). Add domain-specific properties per event type.
+
+Standard base properties (set once in your analytics wrapper):
+- `user_id` — authenticated user identifier, null for anonymous
+- `session_id` — current session identifier
+- `page_url` — full URL at time of event
+- `page_path` — pathname only, for grouping
+- `referrer` — document.referrer at session start
+
+Event-specific properties follow the same snake_case convention: `product_id`, `plan_name`, `error_code`, `step_number`.
+
+### Taxonomy Governance
+
+Maintain a single source-of-truth event dictionary in your repository (a JSON or YAML file listing every event name, its properties, and its owner). Run a linter in CI that rejects events not in the dictionary. This prevents the taxonomy from drifting as the team grows.
+
+---
+
+## Funnel Analysis
+
+Funnels measure the percentage of users who complete a sequence of steps. Use funnels to identify where users drop off in signup flows, checkout sequences, onboarding, and feature adoption paths.
+
+### PostHog Funnels
+
+PostHog funnels support three step-order modes:
+
+**Sequential (default):** Users must complete steps in the defined order, but other events may occur between steps. Use this for most funnels — it reflects real user behavior where users navigate away and return.
+
+**Strict sequential:** Users must complete steps in exact order with no other events in between. Use this only when intermediate events indicate abandonment, such as a payment flow where any navigation away means failure.
+
+**Any order:** Users must complete all steps but in any sequence. Use this for feature adoption funnels where the order of discovery does not matter.
+
+Configure the mode in the funnel insight settings panel under "Step order."
+
+**Exclusion steps:** Add an exclusion step to filter out users who performed a specific action between two funnel steps. For example, exclude users who visited the pricing page between signup and activation — this isolates users who converted without price hesitation. Exclusion steps are available in sequential and strict sequential modes.
+
+**Conversion window:** Set the maximum time allowed between the first and last step. Default is 14 days. Shorten this for high-intent flows (checkout: 1 hour) and lengthen it for long sales cycles (enterprise trial: 90 days).
+
+**Funnel correlation analysis:** After building a funnel, open the "Correlation analysis" tab. PostHog automatically identifies event properties and person properties that are statistically correlated with higher or lower conversion. This surfaces non-obvious signals — for example, that users who set a profile photo in step 2 convert at 3x the rate of those who skip it. Use correlation results to prioritize product changes, not as causal proof.
+
+**Breakdown:** Split funnel results by a property (browser, plan, country, cohort) to compare conversion rates across segments. Breakdowns reveal whether a drop-off is universal or concentrated in a specific segment.
+
+### GA4 Funnels
+
+GA4 funnels live in the Explorations section (not standard reports). Create a Funnel Exploration from the Explore tab.
+
+**Open funnels:** Users can enter the funnel at any step. A user who completes step 3 without completing steps 1 and 2 still appears in step 3. Use open funnels when users have multiple entry paths to a feature.
+
+**Closed funnels:** Users must complete step 1 to be counted in subsequent steps. This is the standard funnel model. Use closed funnels for linear flows like checkout or signup.
+
+**Step types:** Each step can be a page view (user visited a specific page) or an event (user triggered a specific event). Mix both types in a single funnel.
+
+**Elapsed time:** GA4 shows the median time between each step pair. Use this to identify steps where users stall — a long median time between steps 2 and 3 suggests friction or confusion at step 2.
+
+**Segment comparison:** Apply up to four segments to a funnel exploration to compare conversion rates across user groups. Explorations are private by default — share them explicitly with teammates via the share button.
+
+**Limitations:** GA4 funnels are limited to 10 steps. Funnel Explorations expire after 60 days of inactivity. GA4 applies sampling to Explorations when the dataset exceeds thresholds — check the sampling indicator in the top-right of the exploration. Sampled results are unreliable for small segments.
+
+### Plausible Funnels
+
+Plausible funnels are available on paid plans. Configure them in the Goals section of your site settings.
+
+**Step types:** Each step is either a page visit (URL match) or a custom event. Combine both types in a single funnel.
+
+**Step limits:** Funnels support 2 to 8 steps. For longer flows, split into multiple funnels with overlapping steps.
+
+**Aggregate only:** Plausible funnels show aggregate conversion rates per step. There is no user-level drill-down — you cannot identify which specific users dropped off or replay their sessions from a funnel. This is by design: Plausible's privacy model does not track individual users.
+
+**URL matching:** Use exact URLs or wildcard patterns (e.g., `/checkout/*`) for page-visit steps. Wildcard matching aggregates all matching paths into a single step.
+
+**Use case fit:** Plausible funnels are appropriate for marketing site flows (landing page to signup) and simple product flows where aggregate rates are sufficient. For user-level investigation, pair Plausible with PostHog or Clarity.
+
+---
+
+## Session Recordings
+
+Session recordings capture a video-like replay of individual user sessions. Use recordings to investigate specific drop-off points identified in funnel analysis, reproduce reported bugs, and understand how users interact with new features.
+
+### PostHog Session Recordings
+
+Initialize PostHog with recording enabled:
+
+```javascript
+posthog.init('YOUR_KEY', {
+  session_recording: {
+    maskAllInputs: true,
+    maskTextSelector: null,
+    recordCrossOriginIframes: false,
+  },
+  disable_session_recording: false,
+})
+```
+
+**Input masking:** `maskAllInputs: true` is the default and masks all `<input>`, `<textarea>`, and `<select>` values before they leave the browser. Never disable this without legal review. To mask all text on the page (for highly sensitive UIs), set `maskTextSelector: "*"` — this replaces all text nodes with asterisks.
+
+**Element-level masking:** Add the CSS class `ph-no-capture` to any element to exclude it from recordings entirely. The element's position and size are still captured, but its content is replaced with a placeholder block. Use this for elements that display sensitive data that `maskAllInputs` does not cover (e.g., a `<div>` showing a credit card number).
+
+**Remote masking configuration (March 2025+):** PostHog supports configuring masking rules from the dashboard without a code deploy. Navigate to Project Settings > Session Replay > Masking to add CSS selectors that are applied server-side. Use this to respond quickly to privacy incidents.
+
+**Sampling strategies:**
+
+Use sampling to control recording volume and cost. PostHog supports four sampling mechanisms — combine them:
+
+1. **Sample rate:** Set `sampleRate` between 0 and 1 in the SDK config. A value of 0.2 records 20% of sessions randomly. Apply this as a baseline to cap volume.
+
+2. **URL triggers:** In the PostHog dashboard under Session Replay settings, configure URL patterns that trigger recording regardless of sample rate. Use this to always record sessions on high-value pages (checkout, onboarding) while sampling everything else.
+
+3. **Event triggers:** Configure specific events that start a recording when fired. For example, trigger recording when `payment_failed` fires to capture every failure session without recording all sessions.
+
+4. **Exception triggers:** Enable automatic recording when a JavaScript exception is captured. This ensures you have a replay for every error report. Requires the PostHog exception autocapture to be enabled.
+
+**Minimum duration filter:** Set a minimum session duration (in seconds) to exclude very short sessions from storage. Sessions under 2 seconds are typically bots or accidental page loads. Configure this in Project Settings > Session Replay > Minimum duration.
+
+**Linked funnels:** From a funnel drop-off step in PostHog, click "Watch recordings" to open session replays filtered to users who dropped off at that step. This is the primary workflow for funnel investigation.
+
+### Microsoft Clarity Session Recordings
+
+Clarity provides unlimited session recordings at no cost. There is no sampling limit — every session is recorded by default.
+
+**Automatic behavior detection:** Clarity automatically tags sessions with:
+
+- **Rage clicks:** User clicked the same element three or more times in rapid succession, indicating frustration with an unresponsive element.
+- **Dead clicks:** User clicked an element that produced no visible response, indicating a broken interaction or misleading affordance.
+- **Quick back:** User navigated to a page and immediately returned to the previous page, indicating the page did not meet their expectation.
+
+Filter the recordings list by these tags to surface problematic sessions without manual review.
+
+**AI Copilot:** Clarity's AI Copilot summarizes batches of up to 250 recordings into a natural-language report describing common user behaviors, friction points, and patterns. Use this to get a rapid overview before watching individual recordings. Access it from the Recordings tab via the "Summarize" button.
+
+**Data retention:** Clarity retains recordings for 13 months.
+
+**Privacy controls:** Clarity masks input fields by default. Configure additional masking rules in the Clarity dashboard under Masking. Clarity does not support element-level masking via CSS classes — use the dashboard masking rules instead.
+
+**Integration with PostHog:** If you use both tools, link Clarity session IDs to PostHog events by passing the Clarity session URL as a PostHog event property. This lets you jump from a PostHog funnel drop-off directly to the Clarity recording.
+
+---
+
+## Heatmaps
+
+Heatmaps aggregate interaction data across many sessions into a visual overlay on a page screenshot. Use heatmaps to understand where users click, how far they scroll, and which areas attract attention — without watching individual recordings.
+
+### Heatmap Types
+
+**Click heatmaps:** Show the density of click events across the page. High-density areas indicate elements users interact with most. Low-density areas on interactive elements indicate elements users ignore. Use click heatmaps to validate that primary CTAs receive attention and to identify unexpected click targets.
+
+**Scroll heatmaps:** Show what percentage of sessions reached each vertical position on the page. The fold line (where most users stop scrolling) is visible as a sharp drop in the gradient. Use scroll heatmaps to determine how much of a page users actually see and to decide where to place critical content.
+
+**Area heatmaps (move maps):** Show where users move their mouse cursor. Mouse movement correlates loosely with visual attention — users tend to move the cursor toward content they are reading. Use area heatmaps as a proxy for attention when eye-tracking data is unavailable.
+
+### Technical Internals
+
+Understanding how heatmaps work prevents misinterpretation of the data.
+
+1. **DOM snapshot:** When the heatmap script loads, it captures a snapshot of the page's DOM structure and computed styles. This snapshot is used to reconstruct the page for the overlay.
+
+2. **Event coordinate capture:** Click and mouse-move events are captured with their x/y coordinates relative to the viewport. Scroll depth is captured as a percentage of total page height.
+
+3. **Coordinate normalization:** Because users have different viewport widths, coordinates are normalized to a reference width (typically 1280px for desktop). This allows clicks from different screen sizes to be overlaid on the same page snapshot. Normalization is imperfect for highly responsive layouts where element positions shift significantly.
+
+4. **Density map overlay:** Captured coordinates are aggregated into a density grid. A Gaussian blur is applied to smooth the distribution. The result is rendered as a color gradient overlay (typically blue-green-yellow-red from low to high density) on top of the page snapshot.
+
+**Implication:** Heatmaps are most accurate for pages with stable layouts. Pages with significant A/B test variants, personalization, or dynamic content produce misleading heatmaps because the DOM snapshot may not match what individual users saw.
+
+### PostHog Heatmaps
+
+PostHog heatmaps are accessed via the Toolbar — a browser overlay activated from the PostHog dashboard.
+
+**Activation:** In PostHog, navigate to Toolbar and authorize your domain. Install the PostHog Toolbar browser extension or use the bookmarklet. Navigate to your site while the Toolbar is active to see the heatmap overlay.
+
+**Heatmap types available:** Clickmap (click density), Scrollmap (scroll depth), and Heatmap (combined). Switch between types using the Toolbar panel.
+
+**URL matching:** PostHog heatmaps support wildcard URL matching. Use `*` to match any path segment (e.g., `/product/*/reviews` matches all product review pages). This aggregates heatmap data across parameterized URLs into a single view.
+
+**Data source:** PostHog heatmaps use the same event stream as your other PostHog analytics. No additional instrumentation is required beyond the standard PostHog snippet.
+
+**Filtering:** Filter heatmap data by date range, device type, and person properties using the Toolbar panel. This allows comparison of click patterns between user segments.
+
+### Microsoft Clarity Heatmaps
+
+Clarity heatmaps are available for all recorded pages at no cost.
+
+**Heatmap types:** Click heatmaps, scroll heatmaps, and area (move) heatmaps. Access them from the Heatmaps tab in the Clarity dashboard.
+
+**Predictive heatmaps:** Clarity generates predictive heatmaps for pages with insufficient recorded data by using a machine learning model trained on similar pages. Predictive heatmaps are labeled clearly in the UI. Treat them as directional estimates, not measured data.
+
+**Device segmentation:** Clarity automatically segments heatmaps by device type (desktop, tablet, mobile). Always review each segment separately — click patterns and scroll depth differ significantly between device types. A CTA that receives heavy clicks on desktop may be below the fold on mobile.
+
+**Filtering:** Filter heatmaps by date range, browser, country, and custom segments defined in the Clarity dashboard.
+
+---
+
+## Mobile vs Desktop Analysis
+
+Always analyze mobile and desktop sessions separately. Combining them produces misleading averages that represent neither experience accurately.
+
+Key differences to account for:
+- Scroll depth is typically lower on mobile due to longer pages and smaller viewports.
+- Click targets that are easy to hit on desktop may be too small on mobile, producing rage clicks.
+- Navigation patterns differ: mobile users rely on back buttons and swipe gestures that desktop users do not use.
+- Conversion rates typically differ by 20-40% between mobile and desktop for e-commerce flows.
+
+In PostHog, use breakdown by `$device_type` on funnels and create separate recording filters for mobile sessions. In Clarity, use the device segmentation controls on heatmaps and filter recordings by device type.
+
+---
+
+## Privacy and Consent Requirements
+
+Different analytics features carry different consent obligations. Apply the minimum consent requirement for each feature you use.
+
+| Feature | Consent Required | Basis |
+|---|---|---|
+| Cookieless pageview analytics (Plausible, Fathom, Umami) | No | Legitimate interest / no personal data |
+| PostHog in cookieless mode (`persistence: "memory"`) | No | No persistent identifier |
+| PostHog with cookies (default) | Yes | Cookie sets persistent user ID |
+| GA4 (any configuration) | Yes | Cookies + cross-site tracking |
+| Session recordings (any tool) | Yes | Captures user behavior, potentially personal data |
+| Heatmaps (any tool) | Yes | Aggregated from individual session data |
+| Microsoft Clarity (any feature) | Yes | Cookies + session recording by default |
+
+**Recordings always require consent.** Even if a recording tool masks inputs, the act of capturing user behavior constitutes processing of personal data under GDPR. Gate recording initialization behind consent confirmation.
+
+**Heatmaps always require consent.** Heatmap data is derived from individual session recordings or click events tied to sessions. The aggregated output does not eliminate the consent requirement for the underlying data collection.
+
+**Cookieless tools do not require consent** in most EU jurisdictions when configured correctly. Verify that your specific tool configuration does not set cookies or create persistent identifiers before relying on this exemption. Consult your legal team for jurisdiction-specific guidance.
+
+For consent banner implementation and CMP integration, see `vanilla-cookieconsent.md`. For legal framework details, see `consent-architecture.md`.
+
+---
+
+## Data Retention
+
+Retention limits affect how far back you can query funnels and access recordings. Plan your analysis cadence around these limits.
+
+| Tool | Event Retention | Recording Retention | Notes |
+|---|---|---|---|
+| PostHog (free cloud) | 1 year | 1 year | Recordings count against monthly quota |
+| PostHog (paid cloud) | Configurable | Configurable | Up to 7 years on enterprise |
+| PostHog (self-hosted) | Unlimited | Disk-limited | You manage storage |
+| Microsoft Clarity | 13 months | 13 months | Fixed, cannot be extended |
+| GA4 (free) | 2 months (events) / 14 months (user-level) | Not available | User-level data expires at 14 months |
+| GA4 (360) | Up to 50 months | Not available | Requires paid 360 subscription |
+| Plausible | Unlimited | Not available | Aggregate data only, no recordings |
+
+**Practical implication:** If you need year-over-year funnel comparison, GA4's 14-month user retention is sufficient for annual cohort analysis. PostHog free tier's 1-year retention covers most product analytics needs. Clarity's 13-month retention covers annual seasonal analysis.
+
+---
+
+## Recommended Analytics Stacks
+
+Select a stack based on project stage and requirements. Avoid adding tools that duplicate capabilities you already have.
+
+### Early Stage (Pre-Product-Market Fit)
+
+**Stack:** PostHog free cloud + Microsoft Clarity free
+
+**Rationale:** PostHog provides event analytics, funnels, session recordings, and feature flags in a single free tier. Clarity adds unlimited recordings and heatmaps at no cost. Together they cover all behavioral analytics needs without budget. Both require consent infrastructure.
+
+**Consent requirement:** Both tools require a consent banner. Implement vanilla-cookieconsent with a single analytics category covering both tools.
+
+### Growth SaaS (Post-PMF, Marketing Site + Product)
+
+**Stack:** PostHog paid + Plausible (marketing site) + Clarity (supplemental heatmaps)
+
+**Rationale:** PostHog handles product analytics with higher event and recording quotas. Plausible provides cookieless marketing site analytics that do not require consent, reducing friction for new visitors. Clarity supplements PostHog recordings with free unlimited recordings and predictive heatmaps.
+
+**Consent requirement:** Plausible requires no consent. PostHog and Clarity require consent. Use a two-category consent setup: one for cookieless analytics (Plausible, always on) and one for behavioral analytics (PostHog + Clarity, opt-in).
+
+### E-Commerce
+
+**Stack:** GA4 + Microsoft Clarity + PostHog (exception tracking only)
+
+**Rationale:** GA4 provides the e-commerce event schema (purchase, add_to_cart, begin_checkout) that integrates with Google Ads and Merchant Center. Clarity provides heatmaps and recordings for UX investigation. PostHog exception tracking captures JavaScript errors in the checkout flow without requiring a full PostHog instrumentation.
+
+**Consent requirement:** All three tools require consent. Implement a consent banner with a single analytics category. Use GA4 consent mode v2 to send cookieless pings before consent is granted, preserving conversion modeling.
+
+### Privacy-First / EU-Focused
+
+**Stack:** Plausible or Fathom only
+
+**Rationale:** If your audience is primarily EU-based and your product does not require user-level behavioral analytics, a cookieless tool eliminates the consent banner entirely. This reduces page load friction and avoids the 20-40% consent rejection rate that degrades data quality in other stacks.
+
+**Consent requirement:** None, when configured correctly. Verify with legal counsel for your specific jurisdiction.

--- a/skills/web-analytics-consent/references/google-consent-mode.md
+++ b/skills/web-analytics-consent/references/google-consent-mode.md
@@ -1,0 +1,431 @@
+# Google Consent Mode v2
+
+Sources: Google Consent Mode documentation (developers.google.com/tag-platform/security/guides/consent), Google Tag Manager Help, Microsoft Clarity documentation (learn.microsoft.com/en-us/clarity), vanilla-cookieconsent GitHub (orestbida/cookieconsent)
+
+---
+
+## What Changed on March 7, 2024
+
+Google made Consent Mode v2 mandatory for all advertisers using Google Ads and GA4 in the European Economic Area. Sites that did not upgrade lost access to remarketing audiences, conversion modeling, and audience transfer features for EU traffic.
+
+The upgrade introduced two new consent signals on top of the original five:
+
+- `ad_user_data` — controls whether user data may be sent to Google for advertising purposes
+- `ad_personalization` — controls whether data may be used for personalized advertising (remarketing)
+
+The full set of seven signals is now:
+
+| Signal | Purpose | Typical default |
+|---|---|---|
+| `analytics_storage` | GA4 measurement cookies | denied |
+| `ad_storage` | Google Ads cookies | denied |
+| `ad_user_data` | Sending user data to Google Ads | denied |
+| `ad_personalization` | Personalized / remarketing ads | denied |
+| `functionality_storage` | Functional cookies (preferences) | denied |
+| `personalization_storage` | Personalization cookies | denied |
+| `security_storage` | Security and fraud-prevention cookies | granted |
+
+Set `security_storage` to `granted` by default because these cookies are strictly necessary and do not require consent under most frameworks.
+
+---
+
+## What Breaks Without v2 for EU Users
+
+Failing to implement Consent Mode v2 before the March 2024 deadline causes the following for EEA traffic:
+
+**Remarketing and audience lists** — Google Ads cannot build or use remarketing audiences from users who have not consented. Existing audience lists stop growing for EU users.
+
+**Audience transfer** — GA4 audiences cannot be transferred to Google Ads for targeting.
+
+**Conversion modeling** — Google's machine-learning gap-fill for unobserved conversions is disabled. You lose the statistical recovery of conversions from users who declined cookies.
+
+**Smart Bidding degradation** — Automated bidding strategies (Target CPA, Target ROAS) rely on modeled conversions. Without v2, Smart Bidding receives less signal and performance degrades.
+
+---
+
+## Basic Mode vs Advanced Mode
+
+Choose the mode based on how much data recovery matters and how much implementation complexity you can accept.
+
+### Basic Mode
+
+Tags fire only after the user grants consent. No data is collected before the consent decision. Implementation is simpler: set defaults to `denied`, update to `granted` on accept, and tags handle the rest.
+
+- No cookieless pings sent before consent
+- No conversion modeling for users who decline
+- Simpler to audit and explain to privacy teams
+- Appropriate when legal counsel requires zero data before consent
+
+### Advanced Mode
+
+Tags fire immediately in a cookieless state. Google collects behavioral signals without setting cookies, then uses modeling to reconstruct conversion data for users who declined. This recovers approximately 20-40% of conversions that would otherwise be invisible.
+
+- Cookieless pings fire on page load regardless of consent state
+- Google models conversions from aggregated, cookieless signals
+- Requires more careful implementation to avoid accidental data leakage
+- Appropriate when conversion volume is critical for bidding performance
+
+To enable Advanced Mode, load GTM or the GA4 snippet before the user sees the consent banner. The consent defaults you set tell Google tags to operate in cookieless mode until consent is updated.
+
+---
+
+## Setting Defaults Before Any Tag Fires
+
+The consent defaults must be set before GTM or any GA4/Ads script loads. Place this block in the `<head>` above all other scripts.
+
+```html
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { dataLayer.push(arguments); }
+
+  // Set defaults BEFORE GTM or GA4 loads
+  gtag('consent', 'default', {
+    analytics_storage:      'denied',
+    ad_storage:             'denied',
+    ad_user_data:           'denied',
+    ad_personalization:     'denied',
+    functionality_storage:  'denied',
+    personalization_storage:'denied',
+    security_storage:       'granted',
+    wait_for_update:        500
+  });
+</script>
+
+<!-- GTM snippet goes here, AFTER the consent defaults block -->
+<script>
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-XXXXXXX');
+</script>
+```
+
+The `wait_for_update` parameter (500 milliseconds) tells Google tags to pause before firing while waiting for a consent update. This prevents tags from firing in the denied state when the user has already consented in a previous session and the CMP is about to restore that consent automatically. Use 500ms as the default; increase to 1000ms only if your CMP takes longer to initialize.
+
+---
+
+## Updating Consent After User Decision
+
+Call `gtag('consent', 'update', {...})` inside your CMP callbacks. Pass only the signals that changed — omitted signals retain their current state.
+
+### Accept all
+
+```javascript
+gtag('consent', 'update', {
+  analytics_storage:       'granted',
+  ad_storage:              'granted',
+  ad_user_data:            'granted',
+  ad_personalization:      'granted',
+  functionality_storage:   'granted',
+  personalization_storage: 'granted'
+});
+```
+
+### Reject all (analytics only, no ads)
+
+```javascript
+gtag('consent', 'update', {
+  analytics_storage:       'denied',
+  ad_storage:              'denied',
+  ad_user_data:            'denied',
+  ad_personalization:      'denied',
+  functionality_storage:   'denied',
+  personalization_storage: 'denied'
+});
+```
+
+### Granular update (analytics accepted, ads declined)
+
+```javascript
+gtag('consent', 'update', {
+  analytics_storage:       'granted',
+  ad_storage:              'denied',
+  ad_user_data:            'denied',
+  ad_personalization:      'denied'
+});
+```
+
+---
+
+## Integration with vanilla-cookieconsent
+
+vanilla-cookieconsent exposes `onConsent` (fires on first decision or page load when a saved decision exists) and `onChange` (fires when the user changes a previous decision). Map category names to consent signals in both callbacks.
+
+```javascript
+import 'https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@3.0.1/dist/cookieconsent.umd.js';
+
+function updateGtagConsent(cookie) {
+  const categories = cookie.categories || [];
+
+  gtag('consent', 'update', {
+    analytics_storage:       categories.includes('analytics') ? 'granted' : 'denied',
+    ad_storage:              categories.includes('marketing') ? 'granted' : 'denied',
+    ad_user_data:            categories.includes('marketing') ? 'granted' : 'denied',
+    ad_personalization:      categories.includes('marketing') ? 'granted' : 'denied',
+    functionality_storage:   categories.includes('functional') ? 'granted' : 'denied',
+    personalization_storage: categories.includes('functional') ? 'granted' : 'denied'
+  });
+}
+
+CookieConsent.run({
+  // ... category and UI configuration in vanilla-cookieconsent.md ...
+
+  onConsent({ cookie }) {
+    updateGtagConsent(cookie);
+  },
+
+  onChange({ cookie }) {
+    updateGtagConsent(cookie);
+  }
+});
+```
+
+The `onConsent` callback fires on every page load when a saved preference exists, which restores consent state before `wait_for_update` expires. This is the mechanism that makes returning visitors bypass the banner while still updating gtag correctly.
+
+---
+
+## GA4 Configuration with Consent Mode
+
+When using gtag.js directly (without GTM), add the GA4 config call after the consent defaults block. GA4 automatically respects the consent state set by `gtag('consent', 'default', {...})`.
+
+```html
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { dataLayer.push(arguments); }
+
+  // Consent defaults first
+  gtag('consent', 'default', {
+    analytics_storage:      'denied',
+    ad_storage:             'denied',
+    ad_user_data:           'denied',
+    ad_personalization:     'denied',
+    functionality_storage:  'denied',
+    personalization_storage:'denied',
+    security_storage:       'granted',
+    wait_for_update:        500
+  });
+
+  gtag('js', new Date());
+  gtag('config', 'G-XXXXXXXXXX');
+</script>
+```
+
+GA4 will not set `_ga` or `_gid` cookies until `analytics_storage` is updated to `granted`. In Advanced Mode, GA4 sends cookieless pings immediately; in Basic Mode, it sends nothing until consent is granted.
+
+---
+
+## GTM Custom HTML Tag Approach
+
+When using GTM, load vanilla-cookieconsent via a Custom HTML tag that fires on All Pages with a trigger priority higher than your GA4 and Ads tags. Use the UMD build from jsDelivr so GTM can execute it without module bundling.
+
+### Custom HTML tag: CookieConsent Init
+
+Set this tag to fire on **All Pages**, with **Tag Sequencing** configured to fire before your GA4 Configuration tag.
+
+```html
+<script>
+(function() {
+  // Load vanilla-cookieconsent UMD build
+  var script = document.createElement('script');
+  script.src = 'https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@3.0.1/dist/cookieconsent.umd.js';
+  script.onload = function() {
+
+    function updateGtagConsent(cookie) {
+      var categories = cookie.categories || [];
+      gtag('consent', 'update', {
+        analytics_storage:       categories.indexOf('analytics') > -1 ? 'granted' : 'denied',
+        ad_storage:              categories.indexOf('marketing') > -1 ? 'granted' : 'denied',
+        ad_user_data:            categories.indexOf('marketing') > -1 ? 'granted' : 'denied',
+        ad_personalization:      categories.indexOf('marketing') > -1 ? 'granted' : 'denied',
+        functionality_storage:   categories.indexOf('functional') > -1 ? 'granted' : 'denied',
+        personalization_storage: categories.indexOf('functional') > -1 ? 'granted' : 'denied'
+      });
+    }
+
+    CookieConsent.run({
+      onConsent: function(evt) { updateGtagConsent(evt.cookie); },
+      onChange:  function(evt) { updateGtagConsent(evt.cookie); }
+      // Add category and UI config here
+    });
+  };
+  document.head.appendChild(script);
+})();
+</script>
+```
+
+### GTM tag consent settings
+
+In each GA4 Configuration tag and Google Ads Conversion Tracking tag, open **Advanced Settings > Consent Settings** and set:
+
+- GA4 Configuration: require `analytics_storage`
+- Google Ads Conversion: require `ad_storage` and `ad_user_data`
+- Remarketing tags: require `ad_storage`, `ad_user_data`, and `ad_personalization`
+
+GTM will not fire these tags until the required signals are granted, regardless of when the tag trigger fires.
+
+### Consent Mode in GTM container settings
+
+Enable Consent Overview in the GTM container settings (Admin > Container Settings > Enable consent overview). This provides a dashboard showing which tags require which consent signals and whether they are configured correctly.
+
+---
+
+## Certified vs Non-Certified CMPs
+
+Google maintains a list of Certified CMP Partners for Consent Mode v2. Certified CMPs (such as CookieYes, Cookiebot, OneTrust) integrate Consent Mode automatically and appear in the Google Ads CMP certification list.
+
+vanilla-cookieconsent is not a Google-certified CMP. It works correctly with manual configuration as shown in this document, but you must implement the `gtag('consent', 'update', {...})` calls yourself. The absence of certification does not affect technical functionality — it only affects whether Google Ads surfaces a certification badge in the account.
+
+---
+
+## Microsoft Clarity Consent API
+
+Microsoft Clarity introduced a mandatory consent API for users in the EEA, UK, and Switzerland. From October 31, 2025, Clarity requires explicit consent before setting cookies or collecting identifiable data for users in these regions.
+
+### API call
+
+```javascript
+window.clarity('consent', true);   // user has consented
+window.clarity('consent', false);  // user has declined or not yet decided
+```
+
+Call `window.clarity('consent', false)` before Clarity initializes, or immediately after, to put Clarity into cookieless mode. Call `window.clarity('consent', true)` after the user grants consent.
+
+### Behavior when consent is denied
+
+When consent is denied or not yet given, Clarity operates in cookieless mode:
+
+- No cookies are set (`_clck`, `_clsk` are not written)
+- Session recordings are disabled
+- Heatmaps are not collected
+- Aggregate page-level metrics may still be collected without identifying individual users
+
+### Behavior when consent is granted
+
+When consent is granted, Clarity operates normally:
+
+- Cookies are set for session continuity
+- Session recordings are captured
+- Heatmaps are generated
+- Full analytics features are available
+
+---
+
+## Clarity Consent Mode v2 Integration Pattern
+
+Integrate Clarity consent into the same CMP callbacks used for gtag. Call `window.clarity('consent', ...)` alongside the gtag update.
+
+### With vanilla-cookieconsent
+
+```javascript
+function updateAllConsent(cookie) {
+  var categories = cookie.categories || [];
+  var analyticsGranted = categories.includes('analytics');
+  var marketingGranted = categories.includes('marketing');
+
+  // Update Google Consent Mode
+  gtag('consent', 'update', {
+    analytics_storage:       analyticsGranted ? 'granted' : 'denied',
+    ad_storage:              marketingGranted ? 'granted' : 'denied',
+    ad_user_data:            marketingGranted ? 'granted' : 'denied',
+    ad_personalization:      marketingGranted ? 'granted' : 'denied',
+    functionality_storage:   categories.includes('functional') ? 'granted' : 'denied',
+    personalization_storage: categories.includes('functional') ? 'granted' : 'denied'
+  });
+
+  // Update Microsoft Clarity
+  if (typeof window.clarity === 'function') {
+    window.clarity('consent', analyticsGranted);
+  }
+}
+
+CookieConsent.run({
+  onConsent({ cookie }) { updateAllConsent(cookie); },
+  onChange({ cookie })  { updateAllConsent(cookie); }
+});
+```
+
+### Clarity initialization order
+
+Load the Clarity snippet in the `<head>` before the consent banner initializes. Clarity is designed to receive the consent signal after initialization — calling `window.clarity('consent', false)` after the snippet loads correctly switches it to cookieless mode.
+
+```html
+<!-- Clarity snippet (loads first) -->
+<script type="text/javascript">
+  (function(c,l,a,r,i,t,y){
+    c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+    t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+    y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+  })(window, document, "clarity", "script", "YOUR_CLARITY_ID");
+</script>
+
+<!-- Immediately deny consent for EEA/UK/CH until user decides -->
+<script>
+  window.clarity = window.clarity || function() {
+    (window.clarity.q = window.clarity.q || []).push(arguments);
+  };
+  window.clarity('consent', false);
+</script>
+```
+
+The queuing pattern (`window.clarity.q`) ensures the consent call is queued even if the Clarity script has not finished loading. Clarity processes the queue on initialization.
+
+---
+
+## Geo-Targeting Consent Defaults
+
+For sites with global traffic, apply `denied` defaults only to EEA, UK, and Switzerland users using the `region` parameter. Users outside these regions receive `granted` defaults and are not shown the consent banner.
+
+```javascript
+gtag('consent', 'default', {
+  analytics_storage:      'denied',
+  ad_storage:             'denied',
+  ad_user_data:           'denied',
+  ad_personalization:     'denied',
+  wait_for_update:        500,
+  region: ['AT','BE','BG','CY','CZ','DE','DK','EE','ES','FI','FR','GR',
+            'HR','HU','IE','IT','LT','LU','LV','MT','NL','PL','PT','RO',
+            'SE','SI','SK','IS','LI','NO','GB','CH']
+});
+
+// Fallback default for all other regions
+gtag('consent', 'default', {
+  analytics_storage:      'granted',
+  ad_storage:             'granted',
+  ad_user_data:           'granted',
+  ad_personalization:     'granted'
+});
+```
+
+Place the region-specific default first. Google processes defaults in order and the more specific region array takes precedence for matching users.
+
+---
+
+## Verification and Debugging
+
+### Google Tag Assistant
+
+Use Tag Assistant (tagassistant.google.com) to verify consent signals are firing correctly. The Consent tab shows the current state of all seven signals and whether tags are being held or fired.
+
+### GTM Preview mode
+
+In GTM Preview, the Consent tab in the tag details panel shows which consent signals a tag requires and whether they were granted at the time the tag fired.
+
+### Browser console
+
+Inspect the dataLayer to confirm consent events are being pushed:
+
+```javascript
+// In browser console
+dataLayer.filter(e => e[0] === 'consent');
+// Should show 'default' event on load and 'update' event after user decision
+```
+
+### Common mistakes
+
+- Placing the consent defaults block after the GTM snippet — tags fire before defaults are set
+- Omitting `ad_user_data` and `ad_personalization` — these are the v2-specific signals; omitting them means you are still on v1
+- Not calling `gtag('consent', 'update', {...})` in the `onConsent` callback — returning visitors who already consented will not have their consent restored
+- Setting `wait_for_update` too low (under 300ms) on slow connections — tags fire in denied state before the CMP restores saved consent
+- Forgetting to call `window.clarity('consent', true)` after the user accepts — Clarity remains in cookieless mode for the session even though the user consented

--- a/skills/web-analytics-consent/references/posthog-integration.md
+++ b/skills/web-analytics-consent/references/posthog-integration.md
@@ -1,0 +1,333 @@
+# PostHog Integration
+
+Sources: PostHog JS SDK (posthog-js), PostHog Node SDK (posthog-node), PostHog documentation (posthog.com/docs), Next.js documentation (nextjs.org/docs)
+
+---
+
+## Next.js Integration via instrumentation-client.ts
+
+The modern pattern for initializing PostHog in Next.js App Router projects uses `instrumentation-client.ts`. This file runs once on the client before any React component mounts, replacing the older `<PHProvider>` wrapper pattern.
+
+Enable the instrumentation hook in `next.config.js`:
+
+```js
+const nextConfig = {
+  experimental: { instrumentationHook: true },
+}
+module.exports = nextConfig
+```
+
+Create `instrumentation-client.ts` at the project root:
+
+```ts
+// instrumentation-client.ts
+import posthog from 'posthog-js'
+
+export function register() {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+    api_host: '/ingest',
+    ui_host: 'https://us.posthog.com',
+    capture_pageview: 'history_change',
+    capture_pageleave: true,
+    persistence: 'localStorage+cookie',
+  })
+}
+```
+
+After initialization, import and use `posthog` directly from `posthog-js` in any client component. React hooks from `posthog-js/react` (such as `useFeatureFlagEnabled`) work automatically without additional provider setup.
+
+---
+
+## posthog.init() Key Options
+
+| Option | Type | Default | Purpose |
+|--------|------|---------|---------|
+| `api_host` | string | `'https://us.posthog.com'` | Ingestion endpoint; set to `/ingest` with reverse proxy |
+| `ui_host` | string | — | PostHog UI host; required when `api_host` is a proxy path |
+| `persistence` | string | `'localStorage+cookie'` | Storage mode for identity and flags |
+| `capture_pageview` | boolean \| `'history_change'` | `true` | Use `'history_change'` for SPA routing |
+| `autocapture` | boolean | `true` | Capture clicks, inputs, form submissions automatically |
+| `disable_session_recording` | boolean | `false` | Prevent session recordings from starting |
+| `maskAllInputs` | boolean | `true` | Mask all input field values in recordings |
+| `maskTextSelector` | string | — | CSS selector for text nodes to mask |
+| `opt_out_capturing_by_default` | boolean | `false` | Start opted out; no data sent until `opt_in_capturing()` called |
+| `loaded` | function | — | Callback fired after initialization with the PostHog instance |
+
+---
+
+## Persistence Modes
+
+PostHog stores identity, feature flags, and session data locally. The `persistence` option controls where:
+
+**`'localStorage+cookie'`** (default) — Writes to both `localStorage` and a cookie. Most durable identity across sessions and subdomains. Requires consent under GDPR.
+
+**`'localStorage'`** — Writes only to `localStorage`. No cross-subdomain identity. Requires consent under GDPR.
+
+**`'cookie'`** — Writes only to a cookie. Enables cross-subdomain identity. Requires consent.
+
+**`'memory'`** — Stores state in JavaScript memory only. Lost on page reload. No data written to the user's device. The only mode that does not require prior consent under a strict GDPR interpretation.
+
+Use `'memory'` as the initial mode before consent is granted, then switch to a durable mode after the user accepts.
+
+---
+
+## Consent-Gated Initialization Pattern
+
+Initialize PostHog immediately in `'memory'` mode with capturing disabled, then upgrade persistence and enable capturing after the user grants consent. This avoids deferring initialization while ensuring no persistent data is written before consent.
+
+```ts
+// instrumentation-client.ts
+import posthog from 'posthog-js'
+
+export function register() {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+    api_host: '/ingest',
+    ui_host: 'https://us.posthog.com',
+    capture_pageview: false,
+    persistence: 'memory',
+    opt_out_capturing_by_default: true,
+    loaded: () => {
+      const hasConsent = localStorage.getItem('analytics_consent') === 'granted'
+      if (hasConsent) enableAnalytics()
+    },
+  })
+}
+
+export function enableAnalytics() {
+  posthog.set_config({ persistence: 'localStorage+cookie' })
+  posthog.opt_in_capturing()
+  posthog.capture('$pageview')
+}
+
+export function disableAnalytics() {
+  posthog.opt_out_capturing()
+  posthog.set_config({ persistence: 'memory' })
+  posthog.reset()
+}
+```
+
+---
+
+## opt_in_capturing() and opt_out_capturing()
+
+**`posthog.opt_in_capturing(options?)`** — Marks the user as opted in. Resumes event capture and session recording. Optional `options`:
+- `capture_event_name`: event to fire on opt-in (default: `'$opt_in'`)
+- `enable_persistence`: whether to re-enable persistence (default: `true`)
+
+**`posthog.opt_out_capturing()`** — Stops all event capture immediately. Clears queued events. Does not delete previously sent data from PostHog servers.
+
+**`posthog.has_opted_in_capturing()`** — Returns `true` if the user has explicitly opted in.
+
+**`posthog.has_opted_out_capturing()`** — Returns `true` if the user has explicitly opted out.
+
+**`posthog.clear_opt_in_out_capturing()`** — Removes the opt-in/opt-out flag. PostHog reverts to the default behavior defined by `opt_out_capturing_by_default`.
+
+**`posthog.reset()`** — Generates a new anonymous distinct ID and clears the identified user. Call this when consent is revoked to sever the link to the previous identity.
+
+---
+
+## Reverse Proxy for Ad-Blocker Bypass
+
+Ad blockers commonly block requests to `us.posthog.com`. Route PostHog traffic through your own domain using Next.js rewrites:
+
+```js
+// next.config.js
+async rewrites() {
+  return [
+    {
+      source: '/ingest/static/:path*',
+      destination: 'https://us-assets.posthog.com/static/:path*',
+    },
+    {
+      source: '/ingest/:path*',
+      destination: 'https://us.posthog.com/:path*',
+    },
+  ]
+},
+```
+
+Set `api_host: '/ingest'` and `ui_host: 'https://us.posthog.com'` in `posthog.init()`. The `/ingest/static/` rewrite serves the PostHog JS bundle from your domain, preventing the script tag itself from being blocked.
+
+For EU region, replace `us.posthog.com` with `eu.posthog.com` and `us-assets.posthog.com` with `eu-assets.posthog.com`.
+
+---
+
+## EU Region Setup
+
+PostHog operates a Frankfurt-based EU cloud for data residency compliance. Use the EU ingestion endpoint:
+
+```ts
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+  api_host: '/ingest',          // via reverse proxy pointing to eu.posthog.com
+  ui_host: 'https://eu.posthog.com',
+})
+```
+
+The EU cloud API key is distinct from the US cloud key. Create a separate project in the EU region.
+
+---
+
+## Privacy Masking Controls
+
+**`maskAllInputs`** (default: `true`) — Replaces all input field values with asterisks in recordings. Disable only after reviewing all inputs for sensitive data.
+
+**`maskTextSelector`** — CSS selector targeting text nodes to mask. Use `"*"` to mask all text content, leaving only structural layout visible in recordings.
+
+**`ph-no-capture` CSS class** — Add to any HTML element to exclude it and its children from recordings entirely. No configuration required:
+
+```html
+<div class="ph-no-capture">
+  <input type="text" placeholder="Sensitive field" />
+</div>
+```
+
+**`maskInputFn`** — Custom function to transform input values before capture. Receives the input element and returns the string to record:
+
+```ts
+posthog.init(key, {
+  session_recording: {
+    maskInputFn: (text, element) => {
+      if (element?.dataset.sensitive === 'true') return '*'.repeat(text.length)
+      return text
+    },
+  },
+})
+```
+
+**`maskTextFn`** — Custom function to transform text node content before capture. Useful for masking patterns like email addresses across all text nodes:
+
+```ts
+session_recording: {
+  maskTextFn: (text) =>
+    text.replace(/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, '[email]'),
+},
+```
+
+**Remote masking configuration** (since March 2025) — Configure masking rules from the PostHog dashboard without redeploying. Remote configuration overrides local `maskTextSelector` settings.
+
+---
+
+## Session Recording Controls
+
+**`disable_session_recording: true`** — Disable recordings at initialization. Enable selectively after consent with `posthog.startSessionRecording()`.
+
+**`sampleRate`** — Record only a fraction of sessions. Set between `0` (none) and `1` (all):
+
+```ts
+session_recording: { sampleRate: 0.2 } // Record 20% of sessions
+```
+
+**URL triggers** — Configure from the PostHog dashboard under Session Replay > Settings > URL Triggers. Recordings start when the user navigates to a matching URL and stop when they leave.
+
+**Exception triggers** — Configure recordings to start automatically when a JavaScript exception occurs. Useful for capturing error context without recording all sessions. Configure from the PostHog dashboard.
+
+**Minimum duration filter** — Discard sessions shorter than a configured threshold. Configure from the PostHog dashboard.
+
+---
+
+## Integration with vanilla-cookieconsent
+
+Connect PostHog opt-in/opt-out to vanilla-cookieconsent's `onConsent` and `onChange` callbacks:
+
+```ts
+// instrumentation-client.ts
+import posthog from 'posthog-js'
+import * as CookieConsent from 'vanilla-cookieconsent'
+
+export function register() {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+    api_host: '/ingest',
+    ui_host: 'https://us.posthog.com',
+    persistence: 'memory',
+    opt_out_capturing_by_default: true,
+    capture_pageview: false,
+  })
+
+  CookieConsent.run({
+    // ... cookieconsent configuration in vanilla-cookieconsent.md ...
+    onConsent: () => syncPostHogConsent(),
+    onChange: () => syncPostHogConsent(),
+  })
+}
+
+function syncPostHogConsent() {
+  if (CookieConsent.acceptedCategory('analytics')) {
+    posthog.set_config({ persistence: 'localStorage+cookie' })
+    posthog.opt_in_capturing()
+    posthog.capture('$pageview')
+  } else {
+    posthog.opt_out_capturing()
+    posthog.set_config({ persistence: 'memory' })
+    posthog.reset()
+  }
+}
+```
+
+Use `CookieConsent.acceptedCategory('analytics')` to check consent status rather than inspecting the cookie object directly. Both `onConsent` (first decision) and `onChange` (preference update) must call the same sync function.
+
+---
+
+## PostHog identify() and Consent Implications
+
+`posthog.identify(userId, properties?)` links the anonymous PostHog distinct ID to a known user identity. This constitutes processing of personal data under GDPR. Call `identify()` only after analytics consent is granted:
+
+```ts
+import posthog from 'posthog-js'
+
+export function onUserLogin(user: { id: string; email: string; plan: string }) {
+  if (posthog.has_opted_in_capturing()) {
+    posthog.identify(user.id, { email: user.email, plan: user.plan })
+  }
+}
+```
+
+When consent is revoked, call `posthog.reset()` to generate a new anonymous distinct ID and sever the link to the identified profile. `reset()` does not delete data already sent to PostHog servers.
+
+---
+
+## Server-Side Analytics with PostHog Node SDK
+
+Install the Node SDK separately:
+
+```bash
+npm install posthog-node
+```
+
+Create a singleton client to avoid multiple instantiations:
+
+```ts
+// lib/posthog-server.ts
+import { PostHog } from 'posthog-node'
+
+let client: PostHog | null = null
+
+export function getPostHogClient(): PostHog {
+  if (!client) {
+    client = new PostHog(process.env.POSTHOG_KEY!, {
+      host: 'https://us.posthog.com', // or 'https://eu.posthog.com'
+    })
+  }
+  return client
+}
+```
+
+Capture events from Server Actions or API routes. In serverless environments, call `flushAsync()` before the function returns:
+
+```ts
+// app/api/webhook/route.ts
+import { getPostHogClient } from '@/lib/posthog-server'
+import { NextResponse } from 'next/server'
+
+export async function POST(request: Request) {
+  const ph = getPostHogClient()
+  ph.capture({
+    distinctId: 'server',
+    event: 'webhook_received',
+    properties: { source: 'stripe' },
+  })
+  await ph.flushAsync() // Required in serverless; process may terminate before auto-flush
+  return NextResponse.json({ received: true })
+}
+```
+
+Use the same `distinctId` as client-side events to merge server and client activity into a single user timeline. Server-side events bypass ad blockers entirely because requests originate from your server infrastructure.

--- a/skills/web-analytics-consent/references/tool-selection.md
+++ b/skills/web-analytics-consent/references/tool-selection.md
@@ -1,0 +1,392 @@
+# Tool Selection and Pricing Guide
+
+Sources: PostHog documentation (posthog.com/docs), Plausible Analytics documentation (plausible.io/docs), Umami documentation (umami.is/docs), Google Analytics 4 documentation (support.google.com/analytics), Microsoft Clarity documentation (clarity.microsoft.com), Vercel Web Analytics documentation (vercel.com/docs/analytics), Fathom Analytics documentation (usefathom.com/docs), IAPP Privacy Tech Vendor Report 2024, Cookieless Tracking State of the Industry 2024.
+
+---
+
+## Overview
+
+Analytics tools divide into two categories: consent-required and consent-optional. The distinction determines your compliance architecture before you write a single line of code. Consent-required tools (GA4, Microsoft Clarity) set cookies or fingerprint users in ways that require explicit opt-in under GDPR and ePrivacy. Consent-optional tools (Plausible, Fathom, Umami, Vercel Web Analytics) use aggregated, cookieless measurement that regulators accept without a banner in most EU jurisdictions.
+
+PostHog occupies a middle position: it can operate in a cookieless mode but defaults to cookie-based identification, requiring consent in that configuration.
+
+Choose your tool before designing your consent flow. The tool determines whether you need a consent management platform at all.
+
+---
+
+## Tool Profiles
+
+### PostHog
+
+PostHog is a product analytics platform combining event tracking, session recording, feature flags, A/B testing, and a data warehouse in a single product. Use PostHog when you need behavioral analytics beyond pageviews: funnel analysis, cohort retention, feature adoption, and user-level event streams.
+
+**Free tier (cloud):**
+- 1,000,000 events per month
+- 5,000 session recordings per month
+- 1,000,000 feature flag requests per month
+- 100,000 exception events per month
+- 1,500 survey responses per month
+- 1,000,000 data warehouse rows per month
+- 1 project
+- 1-year data retention
+
+**Paid tier adds:**
+- 6 projects
+- 7-year data retention
+- SSO and advanced permissions
+- Priority support
+
+**Data residency:** US (Virginia) and EU (Frankfurt). Select region at organization creation; cannot migrate afterward.
+
+**Cookie usage:** Uses cookies by default for cross-session user identification. Supports `persistence: 'memory'` for session-only tracking without cookies, and `disable_persistence: true` for fully stateless operation. Cookieless mode loses cross-session user stitching.
+
+**Self-hosting:** Open-source (MIT for core). Self-hosted via Docker Compose or Kubernetes. Self-hosted removes data residency concerns but requires infrastructure management. PostHog does not provide support for self-hosted free tier.
+
+**Consent integration:** Requires consent banner when using default cookie persistence. Call `posthog.opt_out_capturing()` before initialization for users who decline. Supports `loaded` callback to delay initialization until consent is granted.
+
+---
+
+### Google Analytics 4
+
+GA4 is Google's current analytics platform, replacing Universal Analytics. Use GA4 when you need integration with Google Ads, Search Console, or BigQuery export, or when stakeholders require Google's reporting ecosystem.
+
+**Free tier:**
+- Unlimited properties (with limits per account)
+- 10,000,000 events per day per property
+- Data sampling applies above 500,000 sessions in standard reports
+- 14 months of data retention (default); configurable to 2 months or 14 months
+- BigQuery export free up to 1,000,000 events per day (then $0.05 per 1,000 events)
+
+**GA4 360 (paid):**
+- Starts at approximately $50,000/year
+- Unsampled reports
+- Extended data retention (up to 50 months)
+- Higher BigQuery export limits
+- SLA guarantees
+
+**Data residency:** Data processed on Google servers globally. EU data residency available only through GA4 360 with a Google Cloud region selection. Standard GA4 does not guarantee EU-only processing.
+
+**Cookie usage:** Sets `_ga` and `_ga_*` cookies for user and session identification. These are persistent cookies (2-year default expiry) requiring explicit consent under GDPR and ePrivacy Directive. Cannot operate without cookies in standard configuration.
+
+**Self-hosting:** Not available. GA4 is a Google-hosted SaaS product exclusively.
+
+**Consent integration:** Requires a consent management platform. Supports Consent Mode v2, which sends cookieless pings when consent is declined, allowing Google to model conversions. Without Consent Mode v2, Google Ads conversion modeling degrades significantly for EU traffic.
+
+---
+
+### Plausible Analytics
+
+Plausible is a lightweight, privacy-first analytics tool focused on pageviews, referrers, and basic event tracking. Use Plausible when you need simple traffic analytics without a consent banner and want a hosted solution with EU data residency.
+
+**Free tier:** None for hosted cloud. Plausible does not offer a free plan.
+
+**Paid cloud pricing:**
+- $9/month for up to 10,000 pageviews
+- $19/month for up to 100,000 pageviews
+- $49/month for up to 1,000,000 pageviews
+- $99/month for up to 10,000,000 pageviews
+- Annual billing provides two months free
+
+**Data residency:** EU only. Servers in Germany (Hetzner). No data transferred to US servers.
+
+**Cookie usage:** No cookies. No persistent identifiers. Uses a daily rotating hash of IP address, user agent, and site domain to deduplicate pageviews within a 24-hour window. This approach is accepted by most EU data protection authorities as not constituting personal data processing.
+
+**Self-hosting:** Open-source (AGPL). Self-hosted via Docker. Community-supported. Self-hosted version is fully featured but requires a server and maintenance.
+
+**Consent integration:** No consent banner required for standard pageview tracking in most EU jurisdictions. Adding custom events that track user behavior may require reassessment. Verify with your DPA if tracking logged-in users or combining Plausible data with other identifiers.
+
+---
+
+### Umami
+
+Umami is an open-source, self-hostable analytics platform with a focus on simplicity and privacy. Use Umami when you need a free, self-hosted alternative to Plausible with no cookies and full data ownership.
+
+**Free tier (Umami Cloud):**
+- 100,000 events per month
+- Unlimited websites
+- 90-day data retention
+
+**Paid cloud pricing:**
+- $9/month for 1,000,000 events
+- $19/month for 10,000,000 events
+
+**Data residency:** Self-hosted: your infrastructure, your choice. Umami Cloud: US-based (Vercel infrastructure). For EU data residency, self-host on EU infrastructure.
+
+**Cookie usage:** No cookies. No personal data stored. Uses a session-based approach that does not persist across browser sessions. Compliant with GDPR without a consent banner.
+
+**Self-hosting:** Open-source (MIT). Runs on Node.js with PostgreSQL or MySQL. Deploy on any VPS, Railway, Render, or Vercel. Self-hosted is free with no event limits beyond your infrastructure capacity.
+
+**Consent integration:** No consent banner required. Umami explicitly states it does not collect personal data. Suitable for privacy-first deployments where you want zero compliance overhead.
+
+---
+
+### Microsoft Clarity
+
+Microsoft Clarity is a free behavioral analytics tool providing session recordings, heatmaps, and rage-click detection. Use Clarity when you need qualitative UX insights (recordings, heatmaps) at no cost and are already using Microsoft or Azure products.
+
+**Free tier:** Completely free. No paid tiers. No event or recording limits advertised (subject to fair use).
+
+**Paid tier:** Does not exist. Clarity is entirely free.
+
+**Data residency:** Data stored on Microsoft Azure servers. US-based processing. No EU-only data residency option. Microsoft processes data under its standard privacy terms.
+
+**Cookie usage:** Sets cookies for session identification and recording. Requires consent banner under GDPR. Microsoft's own documentation recommends implementing a consent mechanism before loading Clarity.
+
+**Self-hosting:** Not available. Clarity is a Microsoft-hosted SaaS product.
+
+**Consent integration:** Requires explicit consent. Use `clarity("consent", false)` to initialize Clarity in a non-recording state and call `clarity("consent", true)` after the user accepts. Without this, Clarity records sessions before consent is obtained, which violates GDPR.
+
+---
+
+### Vercel Web Analytics
+
+Vercel Web Analytics is a privacy-compliant pageview analytics product built into the Vercel platform. Use Vercel Web Analytics when your project is deployed on Vercel and you need basic traffic analytics without a consent banner or additional tooling.
+
+**Free tier:** Included in all Vercel plans. No separate pricing for basic analytics.
+
+**Paid tier:** Advanced analytics (audience breakdown, custom events) available on Pro and Enterprise Vercel plans ($20/month and up for Pro).
+
+**Data residency:** Vercel infrastructure (AWS-based). Edge network globally distributed. No guaranteed EU-only processing for standard plans.
+
+**Cookie usage:** No cookies. Uses a hash-based approach similar to Plausible. Does not store IP addresses or personal identifiers. Privacy-compliant without a consent banner.
+
+**Self-hosting:** Not available as a standalone product. Tied to Vercel deployment infrastructure.
+
+**Consent integration:** No consent banner required for standard pageview tracking. Custom events that track user-specific behavior may require reassessment depending on what data is attached to those events.
+
+---
+
+### Fathom Analytics
+
+Fathom is a privacy-first analytics platform similar to Plausible, with a focus on simplicity, EU data residency, and GDPR compliance. Use Fathom when you want a hosted, cookieless analytics solution with EU data residency and are willing to pay a premium for a polished product.
+
+**Free tier:** None. Fathom does not offer a free plan.
+
+**Paid pricing:**
+- $15/month for up to 100,000 pageviews
+- $25/month for up to 200,000 pageviews
+- $50/month for up to 500,000 pageviews
+- $100/month for up to 1,000,000 pageviews
+- Annual billing provides two months free
+
+**Data residency:** EU data residency available. Fathom routes EU visitor data through EU infrastructure. US data processed on US infrastructure. Configurable per site.
+
+**Cookie usage:** No cookies. No personal data collected. Uses a similar daily-hash approach to Plausible. Accepted by EU regulators as not requiring a consent banner.
+
+**Self-hosting:** Not available. Fathom is a hosted-only product.
+
+**Consent integration:** No consent banner required. Fathom is designed to be deployed without a CMP. If you add custom event tracking that captures user-identifiable data, reassess.
+
+---
+
+## Comparison Tables
+
+### Feature Comparison
+
+| Tool | Free Tier | Cookies | Self-Host | EU Residency | Session Recording | Feature Flags |
+|------|-----------|---------|-----------|--------------|-------------------|---------------|
+| PostHog | Yes (1M events) | Optional | Yes | Yes (Frankfurt) | Yes (5K/mo free) | Yes |
+| GA4 | Yes (10M events/day) | Required | No | 360 only | No (native) | No |
+| Plausible | No | No | Yes (AGPL) | Yes (Germany) | No | No |
+| Umami | Yes (100K events) | No | Yes (MIT) | Self-host only | No | No |
+| Microsoft Clarity | Yes (unlimited) | Required | No | No | Yes (unlimited) | No |
+| Vercel Analytics | Yes (Vercel plans) | No | No | No | No | No |
+| Fathom | No | No | No | Yes | No | No |
+
+### Pricing at Scale
+
+| Tool | 100K pageviews/mo | 1M pageviews/mo | 10M pageviews/mo |
+|------|-------------------|-----------------|------------------|
+| PostHog | Free | Free | ~$450 (events vary) |
+| GA4 | Free | Free | Free (sampling applies) |
+| Plausible | $19/mo | $49/mo | $99/mo |
+| Umami Cloud | Free | $9/mo | $19/mo |
+| Microsoft Clarity | Free | Free | Free |
+| Vercel Analytics | Free (Vercel Pro) | Free (Vercel Pro) | Contact sales |
+| Fathom | $15/mo | $100/mo | Contact sales |
+
+### Consent Requirement
+
+| Tool | Consent Required | Cookieless Mode | GDPR Without Banner |
+|------|-----------------|-----------------|---------------------|
+| PostHog (default) | Yes | Partial (loses cross-session) | No |
+| PostHog (memory mode) | No | Yes | Yes |
+| GA4 | Yes | No | No |
+| Plausible | No | Yes (always) | Yes |
+| Umami | No | Yes (always) | Yes |
+| Microsoft Clarity | Yes | No | No |
+| Vercel Analytics | No | Yes (always) | Yes |
+| Fathom | No | Yes (always) | Yes |
+
+---
+
+## Decision Tree
+
+Start here and follow the branches to your tool recommendation.
+
+```
+Do you need session recordings or heatmaps?
+|
++-- Yes --> Do you have budget?
+|           |
+|           +-- Yes --> PostHog (recordings + full product analytics)
+|           |           Microsoft Clarity (free, recordings only, requires consent)
+|           |
+|           +-- No  --> Microsoft Clarity (free, requires consent banner)
+|                       PostHog free tier (5K recordings/mo)
+|
++-- No  --> Do you need feature flags or A/B testing?
+            |
+            +-- Yes --> PostHog (only tool combining analytics + flags)
+            |
+            +-- No  --> Do you need a consent-free deployment?
+                        |
+                        +-- Yes --> Are you on Vercel?
+                        |           |
+                        |           +-- Yes --> Vercel Web Analytics (zero setup)
+                        |           |
+                        |           +-- No  --> Do you have a budget?
+                        |                       |
+                        |                       +-- Yes --> Plausible or Fathom
+                        |                       |           (Fathom if EU residency critical)
+                        |                       |
+                        |                       +-- No  --> Umami self-hosted
+                        |                                   (free, MIT license)
+                        |
+                        +-- No  --> Do you need Google Ads integration?
+                                    |
+                                    +-- Yes --> GA4 (required for Ads ecosystem)
+                                    |
+                                    +-- No  --> PostHog or GA4
+                                                (PostHog for product analytics,
+                                                 GA4 for marketing analytics)
+```
+
+---
+
+## Pricing Gotchas
+
+### PostHog Event Counting
+
+PostHog counts every distinct event call against your monthly quota. A single pageview with autocapture enabled can generate 5-15 events: `$pageview`, `$pageleave`, DOM click events, form interactions, and rage clicks. A site with 50,000 monthly visitors can consume 500,000-750,000 events before you add any custom tracking. Audit your autocapture configuration before assuming the free tier covers your traffic.
+
+Disable autocapture in production if you only need pageviews and explicit custom events:
+
+```javascript
+posthog.init('YOUR_KEY', {
+  autocapture: false,
+  capture_pageview: true
+})
+```
+
+Session recordings count separately from events. 5,000 recordings per month sounds generous but depletes quickly on high-traffic sites. Set `session_recording_sample_rate` to limit recording to a percentage of sessions.
+
+### GA4 Data Sampling
+
+GA4 applies data sampling in standard reports when a date range contains more than 500,000 sessions for a property. Sampled reports show estimated data, not actual counts. For high-traffic sites, this means your conversion rates, funnel drop-offs, and event counts are approximations. GA4 360 removes sampling but costs approximately $50,000/year. BigQuery export provides unsampled raw data but requires SQL knowledge and incurs BigQuery storage and query costs.
+
+### Plausible No Free Tier
+
+Plausible has no free hosted tier. The $9/month entry price is for 10,000 pageviews. Sites exceeding 10,000 pageviews move to the next tier automatically. If you need Plausible without cost, self-host it on a $5/month VPS. The self-hosted version is fully featured and has no pageview limits beyond your server capacity.
+
+### Fathom Pageview Definition
+
+Fathom counts pageviews, not sessions or users. A user visiting 10 pages in one session counts as 10 pageviews against your plan limit. Sites with high pages-per-session ratios (content sites, documentation, e-commerce) will hit plan limits faster than expected. Calculate your average pages-per-session before selecting a Fathom plan.
+
+### Microsoft Clarity and GDPR
+
+Clarity is free but requires a consent banner. Many teams deploy Clarity assuming "free = no compliance overhead." This is incorrect. Clarity sets cookies and records sessions, both of which require explicit consent under GDPR. Deploying Clarity without a consent mechanism exposes you to regulatory risk. The cost of a CMP (typically $10-50/month for small sites) must be factored into the "free" calculation.
+
+### PostHog EU Region Lock-In
+
+PostHog requires you to select your data region (US or EU) when creating your organization. You cannot migrate data between regions after creation. If you start on US and later need EU data residency for compliance, you must create a new organization and lose historical data. Select EU (Frankfurt) from the start if there is any possibility of EU compliance requirements.
+
+### GA4 Consent Mode Dependency
+
+GA4 Consent Mode v2 is now required for Google Ads conversion modeling in the EU. Without implementing Consent Mode v2 correctly, Google cannot model conversions for users who decline cookies, causing reported conversion rates to drop significantly (often 20-40% for EU traffic). Implementing Consent Mode v2 requires a certified CMP or custom implementation. This is an ongoing maintenance cost, not a one-time setup.
+
+### Umami Cloud Data Retention
+
+Umami Cloud's free tier retains data for only 90 days. If you need historical trend analysis beyond three months, you must upgrade to a paid plan or self-host. Self-hosted Umami retains data indefinitely (limited only by your database storage).
+
+---
+
+## Recommended Stacks
+
+### Early-Stage Startup (Pre-Product-Market Fit)
+
+**Primary:** PostHog free tier
+**Rationale:** The free tier covers 1M events/month, includes session recordings, feature flags, and A/B testing. A single tool replaces Mixpanel, Hotjar, and LaunchDarkly. Consent banner required if using default cookie persistence; use memory mode to avoid it at the cost of cross-session tracking.
+
+**Configuration:** Start with EU region. Enable autocapture selectively. Use feature flags for rollouts from day one.
+
+**Add if needed:** Vercel Web Analytics for marketing site traffic (if deployed on Vercel), keeping PostHog for product analytics.
+
+---
+
+### Growth-Stage SaaS (Post-PMF, Scaling)
+
+**Primary:** PostHog (paid) for product analytics and feature management
+**Secondary:** Plausible for marketing site traffic
+**Rationale:** PostHog paid tier provides multi-project support and extended retention for product analytics. Plausible handles marketing site traffic without a consent banner, keeping the marketing funnel clean. Avoid GA4 unless Google Ads integration is required.
+
+**Add if needed:** GA4 with Consent Mode v2 if running Google Ads campaigns. Keep PostHog as the source of truth for product metrics.
+
+---
+
+### E-Commerce
+
+**Primary:** GA4 with Consent Mode v2
+**Secondary:** Microsoft Clarity for UX analysis
+**Rationale:** GA4 integrates natively with Google Ads, Google Merchant Center, and Google Shopping. E-commerce conversion tracking requires the Google ecosystem. Clarity provides free session recordings and heatmaps for checkout funnel optimization. Both require a consent banner; implement a CMP that supports Consent Mode v2.
+
+**Required:** A certified CMP (Cookiebot, OneTrust, Usercentrics) for Consent Mode v2 compliance.
+
+**Add if needed:** PostHog for product analytics if you have a logged-in user experience (accounts, wishlists, subscriptions).
+
+---
+
+### Privacy-First / EU-Focused
+
+**Primary:** Plausible (hosted) or Umami (self-hosted)
+**Secondary:** None required
+**Rationale:** No consent banner, no cookies, no personal data. Plausible provides a polished hosted experience with EU data residency. Umami self-hosted provides the same capabilities at infrastructure cost only. Neither tool provides session recordings or user-level analytics; this is a deliberate trade-off for compliance simplicity.
+
+**When to upgrade:** If you need session recordings, add PostHog in memory mode (cookieless) with a consent banner, or accept that recordings require consent infrastructure.
+
+---
+
+### Internal Tools / B2B SaaS
+
+**Primary:** PostHog (EU region)
+**Rationale:** Internal tools and B2B SaaS typically have authenticated users. PostHog's user identification, group analytics (company-level tracking), and feature flags are purpose-built for this use case. Consent requirements are simpler when users are employees or authenticated customers with a terms-of-service agreement.
+
+**Configuration:** Use `posthog.identify()` with your internal user ID. Use group analytics to track company-level feature adoption. Disable session recordings for sensitive internal tools.
+
+---
+
+## Tool Limitations Summary
+
+| Tool | Primary Limitation | Secondary Limitation |
+|------|-------------------|---------------------|
+| PostHog | Event counting depletes free tier fast | EU region must be selected at creation |
+| GA4 | Data sampling above 500K sessions | Requires Google ecosystem for full value |
+| Plausible | No free hosted tier | No user-level or session analytics |
+| Umami | Cloud has 90-day retention on free tier | No session recordings |
+| Microsoft Clarity | Requires consent banner | No EU data residency |
+| Vercel Analytics | Vercel-only deployment | Limited event customization |
+| Fathom | No free tier, higher cost than Plausible | No self-hosting option |
+
+---
+
+## Migration Considerations
+
+Switching analytics tools mid-project loses historical data unless you export it first. Plan your tool selection before launch when possible.
+
+**From GA4 to PostHog:** Export GA4 data to BigQuery before switching. PostHog's data warehouse can ingest BigQuery exports for historical analysis. Event schemas differ; map GA4 event names to PostHog equivalents during migration.
+
+**From PostHog to Plausible:** Plausible does not support event-level data import. You lose all historical behavioral data. Export PostHog data to your own storage before switching if retention matters.
+
+**From Universal Analytics to GA4:** UA data is no longer accessible in the GA4 interface. If you have UA historical data, it must have been exported to BigQuery before the UA sunset deadline (July 2024). New GA4 properties start with no historical data.
+
+**Self-hosted to cloud:** Umami and Plausible both support data export from self-hosted instances. Verify export format compatibility with the cloud version before migrating.

--- a/skills/web-analytics-consent/references/vanilla-cookieconsent.md
+++ b/skills/web-analytics-consent/references/vanilla-cookieconsent.md
@@ -1,0 +1,446 @@
+# vanilla-cookieconsent v3
+
+Sources: cookieconsent.orestbida.com, github.com/orestbida/cookieconsent, npm vanilla-cookieconsent v3.1.0
+
+vanilla-cookieconsent is a lightweight (~7KB gzipped), dependency-free consent management library. It handles consent UI, cookie storage, script gating, and programmatic consent queries. MIT license, ~115K weekly npm downloads, WCAG-compliant dialog, 40+ languages.
+
+---
+
+## Installation
+
+### npm
+
+```bash
+npm install vanilla-cookieconsent
+```
+
+```js
+import CookieConsent from 'vanilla-cookieconsent';
+import 'vanilla-cookieconsent/dist/cookieconsent.css';
+```
+
+### CDN
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vanilla-cookieconsent/dist/cookieconsent.css" />
+<script defer src="https://cdn.jsdelivr.net/npm/vanilla-cookieconsent/dist/cookieconsent.umd.js"></script>
+```
+
+CDN exposes `window.CookieConsent`. Call `CookieConsent.run(config)` once on page load.
+
+---
+
+## Categories
+
+Define categories under the `categories` key. Each maps to a named consent group referenced by scripts and callbacks.
+
+```js
+categories: {
+  necessary: {
+    enabled: true,   // pre-checked
+    readOnly: true,  // user cannot uncheck
+  },
+  analytics: {
+    enabled: false,  // opt-in by default
+    autoClear: {
+      cookies: [
+        { name: /^_ga/ },   // regex matches _ga, _ga_XXXXXXXX
+        { name: '_gid' },   // exact string match
+        { name: /^_gat/ },
+      ],
+      reloadPage: false,    // set true when script cannot stop without reload
+    },
+  },
+  marketing: {
+    enabled: false,
+    autoClear: {
+      cookies: [
+        { name: /^_fbp/ },
+        { name: /^_fbc/ },
+      ],
+      reloadPage: false,
+    },
+  },
+  functionality: {
+    enabled: false,  // chat widgets, embedded maps, preference storage
+  },
+},
+```
+
+`autoClear` deletes matching cookies when a category is rejected or withdrawn. String values match exact cookie names; RegExp values test against the name. The library deletes from the current domain and all parent domains.
+
+---
+
+## Script Gating
+
+### Declarative: data-cookiecategory
+
+Set `type="text/plain"` and `data-cookiecategory` on script tags. The library re-enables them after consent by cloning the element with `type="text/javascript"`.
+
+```html
+<!-- External script blocked until analytics consent -->
+<script
+  type="text/plain"
+  data-cookiecategory="analytics"
+  src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXX"
+  async
+></script>
+
+<!-- Inline script blocked until analytics consent -->
+<script type="text/plain" data-cookiecategory="analytics">
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){ dataLayer.push(arguments); }
+  gtag('js', new Date());
+  gtag('config', 'G-XXXXXXXX');
+</script>
+
+<!-- Marketing script -->
+<script
+  type="text/plain"
+  data-cookiecategory="marketing"
+  src="https://connect.facebook.net/en_US/fbevents.js"
+></script>
+```
+
+### Programmatic: onConsent / onChange
+
+Use callbacks for SPA analytics clients or when you need to call disable methods on rejection.
+
+```js
+onConsent: () => {
+  // Fires on every page load when valid consent exists,
+  // and immediately after first consent.
+  if (CookieConsent.acceptedCategory('analytics')) initAnalytics();
+  if (CookieConsent.acceptedCategory('marketing')) initAds();
+},
+
+onChange: ({ changedCategories, changedServices }) => {
+  // Fires when the user updates preferences after initial consent.
+  if (changedCategories.includes('analytics')) {
+    CookieConsent.acceptedCategory('analytics')
+      ? initAnalytics()
+      : disableAnalytics();
+  }
+},
+
+onFirstConsent: ({ cookie }) => {
+  // Fires once, the very first time the user makes a choice.
+},
+```
+
+`changedCategories`: array of category names whose state changed.
+`changedServices`: object mapping category names to arrays of changed service names.
+
+---
+
+## Services
+
+Services add sub-category granularity. A user can accept `analytics` but reject a specific service within it.
+
+```js
+analytics: {
+  enabled: false,
+  services: {
+    ga: {
+      label: 'Google Analytics',
+      onAccept: () => { initGoogleAnalytics(); },
+      onReject: () => { disableGoogleAnalytics(); },
+      cookies: [{ name: /^_ga/ }, { name: '_gid' }],
+    },
+    hotjar: {
+      label: 'Hotjar',
+      onAccept: () => { initHotjar(); },
+      onReject: () => { disableHotjar(); },
+      cookies: [{ name: /^_hj/ }],
+    },
+  },
+},
+```
+
+Link the preferences modal section to the category via `linkedCategory: 'analytics'`; services render as individual toggles automatically. Add `cookieTable: { headers: { name, domain, desc }, body: [{ name, domain, desc }] }` to the section for a disclosure table.
+
+Query service acceptance: `CookieConsent.acceptedService('ga', 'analytics')` returns `true | false`.
+
+---
+
+## Revision System
+
+Increment `revision` to invalidate all existing consents and force re-consent. Use when cookie usage changes materially.
+
+```js
+CookieConsent.run({
+  revision: 2,
+  language: {
+    translations: {
+      en: {
+        consentModal: {
+          description: 'We updated our cookie policy. {{revisionMessage}}',
+          revisionMessage: 'Our cookie usage has changed since your last visit.',
+        },
+      },
+    },
+  },
+});
+```
+
+When the stored revision does not match the configured revision, the library invalidates the existing consent and shows the modal again. `{{revisionMessage}}` renders as an empty string when the revision has not changed.
+
+---
+
+## Dark Mode
+
+Add `cc--darkmode` to the `<html>` element to activate the dark theme.
+
+```js
+// Sync with system preference
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+document.documentElement.classList.toggle('cc--darkmode', prefersDark);
+```
+
+Override CSS variables for both modes:
+
+```css
+:root {
+  --cc-bg: #ffffff;
+  --cc-primary-color: #1a73e8;
+  --cc-btn-primary-bg: #1a73e8;
+  --cc-btn-primary-color: #ffffff;
+  --cc-btn-secondary-bg: #f1f3f4;
+  --cc-btn-secondary-color: #3c4043;
+}
+
+.cc--darkmode {
+  --cc-bg: #1e1e1e;
+  --cc-primary-color: #8ab4f8;
+  --cc-btn-primary-bg: #8ab4f8;
+  --cc-btn-primary-color: #202124;
+  --cc-btn-secondary-bg: #3c4043;
+  --cc-btn-secondary-color: #e8eaed;
+}
+```
+
+---
+
+## Internationalization (i18n)
+
+### Inline Translations
+
+```js
+language: {
+  default: 'en',
+  autoDetect: 'browser',  // or 'document' to read <html lang="">
+  translations: {
+    en: {
+      consentModal: {
+        title: 'Cookie consent',
+        description: 'We use cookies to improve your experience.',
+        acceptAllBtn: 'Accept all',
+        acceptNecessaryBtn: 'Reject all',
+        showPreferencesBtn: 'Manage preferences',
+        footer: '<a href="/privacy">Privacy Policy</a>',
+      },
+      preferencesModal: {
+        title: 'Cookie preferences',
+        acceptAllBtn: 'Accept all',
+        acceptNecessaryBtn: 'Reject all',
+        savePreferencesBtn: 'Save preferences',
+        closeIconLabel: 'Close',
+        sections: [/* linkedCategory sections */],
+      },
+    },
+  },
+},
+```
+
+### External JSON Translations
+
+Point each locale key to a URL; the library fetches on demand. The JSON file mirrors the inline translation object structure.
+
+```js
+translations: {
+  en: '/locales/cookieconsent/en.json',
+  de: '/locales/cookieconsent/de.json',
+},
+```
+
+Switch language at runtime: `CookieConsent.setLanguage('de')`.
+
+---
+
+## GUI Options
+
+```js
+guiOptions: {
+  consentModal: {
+    layout: 'box',            // 'box' | 'cloud' | 'bar'
+    position: 'bottom right', // 'bottom left|center|right', 'top left|center|right', 'middle left|center|right'
+    equalWeightButtons: true, // accept and reject buttons same width
+    flipButtons: false,       // swap button order
+  },
+  preferencesModal: {
+    layout: 'box',            // 'box' | 'bar'
+    position: 'right',        // 'left' | 'right' (bar layout only)
+    equalWeightButtons: true,
+    flipButtons: false,
+  },
+},
+```
+
+Layout guidance: `box` is a compact floating card (default); `cloud` is a wider centered card; `bar` is a full-width banner at top or bottom.
+
+---
+
+## Programmatic API
+
+All methods are on the `CookieConsent` import or `window.CookieConsent` (CDN).
+
+### Modal Control
+
+```js
+CookieConsent.show();             // Show consent modal
+CookieConsent.show(true);         // Force show even if consent exists
+CookieConsent.hide();             // Hide consent modal
+CookieConsent.showPreferences();  // Open preferences modal
+CookieConsent.hidePreferences();  // Close preferences modal
+```
+
+### Consent Actions
+
+```js
+CookieConsent.acceptAll();                             // Accept all categories
+CookieConsent.acceptCategory('analytics');             // Accept one category
+CookieConsent.acceptCategory(['analytics', 'marketing']); // Accept multiple
+CookieConsent.acceptCategory([]);                      // Accept none (necessary only)
+CookieConsent.reset(true);                             // Clear consent cookie and reload
+```
+
+### Consent Queries
+
+```js
+CookieConsent.validConsent();                    // true | false — valid, non-expired, current revision
+CookieConsent.acceptedCategory('analytics');     // true | false
+CookieConsent.acceptedService('ga', 'analytics'); // true | false
+
+const prefs = CookieConsent.getUserPreferences();
+// { acceptType: 'all'|'necessary'|'custom', acceptedCategories: [], rejectedCategories: [] }
+
+const cookie = CookieConsent.getCookie();        // full parsed cc_cookie object
+const id     = CookieConsent.getCookie('consentId'); // specific field
+```
+
+### Callbacks Reference
+
+| Callback | Fires | Arguments |
+|---|---|---|
+| `onFirstConsent` | Once, after first-ever consent | `{ cookie }` |
+| `onConsent` | Every page load with valid consent; after first consent | `{ cookie }` |
+| `onChange` | When user updates preferences | `{ cookie, changedCategories, changedServices }` |
+| `onModalReady` | Modal DOM ready, before shown | `{ modalName }` |
+| `onModalShow` | Modal becomes visible | `{ modalName }` |
+| `onModalHide` | Modal hidden | `{ modalName }` |
+
+`modalName` is `'consentModal'` or `'preferencesModal'`.
+
+---
+
+## Storage Mechanism
+
+Consent is stored in a first-party cookie named `cc_cookie` (configurable). The value is a JSON string:
+
+```json
+{
+  "consentId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "consentTimestamp": "2024-01-15T10:30:00.000Z",
+  "lastConsentTimestamp": "2024-01-20T14:22:00.000Z",
+  "revision": 2,
+  "categories": ["necessary", "analytics"],
+  "services": { "analytics": ["ga"] }
+}
+```
+
+Fields: `consentId` (UUID, stable), `consentTimestamp` (first consent), `lastConsentTimestamp` (last update), `revision`, `categories` (accepted names), `services` (accepted names per category).
+
+Cookie attributes: `SameSite=Lax; Secure` on HTTPS. Default expiry: 182 days. Configure via `cookie: { name, expiresAfterDays, sameSite, useLocalStorage }`.
+
+---
+
+## Accessibility
+
+The consent modal renders as `role="dialog"` with `aria-modal="true"` and `aria-labelledby` pointing to the modal title. The preferences modal follows the same pattern.
+
+Built-in features (no configuration required):
+- Focus trap: Tab and Shift+Tab cycle within the open modal.
+- Focus restoration: Focus returns to the triggering element on close.
+- Keyboard: Escape closes the preferences modal; Enter and Space activate buttons.
+- Screen reader: Modal title announced on open via `aria-labelledby`.
+
+Open the preferences modal from a footer link without JavaScript:
+
+```html
+<a href="#" data-cc="show-preferencesModal">Cookie settings</a>
+```
+
+---
+
+## React and Next.js Integration
+
+Create a client component that calls `CookieConsent.run()` inside `useEffect` with an empty dependency array. This ensures the library initializes once in the browser and never on the server.
+
+```tsx
+// components/CookieConsentProvider.tsx
+'use client';
+
+import { useEffect } from 'react';
+import CookieConsent from 'vanilla-cookieconsent';
+import 'vanilla-cookieconsent/dist/cookieconsent.css';
+
+export default function CookieConsentProvider() {
+  useEffect(() => {
+    CookieConsent.run({
+      categories: {
+        necessary: { enabled: true, readOnly: true },
+        analytics: { enabled: false },
+        marketing: { enabled: false },
+      },
+      onConsent: () => {
+        if (CookieConsent.acceptedCategory('analytics')) initAnalytics();
+      },
+      onChange: ({ changedCategories }) => {
+        if (changedCategories.includes('analytics')) {
+          CookieConsent.acceptedCategory('analytics')
+            ? initAnalytics()
+            : disableAnalytics();
+        }
+      },
+      language: {
+        default: 'en',
+        translations: { en: '/locales/cookieconsent/en.json' },
+      },
+    });
+  }, []);
+
+  return null;
+}
+```
+
+Mount `<CookieConsentProvider />` in the root layout (`app/layout.tsx`). Read consent in any client component: `CookieConsent.acceptedCategory('analytics')` is safe to call after `run()` has executed. If consent is not yet given, call `CookieConsent.showPreferences()`.
+
+---
+
+## Config Shape Summary
+
+Top-level keys accepted by `CookieConsent.run()`:
+
+| Key | Type | Purpose |
+|---|---|---|
+| `revision` | number | Increment to force re-consent |
+| `cookie` | object | `name`, `expiresAfterDays`, `sameSite`, `useLocalStorage` |
+| `guiOptions` | object | `consentModal` and `preferencesModal` layout/position |
+| `categories` | object | Category definitions with `enabled`, `readOnly`, `autoClear`, `services` |
+| `language` | object | `default`, `autoDetect`, `translations` (inline or URL) |
+| `onFirstConsent` | function | `({ cookie })` — fires once on first-ever consent |
+| `onConsent` | function | `({ cookie })` — fires on every page load with valid consent |
+| `onChange` | function | `({ cookie, changedCategories, changedServices })` — fires on preference update |
+| `onModalReady` | function | `({ modalName })` — fires when modal DOM is ready |
+| `onModalShow` | function | `({ modalName })` — fires when modal becomes visible |
+| `onModalHide` | function | `({ modalName })` — fires when modal is hidden |

--- a/skills/web-analytics-consent/skills.json
+++ b/skills/web-analytics-consent/skills.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/web-analytics-consent",
+  "version": "0.0.1",
+  "description": "Privacy-compliant web analytics and cookie consent implementation. Covers tool selection (PostHog, GA4, Plausible, Umami, Clarity), cookie consent banners (vanilla-cookieconsent v3, GDPR/CCPA compliance), consent-gated script loading, Google Consent Mode v2, funnel analysis, session recordings, heatmaps, Next.js integration patterns, and opt-in/opt-out architecture with free-tier pricing comparison. Triggers: analytics, cookie consent, GDPR, cookie banner, PostHog, Google Analytics, GA4, Plausible, Umami, Microsoft Clarity, session recording, heatmap, consent mode, privacy compliance, CCPA, cookieconsent, funnel analysis, event tracking, opt-in, opt-out.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

- Adds new `@tank/web-analytics-consent` skill (v0.0.1)
- Covers tool selection (PostHog, GA4, Plausible, Umami, Clarity), cookie consent banners (vanilla-cookieconsent v3), GDPR/CCPA compliance, consent-gated script loading, Google Consent Mode v2, funnel analysis, session recordings, heatmaps, and Next.js integration patterns

## Files

- `SKILL.md` (188 lines) — Main skill file with workflow, trigger phrases, and file index
- `skills.json` — Package manifest with permissions
- 6 reference files (287–446 lines each):
  - `tool-selection.md` — Analytics tool comparison and pricing
  - `consent-architecture.md` — GDPR/CCPA legal framework and consent patterns
  - `vanilla-cookieconsent.md` — Cookie consent banner setup
  - `posthog-integration.md` — PostHog with Next.js and consent gating
  - `google-consent-mode.md` — Consent Mode v2, GA4, GTM, Clarity
  - `funnels-sessions-heatmaps.md` — Event taxonomy, funnels, recordings, heatmaps