### PR TITLE
feat(web-analytics-consent): expand to 9 references for v0.0.2

### DIFF
--- a/skills/web-analytics-consent/SKILL.md
+++ b/skills/web-analytics-consent/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: "@tank/web-analytics-consent"
-description: "Privacy-compliant web analytics and cookie consent implementation. Covers
-tool selection (PostHog, GA4, Plausible, Umami, Clarity), cookie consent banners
-(vanilla-cookieconsent v3, GDPR/CCPA compliance), consent-gated script loading,
-Google Consent Mode v2, funnel analysis, session recordings, heatmaps, Next.js
-integration patterns, and opt-in/opt-out architecture with free-tier pricing
-comparison.\n\nTrigger phrases: \"analytics\", \"cookie consent\", \"GDPR\",
-\"cookie banner\", \"PostHog\", \"Google Analytics\", \"GA4\", \"Plausible\",
-\"Umami\", \"Microsoft Clarity\", \"session recording\", \"heatmap\",
-\"consent mode\", \"privacy compliance\", \"CCPA\", \"cookieconsent\",
-\"funnel analysis\", \"event tracking\", \"opt-in\", \"opt-out\""
+description: "Privacy-compliant web analytics and cookie consent. Covers tool selection
+(PostHog, GA4, Plausible, Umami, Clarity), cookie consent (vanilla-cookieconsent
+v3, GDPR/CCPA), Google Consent Mode v2, funnels, session recordings, heatmaps,
+tracking plans, server-side tracking, ad blocker resilience, A/B testing,
+feature flags, and Next.js integration.\n\nTrigger phrases: \"analytics\",
+\"cookie consent\", \"GDPR\", \"PostHog\", \"GA4\", \"Plausible\", \"Umami\",
+\"Clarity\", \"session recording\", \"heatmap\", \"consent mode\", \"CCPA\",
+\"cookieconsent\", \"funnel\", \"event tracking\", \"opt-in\", \"opt-out\",
+\"tracking plan\", \"server-side tracking\", \"ad blocker\", \"A/B testing\",
+\"feature flags\", \"reverse proxy analytics\""
 triggers:
 - analytics
 - cookie consent
@@ -34,6 +34,11 @@ triggers:
 - vanilla-cookieconsent
 - consent-gated
 - ePrivacy
+- tracking plan
+- server-side tracking
+- reverse proxy analytics
+- A/B testing
+- feature flags
 ---
 
 # Core Philosophy
@@ -84,6 +89,9 @@ Does the tool set cookies or access device storage?
 4. **If using Google products**: Implement Consent Mode v2. See `references/google-consent-mode.md`.
 5. **Integrate analytics tool**: PostHog with consent gating. See `references/posthog-integration.md`.
 6. **Set up advanced features**: Funnels, session recordings, heatmaps. See `references/funnels-sessions-heatmaps.md`.
+7. **Design tracking plan**: Event taxonomy, TypeScript typed wrappers, governance. See `references/tracking-plan.md`.
+8. **Add server-side tracking**: Reverse proxy, Node SDK, hybrid architecture. See `references/server-side-tracking.md`.
+9. **Run experiments**: Feature flags, A/B tests, statistical rigor. See `references/ab-testing-feature-flags.md`.
 
 # Common Patterns
 
