### PR TITLE
feat(angular-migrations): add Angular v18-v21 migration skill

### DIFF
--- a/skills/angular-migrations/SKILL.md
+++ b/skills/angular-migrations/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: "@tank/angular-migrations"
+description: |
+  Expert Angular migration guidance for version upgrades from v18 through v21.
+  Covers every migration path (v18 to v19, v19 to v20, v20 to v21), breaking changes,
+  official migration schematics, signals adoption, zoneless transition, and
+  build/test tooling changes. Provides step-by-step upgrade procedures,
+  compatibility matrices, automated schematic commands, and strategies for
+  large-scale enterprise migrations. Synthesizes official Angular blog posts,
+  angular.dev documentation, update.angular.dev guides, and community migration
+  patterns.
+
+  Trigger phrases: "angular migration", "angular upgrade", "ng update",
+  "angular 18", "angular 19", "angular 20", "angular 21", "upgrade angular",
+  "migrate angular", "angular breaking changes", "angular version upgrade",
+  "angular standalone migration", "angular signals migration",
+  "angular zoneless", "zone.js removal", "karma to vitest",
+  "angular control flow migration", "ng generate migration",
+  "angular update guide", "angular compatibility", "angular deprecation"
+---
+# Angular Migrations (v18 through v21)
+
+## Core Philosophy
+
+- Upgrade one major version at a time — skipping versions risks missing migration schematics and accumulating unresolved breaking changes.
+- Run official schematics before manual fixes — Angular provides automated migrations for most breaking changes; manual work is the last resort.
+- Signals, standalone, and zoneless are the destination — every migration should move closer to the modern Angular paradigm, not just fix compilation errors.
+- Test at every step — run `ng build`, `ng test`, and e2e after each version bump before proceeding.
+- Treat migration as architecture, not syntax — version upgrades after v18 are architectural shifts (reactivity model, change detection, module system), not just API renames.
+
+## Quick-Start: Which Migration?
+
+| Starting Version | Target | Key Theme | Reference |
+|-----------------|--------|-----------|-----------|
+| v18 | v19 | Standalone default, signals stable | `references/v18-to-v19.md` |
+| v19 | v20 | Build system change, Karma removed | `references/v19-to-v20.md` |
+| v20 | v21 | Zoneless default, Vitest, Signal Forms | `references/v20-to-v21.md` |
+| Any | Signals | Decorator→signal function migration | `references/signals-migration.md` |
+| Any | Zoneless | Zone.js removal strategy | `references/zoneless-migration.md` |
+
+## Version Compatibility Matrix
+
+| Angular | TypeScript | Node.js | RxJS | Zone.js |
+|---------|-----------|---------|------|---------|
+| v18 | 5.4 | >=18.19.1 | 6.x / 7.x | Required |
+| v19 | 5.6 | >=18.19.1 | 6.x / 7.x | Required (default) |
+| v20 | 5.8 | >=20.11.1 | 7.x / 8.x | Optional (stable zoneless) |
+| v21 | 5.8+ | >=20.11.1 | 7.x / 8.x | Not included by default |
+
+## Universal Upgrade Procedure
+
+For each major version jump:
+
+1. Create a branch: `git checkout -b upgrade/angular-{target}`
+2. Ensure current tests pass: `ng build && ng test`
+3. Update Angular: `ng update @angular/cli@{target} @angular/core@{target}`
+4. If using Angular Material: `ng update @angular/material@{target}`
+5. Run migration schematics (see reference for each version)
+6. Fix remaining compiler/type errors manually
+7. Run full test suite: `ng build --configuration production && ng test`
+8. Review deprecation warnings and address them
+
+## Recommended Schematic Order
+
+Run these schematics after each version upgrade in this order — each
+builds on the previous:
+
+```
+1. ng generate @angular/core:standalone
+2. ng generate @angular/core:control-flow
+3. ng generate @angular/core:inject
+4. ng generate @angular/core:signal-input-migration
+5. ng generate @angular/core:output-migration
+6. ng generate @angular/core:signal-queries-migration
+7. ng generate @angular/core:route-lazy-loading
+8. ng generate @angular/core:cleanup-unused-imports
+9. ng generate @angular/core:self-closing-tags
+10. ng generate @angular/core:common-to-standalone
+```
+
+Not all schematics exist in all versions. Run what's available.
+See `references/migration-schematics.md` for details on each.
+
+## Common Migration Problems
+
+| Problem | Version | Cause | Fix |
+|---------|---------|-------|-----|
+| `ng test` fails after upgrade | v20+ | Karma removed from `@angular/build` | Install `@angular-devkit/build-angular` or migrate to Vitest |
+| Zoneless + Zone.js warning (NG0914) | v21 | Zone.js still in polyfills | Remove `zone.js` from `angular.json` polyfills |
+| `effect()` outside injection context | v19+ | Called outside constructor/DI | Move to constructor or field initializer |
+| Signal input type mismatch | v19+ | `input()` returns `InputSignal<T>` | Append `()` to read: `this.name()` not `this.name` |
+| Third-party lib expects Zone.js | v21 | Library uses zone-patched async | Use `provideZoneChangeDetection()` as fallback |
+| SSR hydration mismatch | v19+ | DOM differs between server/client | Use `@defer (hydrate on ...)` or fix deterministic rendering |
+| Template type narrowing breaks | v19+ | Signal inputs in `@if` blocks | Add `!` to signal calls inside narrowed blocks |
+
+## Multi-Version Jump Strategy
+
+Jumping from v18 to v21 requires three sequential upgrades.
+Do not skip versions.
+
+```
+v18 → v19 (standalone + signals stable)
+     → v20 (build system + testing)
+          → v21 (zoneless + signal forms)
+```
+
+At each step: upgrade → run schematics → fix errors → test → commit → next.
+
+## Signals Adoption Roadmap
+
+| What to Migrate | From | To | Schematic |
+|----------------|------|----|-----------|
+| Component inputs | `@Input()` | `input()` / `input.required()` | `signal-input-migration` |
+| Component outputs | `@Output() + EventEmitter` | `output()` | `output-migration` |
+| View/content queries | `@ViewChild()` / `@ContentChildren()` | `viewChild()` / `contentChildren()` | `signal-queries-migration` |
+| Two-way binding | `@Input() + @Output()` | `model()` | Manual |
+| Constructor DI | `constructor(private svc: Svc)` | `svc = inject(Svc)` | `inject` |
+| UI state | `BehaviorSubject` | `signal()` / `computed()` | Manual |
+| Async data | `subscribe()` patterns | `resource()` / `rxResource()` | Manual |
+
+For detailed migration patterns, see `references/signals-migration.md`.
+
+## Angular Material Considerations
+
+Angular Material follows the same major versioning. Always update together:
+
+```bash
+ng update @angular/cli@{ver} @angular/core@{ver} @angular/material@{ver}
+```
+
+Material-specific schematics run automatically during `ng update`.
+Material v20+ adopts the M3 design system — visual regressions are possible.
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/v18-to-v19.md` | Complete v18→v19 migration: standalone default, signals stable, incremental hydration, TypeScript 5.6 |
+| `references/v19-to-v20.md` | Complete v19→v20 migration: build system change, Karma removal, naming conventions, TypeScript 5.8 |
+| `references/v20-to-v21.md` | Complete v20→v21 migration: zoneless default, Signal Forms, Angular Aria, Vitest stable |
+| `references/signals-migration.md` | Signal adoption across versions: input/output/query migration, RxJS interop, patterns |
+| `references/zoneless-migration.md` | Zone.js removal: compatibility checklist, OnPush, PendingTasks, testing, SSR |
+| `references/migration-schematics.md` | All 14 official schematics: commands, flags, behavior, limitations |
+| `references/testing-and-build-tooling.md` | Karma→Vitest migration, build system changes, Angular Material updates |

--- a/skills/angular-migrations/references/migration-schematics.md
+++ b/skills/angular-migrations/references/migration-schematics.md
@@ -1,0 +1,428 @@
+# Angular Migration Schematics Reference
+
+Sources: angular.dev/reference/migrations, Angular Blog (signal-input-migrations), Angular GitHub angular/angular, ngxtension documentation
+
+Covers: all 14 official Angular migration schematics with commands, behavior, flags, limitations, and recommended execution order.
+
+## Complete Schematics List
+
+| # | Schematic | Introduced | Purpose |
+|---|-----------|-----------|---------|
+| 1 | `standalone` | v15.2 | Convert NgModule components to standalone |
+| 2 | `control-flow` | v17 | Convert `*ngIf/*ngFor/*ngSwitch` to `@if/@for/@switch` |
+| 3 | `inject` | v19 | Convert constructor injection to `inject()` |
+| 4 | `route-lazy-loading` | v19 | Convert eager routes to lazy-loaded |
+| 5 | `signal-input-migration` | v19 | Convert `@Input()` to `input()` |
+| 6 | `output-migration` | v19 | Convert `@Output()` to `output()` |
+| 7 | `signal-queries-migration` | v19 | Convert `@ViewChild` etc. to signal queries |
+| 8 | `cleanup-unused-imports` | v19 | Remove unused standalone imports |
+| 9 | `self-closing-tags` | v20 | Convert `<comp></comp>` to `<comp />` |
+| 10 | `ngclass-to-class` | v21 | Convert `[ngClass]` to `[class]` bindings |
+| 11 | `ngstyle-to-style` | v21 | Convert `[ngStyle]` to `[style]` bindings |
+| 12 | `router-testing-module-migration` | v21 | Convert `RouterTestingModule` to `RouterModule` |
+| 13 | `common-to-standalone` | v21 | Replace `CommonModule` with individual imports |
+| 14 | `refactor-jasmine-vitest` | v21 | Convert Jasmine tests to Vitest |
+
+## Recommended Execution Order
+
+Run schematics in this order after each version upgrade. Each builds
+on the previous — standalone first because signal migrations work
+best with standalone components.
+
+```bash
+# 1. Module structure
+ng generate @angular/core:standalone
+ng generate @angular/core:common-to-standalone
+
+# 2. Template syntax
+ng generate @angular/core:control-flow
+ng generate @angular/core:self-closing-tags
+ng generate @angular/core:ngclass-to-class
+ng generate @angular/core:ngstyle-to-style
+
+# 3. Component API
+ng generate @angular/core:inject
+ng generate @angular/core:signal-input-migration
+ng generate @angular/core:output-migration
+ng generate @angular/core:signal-queries-migration
+
+# 4. Routing
+ng generate @angular/core:route-lazy-loading
+
+# 5. Cleanup
+ng generate @angular/core:cleanup-unused-imports
+
+# 6. Testing (v21+)
+ng generate @angular/core:router-testing-module-migration
+ng g @schematics/angular:refactor-jasmine-vitest
+```
+
+## Schematic 1: Standalone Migration
+
+```bash
+ng generate @angular/core:standalone
+```
+
+### What It Does
+
+1. Converts components/directives/pipes to standalone
+2. Adds required imports to each standalone entity
+3. Updates NgModule declarations/imports/exports
+4. Can optionally remove empty NgModules
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--path` | Project root | Target specific directory |
+| `--mode` | `convert-to-standalone` | One of: `convert-to-standalone`, `prune-modules`, `standalone-bootstrap` |
+
+### Modes
+
+- `convert-to-standalone` — Converts declarations to standalone, adds imports
+- `prune-modules` — Removes NgModules that are no longer needed
+- `standalone-bootstrap` — Converts app bootstrap from NgModule to standalone
+
+Run in order: convert → prune → bootstrap.
+
+### Limitations
+
+- Cannot handle dynamic module loading patterns
+- May miss imports if modules re-export from other modules
+- Complex circular dependencies may need manual resolution
+
+## Schematic 2: Control Flow Migration
+
+```bash
+ng generate @angular/core:control-flow
+```
+
+### What It Does
+
+Converts structural directives to built-in control flow:
+
+| Before | After |
+|--------|-------|
+| `*ngIf="condition"` | `@if (condition) { ... }` |
+| `*ngIf="x; else tpl"` | `@if (x) { ... } @else { ... }` |
+| `*ngFor="let item of items; trackBy: trackFn"` | `@for (item of items; track item.id) { ... }` |
+| `*ngSwitch / *ngSwitchCase` | `@switch / @case` |
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--path` | Project root | Target specific directory |
+| `--format` | N/A | Code formatting |
+
+### Important: `@for` Requires `track`
+
+The `track` expression is mandatory in `@for`. The schematic converts
+`trackBy` functions but may need manual adjustment:
+
+```html
+<!-- Schematic output — verify track expression -->
+@for (item of items; track item.id) {
+  <div>{{ item.name }}</div>
+} @empty {
+  <div>No items</div>
+}
+```
+
+### `@empty` Block
+
+`@for` supports `@empty` for empty collections — this is new
+functionality not available with `*ngFor`. The schematic does NOT
+add `@empty` blocks (it only converts existing code).
+
+## Schematic 3: inject() Migration
+
+```bash
+ng generate @angular/core:inject
+```
+
+### What It Does
+
+Converts constructor-based dependency injection to the `inject()` function:
+
+```typescript
+// Before
+constructor(private http: HttpClient, @Optional() private logger: Logger) {}
+
+// After
+private http = inject(HttpClient);
+private logger = inject(Logger, { optional: true });
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--path` | Project root | Target specific directory |
+
+### Limitations
+
+- Cannot convert constructors with complex logic beyond DI
+- Constructor parameters used in `super()` calls need manual handling
+- Some decorator combinations may not convert cleanly
+
+## Schematic 4: Route Lazy Loading
+
+```bash
+ng generate @angular/core:route-lazy-loading
+```
+
+### What It Does
+
+Converts eagerly loaded component routes to lazy-loaded ones:
+
+```typescript
+// Before
+{ path: 'users', component: UsersComponent }
+
+// After
+{ path: 'users', loadComponent: () => import('./users').then(m => m.UsersComponent) }
+```
+
+### Limitations
+
+- Only converts component routes (not module routes)
+- Cannot determine if lazy loading is appropriate for all routes
+- Guard and resolver imports may need manual adjustment
+
+## Schematic 5: Signal Input Migration
+
+```bash
+ng generate @angular/core:signal-input-migration
+```
+
+### What It Does
+
+1. Converts `@Input()` declarations to `input()` / `input.required()`
+2. Updates template references (adds `()` for reads)
+3. Updates host binding references
+4. Preserves types, defaults, aliases, transforms
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--path` | Project root | Target specific directory |
+| `--best-effort-mode` | false | Continue despite partial failures |
+| `--insert-todos` | false | Add TODO comments for manual fixes |
+| `--analysis-dir` | N/A | Save analysis results |
+
+### VSCode Integration
+
+The migration is also available as a code refactor action in VSCode.
+Install the latest Angular Language Service extension and click
+the lightbulb on `@Input()` decorators.
+
+### Known Limitations
+
+- Inputs accessed via string-based APIs (like `@HostListener` arguments)
+  may not be migrated
+- Inputs used in `ngOnChanges` need manual conversion (signals don't
+  trigger `ngOnChanges`)
+- Type narrowing in templates may need `!` operator
+
+## Schematic 6: Output Migration
+
+```bash
+ng generate @angular/core:output-migration
+```
+
+### What It Does
+
+Converts `@Output() + EventEmitter` to `output()`:
+
+```typescript
+// Before
+@Output() clicked = new EventEmitter<void>();
+
+// After
+clicked = output<void>();
+```
+
+### Limitations
+
+- Outputs subscribed to with `.subscribe()` need manual migration
+  (anti-pattern, but exists in some codebases)
+- Complex EventEmitter subclasses may not convert
+
+## Schematic 7: Signal Queries Migration
+
+```bash
+ng generate @angular/core:signal-queries-migration
+```
+
+### What It Does
+
+Converts decorator-based queries to signal queries:
+
+```typescript
+// Before
+@ViewChild('ref') ref!: ElementRef;
+@ViewChildren(MyComp) comps!: QueryList<MyComp>;
+
+// After
+ref = viewChild.required<ElementRef>('ref');
+comps = viewChildren(MyComp);
+```
+
+### Limitations
+
+- `QueryList`-specific APIs (`.changes`, `.toArray()`, `.first`, `.last`)
+  need manual conversion — signal queries return `Signal<readonly T[]>`
+- Code using `ngAfterViewInit` to access queries may need refactoring
+
+## Schematic 8: Cleanup Unused Imports
+
+```bash
+ng generate @angular/core:cleanup-unused-imports
+```
+
+### What It Does
+
+Removes unused imports from standalone component `imports` arrays.
+Also removes unused TypeScript imports.
+
+## Schematic 9: Self-Closing Tags
+
+```bash
+ng generate @angular/core:self-closing-tags
+```
+
+### What It Does
+
+Converts component tags with no content to self-closing:
+
+```html
+<!-- Before -->
+<app-header></app-header>
+
+<!-- After -->
+<app-header />
+```
+
+## Schematics 10-11: NgClass/NgStyle to Bindings
+
+```bash
+ng generate @angular/core:ngclass-to-class
+ng generate @angular/core:ngstyle-to-style
+```
+
+### What They Do
+
+Convert directive-based class/style bindings to native bindings:
+
+```html
+<!-- Before -->
+<div [ngClass]="{'active': isActive}">
+<div [ngStyle]="{'color': textColor}">
+
+<!-- After -->
+<div [class.active]="isActive">
+<div [style.color]="textColor">
+```
+
+Reduces dependency on `CommonModule`.
+
+## Schematic 12: RouterTestingModule Migration
+
+```bash
+ng generate @angular/core:router-testing-module-migration
+```
+
+### What It Does
+
+Converts `RouterTestingModule` to `RouterModule` + `provideLocationMocks()`:
+
+```typescript
+// Before
+TestBed.configureTestingModule({
+  imports: [RouterTestingModule.withRoutes(routes)]
+});
+
+// After
+TestBed.configureTestingModule({
+  imports: [RouterModule.forRoot(routes)],
+  providers: [provideLocationMocks()]
+});
+```
+
+## Schematic 13: CommonModule to Standalone
+
+```bash
+ng generate @angular/core:common-to-standalone
+```
+
+### What It Does
+
+Replaces `CommonModule` import with individual directive/pipe imports:
+
+```typescript
+// Before
+@Component({
+  imports: [CommonModule]
+})
+
+// After
+@Component({
+  imports: [NgIf, NgFor, AsyncPipe]  // only what's used
+})
+```
+
+Best combined with control-flow migration — after converting `*ngIf` to
+`@if`, the `NgIf` import is no longer needed.
+
+## Schematic 14: Jasmine to Vitest
+
+```bash
+ng g @schematics/angular:refactor-jasmine-vitest
+```
+
+Note: This uses `@schematics/angular`, not `@angular/core`.
+
+### What It Does
+
+- Converts Jasmine test syntax to Vitest equivalents
+- Updates imports (`describe`, `it`, `expect` from `vitest`)
+- Converts Jasmine matchers to Vitest matchers
+
+### Limitations
+
+- Custom Jasmine matchers need manual conversion
+- `done()` callback patterns may need manual conversion
+- Jasmine spies → Vitest spies syntax differs
+
+## Third-Party Migration Tools
+
+### ngxtension
+
+Community schematics that complement official ones:
+
+```bash
+npx ng add ngxtension
+
+# Signal inputs (alternative to official)
+npx ng g ngxtension:convert-signal-inputs
+
+# Signal outputs (alternative to official)
+npx ng g ngxtension:convert-outputs
+
+# Per-file targeting
+npx ng g ngxtension:convert-signal-inputs --path=libs/feature-xyz/my-comp.ts
+```
+
+### Nx Migrate
+
+For Nx workspaces, use `nx migrate` instead of `ng update`:
+
+```bash
+nx migrate @angular/core@21
+nx migrate --run-migrations
+```
+
+Nx handles workspace-level concerns and runs Angular schematics
+automatically during migration.

--- a/skills/angular-migrations/references/signals-migration.md
+++ b/skills/angular-migrations/references/signals-migration.md
@@ -1,0 +1,377 @@
+# Angular Signals Migration
+
+Sources: Angular Blog (signal-input-migrations), angular.dev/reference/migrations, angular-university.io (signal-components guide), angularspace.com (migrating-to-signals), dev.to (signals v17.3 to v21 operator's manual)
+
+Covers: signal adoption path from decorators to signal functions, version-by-version API timeline, migration schematics, RxJS interop, and architectural patterns for signal-based Angular apps.
+
+## Signal API Timeline
+
+| API | Introduced | Dev Preview | Stable | Migration Schematic |
+|-----|-----------|-------------|--------|-------------------|
+| `signal()` | v16 | v16 | v17 | N/A (new API) |
+| `computed()` | v16 | v16 | v17 | N/A (new API) |
+| `effect()` | v16 | v16-v19 | v20 | N/A (new API) |
+| `input()` | v17.1 | v17.1-v18 | v19 | `signal-input-migration` |
+| `input.required()` | v17.1 | v17.1-v18 | v19 | `signal-input-migration` |
+| `output()` | v17.3 | v17.3-v18 | v19 | `output-migration` |
+| `model()` | v17.2 | v17.2-v18 | v19 | Manual |
+| `viewChild()` | v17.2 | v17.2-v18 | v19 | `signal-queries-migration` |
+| `viewChildren()` | v17.2 | v17.2-v18 | v19 | `signal-queries-migration` |
+| `contentChild()` | v17.2 | v17.2-v18 | v19 | `signal-queries-migration` |
+| `contentChildren()` | v17.2 | v17.2-v18 | v19 | `signal-queries-migration` |
+| `linkedSignal()` | v19 | v19 | v20 | N/A (new API) |
+| `resource()` | v19 | v19 | v20 | N/A (new API) |
+| `rxResource()` | v19 | v19 | v20 | N/A (new API) |
+| `toSignal()` | v16 | v16-v19 | v20 | N/A (interop) |
+| `toObservable()` | v16 | v16-v19 | v20 | N/A (interop) |
+| Signal Forms | v21 | v21 (experimental) | TBD | N/A (new API) |
+
+## Migration 1: @Input() to input()
+
+### Before (Decorator-Based)
+
+```typescript
+@Component({...})
+export class UserCard {
+  @Input() name: string = '';
+  @Input({ required: true }) userId!: string;
+  @Input({ alias: 'color' }) themeColor: string = 'blue';
+  @Input({ transform: booleanAttribute }) disabled: boolean = false;
+}
+```
+
+### After (Signal-Based)
+
+```typescript
+@Component({...})
+export class UserCard {
+  name = input<string>('');
+  userId = input.required<string>();
+  themeColor = input<string>('blue', { alias: 'color' });
+  disabled = input(false, { transform: booleanAttribute });
+}
+```
+
+### Key Differences
+
+| Aspect | `@Input()` | `input()` |
+|--------|-----------|-----------|
+| Reading value | `this.name` | `this.name()` (function call) |
+| Type | `string` | `InputSignal<string>` |
+| Reactivity | None (need `ngOnChanges`) | Reactive (use in `computed`/`effect`) |
+| Required | `!` assertion | `input.required<T>()` |
+| Transform | Same | Same |
+| Alias | Same | Same |
+
+### Automated Migration
+
+```bash
+ng generate @angular/core:signal-input-migration
+```
+
+The schematic:
+- Converts `@Input()` declarations to `input()`
+- Updates template references (adds `()` to input reads)
+- Updates component class references
+- Preserves types, defaults, aliases, transforms
+
+### Common Issue: Type Narrowing in Templates
+
+Signal inputs in `@if` blocks may cause type narrowing issues:
+
+```html
+<!-- May fail: compiler narrows type after @if check -->
+@if (user()) {
+  <span>{{ user()!.name }}</span>  <!-- Add ! for narrowing -->
+}
+```
+
+### Third-Party Alternative: ngxtension
+
+```bash
+npx ng add ngxtension
+npx ng g ngxtension:convert-signal-inputs
+npx ng g ngxtension:convert-signal-inputs --path=libs/feature-xyz
+```
+
+## Migration 2: @Output() to output()
+
+### Before
+
+```typescript
+@Component({...})
+export class SearchBar {
+  @Output() search = new EventEmitter<string>();
+  @Output('changed') valueChanged = new EventEmitter<string>();
+
+  onSearch(term: string) {
+    this.search.emit(term);
+  }
+}
+```
+
+### After
+
+```typescript
+@Component({...})
+export class SearchBar {
+  search = output<string>();
+  valueChanged = output<string>({ alias: 'changed' });
+
+  onSearch(term: string) {
+    this.search.emit(term);
+  }
+}
+```
+
+### Key Differences
+
+| Aspect | `@Output() + EventEmitter` | `output()` |
+|--------|---------------------------|-----------|
+| Type | `EventEmitter<T>` (extends Subject) | `OutputEmitterRef<T>` |
+| RxJS dependency | Yes (EventEmitter extends Subject) | No |
+| `.emit()` | Same | Same |
+| `.subscribe()` | Available (anti-pattern) | Not available |
+| Alias | Same | Same |
+
+### Automated Migration
+
+```bash
+ng generate @angular/core:output-migration
+```
+
+### RxJS Interop for Outputs
+
+Bridge between RxJS and the new output API:
+
+```typescript
+import { outputFromObservable, outputToObservable } from '@angular/core/rxjs-interop';
+
+// Convert Observable to output
+search$ = new Subject<string>();
+search = outputFromObservable(this.search$);
+
+// Convert output to Observable
+searchObservable$ = outputToObservable(this.search);
+```
+
+## Migration 3: @ViewChild/@ContentChild to Signal Queries
+
+### Before
+
+```typescript
+@Component({...})
+export class TabPanel {
+  @ViewChild('container') container!: ElementRef;
+  @ViewChildren(TabComponent) tabs!: QueryList<TabComponent>;
+  @ContentChild(HeaderComponent) header?: HeaderComponent;
+  @ContentChildren(ItemComponent) items!: QueryList<ItemComponent>;
+}
+```
+
+### After
+
+```typescript
+@Component({...})
+export class TabPanel {
+  container = viewChild.required<ElementRef>('container');
+  tabs = viewChildren(TabComponent);
+  header = contentChild(HeaderComponent);
+  items = contentChildren(ItemComponent);
+}
+```
+
+### Key Differences
+
+| Aspect | Decorator Query | Signal Query |
+|--------|----------------|-------------|
+| Type | `ElementRef` / `QueryList<T>` | `Signal<ElementRef>` / `Signal<readonly T[]>` |
+| Reading | `this.container` | `this.container()` |
+| Required | `!` assertion | `.required()` variant |
+| Lifecycle | Available after `ngAfterViewInit` | Available as signal immediately |
+| Change detection | Manual (QueryList.changes) | Reactive (signal updates) |
+
+### Automated Migration
+
+```bash
+ng generate @angular/core:signal-queries-migration
+```
+
+## Migration 4: Constructor DI to inject()
+
+### Before
+
+```typescript
+@Component({...})
+export class UserService {
+  constructor(
+    private http: HttpClient,
+    @Inject(API_URL) private apiUrl: string,
+    @Optional() private logger?: LoggerService
+  ) {}
+}
+```
+
+### After
+
+```typescript
+@Component({...})
+export class UserService {
+  private http = inject(HttpClient);
+  private apiUrl = inject(API_URL);
+  private logger = inject(LoggerService, { optional: true });
+}
+```
+
+### Automated Migration
+
+```bash
+ng generate @angular/core:inject
+```
+
+## Migration 5: BehaviorSubject to Signal (Manual)
+
+No schematic exists — this is a manual architectural migration.
+
+### Before (RxJS State)
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class CartService {
+  private items$ = new BehaviorSubject<CartItem[]>([]);
+  readonly items = this.items$.asObservable();
+  readonly total$ = this.items$.pipe(
+    map(items => items.reduce((sum, i) => sum + i.price, 0))
+  );
+
+  addItem(item: CartItem) {
+    this.items$.next([...this.items$.value, item]);
+  }
+}
+```
+
+### After (Signal State)
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class CartService {
+  private _items = signal<CartItem[]>([]);
+  readonly items = this._items.asReadonly();
+  readonly total = computed(() =>
+    this._items().reduce((sum, i) => sum + i.price, 0)
+  );
+
+  addItem(item: CartItem) {
+    this._items.update(list => [...list, item]);
+  }
+}
+```
+
+### When to Migrate to Signals vs Keep RxJS
+
+| Use Case | Use Signals | Use RxJS |
+|----------|------------|---------|
+| Component-local UI state | Yes | No |
+| Derived/computed values | Yes (`computed()`) | No |
+| Simple service state | Yes | No |
+| HTTP requests | No | Yes (`HttpClient`) |
+| WebSocket streams | No | Yes |
+| Complex async orchestration | No | Yes (operators) |
+| Debounce/throttle/retry | No | Yes (operators) |
+| Router events | No | Yes (then `toSignal()`) |
+| Form value streams | Depends | Reactive Forms: Yes |
+| Global state (NgRx) | Hybrid | Yes (NgRx still RxJS) |
+
+### RxJS-to-Signal Bridge
+
+```typescript
+import { toSignal, toObservable } from '@angular/core/rxjs-interop';
+
+// Observable → Signal
+readonly routeId = toSignal(
+  this.route.params.pipe(map(p => p['id'])),
+  { initialValue: '' }
+);
+
+// Signal → Observable
+readonly items$ = toObservable(this.items);
+```
+
+## Migration 6: Async Data Loading with resource()
+
+### Before (Manual Loading Pattern)
+
+```typescript
+@Component({...})
+export class FruitDetail {
+  fruit?: Fruit;
+  loading = false;
+  error?: Error;
+
+  constructor(private http: HttpClient) {}
+
+  ngOnInit() {
+    this.loading = true;
+    this.http.get<Fruit>('/api/fruit/1').subscribe({
+      next: (f) => { this.fruit = f; this.loading = false; },
+      error: (e) => { this.error = e; this.loading = false; }
+    });
+  }
+}
+```
+
+### After (resource API — v20+)
+
+```typescript
+@Component({...})
+export class FruitDetail {
+  fruitId = input.required<string>();
+
+  fruitDetail = resource({
+    request: this.fruitId,
+    loader: async ({ request: id }) => {
+      const response = await fetch(`/api/fruit/${id}`);
+      return response.json() as Promise<Fruit>;
+    }
+  });
+
+  // Access: fruitDetail.value(), fruitDetail.isLoading(), fruitDetail.error()
+}
+```
+
+### rxResource (RxJS Variant)
+
+```typescript
+fruitDetail = rxResource({
+  request: this.fruitId,
+  loader: ({ request: id }) =>
+    this.http.get<Fruit>(`/api/fruit/${id}`)
+});
+```
+
+## Incremental Adoption Strategy
+
+Adopt signals incrementally — do not rewrite everything at once.
+
+### Phase 1: New Code Only
+Write all new components with signal inputs/outputs/queries.
+Existing code stays as-is.
+
+### Phase 2: Run Automated Schematics
+```bash
+ng generate @angular/core:signal-input-migration
+ng generate @angular/core:output-migration
+ng generate @angular/core:signal-queries-migration
+ng generate @angular/core:inject
+```
+
+### Phase 3: Convert Services
+Migrate `BehaviorSubject` patterns in services to signals.
+Start with leaf services (no downstream consumers).
+
+### Phase 4: Adopt resource() for Data Loading
+Replace manual loading patterns with `resource()` or `rxResource()`.
+
+### Phase 5: Remove Unnecessary RxJS
+After signals are widespread, audit for RxJS usage that can be
+simplified. Keep RxJS for genuine async orchestration.

--- a/skills/angular-migrations/references/testing-and-build-tooling.md
+++ b/skills/angular-migrations/references/testing-and-build-tooling.md
@@ -1,0 +1,353 @@
+# Testing and Build Tooling Migration
+
+Sources: Angular Blog (announcing-angular-v21, meet-angular-v19), angular.dev/guide/testing, yeou.dev upgrade guide, AngularUX playbook, community Vitest migration guides
+
+Covers: Karma to Vitest migration, build system changes (webpack to esbuild), Angular Material/CDK updates, HMR behavior, and monorepo/workspace considerations.
+
+## Build System Evolution
+
+| Version | Default Builder | Webpack Status | esbuild Status |
+|---------|----------------|---------------|----------------|
+| v15 | `@angular-devkit/build-angular` (webpack) | Primary | N/A |
+| v16-v17 | `@angular-devkit/build-angular` | Primary | Opt-in (dev) |
+| v18 | `@angular-devkit/build-angular` (application builder) | Available | Default |
+| v19 | `@angular-devkit/build-angular` (application builder) | Deprecated | Default |
+| v20 | `@angular/build` | Removed from default | Default (only option) |
+| v21 | `@angular/build` | Removed | Default |
+
+### Key Change: v20 Builder Package
+
+In v20, the default build package changed from `@angular-devkit/build-angular`
+to `@angular/build`. The new package:
+
+- Uses esbuild for all builds (dev and prod)
+- Uses Vite for dev server
+- Does NOT include Karma support
+- Faster builds (2-4x improvement reported)
+- Better tree-shaking and smaller bundles
+
+### Migration: Verify Builder in angular.json
+
+```json
+{
+  "projects": {
+    "my-app": {
+      "architect": {
+        "build": {
+          "builder": "@angular/build:application"
+        },
+        "serve": {
+          "builder": "@angular/build:dev-server"
+        }
+      }
+    }
+  }
+}
+```
+
+If you see `@angular-devkit/build-angular:application`, the build works
+the same — the package name change is the main difference.
+
+### Custom Webpack Configuration
+
+If your project uses custom webpack config (via `@angular-builders/custom-webpack`
+or similar), you must either:
+
+1. Port webpack customizations to esbuild plugins
+2. Stay on `@angular-devkit/build-angular` (deprecated, limited lifespan)
+3. Use Angular CLI's `--define` flag for simple substitutions
+
+## Test Runner Evolution
+
+| Version | Default Runner | Karma Status | Vitest Status |
+|---------|---------------|-------------|---------------|
+| v18 | Karma + Jasmine | Default | N/A |
+| v19 | Karma + Jasmine | Default | Experimental |
+| v20 | Karma (via bridge) | Removed from `@angular/build` | Experimental |
+| v21 | Vitest | Not supported | Stable (default) |
+
+## Karma to Vitest Migration
+
+### Phase 1: Install Vitest (v20+)
+
+The Angular CLI provides experimental Vitest support:
+
+```bash
+# If using @angular/build (v20+), Karma is gone
+# Install the old builder as a bridge if needed:
+npm install @angular-devkit/build-angular --save-dev
+```
+
+### Phase 2: Run Migration Schematic (v21+)
+
+```bash
+ng g @schematics/angular:refactor-jasmine-vitest
+```
+
+This converts Jasmine syntax to Vitest:
+
+| Jasmine | Vitest |
+|---------|--------|
+| `describe()` | `describe()` (same) |
+| `it()` | `it()` (same) |
+| `beforeEach()` | `beforeEach()` (same) |
+| `expect(x).toBe(y)` | `expect(x).toBe(y)` (same) |
+| `expect(x).toEqual(y)` | `expect(x).toEqual(y)` (same) |
+| `jasmine.createSpy()` | `vi.fn()` |
+| `spyOn(obj, 'method')` | `vi.spyOn(obj, 'method')` |
+| `jasmine.objectContaining()` | `expect.objectContaining()` |
+| `jasmine.any(Number)` | `expect.any(Number)` |
+| `done()` callback | `async/await` or return Promise |
+
+### Phase 3: Update angular.json Test Target
+
+```json
+{
+  "test": {
+    "builder": "@angular/build:unit-test",
+    "options": {
+      "tsConfig": "tsconfig.spec.json",
+      "runner": "vitest"
+    }
+  }
+}
+```
+
+### Phase 4: Update Test Configuration
+
+Create `vitest.config.ts` if custom configuration needed:
+
+```typescript
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['src/**/*.spec.ts'],
+  },
+});
+```
+
+### Phase 5: Fix Manual Conversion Items
+
+The schematic doesn't handle everything:
+
+| Pattern | Manual Fix Required |
+|---------|-------------------|
+| Custom Jasmine matchers | Rewrite as Vitest matchers or plugins |
+| `done()` callback async | Convert to `async/await` |
+| Jasmine clock | Use `vi.useFakeTimers()` |
+| `jasmine.createSpyObj()` | Create object with `vi.fn()` methods |
+| Karma-specific config | Remove karma.conf.js, add vitest config |
+| Test harnesses | Verify Angular CDK test harnesses work |
+
+### Common Vitest Migration Issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `Cannot find module 'vitest'` | Vitest not installed | `npm install vitest --save-dev` |
+| `ReferenceError: describe is not defined` | Globals not enabled | Add `globals: true` to vitest config |
+| Angular DI fails in tests | TestBed not configured | Ensure `TestBed.configureTestingModule` runs in `beforeEach` |
+| `HttpClientTestingModule` not found | Import changed | Use `provideHttpClientTesting()` |
+| Slow test startup | Missing optimization | Ensure test target uses `@angular/build:unit-test` |
+
+## Alternative: Karma Bridge (Temporary)
+
+For teams not ready to migrate tests, keep Karma working in v20+:
+
+```bash
+npm install @angular-devkit/build-angular --save-dev
+```
+
+Update angular.json test target:
+
+```json
+{
+  "test": {
+    "builder": "@angular-devkit/build-angular:karma",
+    "options": {
+      "polyfills": ["zone.js", "zone.js/testing"],
+      "tsConfig": "tsconfig.spec.json",
+      "karmaConfig": "karma.conf.js"
+    }
+  }
+}
+```
+
+This is a temporary bridge — plan for Vitest migration.
+
+## Alternative: Jest Migration
+
+Jest is also supported but not the official recommendation:
+
+```bash
+npm install jest @angular-builders/jest --save-dev
+```
+
+Angular's direction is clearly Vitest. Jest works but won't receive
+first-party support.
+
+## Hot Module Replacement (HMR)
+
+### v19: HMR for Styles (New)
+
+Enabled by default in dev server. CSS/SCSS changes apply without
+full page reload — component state is preserved.
+
+Implementation: Styles use `<link>` tags instead of inline `<style>`.
+
+### v19: HMR for Templates (Experimental)
+
+Template changes trigger component reload. Component state is NOT
+preserved (unlike style HMR).
+
+### Known Issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| Style flickering on initial load | `<link>` tag loading delay | Disable HMR: `ng serve --no-hmr` |
+| State lost on template change | Template HMR reloads component | Expected behavior |
+| Styles not applying | HMR style injection failed | Full page reload (`Ctrl+Shift+R`) |
+
+### Disabling HMR
+
+```bash
+ng serve --no-hmr
+```
+
+Or in `angular.json`:
+
+```json
+{
+  "serve": {
+    "options": {
+      "hmr": false
+    }
+  }
+}
+```
+
+## Angular Material and CDK Updates
+
+### Version Alignment
+
+Angular Material follows the same major versioning. Always update together:
+
+```bash
+ng update @angular/cli@{ver} @angular/core@{ver} @angular/material@{ver}
+```
+
+### Material Design 3 (M3)
+
+Starting with Material v20, M3 is the default design system:
+
+- Visual appearance changes (colors, shapes, typography)
+- Some component APIs changed
+- Custom themes may need updating
+
+### Material Migration Schematics
+
+Material runs its own schematics during `ng update`:
+
+- Component API updates
+- Theme system updates
+- Deprecated component removals
+
+### CDK Test Harnesses
+
+CDK component test harnesses work with both Karma and Vitest.
+No migration needed for harness-based tests.
+
+```typescript
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+
+let loader: HarnessLoader;
+
+beforeEach(() => {
+  const fixture = TestBed.createComponent(MyComponent);
+  loader = TestbedHarnessEnvironment.loader(fixture);
+});
+
+it('should work', async () => {
+  const button = await loader.getHarness(MatButtonHarness);
+  await button.click();
+});
+```
+
+## Monorepo and Workspace Considerations
+
+### Nx Workspaces
+
+Use `nx migrate` instead of `ng update`:
+
+```bash
+# Generate migrations
+nx migrate @angular/core@21
+
+# Run migrations
+nx migrate --run-migrations
+
+# Verify
+nx run-many --target=build --all
+nx run-many --target=test --all
+```
+
+Nx handles:
+- Cross-project dependency updates
+- Workspace-level configuration
+- Parallel builds and tests
+- Affected project detection
+
+### Multi-App Workspaces
+
+For Angular CLI workspaces with multiple projects:
+
+```bash
+# Update applies to all projects
+ng update @angular/core@21 @angular/cli@21
+
+# Run schematics per project
+ng generate @angular/core:standalone --project=app1
+ng generate @angular/core:standalone --project=app2
+
+# Or target all with --path
+ng generate @angular/core:signal-input-migration --path=projects/
+```
+
+### Library Considerations
+
+If you maintain Angular libraries:
+
+- Libraries should support at least 2 Angular major versions
+- Use peer dependencies with range: `"@angular/core": ">=20.0.0"`
+- Test against multiple Angular versions in CI
+- Keep `NgZone.run()` / `NgZone.runOutsideAngular()` for Zone.js
+  compatibility (even if your library is zoneless)
+- Consider providing migration schematics for breaking changes
+
+## CI/CD Pipeline Updates
+
+After upgrading, update CI configuration:
+
+```yaml
+# Example: GitHub Actions
+- uses: actions/setup-node@v4
+  with:
+    node-version: '20'  # v20+ required for Angular 20+
+
+# Build
+- run: ng build --configuration production
+
+# Test (v21+ with Vitest)
+- run: ng test --watch=false --browsers=ChromeHeadless
+
+# Or Vitest
+- run: ng test
+```
+
+Ensure CI uses:
+- Node.js >= 20.11.1
+- Correct test runner (Vitest or Karma bridge)
+- Updated cache keys (package-lock.json changes)

--- a/skills/angular-migrations/references/v18-to-v19.md
+++ b/skills/angular-migrations/references/v18-to-v19.md
@@ -1,0 +1,258 @@
+# Angular v18 to v19 Migration Guide
+
+Sources: Angular Blog (meet-angular-v19), angular.dev/reference/migrations, Angular GitHub CHANGELOG 19.0.0, community migration guides
+
+Covers: all breaking changes, automatic schematics, new features, deprecations, common pitfalls, and post-migration verification for the v18→v19 upgrade.
+
+## Prerequisites
+
+| Requirement | Value |
+|-------------|-------|
+| TypeScript | >=5.5 (v18 used 5.4 — must upgrade) |
+| Node.js | >=18.19.1 or >=20.11.1 or >=22.0.0 (no change from v18) |
+| RxJS | 6.x or 7.x (no change) |
+| Angular | Latest v18 patch first |
+
+## Upgrade Command
+
+```bash
+# Ensure latest v18 patch first
+ng update @angular/core@18 @angular/cli@18
+
+# Main upgrade
+ng update @angular/core@19 @angular/cli@19
+
+# Angular Material (if used)
+ng update @angular/material@19
+
+# NgRx (if used)
+ng update @ngrx/store@19
+```
+
+## Breaking Changes
+
+### Standalone Components by Default (HIGH IMPACT)
+
+Components, directives, and pipes are now `standalone: true` by default.
+The `ng update` schematic handles this automatically:
+
+- Removes explicit `standalone: true` from already-standalone entities
+- Adds `standalone: false` to entities declared in NgModules
+
+NgModules are NOT deprecated — they still work, but components in them
+must now explicitly opt out of standalone.
+
+Common post-migration errors:
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Component X is standalone, and cannot be declared in an NgModule` | Schematic missed a component | Add `standalone: false` to component |
+| `Can't bind to 'ngModel' since it isn't a known property` | Module imports missing in standalone component | Add `FormsModule` to component imports array |
+| `'imports' is only valid on a component that is standalone` | Component in NgModule has imports | Either go standalone or move imports to the module |
+
+Optional compiler enforcement:
+
+```json
+{
+  "angularCompilerOptions": {
+    "strictStandalone": true
+  }
+}
+```
+
+### Template `this.foo` Behavior Change (MEDIUM IMPACT)
+
+`this.foo` in templates now always refers to the class property, never to
+template context variables (like loop variables from `*ngFor`).
+
+```html
+<!-- v18: this.item could refer to *ngFor variable -->
+<!-- v19: this.item ALWAYS refers to class property -->
+<div *ngFor="let item of items">{{ this.item }}</div>
+
+<!-- Fix: remove this. prefix -->
+<div *ngFor="let item of items">{{ item }}</div>
+```
+
+No automatic migration — requires manual template audit. Search templates
+for `this.` usage inside structural directives.
+
+### Effect Timing Changes (MEDIUM IMPACT)
+
+Two timing changes for `effect()`:
+
+1. Effects triggered during change detection (e.g., by input signals) now
+   run before template rendering, not after
+2. Effects triggered outside CD now run as part of CD instead of as a
+   microtask
+
+Test impact: `fakeAsync` tests may need additional `tick()` or `flush()`.
+
+Also deprecated: `allowSignalWrites: true` — signal writes in effects are
+now allowed by default.
+
+```typescript
+// v18
+effect(() => {
+  this.derived.set(this.source());
+}, { allowSignalWrites: true }); // deprecated in v19
+
+// v19
+effect(() => {
+  this.derived.set(this.source());
+}); // just works
+```
+
+### TestBed Error Rethrow (MEDIUM IMPACT)
+
+`ApplicationRef.tick` errors are now rethrown in TestBed instead of being
+silently swallowed. Tests that previously passed may now surface real errors.
+
+```typescript
+// Option 1: Fix the underlying error (preferred)
+
+// Option 2: Expect the error
+expect(() => TestBed.inject(ApplicationRef).tick()).toThrow();
+
+// Option 3: Disable rethrow (temporary workaround)
+TestBed.configureTestingModule({
+  rethrowApplicationErrors: false
+});
+```
+
+### Router Changes
+
+`Router.errorHandler` property removed. Migrate to:
+
+```typescript
+// v19
+provideRouter(routes, withNavigationErrorHandler((error) => { ... }));
+```
+
+`BrowserModule.withServerTransition()` removed. Use `APP_ID` token:
+
+```typescript
+// v19
+providers: [{ provide: APP_ID, useValue: 'my-app' }]
+```
+
+### Other Breaking Changes
+
+| Change | Impact | Migration |
+|--------|--------|-----------|
+| `ExperimentalPendingTasks` renamed to `PendingTasks` | Low | Auto-migrated by `ng update` |
+| `KeyValueDiffers.factories` removed | Low | Remove any usage |
+| Zone coalescing timers now visible to `fakeAsync` | Medium | Add `tick()`/`flush()` to affected tests |
+| `ComponentFixture.autoDetect` attaches to `ApplicationRef` | Low | Custom error handlers may see new errors |
+| Empty `projectableNodes` renders fallback content | Low | Pass non-empty array to prevent fallback |
+| `ng add @angular/localize` `name` option removed | Low | Use `--project` instead |
+| Custom elements CD timing changed | Low | Update tests relying on CD timing |
+
+## New Features Affecting Migration
+
+### Signal APIs Graduated to Stable
+
+These APIs moved from developer preview to stable:
+
+| API | Now Stable |
+|-----|-----------|
+| `input()` / `input.required()` | Yes |
+| `output()` | Yes |
+| `model()` | Yes |
+| `viewChild()` / `viewChildren()` | Yes |
+| `contentChild()` / `contentChildren()` | Yes |
+| `takeUntilDestroyed()` | Yes |
+| `outputFromObservable()` / `outputToObservable()` | Yes |
+
+Still in developer preview: `effect()`, `toObservable()`, `toSignal()`,
+`afterRender()`, `afterNextRender()`.
+
+New experimental APIs:
+
+- `linkedSignal()` — writable signal linked to a computed source
+- `resource()` — async data loading with signals
+- `rxResource()` — RxJS-based variant of resource
+- `afterRenderEffect()` — effect that runs after rendering
+
+### Incremental Hydration (Developer Preview)
+
+Lazy-load and hydrate SSR components on triggers using `@defer`:
+
+```typescript
+// Enable
+provideClientHydration(withIncrementalHydration());
+```
+
+```html
+@defer (hydrate on viewport) {
+  <shopping-cart/>
+}
+```
+
+### Event Replay Enabled by Default
+
+For SSR apps, user events during hydration are now automatically replayed.
+No opt-in required.
+
+### Server Route Configuration
+
+Route-level render mode control:
+
+```typescript
+import { RenderMode, ServerRoute } from '@angular/ssr';
+
+export const serverRouteConfig: ServerRoute[] = [
+  { path: '/login', mode: RenderMode.Server },
+  { path: '/home', mode: RenderMode.Prerender },
+  { path: '/dashboard', mode: RenderMode.Client },
+];
+```
+
+### `@let` Template Syntax (Stable)
+
+```html
+@let user = userSignal();
+@let greeting = 'Hello, ' + user.name;
+<p>{{ greeting }}</p>
+```
+
+### HMR for Styles (Default)
+
+CSS/SCSS changes apply without full page reload. Enabled by default.
+May cause style flickering — disable with `ng serve --no-hmr` if needed.
+
+### Unused Import Diagnostic
+
+New `unusedStandaloneImports` diagnostic warns about unused imports in
+standalone component `imports` arrays.
+
+## Deprecations
+
+| Item | Replacement |
+|------|-------------|
+| `effect({ allowSignalWrites: true })` | Remove option (writes allowed by default) |
+| Explicit `standalone: true` | Omit (it's now the default) |
+| `ExperimentalPendingTasks` | `PendingTasks` |
+| Webpack builder (`@angular-devkit/build-angular`) | Application builder (`@angular/build`) |
+
+## Post-Migration Checklist
+
+```
+VERIFICATION
+[ ] All components in NgModules have standalone: false
+[ ] No template uses this.variable for context variables
+[ ] Router.errorHandler migrated to withNavigationErrorHandler()
+[ ] BrowserModule.withServerTransition() replaced with APP_ID
+[ ] fakeAsync tests pass (check for timer zone changes)
+[ ] TestBed tests pass (check for newly surfaced errors)
+[ ] ng build --configuration production succeeds
+[ ] ng test passes
+
+OPTIONAL IMPROVEMENTS
+[ ] ng generate @angular/core:signal-input-migration
+[ ] ng generate @angular/core:output-migration
+[ ] ng generate @angular/core:signal-queries-migration
+[ ] ng generate @angular/core:inject
+[ ] ng generate @angular/core:cleanup-unused-imports
+[ ] ng generate @angular/core:route-lazy-loading
+```

--- a/skills/angular-migrations/references/v19-to-v20.md
+++ b/skills/angular-migrations/references/v19-to-v20.md
@@ -1,0 +1,279 @@
+# Angular v19 to v20 Migration Guide
+
+Sources: Angular Blog (angular-v20), angular.dev/update-guide, yeou.dev upgrade guide, community migration guides, AngularUX playbook
+
+Covers: all breaking changes, build system transition, Karma removal, naming conventions, TypeScript/Node requirements, and post-migration steps for the v19→v20 upgrade.
+
+## Prerequisites
+
+| Requirement | Value |
+|-------------|-------|
+| TypeScript | >=5.8 (v19 used 5.5-5.6 — must upgrade) |
+| Node.js | >=20.11.1 (v19 allowed 18.x — Node 18 dropped) |
+| RxJS | 7.x or 8.x (RxJS 6 dropped) |
+| Angular | Latest v19 patch first |
+
+## Upgrade Command
+
+```bash
+# Ensure latest v19 patch
+ng update @angular/core@19 @angular/cli@19
+
+# Main upgrade
+ng update @angular/core@20 @angular/cli@20
+
+# Angular Material (if used)
+ng update @angular/core@20 @angular/cli@20 @angular/material@20
+```
+
+## Breaking Changes
+
+### Build Package Change (HIGH IMPACT)
+
+The default build package changes from `@angular-devkit/build-angular` to
+`@angular/build`. The new package does NOT include Karma support.
+
+Impact: `ng test` fails immediately if you use Karma.
+
+```bash
+# Temporary fix: reinstall old builder for Karma compatibility
+npm install @angular-devkit/build-angular --save-dev
+```
+
+Long-term: migrate to Vitest or Jest. See `references/testing-and-build-tooling.md`.
+
+### Karma Removed (HIGH IMPACT)
+
+The Angular CLI no longer ships Karma support in the new build package.
+This is the most disruptive change for projects with extensive Karma/Jasmine test suites.
+
+Options:
+
+| Path | Effort | Recommendation |
+|------|--------|---------------|
+| Install `@angular-devkit/build-angular` | Low | Temporary bridge — buys time |
+| Migrate to Vitest | Medium | Recommended — Angular's future direction |
+| Migrate to Jest | Medium | Alternative if team prefers Jest |
+
+### Node.js 18 Dropped
+
+Node.js 18 is no longer supported. Minimum is now Node.js 20.11.1.
+
+```bash
+node --version  # Must be >=20.11.1
+nvm use 20      # If using nvm
+```
+
+### RxJS 6 Dropped
+
+RxJS 6 is no longer supported. Must use RxJS 7.x or 8.x.
+
+If upgrading from RxJS 6:
+- Remove `rxjs-compat` package
+- Update import paths from `rxjs/internal/*` to `rxjs`
+- Replace deprecated operators
+
+If upgrading to RxJS 8:
+- `retry()` semantics changed (delays, count behavior)
+- Some operator signatures tightened
+- Check for breaking changes in RxJS 8 changelog
+
+### TypeScript 5.8 Required
+
+Minimum TypeScript version is 5.8. Key TypeScript 5.8 features:
+
+- `--erasableSyntaxOnly` for Node.js `--experimental-strip-types`
+- Granular checks for branches in return expressions
+- Checked import attributes
+
+### New Naming Convention (MEDIUM IMPACT)
+
+Angular 20 introduces an official convention that drops traditional suffixes:
+
+```
+# Old naming
+user-profile.component.ts
+auth.service.ts
+highlight.directive.ts
+auth.guard.ts
+
+# New naming
+user-profile.ts
+auth-store.ts
+highlight.ts
+auth.ts
+```
+
+The `ng generate` command in v20 uses the new naming by default.
+Existing files are NOT automatically renamed — this is opt-in.
+
+Naming rules:
+- Use dashes: `user-profile.ts`
+- Match class name and filename
+- Keep `.spec.ts` for tests
+- Focus on intent, not type (e.g., `user-api.ts` not `user.service.ts`)
+
+### Signals Fully Stable
+
+All core signal reactive primitives are now stable:
+
+- `effect()` graduated from developer preview to stable
+- `toSignal()` and `toObservable()` graduated to stable
+- `afterRender()` and `afterNextRender()` graduated to stable
+- `resource()` graduated to stable
+
+### Zoneless Change Detection Stable (v20.2)
+
+`provideZonelessChangeDetection()` is stable as of v20.2. No longer
+experimental — safe for production use.
+
+```typescript
+// Stable in v20.2+
+bootstrapApplication(AppComponent, {
+  providers: [provideZonelessChangeDetection()]
+});
+```
+
+### TestBed.inject Behavior Change
+
+`TestBed.inject` behavior tightened around type safety. Some previously
+loose type casts may fail.
+
+### Opera Browser Support Dropped
+
+If your `browserslist` includes Opera, you may need to remove it to
+avoid warnings or build issues.
+
+## New Features Affecting Migration
+
+### Signal-Based Reactivity — Full Ecosystem
+
+With all signal APIs stable, v20 marks the point where the full
+signal-based architecture is production-ready:
+
+- Signal inputs/outputs/queries (stable since v19, reinforced in v20)
+- `resource()` for async data loading
+- `rxResource()` for RxJS-based async data
+- `effect()` for side effects
+- `linkedSignal()` for derived writable state
+
+### New Folder Structure Convention
+
+Angular 20 promotes a feature-based folder structure:
+
+```
+src/
+├── core/
+│   └── auth/
+│       ├── auth-store.ts
+│       ├── login.ts
+│       └── register.ts
+├── features/
+│   └── users/
+│       ├── user-profile.ts
+│       ├── user-api.ts
+│       └── user-settings.ts
+```
+
+### SSR Hydration Improvements
+
+- Better hydration stability and debugging
+- Reduced hydration mismatches
+- Tighter integration with signals
+
+### Control Flow — Fully Mature
+
+`@for`, `@if`, `@switch`, `@let`, `@defer` are all fully stable.
+The migration schematic handles conversion:
+
+```bash
+ng generate @angular/core:control-flow
+```
+
+`track` is mandatory in `@for` (encourages best practices):
+
+```html
+@for (item of items; track item.id) {
+  <div>{{ item.name }}</div>
+} @empty {
+  <div>No items</div>
+}
+```
+
+## Migration Schematics
+
+Run after `ng update`:
+
+```bash
+# Most important for v20
+ng generate @angular/core:standalone          # If not done in v19
+ng generate @angular/core:control-flow        # Convert *ngIf/*ngFor
+ng generate @angular/core:inject              # Constructor -> inject()
+ng generate @angular/core:signal-input-migration
+ng generate @angular/core:output-migration
+ng generate @angular/core:signal-queries-migration
+ng generate @angular/core:route-lazy-loading
+ng generate @angular/core:cleanup-unused-imports
+ng generate @angular/core:self-closing-tags
+```
+
+## Common Pitfalls
+
+### Pitfall 1: `ng test` Fails Immediately
+
+Symptom: `ng test` command fails with builder error.
+Cause: `@angular/build` doesn't include Karma plugin.
+Fix: `npm install @angular-devkit/build-angular --save-dev` or migrate tests.
+
+### Pitfall 2: Node.js Version Mismatch
+
+Symptom: `ng update` refuses to run.
+Cause: Running Node.js 18.x.
+Fix: Upgrade to Node.js 20.11.1+.
+
+### Pitfall 3: RxJS 6 Incompatibility
+
+Symptom: Import errors, missing operators.
+Cause: RxJS 6 no longer supported.
+Fix: Upgrade to RxJS 7.x minimum. Remove `rxjs-compat`.
+
+### Pitfall 4: RxJS 8 Retry Semantics
+
+Symptom: Retry logic behaves differently after RxJS 8 upgrade.
+Cause: `retry()` operator changed delay/count behavior.
+Fix: Review and adjust retry configurations.
+
+### Pitfall 5: TypeScript 5.8 Type Errors
+
+Symptom: New type errors in existing code.
+Cause: Stricter TypeScript 5.8 checks.
+Fix: Address type errors — they often reveal real bugs.
+
+### Pitfall 6: Third-Party Library Compatibility
+
+Symptom: Peer dependency conflicts.
+Cause: Libraries not yet compatible with Angular 20.
+Fix: Check library changelogs, update or find alternatives.
+
+## Post-Migration Checklist
+
+```
+CRITICAL
+[ ] Node.js >= 20.11.1 verified
+[ ] TypeScript >= 5.8 verified
+[ ] RxJS >= 7.x verified (6.x removed)
+[ ] ng build --configuration production succeeds
+[ ] ng test passes (Karma workaround or Vitest migration)
+
+RECOMMENDED
+[ ] Plan Karma → Vitest migration (v21 makes Vitest default)
+[ ] Evaluate zoneless change detection (stable in v20.2)
+[ ] Run all migration schematics (signals, control flow, inject)
+[ ] Consider adopting new naming conventions for new files
+
+VERIFY
+[ ] No deprecated API warnings in build output
+[ ] SSR hydration works correctly (if applicable)
+[ ] Third-party libraries updated and compatible
+[ ] E2E tests pass
+```

--- a/skills/angular-migrations/references/v20-to-v21.md
+++ b/skills/angular-migrations/references/v20-to-v21.md
@@ -1,0 +1,312 @@
+# Angular v20 to v21 Migration Guide
+
+Sources: Angular Blog (announcing-angular-v21), angular.dev/guide/zoneless, angular.love/angular-21, community transition guides (2025-2026)
+
+Covers: zoneless by default, Signal Forms, Angular Aria, Vitest stable, MCP server, template enhancements, and all breaking changes for the v20→v21 upgrade.
+
+## Prerequisites
+
+| Requirement | Value |
+|-------------|-------|
+| TypeScript | >=5.8 (same as v20) |
+| Node.js | >=20.11.1 (same as v20) |
+| RxJS | 7.x or 8.x (same as v20) |
+| Angular | Latest v20 patch first |
+
+## Upgrade Command
+
+```bash
+ng update @angular/core@21 @angular/cli@21
+
+# Angular Material (if used)
+ng update @angular/core@21 @angular/cli@21 @angular/material@21
+```
+
+## Breaking Changes
+
+### Zoneless by Default (HIGH IMPACT)
+
+New Angular 21 applications no longer include Zone.js. Existing apps
+upgrading are NOT automatically switched — but this signals the direction.
+
+For existing apps, the choice:
+
+| Option | When to Use | How |
+|--------|-------------|-----|
+| Stay with Zone.js | Large legacy codebase, third-party deps need it | `provideZoneChangeDetection({ eventCoalescing: true })` |
+| Go zoneless | Modern codebase, signals adopted, OnPush everywhere | `provideZonelessChangeDetection()` + remove zone.js |
+| Gradual transition | Mixed codebase | Keep Zone.js, start converting components to signals |
+
+If you enabled zoneless but Zone.js is still in polyfills, Angular throws
+warning `NG0914`. Fix by removing `zone.js` from `angular.json`:
+
+```json
+// angular.json — remove from BOTH build and test targets
+{
+  "architect": {
+    "build": {
+      "options": {
+        "polyfills": []  // remove "zone.js"
+      }
+    },
+    "test": {
+      "options": {
+        "polyfills": []  // remove "zone.js/testing"
+      }
+    }
+  }
+}
+```
+
+Then uninstall Zone.js entirely:
+
+```bash
+npm uninstall zone.js
+```
+
+See `references/zoneless-migration.md` for the full zoneless compatibility
+checklist and migration strategy.
+
+### Vitest as Default Test Runner (HIGH IMPACT)
+
+Vitest support is now stable and is the default test runner for new projects.
+
+If you already migrated away from Karma in v20, no action needed.
+If you're still on Karma with the `@angular-devkit/build-angular` bridge:
+
+```bash
+# Migrate Jasmine tests to Vitest
+ng g @schematics/angular:refactor-jasmine-vitest
+```
+
+See `references/testing-and-build-tooling.md` for detailed migration.
+
+### Template Compilation Changes (v21.1)
+
+Multiple switch case matching:
+
+```html
+<!-- v21.0: had to repeat template for each case -->
+@switch (status) {
+  @case ('pending') { <app-loading /> }
+  @case ('processing') { <app-loading /> }
+}
+
+<!-- v21.1: multiple cases share template -->
+@switch (status) {
+  @case ('pending', 'processing') { <app-loading /> }
+  @case ('completed') { <app-success /> }
+}
+```
+
+### Angular 21.2 Changes
+
+- Arrow function support in templates
+- Eager change detection mode
+- Signal Forms improvements (`FormRoot`, `transformed`)
+
+## New Features Affecting Migration
+
+### Signal Forms (Experimental)
+
+A new forms library built on signals. Experimental — pilot it, don't
+bet production on it yet.
+
+```typescript
+import { form, Field } from '@angular/forms/signals';
+
+@Component({
+  imports: [Field],
+  template: `
+    Email: <input [field]="loginForm.email">
+    Password: <input [field]="loginForm.password">
+  `
+})
+export class LoginForm {
+  login = signal({
+    email: '',
+    password: ''
+  });
+
+  loginForm = form(this.login);
+}
+```
+
+Key differences from Reactive Forms:
+- Model defined by a signal (auto-syncs with fields)
+- Full type safety for form fields
+- No `ControlValueAccessor` needed for custom components
+- Schema-based validation built in
+- Experimental — API may change
+
+### Angular Aria (Developer Preview)
+
+Headless accessible UI components you style yourself. Includes:
+Accordion, Combobox, Grid, Listbox, Menu, Tabs, Toolbar, Tree.
+
+```bash
+npm i @angular/aria
+```
+
+Not a migration concern — purely additive. Offers an alternative to
+Angular Material for teams wanting custom styling.
+
+### MCP Server for AI Agents
+
+Angular CLI MCP server with 7 stable and experimental tools. Allows
+AI coding assistants to use Angular features directly.
+
+Setup: `ng mcp` or configure in IDE. Not a migration concern.
+
+### Template Improvements
+
+`@defer` enhancements:
+- IntersectionObserver options support for viewport triggers
+- Better error boundaries
+
+`@let` improvements:
+- More complex expressions supported
+- Better type inference
+
+### SSR and Hydration Improvements
+
+- Improved hydration stability
+- Better partial rendering
+- Signal-aware serialization
+- `PendingTasks` integration for zoneless SSR
+
+## Signals as the Default Mental Model
+
+In v21, signals are no longer "optional nice-to-have" — they are the
+default mental model for UI state:
+
+- New APIs and examples assume signals
+- Tooling and DevTools are optimized around them
+- `BehaviorSubject` for UI state becomes a code smell
+- Local component state should be signals
+
+RxJS stays important but is now clearly async-focused (HTTP, WebSocket,
+router events, complex async orchestration).
+
+### Signal-in-a-Service Pattern (Recommended)
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class UserStore {
+  // Private writable signal
+  private _users = signal<User[]>([]);
+
+  // Public readonly access
+  readonly users = this._users.asReadonly();
+  readonly count = computed(() => this._users().length);
+  readonly activeUsers = computed(() =>
+    this._users().filter(u => u.active)
+  );
+
+  // Public methods mutate state
+  addUser(user: User) {
+    this._users.update(list => [...list, user]);
+  }
+}
+```
+
+## Migration Strategy for Large Codebases
+
+### Step 1: Audit Current State
+
+Before upgrading:
+- Where do you use RxJS purely for UI state?
+- How many components rely on Zone.js side effects?
+- Is OnPush used consistently?
+- Is SSR enabled? Where does it break?
+
+### Step 2: Introduce Signals Strategically
+
+Start with:
+- Component-local state → `signal()`
+- Derived UI logic → `computed()`
+- View models → `signal()` + `computed()`
+
+Rules:
+- UI state → Signals
+- Async flows → RxJS
+- Global state → NgRx (still valid)
+
+### Step 3: Prepare for Zoneless
+
+Checklist before enabling:
+- [ ] OnPush everywhere (or signal-based updates)
+- [ ] No reliance on implicit async updates
+- [ ] No `setTimeout`/side effects to "trigger" UI refreshes
+- [ ] Third-party libs compatible with zoneless
+
+Once clean, enabling zoneless is a configuration change, not a refactor.
+
+### Step 4: Upgrade
+
+```bash
+ng update @angular/core@21 @angular/cli@21
+```
+
+## Common Pitfalls
+
+### Pitfall 1: Zoneless + Zone.js Still Loaded (NG0914)
+
+Symptom: Warning `NG0914` in console.
+Cause: Enabled zoneless but `zone.js` still in polyfills.
+Fix: Remove from `angular.json` polyfills and uninstall.
+
+### Pitfall 2: Third-Party Libraries Expect Zone.js
+
+Symptom: UI doesn't update after async operations from a library.
+Cause: Library relies on Zone.js patches.
+Fix: Use `provideZoneChangeDetection()` as fallback, or wrap
+library calls with `ChangeDetectorRef.markForCheck()`.
+
+### Pitfall 3: `effect()` Outside Injection Context
+
+Symptom: Error "effect() can only be used within an injection context".
+Cause: `effect()` called outside constructor or DI context.
+Fix: Move to constructor, field initializer, or function called within
+injection context.
+
+### Pitfall 4: Signal Forms Breaking Changes
+
+Symptom: Signal Forms API changed between minor versions.
+Cause: API is experimental.
+Fix: Check release notes for each minor version. Pin to specific
+version if stability needed.
+
+### Pitfall 5: Vitest Migration Incomplete
+
+Symptom: Tests fail after running Jasmine→Vitest schematic.
+Cause: Schematic doesn't handle all Jasmine patterns.
+Fix: Manually convert remaining Jasmine-specific patterns (custom
+matchers, `done()` callbacks, etc.).
+
+## Post-Migration Checklist
+
+```
+CRITICAL
+[ ] ng build --configuration production succeeds
+[ ] ng test passes (Vitest or Karma bridge)
+[ ] No NG0914 warnings (zoneless + zone.js conflict)
+[ ] SSR hydration works (if applicable)
+
+ARCHITECTURE DECISIONS
+[ ] Decide: zoneless now or later?
+[ ] Decide: Signal Forms for new forms?
+[ ] Decide: Angular Aria vs Material for new components?
+
+RECOMMENDED
+[ ] Run remaining migration schematics
+[ ] Convert key services to signal-in-a-service pattern
+[ ] Profile change detection (zoneless reduces CD cycles)
+[ ] Update internal coding guidelines for signals-first
+[ ] Plan Reactive Forms → Signal Forms pilot (experimental)
+
+VERIFY
+[ ] Third-party libraries compatible
+[ ] E2E tests pass
+[ ] Performance metrics stable or improved
+```

--- a/skills/angular-migrations/references/zoneless-migration.md
+++ b/skills/angular-migrations/references/zoneless-migration.md
@@ -1,0 +1,364 @@
+# Angular Zoneless Migration
+
+Sources: angular.dev/guide/zoneless, Angular Blog (announcing-angular-v21, meet-angular-v19), community zoneless migration guides (2024-2026)
+
+Covers: Zone.js removal strategy, zoneless compatibility requirements, change detection behavior, testing, SSR considerations, and incremental migration path.
+
+## Zoneless Timeline
+
+| Version | Zone.js Status | API |
+|---------|---------------|-----|
+| v18 | Required (default) | `provideExperimentalZonelessChangeDetection()` (experimental) |
+| v19 | Required (default) | Same experimental API |
+| v20 | Optional | `provideZonelessChangeDetection()` (stable in v20.2) |
+| v21 | Not included by default | Zoneless is the default for new apps |
+
+## Why Go Zoneless
+
+Zone.js patches browser async APIs (setTimeout, Promise, fetch, DOM events)
+and triggers change detection whenever any async operation completes. This
+creates problems:
+
+- **Performance**: Change detection runs far more often than necessary because
+  Zone.js cannot know whether state actually changed
+- **Bundle size**: Zone.js adds ~13KB gzipped to every application
+- **Startup cost**: Patching all browser APIs adds initialization overhead
+- **Debugging**: Stack traces become harder to read with Zone.js monkey-patching
+- **Compatibility**: Some browser APIs can't be patched (async/await), and some
+  libraries conflict with Zone.js patching
+
+Zoneless Angular uses signals and explicit notifications instead — change
+detection runs only when something actually changed.
+
+## Enabling Zoneless
+
+### For New Apps (v21+)
+
+Zoneless is the default. Verify `provideZoneChangeDetection` is NOT used
+anywhere to override the default.
+
+### For Existing Apps (v20+)
+
+```typescript
+// app.config.ts
+import { provideZonelessChangeDetection } from '@angular/core';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZonelessChangeDetection(),
+    // ... other providers
+  ]
+};
+```
+
+### For NgModule-Based Apps
+
+```typescript
+@NgModule({
+  providers: [provideZonelessChangeDetection()],
+})
+export class AppModule {}
+```
+
+### Removing Zone.js from Build
+
+After enabling zoneless, remove Zone.js from the build:
+
+1. Remove from `angular.json` polyfills (both `build` and `test` targets):
+
+```json
+{
+  "architect": {
+    "build": {
+      "options": {
+        "polyfills": []
+      }
+    },
+    "test": {
+      "options": {
+        "polyfills": []
+      }
+    }
+  }
+}
+```
+
+2. Remove from `polyfills.ts` if it exists:
+
+```typescript
+// Remove these lines:
+// import 'zone.js';
+// import 'zone.js/testing';
+```
+
+3. Uninstall the package:
+
+```bash
+npm uninstall zone.js
+```
+
+If Zone.js is still loaded when zoneless is enabled, Angular throws
+warning `NG0914`.
+
+## Compatibility Requirements
+
+Angular requires explicit change detection notifications in zoneless mode.
+These notifications tell Angular when to check for updates:
+
+### Notification Mechanisms
+
+| Mechanism | Description |
+|-----------|-------------|
+| Signal update | Updating a signal read in a template |
+| `ChangeDetectorRef.markForCheck()` | Manual notification (called by `AsyncPipe`) |
+| `ComponentRef.setInput()` | Programmatic input setting |
+| Bound host/template listener callbacks | Event handlers |
+| Attaching a dirty view | View marked dirty by above mechanisms |
+
+### OnPush Compatibility
+
+`OnPush` components are already compatible with zoneless because they
+rely on the same notification mechanisms. Making all components OnPush
+is the recommended first step toward zoneless.
+
+OnPush is recommended but not required. Components can use `Default`
+strategy as long as they notify Angular of changes via the mechanisms
+above.
+
+### What Must Be Removed
+
+| Pattern | Why It Breaks | Replacement |
+|---------|--------------|-------------|
+| `NgZone.onMicrotaskEmpty` | Never emits in zoneless | `afterNextRender()` |
+| `NgZone.onUnstable` | Never emits | Remove or use signals |
+| `NgZone.onStable` | Never emits | `afterNextRender()` / `afterEveryRender()` |
+| `NgZone.isStable` | Always `true` | Remove condition |
+| Implicit async change detection | Zone.js not patching | Use signals or `markForCheck()` |
+
+### What Still Works
+
+| Pattern | Status |
+|---------|--------|
+| `NgZone.run()` | Works (no-op but compatible) |
+| `NgZone.runOutsideAngular()` | Works (no-op but compatible) |
+| `AsyncPipe` | Works (calls `markForCheck()` internally) |
+| Manual `markForCheck()` | Works |
+| Signal-based templates | Works (primary mechanism) |
+
+Keep `NgZone.run()` and `NgZone.runOutsideAngular()` in library code —
+removing them can cause regressions for consumers still using Zone.js.
+
+## Pre-Migration Compatibility Audit
+
+Before enabling zoneless, audit your codebase:
+
+### Step 1: Find Zone.js Dependencies
+
+Search for these patterns in your codebase:
+
+```
+NgZone.onMicrotaskEmpty
+NgZone.onUnstable
+NgZone.onStable
+NgZone.isStable
+```
+
+Each must be replaced before going zoneless.
+
+### Step 2: Find Implicit Change Detection
+
+Look for patterns that rely on Zone.js triggering CD:
+
+```typescript
+// BREAKS in zoneless — no Zone.js to detect the setTimeout
+setTimeout(() => {
+  this.data = newData;  // UI won't update
+}, 1000);
+
+// FIX: Use signals
+private _data = signal(initialData);
+setTimeout(() => {
+  this._data.set(newData);  // Signal notifies Angular
+}, 1000);
+```
+
+```typescript
+// BREAKS in zoneless — Promise completion not detected
+async loadData() {
+  this.data = await fetchData();  // UI won't update
+}
+
+// FIX: Use signals
+private _data = signal(initialData);
+async loadData() {
+  this._data.set(await fetchData());  // Signal notifies
+}
+```
+
+### Step 3: Check Third-Party Libraries
+
+Libraries that assume Zone.js patches async operations will not trigger
+change detection in zoneless mode. Common issues:
+
+- UI libraries that modify DOM outside Angular
+- State management libraries that use Zone.js for change notification
+- Animation libraries that use requestAnimationFrame
+
+For incompatible libraries, options:
+1. Update to a version that supports zoneless
+2. Wrap with `ChangeDetectorRef.markForCheck()`
+3. Fall back to Zone.js temporarily
+
+### Step 4: Verify OnPush Coverage
+
+Components using `ChangeDetectionStrategy.Default` without signals
+will not update in zoneless mode unless they use `markForCheck()`.
+
+Recommended: Convert all components to OnPush as an intermediate step.
+
+## SSR Considerations
+
+### PendingTasks for Server Rendering
+
+Without Zone.js, Angular cannot automatically determine when async work
+is complete for SSR serialization. Use `PendingTasks`:
+
+```typescript
+const taskService = inject(PendingTasks);
+
+// Option 1: run() wraps async work
+taskService.run(async () => {
+  const result = await loadDataForSSR();
+  this.state.set(result);
+});
+
+// Option 2: Manual add/remove for complex cases
+const cleanup = taskService.add();
+try {
+  await doWork();
+} finally {
+  cleanup();
+}
+```
+
+### pendingUntilEvent for Observables
+
+```typescript
+import { pendingUntilEvent } from '@angular/core/rxjs-interop';
+
+readonly data = someObservable.pipe(pendingUntilEvent());
+```
+
+Keeps the application "unstable" (prevents serialization) until the
+observable emits, completes, errors, or is unsubscribed.
+
+## Testing in Zoneless Mode
+
+### TestBed Configuration
+
+When `zone.js` is not loaded, TestBed runs zoneless by default.
+To force zoneless when `zone.js` is loaded:
+
+```typescript
+TestBed.configureTestingModule({
+  providers: [provideZonelessChangeDetection()],
+});
+
+const fixture = TestBed.createComponent(MyComponent);
+await fixture.whenStable();  // Preferred over fixture.detectChanges()
+```
+
+### Prefer `whenStable()` Over `detectChanges()`
+
+In zoneless mode, prefer `await fixture.whenStable()` instead of
+`fixture.detectChanges()`. This lets Angular decide when to run CD
+based on notifications — matching production behavior.
+
+`fixture.detectChanges()` still works but forces CD regardless of
+whether Angular would have scheduled it.
+
+### ExpressionChangedAfterItHasBeenCheckedError
+
+TestBed in zoneless mode enforces OnPush compatibility. If a test
+updates a component property without notification:
+
+```typescript
+// This will throw ExpressionChangedAfterItHasBeenChecked:
+fixture.componentInstance.someValue = 'newValue';
+fixture.detectChanges();
+
+// Fix: Use signals
+fixture.componentInstance.someSignal.set('newValue');
+await fixture.whenStable();
+
+// Or: Mark for check explicitly
+fixture.componentInstance.someValue = 'newValue';
+fixture.changeDetectorRef.markForCheck();
+await fixture.whenStable();
+```
+
+### Debug Mode: Exhaustive Change Check
+
+For development, enable periodic checks that catch missed notifications:
+
+```typescript
+provideCheckNoChangesConfig({
+  exhaustive: true,
+  interval: 500 // milliseconds
+});
+```
+
+Throws `ExpressionChangedAfterItHasBeenCheckedError` if bindings
+updated without notification.
+
+## Incremental Migration Path
+
+### Phase 1: Add OnPush Everywhere
+
+Convert all components to `ChangeDetectionStrategy.OnPush`. This is
+compatible with Zone.js and prepares for zoneless.
+
+### Phase 2: Convert to Signals
+
+Run migration schematics for signal inputs, outputs, queries.
+Convert service state to signals. See `references/signals-migration.md`.
+
+### Phase 3: Eliminate Zone.js Dependencies
+
+Remove `NgZone.onMicrotaskEmpty`, `NgZone.onStable`, etc.
+Replace implicit async detection with signal updates.
+
+### Phase 4: Enable Zoneless
+
+```typescript
+providers: [provideZonelessChangeDetection()]
+```
+
+Keep Zone.js in polyfills initially — test thoroughly.
+
+### Phase 5: Remove Zone.js
+
+Remove from polyfills, uninstall package. Test again.
+
+### Fallback
+
+If issues arise, revert to Zone.js:
+
+```typescript
+providers: [
+  provideZoneChangeDetection({ eventCoalescing: true })
+]
+```
+
+Add `zone.js` back to polyfills.
+
+## Common Zoneless Pitfalls
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| UI doesn't update after async op | No signal/markForCheck | Use signal or call `markForCheck()` |
+| NG0914 warning | Zone.js still loaded | Remove from polyfills |
+| Third-party component doesn't render | Library expects Zone.js | Update library or wrap with `markForCheck()` |
+| SSR hangs indefinitely | Async task not tracked | Use `PendingTasks` |
+| Tests fail with ExpressionChanged | Property set without notification | Use signals or `markForCheck()` |
+| `NgZone.isStable` always true | Expected — zoneless has no zone | Remove isStable checks |

--- a/skills/angular-migrations/skills.json
+++ b/skills/angular-migrations/skills.json
@@ -1,0 +1,16 @@
+{
+  "name": "@tank/angular-migrations",
+  "version": "1.0.0",
+  "description": "Expert Angular migration guidance for version upgrades from v18 through v21. Covers every migration path (v18 to v19, v19 to v20, v20 to v21), breaking changes, official migration schematics, signals adoption, zoneless transition, Karma-to-Vitest migration, and build tooling changes. Provides step-by-step upgrade procedures, compatibility matrices, and enterprise migration strategies. Triggers: angular migration, angular upgrade, ng update, angular 18, angular 19, angular 20, angular 21, upgrade angular, migrate angular, angular breaking changes, angular version upgrade, standalone migration, signals migration, zoneless, zone.js removal, karma to vitest, control flow migration, angular update guide, angular compatibility, angular deprecation.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": ["**/*"],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

- Adds `@tank/angular-migrations` skill (v1.0.0) covering Angular version upgrades from v18 through v21
- 7 reference files (2,515 lines total) covering version-specific guides, signals migration, zoneless transition, all 14 official schematics, and testing/build tooling changes
- 22 trigger phrases for reliable activation
- Validated with `quick_validate.py` — all checks pass

## Files

| File | Lines | Covers |
|------|-------|--------|
| `SKILL.md` | 144 | Entry point, compatibility matrix, schematic order, common problems |
| `references/v18-to-v19.md` | 258 | Standalone default, signals stable, breaking changes |
| `references/v19-to-v20.md` | 279 | Build system change, Karma removal, Node 18 dropped |
| `references/v20-to-v21.md` | 312 | Zoneless default, Signal Forms, Vitest stable |
| `references/signals-migration.md` | 377 | 6 migration patterns with before/after code |
| `references/zoneless-migration.md` | 364 | Zone.js removal strategy, compatibility audit |
| `references/migration-schematics.md` | 428 | All 14 official schematics with commands/flags |
| `references/testing-and-build-tooling.md` | 353 | Karma→Vitest, esbuild, HMR, Angular Material |