@@ -186,3 +194,6 @@ export function CookieBanner() {
 - `references/posthog-integration.md` — PostHog with Next.js and consent gating
 - `references/google-consent-mode.md` — Consent Mode v2, GA4, GTM, and Clarity
 - `references/funnels-sessions-heatmaps.md` — Event taxonomy, funnels, recordings, and heatmaps
+- `references/tracking-plan.md` — Tracking plan design, typed events, governance, and identity resolution
+- `references/server-side-tracking.md` — Server-side tracking, reverse proxy, ad blocker resilience
+- `references/ab-testing-feature-flags.md` — A/B testing, feature flags, experiments, and statistical rigor

--- a/skills/web-analytics-consent/references/ab-testing-feature-flags.md
+++ b/skills/web-analytics-consent/references/ab-testing-feature-flags.md
@@ -1,0 +1,438 @@
+# A/B Testing and Feature Flags
+
+Sources: PostHog documentation (posthog.com/docs/experiments), PostHog React SDK docs (posthog.com/docs/libraries/react), PostHog Node.js SDK docs (posthog.com/docs/libraries/node), Statsig documentation (docs.statsig.com), LaunchDarkly documentation (docs.launchdarkly.com), GrowthBook documentation (docs.growthbook.io), Kohavi et al. "Trustworthy Online Controlled Experiments" (2020), Fabijan et al. "The Evolution of Continuous Experimentation in Software Product Development" (2017).
+
+---
+
+## Feature Flag Fundamentals
+
+Feature flags decouple deployment from release. Ship code to production, control activation separately. This enables gradual rollouts, instant kill switches, and controlled experiments without redeployment.
+
+### Flag Types
+
+| Type | Use Case | Example Value | PostHog API |
+|------|----------|---------------|-------------|
+| Boolean | Simple on/off gating | `true` / `false` | `isFeatureEnabled('flag-key')` |
+| Multivariate | A/B/n experiments | `'control'` / `'test'` / `'test-2'` | `getFeatureFlag('flag-key')` |
+| Remote config | Dynamic configuration | `{ price: 29, label: 'Pro' }` | `getFeatureFlagPayload('flag-key')` |
+
+### Core Client API
+
+```typescript
+// Boolean check — returns true/false/undefined
+posthog.isFeatureEnabled('new-checkout')
+
+// Variant key — returns string variant name or boolean
+posthog.getFeatureFlag('pricing-experiment')
+// => 'control' | 'variant-a' | 'variant-b' | undefined
+
+// JSON payload — returns parsed object or undefined
+posthog.getFeatureFlagPayload('pricing-config')
+// => { monthlyPrice: 29, annualPrice: 249 } | undefined
+
+// React to flag changes (fires on load and on identity change)
+posthog.onFeatureFlags(() => {
+  const variant = posthog.getFeatureFlag('pricing-experiment')
+  // update UI state
+})
+```
+
+`undefined` means flags have not yet loaded. Always handle this state to prevent flicker — show a skeleton or defer rendering until flags resolve.
+
+### Percentage Rollouts
+
+Rollout percentage is hashed against the distinct ID, so the same user always gets the same variant. Increase rollout percentage incrementally: 5% → 20% → 50% → 100%. Never decrease percentage mid-experiment — this changes which users are included and corrupts data.
+
+### Targeting Rules
+
+Apply targeting before percentage rollout. Rules evaluate in order; first match wins.
+
+| Targeting Dimension | Example Condition | Notes |
+|--------------------|-------------------|-------|
+| User property | `plan = 'pro'` | Set via `posthog.identify()` |
+| Cohort | `cohort_id = 42` | Pre-built cohort in PostHog UI |
+| Geography | `country = 'US'` | Requires GeoIP enrichment |
+| Group | `organization.size > 50` | Requires group analytics |
+| Early access | `$feature_enrollment/flag` | Self-serve opt-in |
+
+---
+
+## PostHog Experiments
+
+Experiments in PostHog are feature flags with statistical analysis layered on top. Every experiment creates a backing feature flag automatically. Participants are assigned to variants when the flag is first evaluated; assignment is sticky.
+
+### Setup Flow
+
+1. Create experiment in PostHog UI — name, hypothesis, variants.
+2. Define primary metric (conversion event) and secondary metrics.
+3. Use the running time calculator — enter baseline conversion rate and minimum detectable effect (MDE). PostHog calculates required sample size per variant.
+4. Set a predetermined end date before launching. Do not extend based on results.
+5. Launch — PostHog begins assigning users and collecting data.
+6. Read results only after reaching significance or the end date.
+
+### Statistical Methods
+
+| Aspect | Bayesian (PostHog default) | Frequentist |
+|--------|---------------------------|-------------|
+| Output | Probability variant is best | p-value, confidence interval |
+| Interpretation | "87% chance test beats control" | "p < 0.05, reject null" |
+| Early stopping | Safer — credible intervals widen | Inflates false positive rate |
+| Sample size | Flexible | Fixed upfront |
+| Best for | Product experiments, fast iteration | Regulatory, clinical contexts |
+
+PostHog uses Bayesian statistics by default. The dashboard shows probability of being best and expected improvement with credible intervals.
+
+### When to Call an Experiment
+
+Call a winner or stop the experiment when ALL of the following are true:
+
+- Probability of being best exceeds 95% (or falls below 5% — declare loser).
+- Each variant has at least 100 conversions (not just exposures).
+- The predetermined duration has elapsed.
+- No significant external events (launches, holidays) contaminated the period.
+
+Do not call experiments early based on promising early results. The peeking problem (see Statistical Pitfalls) guarantees inflated false positive rates.
+
+---
+
+## React Integration
+
+### Pattern 1: Boolean Flag with useFeatureFlagEnabled
+
+```typescript
+// undefined = flags loading, false = disabled, true = enabled
+const isNewCheckout = useFeatureFlagEnabled('new-checkout-flow')
+if (isNewCheckout === undefined) return <CheckoutButtonSkeleton />
+if (!isNewCheckout) return <LegacyCheckoutButton />
+return <NewCheckoutButton />
+```
+
+### Pattern 2: Variant Key with useFeatureFlagVariantKey
+
+```typescript
+const variant = useFeatureFlagVariantKey('pricing-experiment')
+if (variant === undefined) return <PricingSkeleton />
+return (
+  <div>
+    {variant === 'control' && <OriginalPricing />}
+    {variant === 'annual-emphasis' && <AnnualFirstPricing />}
+    {variant === 'monthly-emphasis' && <MonthlyFirstPricing />}
+  </div>
+)
+```
+
+### Pattern 3: JSON Payload with useFeatureFlagPayload
+
+```typescript
+interface PricingConfig { monthlyPrice: number; annualPrice: number }
+const config = useFeatureFlagPayload('pricing-config') as PricingConfig | undefined
+if (!config) return <PricingCardSkeleton />
+return <div><span>${config.monthlyPrice}/mo</span><span>${config.annualPrice}/yr</span></div>
+```
+
+Use remote config payloads to change copy, prices, and layout without code deploys. Keep payloads under 10KB — they are loaded on every page.
+
+### Pattern 4: Declarative PostHogFeature Component
+
+```typescript
+// Boolean flag — match={true} shows children when flag is enabled
+<PostHogFeature flag="new-dashboard" match={true} fallback={<LegacyDashboard />}>
+  <NewDashboard />
+</PostHogFeature>
+
+// Multivariate — match on variant string
+<PostHogFeature flag="hero-experiment" match="variant-b" fallback={<OriginalHero />}>
+  <NewHero />
+</PostHogFeature>
+```
+
+`PostHogFeature` automatically captures a `$feature_view` event when the matched variant renders. Use `fallback` for the control experience.
+
+---
+
+## Next.js Patterns
+
+### Pattern 1: Server Component Flag Evaluation
+
+Evaluate flags server-side to avoid client-side loading states entirely. Requires `posthog-node`.
+
+```typescript
+// app/pricing/page.tsx
+import { PostHog } from 'posthog-node'
+import { cookies } from 'next/headers'
+
+async function PricingPage() {
+  const client = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!)
+  const distinctId = cookies().get('ph_distinct_id')?.value ?? 'anonymous'
+  const flags = await client.getAllFlags(distinctId)
+  await client.shutdown()
+
+  const variant = flags['pricing-experiment'] as string | undefined
+  return variant === 'variant-b' ? <NewPricing /> : <OriginalPricing />
+}
+```
+
+Cache the PostHog client instance across requests in production — do not instantiate per request.
+
+### Pattern 2: Bootstrapping Flags to Prevent Client Flicker
+
+Server evaluates flags, passes them to the client via bootstrap. Client uses bootstrapped values immediately without a network round-trip.
+
+```typescript
+// app/layout.tsx (Server Component)
+async function RootLayout({ children }: { children: React.ReactNode }) {
+  const client = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!)
+  const distinctId = getDistinctIdFromCookies()
+  const flags = await client.getAllFlags(distinctId)
+  await client.shutdown()
+
+  return (
+    <html><body>
+      <PHProvider bootstrap={{ distinctId, featureFlags: flags }}>
+        {children}
+      </PHProvider>
+    </body></html>
+  )
+}
+
+// In PHProvider (client component), pass to posthog.init:
+// bootstrap: { distinctId: props.bootstrap.distinctId, featureFlags: props.bootstrap.featureFlags }
+// See posthog-integration.md for full PHProvider setup.
+```
+
+Bootstrapping eliminates the loading flash. Flags are available synchronously on first render.
+
+### Pattern 3: Middleware-Based Flag Evaluation
+
+Rewrite entire pages at the edge based on flag values. Useful for full-page A/B tests.
+
+```typescript
+// middleware.ts
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { PostHog } from 'posthog-node'
+
+export async function middleware(request: NextRequest) {
+  const client = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!)
+  const distinctId = request.cookies.get('ph_distinct_id')?.value ?? 'anonymous'
+  const variant = await client.getFeatureFlag('landing-page-experiment', distinctId)
+  await client.shutdown()
+
+  if (variant === 'variant-b') {
+    return NextResponse.rewrite(new URL('/landing-b', request.url))
+  }
+  return NextResponse.next()
+}
+
+export const config = { matcher: ['/'] }
+```
+
+Middleware evaluation adds latency. Cache flag decisions in a cookie after first evaluation to avoid per-request PostHog calls.
+
+---
+
+## Common Experiment Types
+
+### UI Experiment — Button Copy
+
+```typescript
+const variant = useFeatureFlagVariantKey('cta-experiment')
+const label = variant === 'action-oriented' ? 'Start Free Trial' : 'Get Started'
+return <button onClick={handleCTA}>{label}</button>
+```
+
+Track `cta_clicked` with `{ variant }` property. Primary metric: click-through rate.
+
+### Pricing Experiment — Payload-Driven
+
+```typescript
+const config = useFeatureFlagPayload('pricing-test') as { price: number; label: string } | undefined
+// Render config.price and config.label — no code change needed for new variants
+```
+
+Payload-driven experiments let non-engineers create new variants. Primary metric: plan conversion rate.
+
+### Funnel Experiment — Onboarding Steps
+
+Gate entire onboarding flows behind a flag. Assign on first visit to `/onboarding`. Track `onboarding_completed` as primary metric, `onboarding_step_N_completed` as secondary metrics.
+
+### Feature Gating — Gradual Rollout with Kill Switch
+
+```typescript
+const isEnabled = useFeatureFlagEnabled('new-search-engine')
+// Roll out to 5% → 25% → 100% over two weeks
+// If error rate spikes, disable flag instantly — no deploy needed
+```
+
+---
+
+## Statistical Pitfalls
+
+### Peeking Problem
+
+Checking results before the predetermined end date and stopping when p < 0.05 inflates the false positive rate to 26% or higher (Kohavi et al.). Commit to a sample size and duration before launch. PostHog's Bayesian approach is more robust to early stopping but still requires discipline.
+
+### Sample Ratio Mismatch (SRM)
+
+SRM occurs when variant assignment ratios deviate significantly from the intended split (e.g., 60/40 instead of 50/50). Causes: redirect-based experiments losing users, bot traffic, caching serving one variant more. PostHog automatically detects SRM and flags affected experiments. Investigate before reading results.
+
+### Multiple Comparisons
+
+Testing 10 metrics at 95% confidence yields an expected 0.5 false positives by chance. Designate one primary metric before launch. Treat secondary metrics as directional signals, not decision criteria. Apply Bonferroni correction if you must test multiple primary metrics.
+
+### Novelty Effect
+
+Users interact with new UI differently simply because it is new. Novelty effects inflate early results for the test variant. Run experiments for at least two weeks to let novelty decay. Segment results by new vs. returning users to detect novelty contamination.
+
+### Survivorship Bias
+
+Analyzing only users who completed a funnel step ignores users who dropped off. If the test variant reduces drop-off, the surviving population differs between variants. Measure from the point of assignment, not from a downstream funnel step.
+
+---
+
+## Experimentation Culture
+
+### Hypothesis Format
+
+```
+We believe [changing X to Y]
+will [increase/decrease metric Z]
+because [causal mechanism or user insight].
+
+Success criteria: Z increases by at least [MDE]% with 95% confidence
+over [N] weeks with [N] users per variant.
+```
+
+Write the hypothesis before building. If you cannot articulate the causal mechanism, the experiment is not ready.
+
+### Experiment Documentation Template
+
+```markdown
+## Experiment: [Name]
+
+**Hypothesis:** We believe [X] will [Y] because [Z].
+**Primary metric:** [event name, conversion definition]
+**Secondary metrics:** [list]
+**Variants:** control (baseline), [variant names]
+**Rollout:** [%] of [segment]
+**Duration:** [start date] – [end date]
+**MDE:** [%] relative change
+**Required sample:** [N] per variant
+
+## Results
+**Winner:** [variant or no significant difference]
+**Primary metric:** [observed change, credible interval]
+**Decision:** [ship / revert / iterate]
+**Learnings:** [what we learned about users]
+```
+
+### Launch Checklist
+
+- [ ] Hypothesis written with causal mechanism
+- [ ] Primary metric defined and tracking verified
+- [ ] Sample size calculated with running time calculator
+- [ ] End date set and calendar reminder added
+- [ ] Variants reviewed by a second engineer
+- [ ] Flag key follows naming convention (`[team]-[description]-[type]`)
+- [ ] Rollout starts at 5% or less for risky changes
+- [ ] Kill switch tested — disabling flag reverts to control
+- [ ] Monitoring alert set for error rate spike
+- [ ] Experiment documented in team wiki
+
+### Kill Criteria
+
+| Signal | Threshold | Action |
+|--------|-----------|--------|
+| Error rate increase | > 2x baseline | Disable flag, investigate |
+| Revenue per user drop | > 5% in test variant | Disable flag, investigate |
+| Crash rate increase | Any statistically significant increase | Disable flag immediately |
+| SRM detected | PostHog flags it | Pause, investigate assignment |
+| P99 latency increase | > 200ms | Disable flag, optimize |
+
+---
+
+## Feature Flag Lifecycle
+
+### Temporary vs Permanent Flags
+
+| Type | Purpose | Lifespan | Example |
+|------|---------|----------|---------|
+| Experiment flag | A/B test, gradual rollout | Days to weeks | `checkout-redesign-exp` |
+| Release flag | Safe deployment, kill switch | Days to months | `new-search-engine` |
+| Entitlement flag | Feature gating by plan | Permanent | `advanced-analytics` |
+| Ops flag | Circuit breaker, maintenance | Permanent | `disable-email-sending` |
+
+### Flag Debt and Cleanup
+
+A flag is stale when: the experiment concluded more than 30 days ago, the feature shipped to 100% more than 60 days ago, or no code references the flag key.
+
+Cleanup process: search codebase for flag key, remove conditional branches, delete flag in PostHog, update tests. Assign flag ownership to the creating team. Review stale flags in quarterly tech debt sessions.
+
+Knight Capital lost $440M in 45 minutes in 2012 because a stale feature flag activated dead code in production — flag hygiene is a safety issue, not just housekeeping.
+
+---
+
+## Platform Comparison
+
+| Platform | Free Tier | Flags | Experiments | Self-Host |
+|----------|-----------|-------|-------------|-----------|
+| PostHog | 1M events/mo | Unlimited | Unlimited | Yes (open source) |
+| Statsig | 2M events/mo | Unlimited | Unlimited | No |
+| LaunchDarkly | No free tier | — | — | No |
+| GrowthBook | Free (self-host) | Unlimited | Unlimited | Yes (primary model) |
+| Unleash | Free (self-host) | Unlimited | Limited | Yes (primary model) |
+| Optimizely | No free tier | — | — | No |
+
+**PostHog** — analytics, session replay, and flags in one platform; best for early-stage products wanting unified data.
+**Statsig** — enterprise-grade experimentation with CUPED variance reduction; strong free tier for high-volume products.
+**LaunchDarkly** — enterprise compliance (SOC 2, HIPAA), audit logs, dedicated support; justified for regulated industries.
+**GrowthBook** — connects to existing data warehouse (BigQuery, Snowflake, Redshift); best for data-mature teams.
+**Unleash** — self-hosted flags with no vendor dependency; requires infrastructure to manage.
+
+---
+
+## Quick Reference Card
+
+### Client-Side API
+
+```typescript
+posthog.isFeatureEnabled('flag-key')           // boolean | undefined
+posthog.getFeatureFlag('flag-key')             // string | boolean | undefined
+posthog.getFeatureFlagPayload('flag-key')      // JsonType | undefined
+posthog.onFeatureFlags(callback)               // fires on load + identity change
+posthog.reloadFeatureFlags()                   // force refresh
+```
+
+### React Hooks
+
+```typescript
+useFeatureFlagEnabled('flag-key')              // boolean | undefined
+useFeatureFlagVariantKey('flag-key')           // string | boolean | undefined
+useFeatureFlagPayload('flag-key')              // JsonType | undefined
+```
+
+### React Component
+
+```typescript
+<PostHogFeature flag="flag-key" match="variant" fallback={<Control />}>
+  <Variant />
+</PostHogFeature>
+```
+
+### Server-Side API (posthog-node)
+
+```typescript
+const client = new PostHog(key)
+await client.isFeatureEnabled('flag-key', distinctId)
+await client.getFeatureFlag('flag-key', distinctId)
+await client.getAllFlags(distinctId)
+await client.shutdown()
+```
+
+### Bootstrapping Pattern
+
+```typescript
+// Server: const flags = await client.getAllFlags(distinctId)
+// Client init: posthog.init(key, { bootstrap: { distinctId, featureFlags: flags } })
+// Result: flags available synchronously, no loading flash
+```

--- a/skills/web-analytics-consent/references/server-side-tracking.md
+++ b/skills/web-analytics-consent/references/server-side-tracking.md
@@ -1,0 +1,389 @@
+# Server-Side Tracking and Ad Blocker Resilience
+
+Sources: PostHog documentation (posthog.com/docs), Google Analytics Measurement Protocol v2 docs, Plausible Analytics API docs, Vercel Edge Middleware docs, Cloudflare Workers documentation, Next.js rewrites documentation.
+
+---
+
+## The Ad Blocker Problem
+
+Roughly 30-40% of technical users block analytics. Developer-focused SaaS products can exceed 50%. This creates systematic data loss that skews funnels, attribution, and product decisions.
+
+| Analytics Tool | No Proxy | With Reverse Proxy | Notes |
+|---|---|---|---|
+| Google Analytics 4 | Very high (40-60%) | Medium (15-25%) | Brave blocks aggressively |
+| PostHog Cloud | High (30-45%) | Low (5-10%) | Proxy eliminates most extension blocking |
+| Plausible Cloud | Low (10-20%) | Very low (2-5%) | Not on most filter lists yet |
+| Umami self-hosted | Very low (2-8%) | Near zero | Custom domain, no known fingerprint |
+
+**Three blocking layers:**
+
+1. **DNS-level (Pi-hole, NextDNS)** — Blocks entire domains before any HTTP request. A reverse proxy on your own domain bypasses this completely.
+2. **Browser extensions (uBlock Origin, AdBlock Plus)** — Match URLs against filter lists. A proxy path on your own domain avoids these patterns until the path gets added to lists — which happens if you use obvious names.
+3. **Browser built-in (Brave Shields, Safari ITP)** — Brave blocks known tracker domains. Safari ITP caps JS-set cookies to 7 days. Server-set cookies are not affected.
+
+**Combined data loss:** A technical SaaS with no mitigation loses 35-55% of events. With a reverse proxy: 10-20%. With full server-side for critical events: 2-5%.
+
+---
+
+## Reverse Proxy Pattern
+
+Route analytics requests through your own domain so they are indistinguishable from your own API calls.
+
+**Critical naming rule:** Never use `/analytics`, `/posthog`, `/tracking`, `/stats`, or `/metrics` as proxy paths — these are on filter lists. Use opaque paths like `/ingest`, `/relay`, or `/api/ph`.
+
+### Next.js rewrites (next.config.js)
+
+```js
+const nextConfig = {
+  async rewrites() {
+    return [
+      // PostHog US region
+      {
+        source: '/ingest/static/:path*',
+        destination: 'https://us-assets.i.posthog.com/static/:path*',
+      },
+      {
+        source: '/ingest/:path*',
+        destination: 'https://us.i.posthog.com/:path*',
+      },
+      // EU region: swap destination to eu-assets.i.posthog.com / eu.i.posthog.com
+    ]
+  },
+  skipTrailingSlashRedirect: true, // required — prevents host header stripping
+}
+module.exports = nextConfig
+```
+
+PostHog client init pointing at the proxy:
+
+```ts
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+  api_host: '/ingest',
+  ui_host: 'https://us.posthog.com',
+})
+```
+
+### Nginx reverse proxy
+
+```nginx
+location /ingest/ {
+    proxy_pass https://us.i.posthog.com/;
+    proxy_ssl_server_name on;
+    proxy_set_header Host us.i.posthog.com;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    rewrite ^/ingest/(.*) /$1 break;
+}
+```
+
+### Cloudflare Workers proxy
+
+```ts
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url)
+    if (!url.pathname.startsWith('/ingest')) return new Response('Not found', { status: 404 })
+    const targetPath = url.pathname.replace('/ingest', '')
+    const proxied = new Request(`https://us.i.posthog.com${targetPath}${url.search}`, {
+      method: request.method,
+      headers: { ...Object.fromEntries(request.headers), host: 'us.i.posthog.com' },
+      body: request.body,
+    })
+    return fetch(proxied)
+  },
+}
+```
+
+### Vercel rewrites (vercel.json)
+
+```json
+{
+  "rewrites": [
+    { "source": "/ingest/static/:path*", "destination": "https://us-assets.i.posthog.com/static/:path*" },
+    { "source": "/ingest/:path*", "destination": "https://us.i.posthog.com/:path*" }
+  ]
+}
+```
+
+Vercel rewrites run at the CDN edge and cannot add server-side secrets. For tools requiring API keys in headers, use a Next.js API route instead.
+
+---
+
+## Server-Side SDKs
+
+Use server-side tracking when the event involves payments or subscriptions, the user may have JavaScript disabled, or the event originates from a backend process (webhook, cron, API call).
+
+### PostHog Node.js SDK
+
+**Singleton pattern** — create once, reuse across requests:
+
+```ts
+// lib/posthog-server.ts
+import { PostHog } from 'posthog-node'
+
+let client: PostHog | null = null
+
+export function getPostHogClient(): PostHog {
+  if (!client) {
+    client = new PostHog(process.env.POSTHOG_KEY!, {
+      host: 'https://us.i.posthog.com',
+      flushAt: 20,
+      flushInterval: 10000,
+    })
+  }
+  return client
+}
+```
+
+**Core operations:**
+
+```ts
+const ph = getPostHogClient()
+
+ph.capture({ distinctId: userId, event: 'payment_completed',
+  properties: { plan: 'pro', amount_cents: 2900, currency: 'usd' } })
+
+ph.identify({ distinctId: userId,
+  properties: { email: user.email, name: user.name } })
+
+ph.groupIdentify({ groupType: 'company', groupKey: orgId,
+  properties: { name: org.name, plan: org.plan } })
+
+const flagEnabled = await ph.isFeatureEnabled('new-dashboard', userId)
+```
+
+**Serverless shutdown** — flush before the function exits:
+
+```ts
+export async function POST(request: Request) {
+  const ph = getPostHogClient()
+  ph.capture({ distinctId: userId, event: 'api_called', properties: {} })
+  await ph.shutdown() // flush remaining events before cold function exits
+  return Response.json({ ok: true })
+}
+```
+
+### GA4 Measurement Protocol
+
+```ts
+export async function sendGA4Event(clientId: string, events: Array<{ name: string; params?: Record<string, unknown> }>) {
+  const url = new URL('https://www.google-analytics.com/mp/collect')
+  url.searchParams.set('api_secret', process.env.GA4_API_SECRET!)
+  url.searchParams.set('measurement_id', process.env.NEXT_PUBLIC_GA4_ID!)
+
+  await fetch(url.toString(), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ client_id: clientId, events: events.slice(0, 25) }),
+    // GA4 limits: 25 events/request, 25 params/event, param values max 100 chars
+  })
+}
+```
+
+Use `/debug/mp/collect` during development — it returns validation errors.
+
+### Plausible server-side
+
+```ts
+export async function trackPlausibleEvent(
+  request: Request, eventName: string, url: string, props?: Record<string, string>
+) {
+  await fetch('https://plausible.io/api/event', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'User-Agent': request.headers.get('user-agent') ?? '',
+      'X-Forwarded-For': request.headers.get('x-forwarded-for')?.split(',')[0].trim() ?? '',
+    },
+    body: JSON.stringify({ domain: process.env.PLAUSIBLE_DOMAIN!, name: eventName, url, props }),
+  })
+}
+```
+
+Pass the original `User-Agent` and `X-Forwarded-For` from the incoming request so Plausible can attribute geo and browser. Plausible hashes and discards the IP immediately.
+
+---
+
+## Hybrid Architecture
+
+```
+Browser                        Your Server                  Analytics Vendor
+  |                                 |                              |
+  |-- page view (PostHog JS) -----> | /ingest proxy ------------>  |
+  |-- button click (PostHog JS) --> | /ingest proxy ------------>  |
+  |-- session recording ----------> | /ingest proxy ------------>  |
+  |                                 |                              |
+  |-- POST /api/checkout ---------> |                              |
+  |                                 |-- ph.capture(payment) -----> |
+  |                                 |<-- Stripe webhook ---------- |
+  |                                 |-- ph.capture(renewal) -----> |
+```
+
+**Event routing decision table:**
+
+| Event Type | Client-side | Server-side | Reason |
+|---|---|---|---|
+| Page view, scroll depth | Yes | Optional | Browser has full URL and referrer |
+| UI click / interaction | Yes | No | Only meaningful in browser context |
+| Session recording | Yes | No | Requires DOM access |
+| Payment completed | No | Yes | Must not be blocked or lost |
+| Subscription created/cancelled | No | Yes | Stripe webhook is authoritative |
+| API usage / quota events | No | Yes | No browser involved |
+| Feature flag evaluated (SSR) | No | Yes | Flag evaluated before HTML sent |
+| Signup completed | Yes | Yes | Duplicate for reliability |
+
+---
+
+## First-Party Cookies
+
+Safari ITP caps JavaScript-set cookies to 7 days when the script domain differs from the page domain. Cookies set by your server via `Set-Cookie` response headers are treated as genuine first-party cookies and are not capped.
+
+| Approach | Safari ITP | XSS Protection | Ad Blocker Resilience | Persistence |
+|---|---|---|---|---|
+| JS-set (document.cookie) | 7-day cap | None | Blocked if script blocked | Up to 7 days (Safari) |
+| Server-set HttpOnly | Not capped | Full | Not affected | Up to 400 days |
+| localStorage | 7-day cap (Safari) | None | Cleared if script blocked | Indefinite |
+
+**Next.js middleware — persistent first-party session cookie:**
+
+```ts
+// middleware.ts
+import { NextRequest, NextResponse } from 'next/server'
+import { randomUUID } from 'crypto'
+
+const SESSION_COOKIE = '__ph_sid' // avoid 'analytics' or 'tracking' in the name
+const ONE_YEAR = 60 * 60 * 24 * 365
+
+export function middleware(request: NextRequest): NextResponse {
+  const response = NextResponse.next()
+  if (!request.cookies.has(SESSION_COOKIE)) {
+    response.cookies.set(SESSION_COOKIE, randomUUID(), {
+      httpOnly: true, sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: ONE_YEAR, path: '/',
+    })
+  }
+  return response
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+}
+```
+
+---
+
+## Edge and Middleware Tracking
+
+Track page views at the edge before the page renders. This captures visits even when JavaScript is disabled or blocked.
+
+**Vercel `after()` for non-blocking analytics (Next.js 15+):**
+
+```ts
+// app/api/checkout/route.ts
+import { after } from 'next/server'
+
+export async function POST(request: Request): Promise<Response> {
+  const result = await processCheckout(await request.json())
+
+  after(async () => {
+    const ph = getPostHogClient()
+    ph.capture({ distinctId: result.userId, event: 'checkout_completed',
+      properties: { plan: result.plan, amount: result.amount } })
+    await ph.shutdown()
+  })
+
+  return Response.json({ success: true, orderId: result.orderId })
+}
+```
+
+**Cloudflare Workers `waitUntil`:**
+
+```ts
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const response = await handleRequest(request, env)
+    ctx.waitUntil(trackEvent(env, { event: 'request_handled', path: new URL(request.url).pathname }))
+    return response
+  },
+}
+```
+
+---
+
+## Performance Patterns
+
+Never await analytics calls in the critical response path.
+
+```ts
+// Correct — fire and forget
+ph.capture({ distinctId: userId, event: 'action_taken', properties: {} })
+return Response.json({ ok: true })
+
+// Wrong — adds analytics latency to every user response
+await ph.capture({ distinctId: userId, event: 'action_taken', properties: {} })
+return Response.json({ ok: true })
+```
+
+Tune PostHog SDK batching to match your traffic:
+
+```ts
+new PostHog(key, {
+  flushAt: 20,          // send when 20 events queued
+  flushInterval: 10000, // or every 10 seconds, whichever comes first
+})
+```
+
+---
+
+## Self-Hosting Quick Reference
+
+| Tool | License | Min RAM | Database | Complexity |
+|---|---|---|---|---|
+| PostHog | MIT (core) | 4 GB | ClickHouse + PostgreSQL | High |
+| Plausible | AGPL | 512 MB | ClickHouse | Low |
+| Umami | MIT | 256 MB | PostgreSQL or MySQL | Very low |
+| Matomo | GPL | 512 MB | MySQL | Medium |
+
+```bash
+# Plausible
+docker run -d -e BASE_URL=https://analytics.yourdomain.com \
+  -e SECRET_KEY_BASE=$(openssl rand -hex 64) -p 8000:8000 \
+  ghcr.io/plausible/community-edition:v2
+
+# Umami
+docker run -d -e DATABASE_URL=postgresql://user:pass@host/umami \
+  -e APP_SECRET=$(openssl rand -hex 32) -p 3000:3000 \
+  ghcr.io/umami-software/umami:postgresql-latest
+```
+
+| Situation | Recommendation |
+|---|---|
+| Early stage, moving fast | Cloud (PostHog free tier, Plausible) |
+| GDPR strict, no third-party transfers | Self-host Plausible or Umami |
+| Need feature flags + replays + analytics | PostHog cloud or self-hosted |
+| High event volume (>1M events/month) | Self-host to control costs |
+| Air-gapped or regulated environment | Self-host |
+
+---
+
+## Data Accuracy Comparison
+
+| Architecture | Typical Accuracy | Complexity |
+|---|---|---|
+| Client-side only, no proxy | 55-70% | Low |
+| Client-side + reverse proxy | 75-85% | Low-medium |
+| Server-side only | 95-99% | Medium |
+| Hybrid (proxy + server-side critical events) | 90-98% | Medium-high |
+| Self-hosted + hybrid | 97-99% | High |
+
+**Recommended architecture by stage:**
+
+| Stage | Architecture |
+|---|---|
+| Startup (0-10k users) | PostHog cloud + Next.js rewrites proxy |
+| Growth (10k-100k users) | PostHog cloud + proxy + server-side for payments |
+| Scale (100k+ users) | Self-hosted PostHog or Plausible + full hybrid |
+| Enterprise | Self-hosted + server-side primary + client-side supplemental |
+
+The proxy pattern alone recovers 15-25 percentage points of lost data with minimal engineering effort. Add server-side tracking for payment and subscription events regardless of stage — these are the events where data loss has direct revenue impact.

--- a/skills/web-analytics-consent/references/tracking-plan.md
+++ b/skills/web-analytics-consent/references/tracking-plan.md
@@ -1,0 +1,437 @@
+# Tracking Plan Design
+
+Sources: PostHog documentation (posthog.com/docs), Amplitude Data Taxonomy Guide (amplitude.com/blog/data-taxonomy-playbook), Segment Analytics Academy (segment.com/academy), Mixpanel Tracking Plan Best Practices (mixpanel.com/blog/tracking-plan), Avo documentation (avo.app/docs), Heap Analytics Engineering Blog, Snowplow Analytics documentation
+
+---
+
+## Why Tracking Plans Matter
+
+Without a tracking plan, analytics data degrades into noise. Teams independently instrument the same user action under different names — `button_click`, `ButtonClicked`, `click_button` — producing three separate events that measure the same thing. Dashboards break when engineers rename events without notifying data consumers. New hires cannot discover what is already tracked, so they add duplicate events. Properties drift: one team sends `user_id` as a string, another as an integer. After 18 months, the event schema is unmaintainable and a full re-instrumentation is the only path forward.
+
+A tracking plan is the contract between product, engineering, and data. It defines what to track, why, and exactly how — before a single line of analytics code is written.
+
+For event naming conventions (Object_Action framework, snake_case rules), see `references/funnels-sessions-heatmaps.md`. For base property conventions (user_id, session_id, platform), see `references/funnels-sessions-heatmaps.md`.
+
+---
+
+## What to Track at Each Stage
+
+Match instrumentation depth to product maturity. Over-tracking at MVP wastes engineering time and creates noise. Under-tracking at Scale leaves growth levers invisible.
+
+### MVP Stage (5-10 events)
+
+Focus exclusively on the critical path: can users reach value, and do they return?
+
+| Event | Trigger | Why It Matters |
+|---|---|---|
+| `user_signed_up` | Account creation completes | Top of funnel; source attribution |
+| `onboarding_completed` | User finishes setup flow | Activation rate; predicts retention |
+| `core_action_performed` | Primary value action taken | The "aha moment"; define per product |
+| `session_started` | App opened after 24h gap | Retention signal; DAU/WAU/MAU |
+| `upgrade_intent_shown` | Paywall or pricing page viewed | Purchase intent before conversion |
+| `subscription_started` | Payment succeeds | Revenue; MRR calculation |
+| `subscription_cancelled` | Cancellation confirmed | Churn; triggers exit survey |
+| `error_encountered` | Unhandled exception or API failure | Quality signal; blocks activation |
+
+Define `core_action_performed` specifically for your product. For a document editor it is `document_created`. For a communication tool it is `message_sent`. For a data pipeline it is `pipeline_run_succeeded`. One event, precisely named.
+
+### Growth Stage (20-40 events)
+
+Once product-market fit is established, instrument the full funnel and feature surface.
+
+**Onboarding funnel** — track each discrete step so you can identify where users drop:
+
+- `onboarding_step_viewed` (with `step_name` property)
+- `onboarding_step_completed`
+- `onboarding_step_skipped`
+- `profile_setup_completed`
+- `integration_connected` (with `integration_name`)
+- `sample_data_imported`
+- `first_invite_sent`
+
+**Feature adoption** — one event per major feature, fired on first meaningful use:
+
+- `feature_discovered` (with `feature_name`, `discovery_source`)
+- `feature_activated` (first successful use)
+- `feature_used` (subsequent uses; throttle to avoid volume explosion)
+- `feature_disabled`
+
+**Collaboration** — `invite_sent` (with `invitee_role`), `invite_accepted`, `content_shared` (with `share_destination`), `comment_added`.
+
+**Billing lifecycle** — `trial_started`, `trial_converted`, `trial_expired`, `plan_upgraded`, `plan_downgraded`, `payment_failed`, `invoice_paid`.
+
+**Engagement** — `notification_received` (with `notification_type`, `channel`), `notification_clicked`, `search_performed` (with `query_length`, `results_count`; never log the query string itself), `export_completed`.
+
+**Error signals** — `api_error_encountered` (with `endpoint`, `status_code`), `validation_error_shown` (with `field_name`), `rate_limit_hit`.
+
+### Scale Stage (50-100+ events)
+
+At scale, instrumentation supports experimentation, performance optimization, and support deflection.
+
+**Experimentation:**
+
+- `experiment_enrolled` (with `experiment_id`, `variant`)
+- `experiment_converted`
+- `feature_flag_evaluated` (with `flag_key`, `value`) — use sampling; do not fire on every page load
+
+**Performance** — `page_load_slow` (with `lcp_ms`, `connection_type`), `api_latency_high` (with `endpoint`, `p95_ms`), `bundle_load_failed`.
+
+**Micro-interactions** (only when A/B testing UI changes) — `tooltip_viewed`, `modal_dismissed`, `empty_state_cta_clicked`.
+
+**Integrations** — `webhook_delivered` (with `destination`, `status_code`), `api_key_created`, `oauth_app_authorized`, `data_sync_completed` (with `source`, `records_synced`, `duration_ms`).
+
+**Support signals** — `help_article_viewed` (with `article_id`), `support_chat_opened`, `in_app_survey_submitted` (with `survey_id`, `score`).
+
+---
+
+## Tracking Plan Document Format
+
+Maintain the tracking plan as a versioned spreadsheet (Google Sheets, Notion database, or Avo). Every event gets one row. Every property gets a sub-row or a linked property library entry.
+
+### Event Schema Columns
+
+| Column | Type | Description |
+|---|---|---|
+| Event Name | string | Exact string sent to analytics (e.g., `subscription_started`) |
+| Description | string | One sentence: what user action triggers this event |
+| Trigger | string | Precise UI or system condition (e.g., "Payment API returns 200") |
+| Platform | enum | `web`, `mobile_ios`, `mobile_android`, `server`, `all` |
+| Properties | list | Names of all properties sent with this event |
+| Owner | string | Team or individual responsible for maintaining this event |
+| Status | enum | `planned`, `implemented`, `deprecated`, `removed` |
+| Date Added | date | When the event was first instrumented |
+| Destinations | list | Which tools receive this event (PostHog, Amplitude, Intercom, etc.) |
+
+### Property Sub-Schema
+
+For each property listed in an event row, document:
+
+| Column | Type | Description |
+|---|---|---|
+| Property Name | string | Exact key sent (e.g., `plan_name`) |
+| Type | enum | `string`, `number`, `boolean`, `array`, `object` |
+| Required | boolean | Whether the property must always be present |
+| Enum Values | list | If string, the allowed values (e.g., `free`, `pro`, `enterprise`) |
+| PII | boolean | Whether this property contains personal data |
+| Example Value | any | A realistic sample value |
+| Notes | string | Edge cases, deprecation notes, migration instructions |
+
+### Status Lifecycle
+
+```
+planned → implemented → deprecated → removed
+```
+
+Never delete rows. Mark events as `deprecated` with a deprecation date and migration note. Archive removed events in a separate sheet tab. This preserves the audit trail when debugging historical data.
+
+---
+
+## TypeScript Typed Event Wrapper
+
+Untyped analytics calls — `posthog.capture('some_event', { prop: value })` — allow typos, missing required properties, and wrong value types to reach production silently. A typed wrapper catches these at compile time.
+
+### EventMap Type Definition
+
+Define a map from event name to its required and optional properties:
+
+```typescript
+// analytics/events.ts
+
+export interface BaseEventProperties {
+  // Cross-reference: base properties (user_id, session_id, etc.)
+  // are defined in funnels-sessions-heatmaps.md
+}
+
+export interface EventMap {
+  user_signed_up: {
+    signup_method: 'email' | 'google' | 'github' | 'saml';
+    referral_source?: string;
+    invite_token?: string;
+  };
+  onboarding_completed: {
+    steps_completed: number;
+    steps_skipped: number;
+    duration_seconds: number;
+    completion_method: 'manual' | 'guided' | 'skipped';
+  };
+  subscription_started: {
+    plan_name: 'free' | 'pro' | 'team' | 'enterprise';
+    billing_interval: 'monthly' | 'annual';
+    trial_converted: boolean;
+    mrr_usd: number;
+    coupon_applied?: string;
+  };
+  subscription_cancelled: {
+    plan_name: string;
+    cancellation_reason: string;
+    days_active: number;
+    mrr_lost_usd: number;
+  };
+  feature_activated: {
+    feature_name: string;
+    discovery_source: 'onboarding' | 'tooltip' | 'search' | 'direct_nav' | 'email';
+  };
+  experiment_enrolled: {
+    experiment_id: string;
+    variant: string;
+    enrollment_source: 'page_load' | 'api' | 'manual';
+  };
+}
+```
+
+### Typed Track Function
+
+```typescript
+// analytics/track.ts
+import posthog from 'posthog-js';
+import type { EventMap } from './events';
+
+export function track<E extends keyof EventMap>(
+  event: E,
+  properties: EventMap[E]
+): void {
+  if (typeof window === 'undefined') return;
+
+  posthog.capture(event, properties);
+}
+```
+
+Usage — TypeScript enforces the correct event name and all required properties:
+
+```typescript
+// Correct — compiles
+track('subscription_started', {
+  plan_name: 'pro',
+  billing_interval: 'annual',
+  trial_converted: true,
+  mrr_usd: 79,
+});
+
+// Error: Argument of type '"subscriptionStarted"' is not assignable
+track('subscriptionStarted', { ... });
+
+// Error: Property 'billing_interval' is missing
+track('subscription_started', {
+  plan_name: 'pro',
+  trial_converted: true,
+  mrr_usd: 79,
+});
+```
+
+### Server-Side Wrapper
+
+For server events (payment webhooks, background jobs), use the same EventMap with the Node.js client:
+
+```typescript
+// analytics/server-track.ts
+import { PostHog } from 'posthog-node';
+import type { EventMap } from './events';
+
+const client = new PostHog(process.env.POSTHOG_KEY!, {
+  host: process.env.POSTHOG_HOST,
+});
+
+export function serverTrack<E extends keyof EventMap>(
+  distinctId: string,
+  event: E,
+  properties: EventMap[E]
+): void {
+  client.capture({ distinctId, event, properties });
+}
+
+// Flush before serverless function exits
+export async function flushAnalytics(): Promise<void> {
+  await client.shutdown();
+}
+```
+
+---
+
+## Event Governance
+
+Instrumentation without governance produces the same chaos as no tracking plan. Governance is the process that keeps the plan accurate as the product evolves.
+
+### CI Linting for Event Names
+
+Add a CI step that validates every `track()` call against the EventMap. Use `ts-morph` to parse the AST and reject unknown event names:
+
+```typescript
+// scripts/lint-analytics.ts — run in CI: ts-node scripts/lint-analytics.ts
+import { Project, SyntaxKind } from 'ts-morph';
+import { EventMap } from '../src/analytics/events';
+
+const validEvents = new Set(Object.keys({} as EventMap));
+const project = new Project({ tsConfigFilePath: 'tsconfig.json' });
+const errors: string[] = [];
+
+for (const file of project.getSourceFiles('src/**/*.{ts,tsx}')) {
+  for (const call of file.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+    const expr = call.getExpression().getText();
+    if (expr !== 'track' && expr !== 'serverTrack') continue;
+    const eventName = call.getArguments()[0]?.getText().replace(/['"]/g, '');
+    if (eventName && !validEvents.has(eventName)) {
+      errors.push(`${file.getFilePath()}:${call.getStartLineNumber()} — unknown event "${eventName}"`);
+    }
+  }
+}
+
+if (errors.length > 0) { console.error('Analytics lint errors:\n' + errors.join('\n')); process.exit(1); }
+```
+
+### Code Review Checklist for Analytics PRs
+
+Include in pull request template when `analytics/events.ts` is modified:
+
+- New event added to tracking plan spreadsheet with all columns filled
+- Event has at least two meaningful properties beyond base properties
+- No PII in any property value (no email, name, IP address)
+- Destinations column updated — does this event need to reach Intercom or just PostHog?
+- Owner assigned
+- If replacing an existing event, old event marked `deprecated` with migration date
+
+### Deprecation Workflow
+
+Follow this sequence to remove an event without breaking dashboards:
+
+1. **Mark deprecated** — Set status to `deprecated` in tracking plan. Add deprecation date and reason. Add a code comment above the `track()` call.
+2. **Notify data consumers** — Ping the team in Slack. List every dashboard, chart, and cohort that uses this event. Give a 30-day migration window.
+3. **Migrate dashboards** — Update all charts to use the replacement event. Verify data continuity by running both events in parallel for one week.
+4. **Remove from code** — Delete the `track()` call and remove the event from `EventMap`. The TypeScript compiler will surface any remaining usages.
+5. **Archive in tracking plan** — Move the row to the `Archived` sheet tab. Do not delete.
+
+### Avo as Dedicated Tooling
+
+For teams with 5+ engineers contributing analytics, consider Avo (avo.app). Avo generates type-safe tracking functions from a visual tracking plan, enforces schemas in CI, and provides a branch-based review workflow for analytics changes. It replaces the manual EventMap approach above with a generated SDK. The tradeoff is vendor dependency and cost; the benefit is a single source of truth that non-engineers can edit.
+
+---
+
+## Group Analytics for B2B
+
+B2C analytics centers on individual users. B2B analytics requires a second dimension: the company (workspace, organization, account). A user's behavior is often less important than their company's behavior — which plan is the company on, how many seats are active, is the company expanding or contracting?
+
+### Identifying Groups in PostHog
+
+```typescript
+// When a user logs in or switches workspace
+posthog.group('company', workspace.id, {
+  name: workspace.name,
+  plan: workspace.plan,                    // 'free' | 'pro' | 'enterprise'
+  mrr_usd: workspace.mrr,
+  seat_count: workspace.activeUserCount,
+  industry: workspace.industry,
+  company_size: workspace.employeeRange,   // '1-10' | '11-50' | '51-200' | '201-1000' | '1000+'
+  created_at: workspace.createdAt,
+  trial_ends_at: workspace.trialEndsAt,
+  health_score: workspace.healthScore,
+});
+```
+
+All subsequent `posthog.capture()` calls on this client will automatically attach the group context. Events become queryable at both the user level and the company level.
+
+### Group Properties to Track
+
+| Property | Type | Why |
+|---|---|---|
+| `plan` | enum | Segment by tier; measure plan-level retention |
+| `mrr_usd` | number | Weight cohorts by revenue; identify high-value accounts |
+| `seat_count` | number | Expansion signal; track seat growth over time |
+| `active_seat_count` | number | Engagement; seats paid vs seats used |
+| `industry` | string | Vertical segmentation; product-market fit by industry |
+| `company_size` | enum | ICP fit; enterprise vs SMB behavior differences |
+| `created_at` | ISO date | Cohort analysis by signup month |
+| `health_score` | number | Composite retention signal; trigger CSM alerts |
+| `integrations_connected` | number | Stickiness; integrations correlate with retention |
+| `trial_ends_at` | ISO date | Conversion urgency; trigger upgrade campaigns |
+
+### Groups vs Cohorts
+
+A **group** is a persistent entity (company) that events associate with. A **cohort** is a dynamic filter at query time (e.g., "Pro plan companies from Q1 with no integrations"). Groups are the data structure; cohorts are the query.
+
+Update group properties server-side when they change, not only on login:
+
+```typescript
+// In your billing webhook handler
+async function handleSubscriptionUpgraded(event: StripeEvent) {
+  const workspace = await db.workspace.findById(event.metadata.workspaceId);
+
+  // Update PostHog group properties
+  serverClient.groupIdentify({
+    groupType: 'company',
+    groupKey: workspace.id,
+    properties: {
+      plan: workspace.plan,
+      mrr_usd: workspace.mrr,
+    },
+  });
+}
+```
+
+---
+
+## Identity Resolution
+
+Analytics data is only as useful as its identity graph. Stitching anonymous sessions to identified users — and resolving the same user across devices — determines whether your funnel analysis reflects reality.
+
+### Anonymous to Identified Stitching
+
+PostHog assigns a random `distinct_id` to every anonymous visitor. When the user signs up or logs in, call `identify()` to merge the anonymous session history with the identified profile:
+
+```typescript
+// On successful login or signup
+posthog.identify(
+  user.id,           // Your internal user ID — never use email
+  {
+    email: user.email,
+    name: user.name,
+    created_at: user.createdAt,
+    plan: user.plan,
+  }
+);
+```
+
+PostHog merges the anonymous `distinct_id` history into the identified profile. All events captured before `identify()` — including the signup funnel — are attributed to the correct user.
+
+### Cross-Device Tracking
+
+When a user logs in on a second device, call `identify()` with the same `user.id`. PostHog resolves both device sessions to the same person. Do not call `posthog.reset()` on login — only call it on logout to start a fresh anonymous session.
+
+```typescript
+// On logout
+posthog.reset();
+// A new anonymous distinct_id is assigned for the next visitor on this device
+```
+
+### Cost Optimization with person_profiles
+
+PostHog charges per identified user profile. For high-traffic marketing pages where most visitors never sign up, use `person_profiles: 'identified_only'` to avoid creating profiles for anonymous visitors:
+
+```typescript
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+  person_profiles: 'identified_only',
+  // Anonymous events are still captured but no profile is created
+  // until posthog.identify() is called
+});
+```
+
+This reduces costs significantly for B2C products with large anonymous traffic volumes. The tradeoff is that pre-signup funnel analysis requires joining anonymous events to identified profiles after the fact, which PostHog handles automatically when `identify()` is called.
+
+### Never Use Email as distinct_id
+
+Using email as the `distinct_id` creates three problems: it exposes PII in event logs, it breaks when users change their email address, and it prevents merging accounts if a user signs up with a different email on a second device. Always use your internal immutable user ID (UUID or integer primary key).
+
+---
+
+## Common Mistakes
+
+| Mistake | Consequence | Fix |
+|---|---|---|
+| PII in event properties | GDPR violation; legal liability; cannot delete from analytics warehouse | Audit all string properties; hash or omit email, name, IP; use user IDs only |
+| Events with no properties | Unqueryable; you know the event happened but not to whom or in what context | Every event needs at minimum the base properties plus 2 domain-specific properties |
+| Inconsistent naming across platforms | Web fires `subscription_started`, mobile fires `SubscriptionStarted`; funnels break | Enforce naming in EventMap; share the type definition across web and mobile codebases |
+| Tracking UI state instead of business outcomes | `modal_opened` tells you nothing; `upgrade_intent_shown` tells you conversion intent | Ask "what business question does this answer?" before adding any event |
+| Dynamic values in event names | `product_123_viewed`, `product_456_viewed` creates unbounded event cardinality; dashboards explode | Use `product_viewed` with a `product_id` property |
+| Double-firing from frontend and backend | Payment events fired by both Stripe webhook handler and checkout UI; revenue appears doubled | Designate one authoritative source per event; document in tracking plan |
+| Not filtering internal employees | Your own team's usage inflates activation and retention metrics | Add an `is_employee` person property; exclude from all product metrics dashboards |
+| Tracking the same metric multiple ways | `subscription_started` and `payment_succeeded` both measure new MRR; reports disagree | One canonical event per business metric; document which event is the source of truth |
+| Missing timestamps on server events | Server events arrive out of order; funnels show impossible sequences | Always pass `timestamp` explicitly on server-side `capture()` calls |
+| No sampling on high-volume events | `scroll_depth_changed` fires 50 times per page; 10M events/month from one event | Sample high-frequency events at 10% or use session recording instead |

--- a/skills/web-analytics-consent/skills.json
+++ b/skills/web-analytics-consent/skills.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/web-analytics-consent",
-  "version": "0.0.1",
-  "description": "Privacy-compliant web analytics and cookie consent. Covers PostHog, GA4, Plausible, Umami, Clarity, vanilla-cookieconsent v3, GDPR/CCPA, consent-gated scripts, Google Consent Mode v2, funnels, session recordings, heatmaps, and Next.js integration. Triggers: analytics, cookie consent, GDPR, cookie banner, PostHog, GA4, Plausible, Umami, Clarity, session recording, heatmap, consent mode, privacy, CCPA, cookieconsent, funnel, event tracking.",
+  "version": "0.0.2",
+  "description": "Privacy-compliant web analytics and cookie consent. Covers PostHog, GA4, Plausible, Umami, Clarity, vanilla-cookieconsent v3, GDPR/CCPA, consent-gated scripts, Google Consent Mode v2, funnels, session recordings, heatmaps, tracking plan design, server-side tracking, ad blocker resilience, A/B testing, feature flags, and Next.js integration. Triggers: analytics, cookie consent, GDPR, cookie banner, PostHog, GA4, Plausible, Umami, Clarity, session recording, heatmap, consent mode, privacy, CCPA, cookieconsent, funnel, event tracking, tracking plan, server-side tracking, ad blocker, reverse proxy, A/B testing, feature flags, experiment.",
   "permissions": {
     "network": {
       "outbound": []


### PR DESCRIPTION
## Summary
- Add 3 new reference files (tracking plans, server-side tracking, A/B testing & feature flags) expanding coverage from 6 to 9 files
- Update SKILL.md with new workflow steps 7-9, file index entries, and trigger keywords
- Bump version to 0.0.2 in skills.json

## New Reference Files
| File | Lines | Topics |
|------|-------|--------|
| `tracking-plan.md` | 437 | Event taxonomy by product stage, TypeScript typed wrappers, CI linting, governance, group analytics, identity resolution |
| `server-side-tracking.md` | 389 | Ad blocker bypass via reverse proxy (Next.js/Nginx/Cloudflare/Vercel), PostHog Node SDK, GA4 Measurement Protocol, hybrid architecture, first-party cookies |
| `ab-testing-feature-flags.md` | 438 | Feature flag types, PostHog experiments, React hooks, Next.js patterns, statistical pitfalls, experimentation culture, flag lifecycle |

All files within 250-450 line range per Tank skill conventions.