### PR TITLE
feat(ast-linter-codemod): add AST linter, codemod, and migration skill

### DIFF
--- a/skills/ast-linter-codemod/SKILL.md
+++ b/skills/ast-linter-codemod/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: "@tank/ast-linter-codemod"
+description: |
+  Build custom linters with auto-fix, write codemods for API migrations, and
+  run large-scale code transforms using ts-morph, jscodeshift, ESLint custom
+  rules, ast-grep, and Babel plugins. Covers AST fundamentals, the Visitor
+  pattern, Fixer API, Collection API, YAML rule authoring, fixture-based
+  testing, migration strategies, formatting preservation, and idempotency.
+  Synthesizes Nystrom (Crafting Interpreters), Kyle (Babel Plugin Handbook),
+  Noback/Votruba (Rector), ESTree spec, and production patterns from React,
+  Next.js, and Angular codemods.
+
+  Trigger phrases: "codemod", "linter", "custom lint rule", "ESLint rule",
+  "auto-fix", "autofix", "ts-morph", "jscodeshift", "ast-grep", "AST",
+  "abstract syntax tree", "code migration", "code transform",
+  "custom ESLint plugin", "Fixer API", "RuleTester", "babel plugin",
+  "recast", "migration script", "deprecation", "API rename",
+  "refactoring tool", "lint rule with fix", "sg rule", "typed linting",
+  "write a codemod", "build a linter", "AST transform"
+---
+
+# AST Linters, Codemods, and Migration Tools
+
+Build linters that catch bugs and fix them automatically. Write codemods that
+migrate entire codebases. Ship migration tools that handle edge cases.
+
+## Core Philosophy
+
+1. **Parse, don't regex.** Text manipulation breaks on edge cases. AST tools
+   understand code structure — template literals, JSX, decorators, and all.
+2. **Every lint rule deserves a fix.** A rule without auto-fix is a rule that
+   creates manual work. Ship the fix with the rule.
+3. **Test with fixtures, not assertions.** Input file → expected output file.
+   Fixtures are readable, diffable, and catch regressions that assertions miss.
+4. **Analyze first, transform second.** Collect all findings before mutating.
+   AST manipulation invalidates nodes — iterating and mutating simultaneously
+   causes forgotten-node bugs.
+5. **Idempotent transforms only.** Running a codemod twice must produce the
+   same output. If it doesn't, the codemod has a detection gap.
+
+## Quick-Start: What Are You Building?
+
+### "I need a custom ESLint rule with auto-fix"
+
+1. Define the pattern to detect (use astexplorer.net to identify node types)
+2. Write the rule with `context.report()` + `fix(fixer)` function
+3. Test with `RuleTester` — valid cases, invalid cases, fix output
+4. Package as an ESLint plugin
+
+See `references/eslint-custom-rules.md`
+
+### "I need a codemod to migrate an API"
+
+1. Pick tool: jscodeshift for JS/TS transforms, ts-morph for type-aware transforms
+2. Write the transform function (find pattern → replace pattern)
+3. Test with input/output fixture pairs
+4. Run with `--dry --print` first, then apply
+
+See `references/jscodeshift-codemods.md` or `references/ts-morph-patterns.md`
+
+### "I need to enforce a pattern across the codebase"
+
+1. If simple pattern: use ast-grep YAML rules (fastest to write)
+2. If needs type information: use ts-morph or typed ESLint rule
+3. If needs CI integration: use ESLint plugin
+
+See `references/ast-grep-rules.md`
+
+### "I need to run a large-scale migration"
+
+1. Audit: identify all patterns to transform
+2. Prototype: write codemod for the most common pattern
+3. Validate: run on a subset, review diffs
+4. Execute: run across codebase with parallel processing
+5. Clean up: fix remaining edge cases manually
+
+See `references/migration-strategies.md`
+
+## Tool Selection Decision Tree
+
+| Scenario | Best Tool | Why |
+|----------|-----------|-----|
+| Quick pattern ban or rename | **ast-grep** | YAML rules, fastest to write, no JS required |
+| ESLint rule with auto-fix for CI | **ESLint custom rule** | Integrates with existing lint pipeline |
+| Type-aware linting or refactoring | **ts-morph** | Full TypeScript type checker access |
+| API migration across many files | **jscodeshift** | Batch processing, formatting preservation via recast |
+| Type-aware API migration | **ts-morph** | Type resolution for ambiguous patterns |
+| Build-time code transform | **Babel plugin** | Integrates with build pipeline |
+| One-off search and replace | **ast-grep CLI** | `sg run --pattern '$OLD' --rewrite '$NEW'` |
+
+## Tool Capabilities Matrix
+
+| Feature | ts-morph | jscodeshift | ESLint | ast-grep | Babel |
+|---------|----------|-------------|--------|----------|-------|
+| Type information | Full | None | Via typed linting | None | None |
+| Format preservation | Manual | Automatic (recast) | Source ranges | Automatic | Via recast |
+| Auto-fix API | DIY | replaceWith/remove | Fixer API | fix: in YAML | path.replaceWith |
+| Testing framework | DIY | defineTest + fixtures | RuleTester | YAML test fixtures | babel-plugin-tester |
+| Speed | Medium | Medium | Fast | Very fast | Fast |
+| Learning curve | Medium | Medium | Low-Medium | Low | High |
+| Language support | TS/JS | JS/TS/Flow | JS/TS/JSX | 25+ languages | JS/TS/JSX/Flow |
+| CI integration | Script | Script | Native | CLI/CI | Build config |
+
+## Common Patterns Across All Tools
+
+### Find → Report → Fix
+
+Every tool follows the same high-level pattern:
+
+```
+1. Parse source into AST
+2. Find nodes matching a pattern (visitor, query, or traversal)
+3. Report the finding (error message, location)
+4. Apply a fix (replace text, insert, remove)
+5. Output modified source (preserving formatting where possible)
+```
+
+### The Dirty Flag
+
+Return `undefined`/`null` when no changes were made. Prevents unnecessary
+file writes and makes diffs clean.
+
+### Import-First Detection
+
+Always check imports before analyzing usage. If the target API isn't imported,
+skip the file entirely. Saves time and avoids false positives.
+
+### Comment Escape Hatches
+
+Support `// codemod-ignore` or `// eslint-disable-next-line` patterns so
+developers can opt out of automated transforms for edge cases.
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|-------------|---------|-----|
+| Regex-based transforms | Breaks on edge cases (strings, comments, JSX) | Use AST tools |
+| Mutating during traversal | Forgotten nodes, infinite loops | Collect changes, then apply |
+| No idempotency test | Running twice corrupts code | Add "already transformed" detection |
+| Fixing without testing | Silent code breakage | Fixture tests for every fix |
+| Ignoring formatting | Clean diffs become noise | Use recast or ast-grep's format preservation |
+| Hardcoding node types | Misses variants (class method vs arrow function) | Handle all syntactic forms |
+| No dry-run mode | Can't preview changes | Always support `--dry` flag |
+
+## Failure Map
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "Node was forgotten" (ts-morph) | Mutated AST during iteration | Collect all changes first, apply after |
+| Fix creates syntax error (ESLint) | Overlapping fix ranges | Use `fixer.replaceTextRange` with exact ranges |
+| Codemod misses some files | Parser mismatch (JS vs TS vs JSX) | Detect file extension, select parser |
+| Formatting destroyed after transform | Wrong printer or missing recast | Use recast for jscodeshift, toSource options |
+| Type information unavailable | Missing tsconfig or wrong project setup | Pass tsConfigFilePath to ts-morph Project |
+| Transform not idempotent | Missing "already transformed" check | Add guard: skip if new pattern already present |
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/ast-fundamentals.md` | AST mental model, parse→transform→generate pipeline, ESTree/TS node types, Visitor pattern, tool selection decision tree, tool comparison matrix |
+| `references/ts-morph-patterns.md` | ts-morph Project setup, node navigation, type system access, linter patterns, codemod patterns, analyze-then-transform, performance |
+| `references/eslint-custom-rules.md` | ESLint rule architecture, Fixer API (all 8 methods), auto-fixable rules, suggestion API, typed linting, RuleTester, plugin scaffolding |
+| `references/jscodeshift-codemods.md` | jscodeshift Collection API, find/filter/replace, formatting preservation, production patterns from React/Next.js codemods |
+| `references/ast-grep-rules.md` | ast-grep pattern syntax, metavariables, YAML rule format, fix/rewrite, constraints, sgconfig, testing, agent integration |
+| `references/migration-strategies.md` | Big Bang vs Gradual vs Module-by-Module, 5-phase toolchain, codemod composition, edge cases, Stripe/Pinterest case studies |
+| `references/testing-transforms.md` | Fixture-based testing, RuleTester, ast-grep YAML tests, idempotency testing, edge case catalog, CI integration |

--- a/skills/ast-linter-codemod/references/ast-fundamentals.md
+++ b/skills/ast-linter-codemod/references/ast-fundamentals.md
@@ -1,0 +1,440 @@
+# AST Fundamentals and Tool Selection
+
+Sources: Nystrom (Crafting Interpreters), Kyle (Babel Plugin Handbook), ESTree Specification, 2025-2026 ecosystem research
+
+This reference is the entry point for the skill. Read it before any tool-specific reference.
+It covers the mental model, the universal pipeline, and the decision logic for choosing tools.
+Examples use TypeScript unless otherwise noted.
+
+---
+
+## 1. The AST Mental Model
+
+Source code is text. Linters and codemods cannot reliably work on text — a regex cannot
+distinguish a function call from a comment containing the same characters. Parsers solve
+this by converting text into an **Abstract Syntax Tree**: a tree of typed nodes where each
+node represents a syntactic construct (a function, an import, a binary expression).
+
+The word "abstract" means the tree captures structure, not formatting. Whitespace, semicolons,
+and parentheses used only for grouping are discarded. What remains is the semantic skeleton.
+
+Every linter and codemod operates on this skeleton:
+- A linter **reads** the tree, finds nodes matching a pattern, and reports violations.
+- A codemod **reads** the tree, mutates matching nodes, and serializes the result back to text.
+
+The tree is the shared interface. Understanding its shape is the prerequisite for everything else.
+
+---
+
+## 2. The Parse → Transform → Generate Pipeline
+
+Every AST tool — ESLint, jscodeshift, ts-morph, Babel, ast-grep — implements the same
+three-phase pipeline internally. Knowing the phases explains why tools behave as they do.
+
+```
+SOURCE TEXT
+    │
+    ▼  PARSE: Lexer → token stream → Parser → AST
+    │         (TypeScript: recursive descent; Babel: Babylon; ast-grep: tree-sitter)
+    ▼  TRANSFORM / ANALYZE: Traverse AST via Visitor pattern
+    │         Linters: read + report violations
+    │         Codemods: read + mutate nodes
+    ▼  GENERATE: Serialize AST back to source text
+               Naive: pretty-print everything (Babel generator)
+               Smart: reprint only changed nodes (recast, used by jscodeshift)
+    ▼
+OUTPUT TEXT (or diagnostic report)
+```
+
+**Why the generate phase matters for codemods**: naive generators reformat the entire file.
+`recast` (used by jscodeshift) tracks which nodes were modified and reprints only those,
+preserving the original formatting of everything else. This is why jscodeshift codemods
+produce minimal diffs. ts-morph uses a similar strategy via the TypeScript printer.
+
+**TypeScript's pipeline adds two extra phases** between parse and transform:
+- **Binder**: walks the AST and creates a symbol table (maps identifiers to declarations)
+- **Checker**: uses the symbol table to perform type inference and validation
+
+ts-morph and the raw TypeScript Compiler API expose the Checker, giving access to resolved
+types. jscodeshift and ast-grep do not — they are syntactic-only tools.
+
+---
+
+## 3. AST Node Types Reference
+
+### ESTree Nodes (JavaScript / TypeScript base)
+
+ESTree is the community standard for JavaScript ASTs. Babel, ESLint, jscodeshift, and
+acorn all use ESTree-compatible node shapes. TypeScript extends ESTree with `TS*` prefixed
+nodes.
+
+| Node Type | Represents | Key Properties |
+|-----------|-----------|----------------|
+| `Program` | Root of the file | `body: Statement[]` |
+| `ImportDeclaration` | `import { X } from 'y'` | `specifiers`, `source` |
+| `ExportNamedDeclaration` | `export const x = ...` | `declaration`, `specifiers` |
+| `ExportDefaultDeclaration` | `export default ...` | `declaration` |
+| `FunctionDeclaration` | `function foo() {}` | `id`, `params`, `body`, `async` |
+| `ArrowFunctionExpression` | `() => {}` | `params`, `body`, `async` |
+| `ClassDeclaration` | `class Foo {}` | `id`, `superClass`, `body` |
+| `MethodDefinition` | Method inside a class | `key`, `value`, `kind`, `static` |
+| `VariableDeclaration` | `const x = 1` | `declarations`, `kind` |
+| `VariableDeclarator` | `x = 1` (inside declaration) | `id`, `init` |
+| `ExpressionStatement` | A statement wrapping an expression | `expression` |
+| `CallExpression` | `foo(a, b)` | `callee`, `arguments` |
+| `MemberExpression` | `obj.prop` | `object`, `property`, `computed` |
+| `Identifier` | Any name: `foo`, `x`, `React` | `name` |
+| `Literal` / `StringLiteral` | `'hello'`, `42`, `true` | `value` |
+| `TemplateLiteral` | `` `Hello ${name}` `` | `quasis`, `expressions` |
+| `ObjectExpression` | `{ a: 1, b: 2 }` | `properties` |
+| `ArrayExpression` | `[1, 2, 3]` | `elements` |
+| `BinaryExpression` | `a + b`, `x === y` | `left`, `operator`, `right` |
+| `AwaitExpression` | `await fetch(url)` | `argument` |
+| `ReturnStatement` | `return x` | `argument` |
+| `IfStatement` | `if (x) {}` | `test`, `consequent`, `alternate` |
+| `BlockStatement` | `{ ... }` | `body: Statement[]` |
+| `JSXElement` | `<Button />` | `openingElement`, `closingElement`, `children` |
+| `JSXAttribute` | `className="foo"` | `name`, `value` |
+
+### TypeScript-Specific Nodes
+
+| Node Type | Represents | Key Properties |
+|-----------|-----------|----------------|
+| `TSTypeAnnotation` | `: string` after a binding | `typeAnnotation` |
+| `TSTypeReference` | `Array<string>`, `Foo` | `typeName`, `typeParameters` |
+| `TSInterfaceDeclaration` | `interface Foo {}` | `id`, `body`, `extends` |
+| `TSTypeAliasDeclaration` | `type Foo = string` | `id`, `typeAnnotation` |
+| `TSAsExpression` | `value as string` | `expression`, `typeAnnotation` |
+| `TSArrayType` | `string[]` | `elementType` |
+| `TSUnionType` | `string \| number` | `types` |
+| `TSIntersectionType` | `A & B` | `types` |
+| `TSPropertySignature` | Property in an interface | `key`, `typeAnnotation`, `optional` |
+| `TSMethodSignature` | Method in an interface | `key`, `params`, `returnType` |
+| `TSEnumDeclaration` | `enum Direction {}` | `id`, `members` |
+| `TSNonNullExpression` | `value!` | `expression` |
+| `Decorator` | `@Injectable()` | `expression` |
+
+**Practical tip**: Use [AST Explorer](https://astexplorer.net/) to inspect the exact node
+shape for any code snippet before writing a transform. Select the parser that matches your
+tool (Babel for jscodeshift, TypeScript for ts-morph/ESLint with typescript-eslint).
+
+---
+
+## 4. The Visitor Pattern
+
+The Visitor pattern is how every AST tool traverses the tree. Instead of writing recursive
+traversal code, you declare handlers for node types. The traversal engine calls your handler
+when it encounters a matching node.
+
+### How Visitors Work
+
+```
+Traversal engine walks the tree depth-first.
+For each node:
+  1. Call visitor[node.type].enter (or visitor[node.type] if no enter/exit split)
+  2. Recurse into children
+  3. Call visitor[node.type].exit
+```
+
+In Babel and ESLint, visitors are plain objects:
+
+```typescript
+// Babel plugin visitor
+visitor: {
+  CallExpression(path) {
+    // called on enter (before children are visited)
+  },
+  FunctionDeclaration: {
+    enter(path) { /* before children */ },
+    exit(path)  { /* after children */ },
+  }
+}
+```
+
+**Enter vs exit**: Use `enter` (the default) when you need to inspect a node before its
+children are processed. Use `exit` when you need to know the final state of a subtree —
+for example, checking whether a function contains any `await` expressions.
+
+### Path vs Node
+
+The `path` object wraps a node and provides the mutation API. The `node` is the raw AST
+data. This distinction matters:
+
+| `path` | `node` |
+|--------|--------|
+| Wrapper with traversal context | Raw AST data object |
+| Has `.parent`, `.scope`, `.key` | Has `.type`, `.start`, `.end` |
+| Has mutation methods: `.replaceWith()`, `.remove()`, `.insertAfter()` | Immutable data |
+| Has type predicates: `.isIdentifier()`, `.isCallExpression()` | No methods |
+
+Always mutate through `path`, not by directly reassigning `node` properties — except for
+simple in-place edits like `path.node.source.value = 'new-module'`, which work because
+recast tracks the node reference.
+
+### Scope and Bindings
+
+Scope tracks which identifiers are declared where. This is essential for safe transforms:
+renaming a variable without scope awareness can accidentally rename a different variable
+with the same name in a different scope.
+
+```typescript
+// Babel: scope-aware rename
+path.scope.rename('oldName', 'newName');
+// Renames only the binding in the current scope and its references
+
+// ESLint: access scope manager
+const scope = context.sourceCode.getScope(node);
+const variable = scope.variables.find(v => v.name === 'target');
+```
+
+ts-morph handles scope automatically through the TypeScript type system — `rename()` and
+`findReferencesAsNodes()` are scope-aware by construction.
+
+---
+
+## 5. Tool Selection Decision Tree
+
+Start here. The wrong tool choice costs hours. The right tool makes the task trivial.
+
+```
+What is the primary goal?
+│
+├── FIND patterns (read-only search)
+│   ├── Any language, structural search → ast-grep (sg run -p '...')
+│   ├── TypeScript with type resolution → TypeScript Language Server / ts-morph
+│   └── Simple text search → ripgrep (not an AST tool)
+│
+├── LINT (report violations, optionally fix)
+│   ├── Standard JS/TS rules, editor integration → ESLint custom rule
+│   ├── Structural patterns, YAML config, no JS needed → ast-grep YAML rules
+│   ├── Security scanning across languages → Semgrep
+│   └── Type-aware lint (needs type info) → ESLint + typescript-eslint
+│
+├── CODEMOD (transform source files)
+│   │
+│   ├── Does the transform need TYPE INFORMATION?
+│   │   ├── Yes (e.g., "add return type", "find all callers of this method") → ts-morph
+│   │   └── No → continue below
+│   │
+│   ├── Is the pattern SIMPLE (one-to-one replacement)?
+│   │   ├── Yes → ast-grep --rewrite (fastest, no code needed)
+│   │   └── No → continue below
+│   │
+│   ├── Is the codebase JAVASCRIPT or TYPESCRIPT (no type info needed)?
+│   │   ├── Yes, complex logic → jscodeshift
+│   │   └── Yes, declarative style → Putout
+│   │
+│   └── Is this a BUILD-TIME transform (runs on every compile)?
+│       ├── Performance critical → SWC plugin (Rust)
+│       └── Ecosystem/plugins matter → Babel plugin
+│
+└── MIGRATE large codebase
+    ├── Flow → TypeScript → flow-to-typescript-codemod (Stripe/Pinterest pattern)
+    ├── JS → TypeScript → ts-migrate (Airbnb)
+    ├── React class → hooks → react-codemod (jscodeshift)
+    ├── Angular @Input/@Output → signals → Angular Schematics (TypeScript Compiler API)
+    └── Custom migration → jscodeshift + recast (syntax) or ts-morph (type-aware)
+```
+
+### Quick Scenario Reference
+
+| Scenario | Tool | Reason |
+|----------|------|--------|
+| Find all async functions without try/catch | ast-grep | Structural, no type info needed |
+| Rename a function across 500 files | ts-morph | Needs cross-file reference tracking |
+| Migrate `lodash` imports to `lodash-es` | jscodeshift | Import string replacement, complex specifier logic |
+| Remove all `console.log` calls | ast-grep `--rewrite` | Simple pattern replacement |
+| Convert class components to hooks | jscodeshift (react-codemod) | Complex AST restructuring |
+| Add return types to all functions | ts-morph | Needs type inference to determine the type |
+| Enforce `import type` for type-only imports | ESLint + typescript-eslint | Needs type checker, editor integration |
+| Detect hardcoded secrets in config objects | ast-grep YAML rule | Structural pattern, no type info |
+| Build-time JSX transform | Babel plugin | Compile-time, ecosystem compatibility |
+| AI agent code search | ast-grep | CLI-first, declarative, LLM-friendly |
+
+---
+
+## 6. Tool Comparison Matrix
+
+| Tool | Type Info | Formatting Preservation | Speed | Learning Curve | Best Fit |
+|------|-----------|------------------------|-------|----------------|----------|
+| **ast-grep** | None (syntactic) | Yes (tree-sitter) | Fastest (Rust) | Low (YAML) | Search, lint, simple transforms, AI agents |
+| **jscodeshift** | None | Yes (via recast) | Medium | Medium | Complex JS/TS codemods |
+| **ts-morph** | Full TypeScript | Partial | Medium | Medium | TypeScript-specific transforms, cross-file analysis |
+| **ESLint custom rule** | Optional (via typescript-eslint) | N/A (reports only) | Fast | Low–Medium | Linting with editor/CI integration |
+| **Babel plugin** | None | No (use recast wrapper) | Medium | Medium | Build-time transforms, transpilation |
+| **TypeScript Compiler API** | Full | No (use printer) | Medium | High | Deep TypeScript tooling, Angular-style migrations |
+| **SWC plugin** | None | No | Fastest (Rust/WASM) | High (Rust) | Build-time, performance-critical transforms |
+| **Putout** | None | Yes (via recast) | Medium | Low | Declarative codemods, ESLint-compatible |
+| **recast** | None | Best-in-class | Medium | Low | Formatting preservation layer (used by others) |
+
+**Type info** is the most important differentiator. If you need to know the resolved type
+of an expression, only ts-morph and the raw TypeScript Compiler API can provide it.
+Everything else is syntactic — it sees the shape of the code, not what types flow through it.
+
+**Formatting preservation** matters for codemods that will be reviewed in PRs. ast-grep
+and jscodeshift (via recast) preserve formatting of unchanged nodes. Babel's generator
+reformats everything — use recast as a wrapper if you need formatting preservation with Babel.
+
+---
+
+## 7. Common AST Operations Cheat Sheet
+
+These are the operations every linter and codemod performs. The pseudocode shows the
+conceptual pattern; tool-specific syntax is in the tool reference files.
+
+### Finding Imports
+
+```
+Goal: find all files that import from 'old-library'
+
+jscodeshift:
+  root.find(ImportDeclaration)
+      .filter(path => path.node.source.value === 'old-library')
+
+ts-morph:
+  sourceFile.getImportDeclarations()
+            .filter(d => d.getModuleSpecifierValue() === 'old-library')
+
+ast-grep:
+  pattern: import $$$SPECIFIERS from 'old-library'
+  or: kind: import_statement + has: string_fragment regex: ^old-library$
+
+ESLint visitor:
+  ImportDeclaration(node) {
+    if (node.source.value === 'old-library') { ... }
+  }
+```
+
+### Finding Function Calls
+
+```
+Goal: find all calls to console.log(...)
+
+jscodeshift:
+  root.find(CallExpression, {
+    callee: { object: { name: 'console' }, property: { name: 'log' } }
+  })
+
+ts-morph:
+  sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)
+            .filter(c => c.getExpression().getText() === 'console.log')
+
+ast-grep:
+  pattern: console.log($$$ARGS)
+
+ESLint visitor:
+  CallExpression(node) {
+    if (node.callee.type === 'MemberExpression'
+        && node.callee.object.name === 'console'
+        && node.callee.property.name === 'log') { ... }
+  }
+```
+
+### Finding Class Patterns
+
+```
+Goal: find class declarations that extend a specific base class
+
+jscodeshift:
+  root.find(ClassDeclaration)
+      .filter(path => path.node.superClass?.name === 'Component')
+
+ts-morph:
+  sourceFile.getClasses()
+            .filter(c => c.getBaseClass()?.getName() === 'Component')
+
+ast-grep:
+  pattern: class $NAME extends Component { $$$BODY }
+
+ESLint visitor:
+  ClassDeclaration(node) {
+    if (node.superClass?.name === 'Component') { ... }
+  }
+```
+
+### Checking Types (ts-morph / TypeScript Compiler API only)
+
+```
+Goal: find function parameters that have no type annotation
+
+ts-morph:
+  sourceFile.getFunctions().forEach(fn => {
+    fn.getParameters().forEach(param => {
+      if (!param.getTypeNode()) {
+        // parameter has no explicit type annotation
+      }
+    })
+  })
+
+TypeScript Compiler API:
+  const checker = program.getTypeChecker();
+  const type = checker.getTypeAtLocation(node);
+  const typeString = checker.typeToString(type);
+  // typeString is the inferred type, even without annotation
+```
+
+### Renaming Across Files
+
+```
+Goal: rename a function and update all call sites
+
+ts-morph (preferred — type-aware, handles all reference forms):
+  const fn = sourceFile.getFunctionOrThrow('oldName');
+  fn.rename('newName');
+  await project.save();
+
+jscodeshift (syntactic — misses dynamic references, renames by identifier name only):
+  root.find(Identifier, { name: 'oldName' })
+      .forEach(path => { path.node.name = 'newName'; })
+```
+
+### Applying Fixes in ESLint Rules
+
+```
+Goal: report a violation with an auto-fix
+
+ESLint rule:
+  context.report({
+    node,
+    message: 'Use === instead of ==',
+    fix(fixer) {
+      return fixer.replaceText(node, node.getText().replace('==', '==='));
+      // or surgical range replacement:
+      return fixer.replaceTextRange([node.range[0], node.range[1]], '===');
+    }
+  });
+
+// For risky fixes, use suggest instead of fix:
+  context.report({
+    node,
+    message: 'Dependency array may be incomplete',
+    suggest: [{
+      desc: 'Add missing dependency',
+      fix(fixer) { return fixer.replaceText(depsNode, newDeps); }
+    }]
+  });
+```
+
+---
+
+## Key Principles
+
+**Detect imports before transforming.** Never assume a library symbol has a specific local
+name. Users write `import { Component as C } from 'react'`. Always scan `ImportDeclaration`
+nodes first to collect the actual local names, then use those names in subsequent searches.
+This pattern appears in every production codemod (React, Next.js, Angular).
+
+**Use dirty flags in jscodeshift.** Return `undefined` (not the source) when no changes
+were made. This prevents jscodeshift from writing unchanged files, keeping diffs clean.
+
+**Prefer in-place mutation over node replacement.** Changing `path.node.source.value`
+preserves surrounding formatting. Replacing the entire node with `replaceWith()` forces
+recast to reprint that node, potentially changing quote style or spacing.
+
+**Suggest, do not fix, when the transform is ambiguous.** The React hooks exhaustive-deps
+rule uses `suggest` instead of `fix` because auto-fixing dependency arrays can introduce
+infinite render loops. When a transform could be wrong in some cases, let the user approve.
+
+**Insert error comments when a transform cannot be automated.** Next.js codemods insert
+`// NEXT_CODEMOD_ERROR: ...` comments when they encounter patterns they cannot safely
+transform. This is better than silently skipping or producing incorrect output.

--- a/skills/ast-linter-codemod/references/ast-grep-rules.md
+++ b/skills/ast-linter-codemod/references/ast-grep-rules.md
@@ -1,0 +1,406 @@
+# ast-grep Rules and Patterns
+
+Sources: ast-grep.github.io documentation, coderabbitai/ast-grep-essentials, ast-grep MCP and agent integrations, 2025-2026 ecosystem research
+
+ast-grep (sg) is a Rust-powered CLI tool for structural code search, linting, and rewriting across 20+ languages. Rules are declarative YAML, making them well-suited for AI agent generation and review.
+
+---
+
+## 1. Pattern Syntax
+
+Patterns are code snippets that match structurally, not textually. Whitespace and formatting differences are ignored; AST shape is what matters.
+
+| Syntax | Matches | Captured? |
+|--------|---------|-----------|
+| `$VAR` | Any single AST node | Yes — use `$VAR` in `fix` |
+| `$$$VARS` | Zero or more nodes (variadic) | Yes — use `$$$VARS` in `fix` |
+| `$_` | Any single node (wildcard) | No |
+
+Metavariable names must be uppercase. The same name used twice enforces equality — `$A === $A` matches only when both sides are identical text.
+
+```bash
+sg run -p 'console.log($MSG)' --lang typescript   # single capture
+sg run -p 'foo($$$ARGS)' --lang javascript         # variadic
+sg run -p '($$$PARAMS) => $BODY' --lang javascript # arrow function
+sg run -p 'use$HOOK($$$)' --lang tsx              # prefix match
+```
+
+Patterns must be syntactically valid code. Use the playground at ast-grep.github.io/playground.html to iterate on patterns and inspect tree-sitter node kinds.
+
+---
+
+## 2. Rule Types
+
+Rules compose three layers: atomic (what to match), relational (where it must appear), and composite (boolean logic).
+
+### Atomic Rules
+
+Three atomic matchers: `pattern` (code template), `kind` (tree-sitter node type), `regex` (text match on node content). Find node kinds with `sg run --debug-query` or the playground.
+
+### Relational Rules
+
+| Key | Meaning | Common use |
+|-----|---------|------------|
+| `inside` | Node is a descendant of the specified node | Scope restriction |
+| `has` | Node has a descendant matching the rule | Content requirement |
+| `follows` | Node appears after the specified node | Import-then-use |
+| `precedes` | Node appears before the specified node | Declaration order |
+
+All relational rules accept `stopBy`:
+- `stopBy: neighbor` (default) — immediate parent/child only
+- `stopBy: end` — search all ancestors/descendants to scope boundary
+
+```yaml
+rule:
+  pattern: await $EXPR
+  inside:
+    kind: arrow_function          # await must be inside arrow function
+
+rule:
+  pattern: Promise.all($A)
+  has:
+    pattern: await $_
+    stopBy: end                   # await anywhere inside Promise.all
+```
+
+### Composite Rules
+
+```yaml
+rule:
+  all:                            # AND — every condition must match
+    - pattern: console.$METHOD($$$)
+    - not:
+        inside:
+          kind: catch_clause
+          stopBy: end
+
+rule:
+  any:                            # OR — at least one must match
+    - pattern: console.log($$$)
+    - pattern: console.debug($$$)
+```
+
+Composite rules nest arbitrarily. `all` inside `any` inside `not` is valid.
+
+---
+
+## 3. YAML Rule Format
+
+```yaml
+id: no-console-in-production   # unique, kebab-case
+language: TypeScript            # JavaScript, Python, Go, Rust, etc.
+severity: warning               # error | warning | info | hint
+message: "Avoid console statements outside catch blocks"
+note: "Use a structured logger. See docs/logging.md"
+url: https://example.com/docs  # shown in IDE hover
+rule:
+  # ... matching logic
+fix: ""                         # optional auto-fix string
+```
+
+`severity: error` causes `sg scan` to exit non-zero. `message` supports metavariable interpolation: `"Found $METHOD call"` substitutes the captured text.
+
+---
+
+## 4. Fix and Rewrite
+
+The `fix` string replaces the matched node. Metavariables are substituted directly:
+
+```yaml
+id: remove-await-in-promise-all
+language: TypeScript
+severity: error
+message: "await inside Promise.all defeats parallelism"
+rule:
+  pattern: await $A
+  inside:
+    pattern: Promise.all($_)
+    stopBy: end
+fix: $A
+```
+
+### Transform Operations
+
+`transform` derives new variables from captured ones before substituting into `fix`:
+
+```yaml
+id: screaming-snake-constant
+language: JavaScript
+rule:
+  pattern: const $NAME = $VALUE
+transform:
+  UPPER:
+    convert:
+      source: $NAME
+      toCase: SCREAMING_SNAKE_CASE
+fix: const $UPPER = $VALUE
+```
+
+| Operation | Purpose |
+|-----------|---------|
+| `replace` | Regex substitution on captured text |
+| `substring` | Slice captured text by index |
+| `convert` | Case conversion: `camelCase`, `snake_case`, `SCREAMING_SNAKE_CASE`, `PascalCase`, `kebab-case` |
+| `rewrite` | Apply a named rewriter sub-rule to the captured node |
+
+`rewrite` enables recursive transformation of captured subtrees — the most powerful option for multi-level migrations.
+
+Apply fixes via `--rewrite` (preview), `--rewrite --interactive` (approve each), or `--rewrite -U` (apply all).
+
+---
+
+## 5. Constraints
+
+Constraints add conditions to captured metavariables after the structural match. A node that matches the pattern but fails a constraint is not reported. Multiple constraints on the same variable combine with AND.
+
+```yaml
+# Restrict METHOD to specific values
+rule:
+  pattern: console.$METHOD($$$)
+constraints:
+  METHOD:
+    regex: "^(log|debug|warn)$"
+
+# Require VALUE to be a literal string, not a variable reference
+constraints:
+  VALUE:
+    kind: string
+
+# Detect weak RSA key sizes (< 2048 bits) via numeric regex
+constraints:
+  R:
+    regex: "^(-?(0|[1-9][0-9]{0,2}|1[0-9]{3}|20[0-3][0-9]|204[0-7]))$"
+```
+
+---
+
+## 6. Project Setup
+
+Place `sgconfig.yml` at the repository root:
+
+```yaml
+ruleDirs:
+  - rules/     # YAML rule files
+utilDirs:
+  - utils/     # reusable rule fragments
+testConfigs:
+  - testDir: tests/
+```
+
+Organize rules by language then category: `rules/typescript/security/`, `rules/javascript/style/`. Test files mirror the rule path under `tests/`. `sg scan` without arguments reads `sgconfig.yml` and applies all rules in `ruleDirs`.
+
+---
+
+## 7. CLI Commands
+
+```bash
+sg run -p 'PATTERN' --lang LANGUAGE [PATH]                         # search
+sg run -p 'PATTERN' --rewrite 'REPLACEMENT' --lang LANGUAGE [PATH] # preview rewrite
+sg run -p 'PATTERN' --rewrite 'REPLACEMENT' -U --lang LANGUAGE     # apply all
+sg scan --rule rules/no-console.yml src/                           # single rule
+sg scan                                                             # full project (sgconfig.yml)
+sg scan --json                                                      # JSON for tooling
+sg test                                                             # run test suite
+sg new rule                                                         # scaffold interactively
+sg lsp                                                              # language server
+```
+
+---
+
+## 8. Testing Rules
+
+Test files mirror the rule file path under `testDir`:
+
+```yaml
+# tests/typescript/style/no-console.yml
+id: no-console-in-production
+valid:
+  - "try { doSomething(); } catch (e) { console.error(e); }"
+invalid:
+  - code: "console.log('hello');"
+  - code: "console.warn('deprecated');"
+```
+
+For rules with `fix`, assert the output with `fixed`:
+
+```yaml
+invalid:
+  - code: "await Promise.resolve(x)"
+    fixed: "Promise.resolve(x)"
+```
+
+Tests fail if a `valid` case is flagged or an `invalid` case is not flagged.
+
+---
+
+## 9. Utility Rules
+
+Utility rules are reusable fragments that other rules reference with `matches`. Define them in `utilDirs` — they do not produce diagnostics on their own.
+
+```yaml
+# utils/is-require-call.yml
+id: is-require-call
+language: JavaScript
+rule:
+  kind: call_expression
+  has:
+    kind: identifier
+    regex: "^require$"
+
+# rules/javascript/no-cjs-require.yml
+id: no-cjs-require
+language: JavaScript
+severity: warning
+message: "Use ES module import instead of require()"
+rule:
+  matches: is-require-call
+```
+
+Compose multiple utilities with `any` and add `constraints` to narrow matches further — for example, matching only numbers below 2048 for a weak RSA key rule:
+
+```yaml
+rule:
+  kind: number
+  any:
+    - matches: MATCH_BITS_NODE_FORGE
+    - matches: MATCH_BITS_NODE_RSA
+constraints:
+  R:
+    regex: "^(-?(0|[1-9][0-9]{0,2}|1[0-9]{3}|20[0-3][0-9]|204[0-7]))$"
+```
+
+---
+
+## 10. Real-World Rule Examples
+
+### Ban Deprecated Library
+
+```yaml
+id: no-moment-js
+language: TypeScript
+severity: error
+message: "moment.js is deprecated. Use date-fns or Temporal instead."
+url: https://momentjs.com/docs/#/-project-status/
+rule:
+  any:
+    - pattern: import $_ from 'moment'
+    - pattern: require('moment')
+```
+
+### Detect Security Issue — JWT Without Verification
+
+```yaml
+id: jwt-simple-noverify
+language: TypeScript
+severity: warning
+message: "Decoding a JWT without verification. Pass false as the third argument only in tests."
+rule:
+  pattern: $JWT.decode($TOKEN, $SECRET, $NOVERIFY $$$)
+  inside:
+    stopBy: end
+    follows:
+      stopBy: end
+      kind: lexical_declaration
+      has:
+        kind: call_expression
+        has:
+          kind: string_fragment
+          regex: "^jwt-simple$"
+constraints:
+  NOVERIFY:
+    any:
+      - regex: "^true$"
+      - kind: string
+```
+
+### Enforce Naming Convention
+
+```yaml
+id: react-component-pascal-case
+language: TSX
+severity: warning
+message: "React component '$NAME' must use PascalCase."
+rule:
+  kind: function_declaration
+  all:
+    - has:
+        kind: identifier
+        pattern: $NAME
+    - has:
+        kind: jsx_element
+        stopBy: end
+constraints:
+  NAME:
+    regex: "^[a-z]"
+```
+
+### Migrate API — Remove React forwardRef Wrapper
+
+```yaml
+id: remove-forward-ref-wrapper
+language: TSX
+severity: hint
+message: "React 19: forwardRef wrapper is no longer needed."
+rule:
+  pattern: forwardRef(($$$PARAMS) => $BODY)
+fix: ($$$PARAMS) => $BODY
+```
+
+### Detect Async Without Error Handling
+
+```yaml
+id: async-without-try-catch
+language: TypeScript
+severity: warning
+message: "Async function uses await but has no try/catch."
+rule:
+  kind: function_declaration
+  all:
+    - has:
+        kind: await_expression
+        stopBy: end
+    - not:
+        has:
+          kind: try_statement
+          stopBy: end
+```
+
+---
+
+## 11. Agent Integration
+
+`ast-grep-mcp` exposes structural search to MCP-compatible agents — agents call `sg_search` with a pattern and language and receive matches with file path, line range, and matched text.
+
+```bash
+npx ast-grep-mcp
+```
+
+For LLM rule generation, fetch the full documentation bundle:
+
+```
+https://ast-grep.github.io/llms-full.txt
+```
+
+Add this directive to `AGENTS.md` to bias agents toward structural search:
+
+```markdown
+Prefer `ast-grep` over `grep` for any search involving code structure.
+- Find async functions: `sg run -p 'async function $NAME($$$) { $$$ }' --lang typescript`
+- Find useEffect calls: `sg run -p 'useEffect($$$)' --lang tsx`
+For multi-file lint rules, write a YAML rule file and run `sg scan --rule rule.yml`.
+```
+
+ast-grep suits agent workflows: YAML rules are straightforward for LLMs to generate, the CLI integrates with any tool-calling mechanism, dry-run by default allows safe previewing, and Rust + tree-sitter speed supports tight loops across TypeScript, Python, Go, Rust, and more.
+
+---
+
+## Rule Key Reference
+
+| Key | Layer | Purpose |
+|-----|-------|---------|
+| `pattern` / `kind` / `regex` | Atomic | What to match |
+| `inside` / `has` / `follows` / `precedes` | Relational | Where it must appear |
+| `all` / `any` / `not` | Composite | Boolean logic |
+| `matches` | Utility | Reference a utility rule by id |
+| `constraints` | Constraint | Regex/kind conditions on metavariables |
+| `stopBy: end` | Modifier | Search all descendants, not just immediate |

--- a/skills/ast-linter-codemod/references/eslint-custom-rules.md
+++ b/skills/ast-linter-codemod/references/eslint-custom-rules.md
@@ -1,0 +1,449 @@
+# ESLint Custom Rules with Auto-Fix
+
+Sources: ESLint official documentation, typescript-eslint documentation, production rules from n8n, puppeteer, twenty, storybook, 2025-2026 ecosystem research
+
+## 1. Rule Architecture
+
+Every ESLint rule exports an object with two required properties: `meta` and `create`.
+
+```typescript
+module.exports = {
+  meta: {
+    type: "problem",       // "problem" | "suggestion" | "layout"
+    fixable: "code",       // required when rule provides auto-fixes
+    hasSuggestions: true,  // required when rule provides suggestions
+    docs: { description: "Disallow bad pattern", recommended: false },
+    messages: { avoidBad: "Avoid '{{name}}'. Use '{{replacement}}' instead." },
+    schema: [{ type: "object", properties: { allow: { type: "boolean" } },
+               additionalProperties: false }],
+  },
+  create(context) {
+    return { CallExpression(node) { /* visitor logic */ } };
+  },
+};
+```
+
+`meta.type` signals intent: `"problem"` for likely bugs, `"suggestion"` for style, `"layout"` for whitespace. Omitting `fixable` when a rule calls fixer methods causes ESLint to throw at runtime.
+
+### Key APIs
+
+| API | Description |
+|---|---|
+| `context.sourceCode` | `SourceCode` instance — primary inspection API |
+| `context.options` | Array of rule options from config |
+| `context.report(descriptor)` | Report a problem with optional fix |
+| `sourceCode.getText(node)` | Raw source text of a node |
+| `sourceCode.getFirstToken(node)` | First token in node |
+| `sourceCode.getTokenBefore(node)` | Token immediately before node |
+| `sourceCode.getTokenAfter(node)` | Token immediately after node |
+| `sourceCode.getScope(node)` | Scope at this node |
+| `sourceCode.getAncestors(node)` | All ancestor nodes (root first) |
+
+### Node Visitor Patterns
+
+`create()` returns an object whose keys are visitor selectors (CSS-like syntax, see section 5):
+
+```typescript
+return {
+  Identifier(node) { },                                     // enter
+  "FunctionDeclaration:exit"(node) { },                     // leave (after children)
+  "TryStatement CallExpression"(node) { },                  // descendant combinator
+  "FunctionDeclaration, ArrowFunctionExpression"(node) { }, // multiple types (OR)
+  "IfStatement:has(ReturnStatement)"(node) { },             // has descendant
+};
+```
+
+---
+
+## 2. The Fixer API
+
+The `fixer` object is passed to the `fix` function inside `context.report()`. All methods return a fix descriptor. Return `null` to skip the fix while still reporting the error.
+
+| Method | Description |
+|---|---|
+| `fixer.replaceText(node, text)` | Replace a node's full source text |
+| `fixer.replaceTextRange([start, end], text)` | Replace by character range |
+| `fixer.insertTextBefore(node, text)` | Insert text before a node |
+| `fixer.insertTextAfter(node, text)` | Insert text after a node |
+| `fixer.insertTextBeforeRange([start, end], text)` | Insert before a range start |
+| `fixer.insertTextAfterRange([start, end], text)` | Insert after a range end |
+| `fixer.remove(node)` | Remove a node entirely |
+| `fixer.removeRange([start, end])` | Remove by character range |
+
+Every AST node carries `range: [startIndex, endIndex]` — character offsets into the source string. Use ranges to operate on text between nodes (punctuation, whitespace) that has no dedicated AST node:
+
+```typescript
+// Remove " as Type" from "value as Type"
+const tokenBeforeAs = sourceCode.getTokenBefore(asKeyword, { includeComments: true });
+return fixer.removeRange([tokenBeforeAs.range[1], node.range[1]]);
+```
+
+### Generator Fixes — Multiple Operations
+
+When a fix requires more than one edit, use a generator. ESLint applies all yielded operations atomically; conflicting operations cause the fix to be skipped for that pass.
+
+```typescript
+context.report({
+  node, messageId: "convertImport",
+  *fix(fixer) {
+    yield fixer.insertTextAfter(importKeyword, " type");
+    yield fixer.replaceText(importDecl.source, `'new-package'`);
+    yield fixer.remove(importDecl.specifiers[0]);
+  },
+});
+```
+
+Return `null` from `fix` to report the error without applying a fix.
+
+---
+
+## 3. Auto-Fixable Rule Pattern
+
+A complete minimal fixable rule. `fixable: "code"` in `meta` is required — ESLint throws without it.
+
+```typescript
+module.exports = {
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+    messages: { unexpectedVar: "Unexpected var, use let or const instead." },
+    schema: [],
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+    return {
+      "VariableDeclaration:exit"(node) {
+        if (node.kind !== "var") return;
+        context.report({
+          node,
+          messageId: "unexpectedVar",
+          fix(fixer) {
+            const varToken = sourceCode.getFirstToken(node, {
+              filter: t => t.value === "var",
+            });
+            return fixer.replaceText(varToken, "let");
+          },
+        });
+      },
+    };
+  },
+};
+```
+
+**Get-transform-replace** is the most common fix pattern: `sourceCode.getText(node)` → transform string → `fixer.replaceText(node, result)`.
+
+---
+
+## 4. Suggestion API
+
+Suggestions appear in editors as "quick fix" options but are not applied by `eslint --fix`. Use suggestions when the fix might change semantics, when multiple valid fixes exist, or when the transform is risky. Do not set `fixable: "code"` on suggestion-only rules.
+
+```typescript
+meta: { hasSuggestions: true, messages: { unexpected: "...", replaceOp: "..." } },
+create(context) {
+  return {
+    BinaryExpression(node) {
+      if (node.operator !== "==") return;
+      context.report({
+        node, messageId: "unexpected",
+        data: { expected: "===", actual: "==" },
+        suggest: [{
+          messageId: "replaceOp",
+          data: { expected: "===", actual: "==" },
+          fix(fixer) { return fixer.replaceText(operatorToken, "==="); },
+        }],
+      });
+    },
+  };
+},
+```
+
+The react-hooks `exhaustive-deps` rule uses suggestions because auto-adding dependencies can cause infinite render loops — the canonical example of when `suggest` beats `fix`.
+
+---
+
+## 5. CSS Selector Syntax
+
+ESLint uses [esquery](https://github.com/estools/esquery) for visitor key matching:
+
+```
+"CallExpression[callee.name='require']"          attribute match
+"CallExpression > MemberExpression"              direct child
+"TryStatement CallExpression"                    descendant (any depth)
+"VariableDeclaration ~ ReturnStatement"          adjacent sibling
+":not(FunctionDeclaration)"                      negation
+":first-child"  ":last-child"  ":nth-child(2)"  position pseudo-classes
+":has(ReturnStatement)"                          has descendant
+"FunctionDeclaration:exit"                       fires after children visited
+"FunctionDeclaration, ArrowFunctionExpression"   multiple types (OR)
+```
+
+Complex selectors have a performance cost proportional to their specificity. Prefer simple type selectors; use attribute selectors only when necessary.
+
+---
+
+## 6. typescript-eslint Rules
+
+Use `@typescript-eslint/utils` for typed rule authoring. `ESLintUtils.RuleCreator` provides full TypeScript inference over `context`, options, and message IDs.
+
+```typescript
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(name => `https://example.com/rules/${name}`);
+
+export const rule = createRule<[{ allow?: boolean }], 'myMessage'>({
+  name: 'my-rule',
+  meta: {
+    type: 'suggestion', fixable: 'code',
+    docs: { description: 'Description here.' },
+    messages: { myMessage: 'Message with {{name}} placeholder.' },
+    schema: [{ type: 'object', properties: { allow: { type: 'boolean' } },
+               additionalProperties: false }],
+  },
+  defaultOptions: [{ allow: false }],
+  create(context, [options]) {
+    return {
+      Identifier(node) {
+        if (!options.allow && node.name === 'bad')
+          context.report({ messageId: 'myMessage', node, data: { name: node.name },
+                           fix: fixer => fixer.replaceText(node, 'good') });
+      },
+    };
+  },
+});
+```
+
+### TypeScript-Specific AST Node Types
+
+```
+AST_NODE_TYPES.TSTypeAnnotation          : string
+AST_NODE_TYPES.TSAsExpression            value as Type
+AST_NODE_TYPES.TSNonNullExpression       value!
+AST_NODE_TYPES.TSTypeAssertionExpression <Type>value
+AST_NODE_TYPES.TSInterfaceDeclaration    interface Foo {}
+AST_NODE_TYPES.TSTypeAliasDeclaration    type Foo = ...
+AST_NODE_TYPES.TSEnumDeclaration         enum Foo {}
+AST_NODE_TYPES.TSUnionType               A | B
+AST_NODE_TYPES.TSIntersectionType        A & B
+AST_NODE_TYPES.TSConditionalType         A extends B ? C : D
+AST_NODE_TYPES.TSMappedType              { [K in T]: V }
+```
+
+---
+
+## 7. Typed Linting
+
+Typed rules access the TypeScript type checker to reason about types, not just syntax. Mark them with `requiresTypeChecking: true` so tooling warns users who run without `parserOptions.project`.
+
+```typescript
+import { ESLintUtils } from '@typescript-eslint/utils';
+import * as tsutils from 'ts-api-utils';
+
+create(context) {
+  const services = ESLintUtils.getParserServices(context);
+  const checker = services.program.getTypeChecker();
+  return {
+    AwaitExpression(node) {
+      const type = services.getTypeAtLocation(node.argument);
+      if (!tsutils.isThenableType(checker, node, type))
+        context.report({ node, messageId: 'await' });
+    },
+  };
+},
+```
+
+| API | Description |
+|---|---|
+| `services.esTreeNodeToTSNodeMap.get(esNode)` | ESTree → TypeScript AST node |
+| `services.getTypeAtLocation(esNode)` | TypeScript type at ESTree node |
+| `services.program.getTypeChecker()` | TypeScript TypeChecker |
+| `tsutils.isNullableType(type)` | Check nullability |
+| `tsutils.isThenableType(checker, node, type)` | Check Promise/thenable |
+| `tsutils.isTypeFlagSet(type, ts.TypeFlags.Any)` | Check type flags |
+| `ESLintUtils.getConstrainedTypeAtLocation(services, node)` | Resolve generic constraints |
+
+Typed rules require a full TypeScript compilation pass. Reserve them for checks that genuinely need type information — nullability, promise handling, type compatibility.
+
+---
+
+## 8. Complex Fix Patterns
+
+When replacing a node that may have leading comments, extend the range to include them. When removing an array element, also remove its trailing comma:
+
+```typescript
+// Preserve leading comments
+fix(fixer) {
+  const comments = sourceCode.getCommentsBefore(node);
+  const start = comments.length > 0 ? comments[0].range[0] : node.range[0];
+  return fixer.replaceTextRange([start, node.range[1]], newText);
+}
+
+// Remove element + trailing comma
+fix(fixer) {
+  const isLast = node.parent.elements.indexOf(node) === node.parent.elements.length - 1;
+  const after = sourceCode.getTokenAfter(node);
+  return (!isLast && after?.value === ",")
+    ? fixer.removeRange([node.range[0], after.range[1]]) : fixer.remove(node);
+}
+```
+
+### Deferred Reporting with `Program:exit`
+
+Collect data across the whole file, then report once traversal is complete. Required for rules that need global context — duplicate imports, file-level limits, cross-node relationships.
+
+```typescript
+create(context) {
+  const seen = new Map<string, Node[]>();
+  return {
+    ImportDeclaration(node) {
+      const src = node.source.value as string;
+      (seen.get(src) ?? seen.set(src, []).get(src)!).push(node);
+    },
+    "Program:exit"() {
+      for (const [src, decls] of seen)
+        if (decls.length > 1)
+          context.report({ node: decls[1], messageId: "duplicateImport", data: { source: src } });
+    },
+  };
+},
+```
+
+---
+
+## 9. RuleTester
+
+`RuleTester` runs rule logic against code strings and asserts on errors, messages, and fix output. It throws synchronously on assertion failure, making it compatible with any test runner.
+
+```typescript
+const { RuleTester } = require("eslint");
+const tester = new RuleTester({ languageOptions: { ecmaVersion: 2022, sourceType: "module" } });
+
+tester.run("no-var", rule, {
+  valid: ["const foo = 'bar';", { code: "let foo;", options: [{ allowLet: true }] }],
+  invalid: [{
+    code: "var foo = bar;",
+    output: "let foo = bar;",          // expected source after --fix
+    errors: [{ messageId: "unexpectedVar", line: 1, column: 1 }],
+  }],
+});
+```
+
+Test suggestions by asserting on the `suggestions` array inside each error object:
+
+```typescript
+errors: [{
+  messageId: "unexpected",
+  suggestions: [{ messageId: "replaceOperator", output: "a === b" }],
+}],
+```
+
+For typed rules, use `@typescript-eslint/rule-tester` with `parserOptions.project`. Integrate with Vitest by assigning `RuleTester.afterAll`, `RuleTester.describe`, `RuleTester.it`.
+
+---
+
+## 10. Plugin Scaffolding
+
+Structure: `eslint-plugin-<name>/index.ts` (entry point) + `lib/rules/*.ts`. `package.json` must include `"eslint"` in `peerDependencies` and `"eslintplugin"` in `keywords`.
+
+```typescript
+// index.ts — build configs after plugin is defined so it can self-reference
+const plugin = {
+  meta: { name: 'eslint-plugin-my-plugin', version: '1.0.0' },
+  rules: { 'rule-one': ruleOne, 'rule-two': ruleTwo },
+  configs: {} as Record<string, TSESLint.FlatConfig.Config>,
+};
+Object.assign(plugin.configs, {
+  recommended: {
+    plugins: { 'my-plugin': plugin },
+    rules: { 'my-plugin/rule-one': 'error', 'my-plugin/rule-two': 'warn' },
+  },
+});
+export default plugin;
+```
+
+```javascript
+// eslint.config.js (flat config)
+import myPlugin from 'eslint-plugin-my-plugin';
+export default [
+  myPlugin.configs.recommended,
+  { rules: { 'my-plugin/rule-one': ['error', { option: true }] } },
+];
+```
+
+---
+
+## 11. Real-World Pattern Catalog
+
+### Ban a Function Call
+```typescript
+CallExpression(node) {
+  if (node.callee.type !== "MemberExpression") return;
+  if (node.callee.object.name !== "console" || node.callee.property.name !== "log") return;
+  context.report({ node, messageId: "noConsoleLog",
+    fix: fixer => node.parent.type === "ExpressionStatement"
+      ? fixer.remove(node.parent) : null });
+},
+```
+
+### Enforce Import Style
+```typescript
+ImportDeclaration(node) {
+  if (!banned.includes(node.source.value)) return;
+  const def = node.specifiers.find(s => s.type === "ImportDefaultSpecifier");
+  if (!def) return;
+  context.report({ node: def, messageId: "useNamedImport", data: { name: def.local.name },
+    fix: fixer => fixer.replaceText(def, `{ ${def.local.name} }`) });
+},
+```
+
+### Scope Analysis
+```typescript
+"Program:exit"(node) {
+  for (const v of context.sourceCode.getScope(node).variables) {
+    if (v.references.length === 0 && v.defs.length > 0)
+      context.report({ node: v.defs[0].name, messageId: "unusedVar", data: { name: v.name } });
+  }
+},
+```
+
+### State Tracking Across Visitors
+```typescript
+create(context) {
+  const stack: number[] = [];
+  return {
+    FunctionDeclaration() { stack.push(0); },
+    "FunctionDeclaration:exit"() { stack.pop(); },
+    IfStatement(node) {
+      if (stack.length && ++stack[stack.length - 1] > 4)
+        context.report({ node, messageId: "tooNested" });
+    },
+  };
+},
+```
+
+### Typed Rule — Remove Unnecessary Non-Null Assertion
+```typescript
+TSNonNullExpression(node) {
+  const type = ESLintUtils.getConstrainedTypeAtLocation(services, node.expression);
+  if (!tsutils.isNullableType(type)) {
+    context.report({ node, messageId: "unnecessaryAssertion",
+      fix(fixer) {
+        const bang = sourceCode.getLastToken(node, t => t.value === "!");
+        return bang ? fixer.removeRange(bang.range) : null;
+      } });
+  }
+},
+```
+
+---
+
+## Rule Authoring Checklist
+
+- Declare `fixable: "code"` in `meta` before calling any fixer method
+- Declare `hasSuggestions: true` in `meta` before using `suggest`
+- Use `messageId` + `messages` map rather than inline message strings
+- Return `null` from `fix` when the transform is not safe to apply automatically
+- Use generator `*fix` for multi-node edits that must apply atomically
+- Use `"Program:exit"` for whole-file analysis requiring global context
+- Use `suggest` instead of `fix` when the change could alter runtime semantics
+- Mark typed rules with `requiresTypeChecking: true` in `docs`

--- a/skills/ast-linter-codemod/references/jscodeshift-codemods.md
+++ b/skills/ast-linter-codemod/references/jscodeshift-codemods.md
@@ -1,0 +1,428 @@
+# jscodeshift Codemod Patterns
+
+Sources: facebook/jscodeshift documentation, reactjs/react-codemod, vercel/next.js codemods, Airbnb engineering, 2025-2026 production patterns
+
+## 1. The Transform Function
+
+Every jscodeshift codemod exports a default function:
+
+```ts
+export default function transformer(
+  file: FileInfo,   // { path: string, source: string }
+  api: API,         // { jscodeshift, stats, report }
+  options: Options  // CLI flags passed via --option=value
+): string | null | undefined {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  // ... transform ...
+  return root.toSource();
+}
+```
+
+Return semantics: **string** → file is written; **null/undefined** → file is skipped; **throw** → file is marked as error.
+
+Declare the parser alongside the transform when the default (`babel`) is wrong:
+
+```ts
+export const parser = 'tsx'; // 'babel' | 'ts' | 'tsx' | 'flow'
+export default function transformer(file, api) { ... }
+```
+
+---
+
+## 2. The Collection API
+
+`j(source)` returns a **Collection** — a chainable wrapper around an array of AST paths. Workflow: find → filter → act.
+
+**Finding nodes**
+
+```ts
+root.find(j.ImportDeclaration)
+root.find(j.ImportDeclaration, { source: { value: 'react' } })
+root.findJSXElements('Link')
+root.findVariableDeclarators('myVar')
+```
+
+**Filtering and inspecting**
+
+```ts
+collection.filter(path => path.node.kind === 'const')
+collection.some(path => path.node.source.value === 'react')
+collection.closest(j.FunctionDeclaration)
+collection.closestScope()
+collection.size()       // count
+collection.nodes()      // raw AST nodes
+collection.get()        // first path
+collection.at(-1)       // last path
+```
+
+**Transforming**
+
+```ts
+collection.replaceWith(path => newNode)
+collection.insertBefore(newNode)
+collection.insertAfter(newNode)
+collection.remove()
+```
+
+**Path object properties**
+
+| Property | Value |
+|---|---|
+| `path.node` | The AST node |
+| `path.parent` | Parent path |
+| `path.parent.node` | Parent AST node |
+| `path.name` | Property name in parent (`'body'`, `'arguments'`, …) |
+| `path.scope` | Scope information |
+
+---
+
+## 3. AST Builder Functions
+
+`j` doubles as a factory for every AST node type.
+
+```ts
+// Identifiers and literals
+j.identifier('myVar')
+j.stringLiteral('hello')
+j.numericLiteral(42)
+j.booleanLiteral(true)
+
+// Imports
+j.importDeclaration([j.importDefaultSpecifier(j.identifier('React'))], j.stringLiteral('react'))
+j.importSpecifier(j.identifier('useState'))
+j.importNamespaceSpecifier(j.identifier('NS'))
+
+// Expressions and statements
+j.callExpression(callee, args)
+j.memberExpression(j.identifier('obj'), j.identifier('prop'))
+j.arrowFunctionExpression(params, body)
+j.variableDeclaration('const', [j.variableDeclarator(j.identifier('x'), j.numericLiteral(1))])
+
+// JSX
+j.jsxElement(openingEl, closingEl, children)
+j.jsxAttribute(j.jsxIdentifier('className'), j.stringLiteral('foo'))
+j.jsxExpressionContainer(j.identifier('value'))
+
+// Comments
+j.commentBlock(' license header ', true, false)
+j.commentLine(' inline comment', true, false)
+```
+
+For complex nodes, extract builder functions by name — keeps the transform body readable and the construction logic testable.
+
+---
+
+## 4. Formatting Preservation
+
+jscodeshift wraps **recast**. When recast parses source, it records the original source positions of every token. When printing, it uses the **original source text** for any node that was not modified — only modified nodes are re-printed by the code generator. Whitespace, comments, and style are preserved for untouched code.
+
+```ts
+root.toSource({ quote: 'single' })              // 'single' | 'double' | 'auto'
+root.toSource({ trailingComma: true, tabWidth: 2 })
+```
+
+Formatting degrades when you replace a node with a freshly built node (recast has no original text to preserve). To preserve quote style on string literals, reuse the original node:
+
+```ts
+const originalSource = importPath.value.source;  // original StringLiteral node
+j.importDeclaration(newSpecifiers, originalSource);
+```
+
+---
+
+## 5. The hasModifications Pattern
+
+Return `null` when no changes were made. This prevents unnecessary file writes and keeps runner output clean (`ok` vs `skip`).
+
+```ts
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasModifications = false;
+
+  root.find(j.MethodDefinition).forEach(path => {
+    if (DEPRECATED_APIS[path.node.key.name]) {
+      path.value.key.name = DEPRECATED_APIS[path.node.key.name];
+      hasModifications = true;
+    }
+  });
+
+  return hasModifications ? root.toSource({ quote: 'single' }) : null;
+}
+```
+
+Use `||=` to accumulate the flag across multiple passes:
+
+```ts
+hasModifications ||= root.find(j.ImportDeclaration, { source: { value: '@next/font' } }).size() > 0;
+```
+
+---
+
+## 6. Import Manipulation
+
+**Finding and classifying specifiers**
+
+```ts
+root.find(j.ImportDeclaration, { source: { value: 'react' } })
+  .forEach(path => {
+    path.value.specifiers?.forEach(spec => {
+      if (j.ImportDefaultSpecifier.check(spec)) { /* default import */ }
+      if (j.ImportNamespaceSpecifier.check(spec)) { /* namespace import */ }
+      if (j.ImportSpecifier.check(spec)) { /* named import */ }
+    });
+  });
+```
+
+**Adding an import** — prepend to `program.body` or insert relative to an existing import:
+
+```ts
+root.get().node.program.body.unshift(
+  j.importDeclaration([j.importSpecifier(j.identifier('createRoot'))], j.literal('react-dom/client'))
+);
+// or:
+root.find(j.ImportDeclaration).at(0).insertBefore(newImport);
+```
+
+**Removing a specifier**
+
+```ts
+root.find(j.ImportSpecifier, { imported: { name: 'forwardRef' } }).remove();
+// Remove the entire declaration if it becomes empty after specifier removal.
+```
+
+**Renaming an import source** — direct mutation is cleaner than `replaceWith` for simple property changes:
+
+```ts
+root.find(j.ImportDeclaration, { source: { value: '@next/font' } })
+  .forEach(path => { path.node.source = j.stringLiteral('next/font'); hasModifications = true; });
+```
+
+---
+
+## 7. Production Patterns from React/Next.js Codemods
+
+### a. Handle all syntactic variants
+
+The same logical concept can appear as different AST node types. `rename-unsafe-lifecycles` covers five variants of the same lifecycle method:
+
+```ts
+const renameDeprecatedApis = path => {
+  const name = path.node.key.name;
+  if (DEPRECATED_APIS[name]) { path.value.key.name = DEPRECATED_APIS[name]; hasModifications = true; }
+};
+
+root.find(j.MethodDefinition).forEach(renameDeprecatedApis);  // ES6 class
+root.find(j.ClassMethod).forEach(renameDeprecatedApis);        // Babel class
+root.find(j.ClassProperty).forEach(renameDeprecatedApis);      // Arrow fn prop
+root.find(j.Property).forEach(renameDeprecatedApis);           // createReactClass
+root.find(j.MemberExpression).forEach(renameDeprecatedCallExpressions);
+```
+
+Audit every syntactic form before shipping a codemod.
+
+### b. Preserve first-node comments
+
+When the first node in a file is removed or replaced, comments attached to it (license headers, `@flow`, `@format`) are lost:
+
+```ts
+function getFirstNode() { return root.find(j.Program).get('body', 0).node; }
+const firstNode = getFirstNode();
+const { comments } = firstNode;
+
+// ... transformations ...
+
+const newFirstNode = getFirstNode();
+if (newFirstNode !== firstNode) { newFirstNode.comments = comments; }
+```
+
+### c. Insert TODO comments for unresolvable cases
+
+When a transform cannot safely automate a case, insert a comment marker rather than silently skipping:
+
+```ts
+linkPath.node.children.unshift(
+  j.jsxText('\n'),
+  j.jsxExpressionContainer.from({
+    expression: j.jsxEmptyExpression.from({
+      comments: [j.commentBlock.from({
+        value: ` TODO: This Link previously used legacyBehavior. Verify the child does not render an <a>. `,
+      })],
+    }),
+  })
+);
+```
+
+This pattern (from `next-codemod/new-link`) leaves a searchable marker developers can grep for and resolve manually.
+
+### d. Chain transforms via reduce
+
+When a migration requires multiple independent passes, compose them so each pass receives the output of the previous:
+
+```ts
+export default function transform(file: FileInfo, api: API) {
+  const transforms = [transformDynamicProps, transformDynamicAPI];
+  return transforms.reduce<string>((source, fn) => {
+    const result = fn(source, api, file.path);
+    return result ?? source;
+  }, file.source);
+}
+```
+
+---
+
+## 8. TypeScript Support
+
+**Parser selection**
+
+```ts
+export const parser = 'tsx';  // static declaration in transform file
+
+// Or dynamically by file extension (Next.js pattern):
+function createParserFromPath(filePath: string) {
+  if (filePath.endsWith('.tsx')) return require('jscodeshift/parser/tsx');
+  if (filePath.endsWith('.ts')) return require('jscodeshift/parser/ts');
+  return require('jscodeshift/parser/babel');
+}
+```
+
+**Type annotation transforms** — use the `TS*` builder family:
+
+```ts
+j.tsTypeAnnotation(
+  j.tsIntersectionType([
+    propType,
+    j.tsTypeLiteral([
+      j.tsPropertySignature.from({
+        key: j.identifier('ref'),
+        typeAnnotation: j.tsTypeAnnotation(
+          j.tsTypeReference.from({
+            typeName: j.tsQualifiedName(j.identifier('React'), j.identifier('RefObject')),
+            typeParameters: j.tsTypeParameterInstantiation([refType]),
+          })
+        ),
+      }),
+    ]),
+  ])
+)
+```
+
+**Common TypeScript node types**
+
+| Node | Description |
+|---|---|
+| `TSTypeAnnotation` | `: Type` annotation |
+| `TSTypeReference` | `Foo<Bar>` type reference |
+| `TSAsExpression` | `x as Type` |
+| `TSNonNullExpression` | `x!` |
+| `TSInterfaceDeclaration` | `interface Foo {}` |
+| `TSTypeAliasDeclaration` | `type Foo = ...` |
+| `TSUnionType` | `A \| B` |
+| `TSIntersectionType` | `A & B` |
+| `TSTypeParameterDeclaration` | `<T>` generic params |
+| `TSTypeParameterInstantiation` | `<string>` generic args |
+
+---
+
+## 9. Running Codemods
+
+```bash
+jscodeshift -t transform.js src/
+jscodeshift -t transform.ts --parser=tsx src/**/*.tsx
+```
+
+| Flag | Purpose |
+|---|---|
+| `--dry` | Print what would change without writing |
+| `--print` | Print transformed output to stdout |
+| `--extensions=ts,tsx` | Limit to file extensions |
+| `--ignore-pattern="**/*.test.ts"` | Skip matching files |
+| `--cpus=8` | Worker count (default: CPU count) |
+| `--verbose=2` | Detailed output per file |
+
+Recommended workflow: run `--dry --print` on one file → review → run on a small subset → `git diff` → run full codemod → run tests and type-check.
+
+Via codemod.com registry:
+
+```bash
+npx codemod react/19/remove-forward-ref --dry-run --target ./src
+```
+
+---
+
+## 10. Common Codemod Templates
+
+**Rename API**
+
+```ts
+const RENAMES = { componentWillMount: 'UNSAFE_componentWillMount' };
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasModifications = false;
+  root.find(j.Identifier).forEach(path => {
+    if (RENAMES[path.node.name]) { path.node.name = RENAMES[path.node.name]; hasModifications = true; }
+  });
+  return hasModifications ? root.toSource() : null;
+}
+```
+
+**Wrap with function**
+
+```ts
+// Before: render(el, container)  →  After: createRoot(container)
+root.find(j.CallExpression, { callee: { name: 'render' } })
+  .replaceWith(path => j.callExpression(j.identifier('createRoot'), [path.node.arguments[1]]));
+```
+
+**Unwrap HOC**
+
+```ts
+// Before: forwardRef(fn)  →  After: fn
+root.find(j.CallExpression, { callee: { name: 'forwardRef' } })
+  .replaceWith(path => path.node.arguments[0]);
+```
+
+**Change import source**
+
+```ts
+root.find(j.ImportDeclaration, { source: { value: 'old-package' } })
+  .forEach(path => { path.node.source = j.stringLiteral('new-package'); hasModifications = true; });
+```
+
+**Add / remove JSX prop**
+
+```ts
+// Remove
+root.findJSXElements('Link').find(j.JSXAttribute, { name: { name: 'legacyBehavior' } }).remove();
+
+// Add
+root.findJSXElements('Image').forEach(path => {
+  path.node.openingElement.attributes.push(j.jsxAttribute(j.jsxIdentifier('priority'), null));
+});
+```
+
+---
+
+## Testing
+
+jscodeshift ships `jscodeshift/dist/testUtils` with `defineTest`. The standard structure uses input/output fixture pairs:
+
+```
+transforms/my-transform.ts
+__tests__/my-transform-test.ts
+__testfixtures__/my-transform/
+  basic.input.ts  /  basic.output.ts
+  edge-case.input.ts  /  edge-case.output.ts
+```
+
+```ts
+import { defineTest } from 'jscodeshift/dist/testUtils';
+const tests = ['basic', 'edge-case'];
+describe('my-transform', () => {
+  tests.forEach(name => defineTest(__dirname, 'my-transform', null, `my-transform/${name}`));
+});
+```
+
+Each edge case — different syntactic variant, comment preservation, no-op file — gets its own fixture pair. See `testing-transforms.md` for the full testing reference.

--- a/skills/ast-linter-codemod/references/migration-strategies.md
+++ b/skills/ast-linter-codemod/references/migration-strategies.md
@@ -1,0 +1,449 @@
+# Large-Scale Migration Strategies
+
+Sources: Stripe Engineering (Flow→TypeScript 3.7M lines), Pinterest Engineering (JS→TypeScript), Noback/Votruba (Rector: Automated Refactoring), Angular/React migration patterns, 2025-2026 industry practices
+
+This reference covers strategy and process for large-scale code migrations. Tool-specific APIs belong in the tool references. Testing patterns belong in testing-transforms.md.
+
+---
+
+## 1. Migration Strategy Selection
+
+Three patterns dominate production migrations. Choose based on codemod maturity, team size, and risk tolerance.
+
+| Strategy | When to Use | Risk | Duration |
+|----------|-------------|------|----------|
+| Big Bang (single PR) | Proven codemod, well-understood migration, small team | High upfront, low ongoing | Days to weeks |
+| Gradual (file-by-file) | Unproven automation, large team, no full coverage | Low per-change, high coordination | Months |
+| Module-by-Module | Well-modularized codebase, clear ownership boundaries | Medium | Weeks to months |
+
+**Big Bang** works when the codemod covers 95%+ of cases automatically. Stripe converted 3.7M lines of Flow to TypeScript in a single weekend PR. The key precondition: they had already validated the codemod on a representative sample and knew the residual manual work was bounded.
+
+**Gradual** is safer but creates a long-lived mixed state. Engineers must maintain two mental models simultaneously. Voluntary adoption without coordination produces inconsistent results — a platform team must own the migration and enforce progress.
+
+**Module-by-Module** requires a dependency graph. Migrate leaf modules first (no internal dependencies), then work inward. This avoids the mixed-state problem of gradual migration while reducing the blast radius of any single change.
+
+Decision matrix:
+
+| Condition | Favors |
+|-----------|--------|
+| Codemod automation > 95% | Big Bang |
+| Codemod automation 70–95% | Module-by-Module |
+| Codemod automation < 70% | Gradual |
+| Team > 50 engineers | Gradual or Module-by-Module |
+| Team < 20 engineers | Big Bang |
+| Zero type errors in baseline | Big Bang |
+| Existing type errors in baseline | Gradual |
+| Monorepo with clear package boundaries | Module-by-Module |
+| Monolith with tangled imports | Big Bang or Gradual |
+
+---
+
+## 2. The 5-Phase Migration Toolchain
+
+Every successful large-scale migration follows this sequence. Skipping phases produces regressions that are expensive to diagnose.
+
+### Phase 1: Audit
+
+Quantify the migration surface before writing a single transform.
+
+- Count files and lines by type: `find src -name "*.flow" | wc -l`
+- Sample 50–100 files manually to identify pattern distribution
+- Categorize patterns: common (>5% of files), uncommon (1–5%), rare (<1%), manual-only
+- Estimate automation coverage: what percentage of files can be fully automated?
+- Identify blockers: patterns that require type information, runtime behavior, or human judgment
+
+Output: a written scope document with pattern catalog and automation estimate. This document drives codemod development priorities.
+
+### Phase 2: Prepare
+
+Set up the infrastructure before running any transforms.
+
+- Configure the target toolchain (TypeScript compiler, new linter, build system)
+- Establish a baseline: run `tsc --noEmit` and record the error count (should be 0 for a clean migration)
+- Run the full test suite and record pass rate
+- Set up CI for the target language/configuration
+- Create a migration branch strategy (single long-lived branch vs. many small PRs)
+- Write the codemod for the 80% common case first; defer edge cases
+
+### Phase 3: Transform
+
+Execute the codemod and handle residual cases.
+
+- Run on a 10% sample first; review diffs manually before full execution
+- Execute the codemod on the full codebase
+- Commit the automated changes separately from manual fixes — this preserves reviewability
+- Triage residual errors: categorize by pattern, fix the most common patterns with additional codemods
+- Insert `// TODO(migration): manual review needed` comments for cases that cannot be automated
+
+The Angular team's approach for large monorepos: use environment variables to shard the migration across CI workers. Run `CURRENT_SHARD=1 NUM_SHARDS=4` to process one quarter of files per worker, then merge results.
+
+### Phase 4: Validate
+
+Confirm the migration did not introduce regressions. See testing-transforms.md for detailed test patterns.
+
+- Type check: `tsc --noEmit` — error count must be equal to or lower than baseline
+- Test suite: pass rate must match baseline
+- Build: production build must succeed
+- Spot-check: manually review 20 randomly selected files
+- Linter: run ESLint or Biome on the output
+
+### Phase 5: Clean Up
+
+Harden the codebase after the migration completes.
+
+- Enable stricter compiler options incrementally (`strict`, `noImplicitAny`, `strictNullChecks`)
+- Add lint rules to prevent regression to the old pattern
+- Remove migration scaffolding (compatibility shims, temporary type aliases)
+- Update documentation and onboarding guides
+- Archive the codemod in the repository for reference
+
+---
+
+## 3. Codemod Composition
+
+Complex migrations require multiple transforms applied in sequence. Composition is the primary tool for managing this complexity.
+
+### Chaining Transforms
+
+The Next.js codemod runner demonstrates the canonical composition pattern:
+
+```typescript
+export default function transform(file: FileInfo, api: API) {
+  const transforms = [transformDynamicProps, transformDynamicAPI];
+  return transforms.reduce<string>((source, transformFn) => {
+    const result = transformFn(source, api, file.path);
+    if (!result) return source;
+    return result;
+  }, file.source);
+}
+```
+
+Each transform receives the output of the previous one. If a transform returns null (no changes), the source passes through unchanged. This pattern allows independent transforms to be developed and tested in isolation, then composed for the full migration.
+
+### Ordering Dependencies
+
+Transform order matters when one transform's output is another's input. Common ordering rules:
+
+1. Import renames before usage renames — rename the module path before renaming the imported symbols
+2. Type annotation additions before type assertion removals — add explicit types before removing casts
+3. Structural changes before cosmetic changes — change the AST shape before adjusting formatting
+4. Removal transforms last — remove deprecated patterns only after replacements are in place
+
+Violating these rules produces intermediate states that fail type checking, which breaks validation between phases.
+
+### Parameterized Codemods
+
+Avoid hardcoding module names and symbol names in transforms. Accept them as options:
+
+```typescript
+export default function transform(file: FileInfo, api: API, options: Options) {
+  const fromModule = options.from || 'old-module';
+  const toModule = options.to || 'new-module';
+  // ...
+}
+// Usage: jscodeshift -t transform.ts --from=lodash --to=lodash-es src/
+```
+
+Parameterization enables the same transform to serve multiple migration targets. The React codemod collection uses this pattern extensively — a single rename transform handles dozens of API changes by accepting the old and new names as parameters.
+
+---
+
+## 4. Formatting Preservation
+
+Formatting preservation is not cosmetic. Diffs that reformat unchanged code are unreviable at scale and generate spurious merge conflicts.
+
+### How recast Preserves Formatting
+
+recast (the formatting layer under jscodeshift) uses a "print only what changed" strategy:
+
+1. Parse source into an AST with source location info attached to every node
+2. When printing, check whether each node was modified
+3. Unmodified nodes: print verbatim from the original source bytes
+4. Modified nodes: pretty-print using the code generator
+
+The result: only the lines you actually changed appear in the diff. A rename of one import path produces a one-line diff even in a 500-line file.
+
+### Comment Handling
+
+Comments are attached to AST nodes as `leadingComments` and `trailingComments`. When you replace a node, comments do not transfer automatically.
+
+Preserve comments on node replacement:
+
+```typescript
+const newNode = j.identifier('newName');
+newNode.comments = path.node.comments;  // transfer explicitly
+j(path).replaceWith(newNode);
+```
+
+For the first node in a file (which often carries license headers or `@flow` annotations), save and restore comments explicitly:
+
+```typescript
+const firstNode = root.find(j.Program).get('body', 0).node;
+const { comments } = firstNode;
+// ... transform ...
+const firstNodeAfter = root.find(j.Program).get('body', 0).node;
+if (firstNodeAfter !== firstNode) {
+  firstNodeAfter.comments = comments;
+}
+```
+
+### Known Pitfalls and Workarounds
+
+| Issue | Tool | Workaround |
+|-------|------|------------|
+| JSXText leading space lost | recast upstream | Use `@putout/recast` fork |
+| Comments lost on node replacement | jscodeshift | Transfer `.comments` manually |
+| Parentheses removed around expressions | @babel/generator | Use recast instead of @babel/generator |
+| Indentation changed | ts-morph | Set `manipulationSettings.setIndentationText()` |
+| Quote style changed | recast | Pass `{ quote: 'single' }` to `toSource()` |
+| Trailing comma added/removed | recast | Pass `{ trailingComma: false }` to `toSource()` |
+
+Prefer in-place mutation over node replacement when possible. Changing `path.node.source.value = 'new-module'` preserves all surrounding formatting. Rebuilding the entire `ImportDeclaration` node loses it.
+
+---
+
+## 5. Edge Cases in Transforms
+
+These patterns appear in nearly every large-scale migration and require explicit handling.
+
+### Template Literals
+
+Template literals have a non-obvious AST structure: alternating `quasis` (static string parts) and `expressions` (interpolated values). Modifying an expression inside a template literal requires indexing into both arrays simultaneously.
+
+When migrating from string concatenation to template literals, watch for expressions that contain backticks — they must be escaped in the output.
+
+Babel 8 introduced a breaking change: TypeScript template literal types (`type T = \`Hello ${string}\``) now produce `TSTemplateLiteralType` nodes instead of `TemplateLiteral`. Check your Babel version when writing transforms that touch template literal types.
+
+### JSX
+
+JSX requires the TSX parser (`--parser=tsx`). Key edge cases:
+
+- Self-closing vs. paired tags: renaming a component requires updating both `openingElement.name` and `closingElement.name`
+- Fragments (`<>...</>`) have no name property — pattern matching on component name will not find them
+- JSXText whitespace: recast issue #886 causes leading spaces in JSXText to be lost on reprint
+- Spread attributes (`<Comp {...props} />`) cannot be matched by attribute name
+
+### Decorators
+
+Decorator AST representation changed between TypeScript legacy decorators (`experimentalDecorators: true`) and TC39 Stage 3 decorators. The same `@Injectable()` syntax produces different AST node types depending on the TypeScript configuration. Detect which mode is active before writing decorator transforms.
+
+Parameter decorators exist only in legacy mode and have no equivalent in Stage 3 decorators — they require manual migration.
+
+### Type Assertions
+
+TypeScript supports two syntaxes for type assertions: `value as Type` (preferred) and `<Type>value` (not valid in TSX files). A migration from angle-bracket assertions to `as` assertions must skip TSX files or handle the parser difference.
+
+### Async/Await
+
+When making a function `async` to support `await`, check for nested sync functions that access the same data. The Next.js `next-async-request-api` codemod handles this by detecting the closest parent function scope for each `await` insertion point — if the closest parent is a sync nested function, it inserts a comment instead of awaiting.
+
+### Destructuring
+
+Object destructuring patterns appear in function parameters, variable declarations, and catch clauses. A rename of a property key must handle all three locations. The property key and the local binding name are separate AST nodes — renaming the key without renaming the local binding (or vice versa) produces broken code.
+
+---
+
+## 6. Pre/Post Migration Validation
+
+Validation gates prevent regressions from reaching production. Run these checks at each phase boundary.
+
+Record the baseline before any transforms: type error count (`tsc --noEmit 2>&1 | grep "error TS" | wc -l`), test pass rate, and build status. Post-migration, each metric must be equal to or better than baseline.
+
+Spot-check protocol: select 20 files at random (`shuf -n 20 <(find src -name "*.ts")`) and review each diff manually. Look for dropped comments, formatting changes in untouched regions, incorrectly inferred type annotations, and partially renamed import paths.
+
+---
+
+## 7. Idempotency
+
+A codemod is idempotent if running it twice produces the same result as running it once. Idempotency is not optional for production codemods — it enables safe re-runs when new files are added or when the codemod is applied incrementally.
+
+The Rector book (Noback/Votruba) identifies idempotency as a first-class requirement and provides a testing recipe: run the transform on its own output and assert the output is unchanged.
+
+Idempotency failures occur when:
+
+- A transform adds a prefix or suffix unconditionally (running twice doubles it)
+- A transform inserts an import without checking whether it already exists
+- A transform renames a symbol that was already renamed by a previous run
+
+Guard against these by checking preconditions before transforming:
+
+```typescript
+// Check before inserting import
+const alreadyImported = root.find(j.ImportDeclaration, {
+  source: { value: 'new-module' }
+}).size() > 0;
+
+if (!alreadyImported) {
+  // insert import
+}
+```
+
+The dirty flag pattern (`let isDirty = false`) naturally supports idempotency: if the precondition check finds nothing to transform, the flag stays false and the file is not written.
+
+---
+
+## 8. Parallel Processing
+
+Large codebases (>10,000 files) require parallel processing to complete migrations in reasonable time.
+
+### Worker Threads
+
+jscodeshift runs transforms in parallel by default, spawning one worker per CPU core. Control parallelism with `--cpus`:
+
+```bash
+npx jscodeshift -t transform.ts src/ --cpus=8
+```
+
+For ts-morph-based tools that do not have a built-in runner, implement worker threads manually:
+
+```typescript
+const NUM_WORKERS = Math.max(1, os.cpus().length);
+for (let i = 0; i < NUM_WORKERS; i++) {
+  const fileChunk = sourceFiles.slice(start, end).map(sf => sf.getFilePath());
+  const worker = new Worker(__filename, { workerData: { filePaths: fileChunk } });
+}
+```
+
+### File Sharding
+
+For migrations that must be distributed across CI workers or run incrementally, shard by file hash:
+
+```typescript
+const isFileInShard = (filePath: string): boolean => {
+  return Math.abs(hashCode(filePath) % NUM_SHARDS) === CURRENT_SHARD - 1;
+};
+// Run as: CURRENT_SHARD=1 NUM_SHARDS=4 node migrate.js
+```
+
+Hash-based sharding ensures each file is processed by exactly one shard and the assignment is deterministic across runs.
+
+### The Angular Shard Pattern
+
+Angular's signal migration uses an environment variable to limit processing to root files during development, then the full set for production:
+
+```bash
+LIMIT_TO_ROOT_NAMES_ONLY=1 node migrate.js   # fast iteration
+node migrate.js                               # full run
+```
+
+---
+
+## 9. Escape Hatches
+
+Not every pattern can be safely automated. Escape hatches allow the codemod to make progress while flagging cases that require human review.
+
+### Ignore Comments
+
+Every production codemod ecosystem supports a per-line opt-out:
+
+```typescript
+// eslint-disable-next-line rule-name
+// ts-morph: check getLeadingCommentRanges() for ignore marker
+// jscodeshift: check path.node.leadingComments for disable comment
+```
+
+Implement ignore support in custom codemods:
+
+```typescript
+const IGNORE_COMMENT = '// migration-ignore-next';
+const hasIgnoreComment = (path: ASTPath): boolean => {
+  return path.node.leadingComments?.some(c =>
+    c.value.trim() === 'migration-ignore-next'
+  ) ?? false;
+};
+```
+
+### TODO Markers
+
+When a transform cannot safely automate a case, insert a structured comment rather than skipping silently or failing:
+
+```typescript
+// Next.js pattern: NEXT_CODEMOD_ERROR_PREFIX
+j.commentBlock(` CODEMOD_ERROR: This Link previously used legacyBehavior. Verify child component does not render an anchor. `);
+```
+
+Structured prefixes (`CODEMOD_ERROR:`, `MIGRATION_TODO:`) allow the team to find all manual review items with a single grep after the automated pass completes.
+
+### Suggest vs. Fix
+
+ESLint distinguishes between `fix` (applied automatically) and `suggest` (requires user approval). Apply the same distinction to codemods:
+
+- Use automated transforms for patterns where the correct output is deterministic
+- Use TODO comments for patterns where the correct output depends on runtime behavior or business logic
+- The React hooks exhaustive-deps rule uses `suggest` instead of `fix` because auto-fixing dependency arrays can introduce infinite render loops
+
+---
+
+## 10. Case Studies
+
+### Stripe: 3.7M Lines Flow → TypeScript (2022)
+
+Scale: 3.7 million lines, single PR, one weekend. Strategy: Big Bang. Stripe contacted Airtable (who had done a similar migration) and built on their open-source `flow-to-typescript-codemod`. The codemod automated 95%+ of conversions; residual `any` types were accepted as technical debt. Single PR avoided long-lived branches; weekend execution minimized team disruption.
+
+Source: stripe.com/blog/migrating-to-typescript
+
+### Pinterest: 3.7M Lines Flow → TypeScript (2025)
+
+Scale: 3.7 million lines, 8 months.
+
+Strategy: Three-phase gradual migration. Pinterest achieved 100% Flow coverage before starting — no files were partially typed. This made the migration all-or-nothing rather than gradual at the file level.
+
+Phase 1 (Setup): Configure TypeScript compiler, set up CI, create migration tooling.
+Phase 2 (Conversion): Run `flow-to-typescript-codemod` (Stripe's tool) on all files, handle edge cases with custom rules.
+Phase 3 (Integration): Daily automated testing, type error triage, gradual rollout.
+
+Key insight: "We achieved 100% Flow coverage first, meaning no gradual transition left. It was all or nothing."
+
+Source: medium.com/pinterest-engineering/migrating-3-7-million-lines-of-flow-code-to-typescript-8a836c88fea5
+
+### Angular Schematics: 14 Official Migrations
+
+Angular ships official migration schematics with each major version (signal migration, output migration, control flow migration). Architecture: a two-phase Tsurge framework — analyze phase collects `Replacement[]` (text spans + new text) by walking the AST; migrate phase applies them. This separation enables parallelism and dry-run mode. The schematics integrate with `ng update @angular/core`, which applies both the npm version bump and the corresponding code transforms automatically.
+
+### React Codemods: Incremental API Evolution
+
+The `reactjs/react-codemod` repository contains 15+ transforms covering React 15 through React 19. The pattern: ship the deprecation warning in version N, ship the codemod alongside the breaking change in version N+1.
+
+- React 16.3: `rename-unsafe-lifecycles` — prefix deprecated lifecycle methods with `UNSAFE_`
+- React 18: `replace-reactdom-render` — `ReactDOM.render()` → `createRoot().render()`
+- React 19: `remove-forward-ref` — unwrap `React.forwardRef()` (ref is now a regular prop)
+
+Engineers run `npx react-codemod <transform-name>` before upgrading.
+
+---
+
+## 11. Migration Planning Checklist
+
+Use this template before starting any migration affecting more than 500 files.
+
+### Pre-Migration Assessment
+
+- [ ] File count and LOC by type (run `find` + `wc -l`)
+- [ ] Pattern catalog: sample 50 files, list all patterns requiring transformation
+- [ ] Automation estimate: what percentage of files can be fully automated?
+- [ ] Blocker identification: which patterns require type information or human judgment?
+- [ ] Baseline recorded: type error count, test pass rate, build status
+- [ ] Strategy selected: Big Bang / Gradual / Module-by-Module (with rationale)
+- [ ] Codemod validated on 10% sample before full execution
+- [ ] Escape hatch defined: ignore comment syntax, TODO marker prefix
+- [ ] Rollback plan: can the migration be reverted if a critical bug is found post-merge?
+
+### Execution Checklist
+
+- [ ] Codemod run in dry-run mode first (`--dry` flag)
+- [ ] Automated changes committed separately from manual fixes
+- [ ] Type check passes (error count <= baseline)
+- [ ] Test suite passes (pass rate >= baseline)
+- [ ] Build succeeds
+- [ ] 20 random files spot-checked manually
+- [ ] All `CODEMOD_ERROR:` markers triaged and resolved or tracked
+- [ ] Linter clean on output
+
+### Post-Migration Hardening
+
+- [ ] Stricter compiler options enabled (incrementally)
+- [ ] Lint rules added to prevent regression
+- [ ] Compatibility shims removed
+- [ ] Codemod archived in repository
+- [ ] Documentation updated
+- [ ] Onboarding guide updated for new patterns

--- a/skills/ast-linter-codemod/references/testing-transforms.md
+++ b/skills/ast-linter-codemod/references/testing-transforms.md
@@ -1,0 +1,356 @@
+# Testing Linters, Codemods, and AST Transforms
+
+Sources: Noback/Votruba (Rector: Automated Refactoring), ESLint RuleTester documentation, jscodeshift testUtils, ast-grep test framework, production test suites from React/Next.js/Angular, 2025-2026 testing patterns
+
+## The Testing Philosophy
+
+A codemod is a pure function: it takes source text (or an AST) and returns transformed source text. Test it like a pure function — fixed input, deterministic output, no side effects.
+
+Three properties every transform must satisfy:
+
+- **Correctness** — the output matches the expected transformation exactly
+- **Idempotency** — running the transform twice produces the same result as running it once
+- **Scope discipline** — the transform only modifies what it claims to modify; unrelated code is untouched
+
+These properties map directly to test types: fixture tests verify correctness, idempotency tests verify stability, and no-op tests verify scope discipline.
+
+---
+
+## Fixture-Based Testing for Codemods
+
+The standard pattern across React, Next.js, and Angular codemods: one input file and one output file per edge case, stored in a `__testfixtures__` directory alongside the transform. Structure:
+
+```
+transforms/remove-forward-ref.ts
+__tests__/remove-forward-ref.test.ts
+__testfixtures__/remove-forward-ref/
+  function-expression.input.ts   function-expression.output.ts
+  arrow-function.input.ts        arrow-function.output.ts
+  typescript-generics.input.tsx  typescript-generics.output.tsx
+```
+
+One fixture per edge case. Name fixtures after the syntactic variant they cover, not after the rule — failures become self-documenting.
+
+### defineTest from jscodeshift/testUtils
+
+```typescript
+import { defineTest, defineInlineTest } from 'jscodeshift/dist/testUtils';
+
+// Reads from __testfixtures__ relative to __dirname
+describe('remove-forward-ref', () => {
+  const tests = [
+    'function-expression',
+    'arrow-function',
+    'typescript-generics',
+    'already-transformed',  // no-op case
+  ];
+
+  tests.forEach(test =>
+    defineTest(
+      __dirname,
+      'remove-forward-ref',
+      null,                                    // options
+      `remove-forward-ref/${test}`             // fixture name
+    )
+  );
+});
+```
+
+For TypeScript fixtures, override the parser in a nested describe:
+
+```typescript
+describe('typescript', () => {
+  beforeEach(() => {
+    jest.mock('../remove-forward-ref', () =>
+      Object.assign(
+        jest.requireActual('../remove-forward-ref'),
+        { parser: 'tsx' }
+      )
+    );
+  });
+  afterEach(() => jest.resetModules());
+
+  tsTests.forEach(test =>
+    defineTest(__dirname, 'remove-forward-ref', null, `remove-forward-ref/ts/${test}`)
+  );
+});
+```
+
+For quick inline cases without fixture files, use `defineInlineTest(transform, options, input, expectedOutput, testName)` from the same package.
+
+---
+
+## ESLint RuleTester
+
+### Basic Setup
+
+```typescript
+import { RuleTester } from 'eslint';
+import rule from '../../src/rules/no-var';
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+ruleTester.run('no-var', rule, {
+  valid: [
+    'const x = 1;',
+    { code: 'let x = 1;', options: [{ allowLet: true }] },
+  ],
+  invalid: [
+    {
+      code: 'var x = 1;',
+      output: 'let x = 1;',          // expected output after --fix
+      errors: [{ messageId: 'unexpectedVar', line: 1, column: 1 }],
+    },
+  ],
+});
+```
+
+The `output` field is the complete file content after applying the fix — not a diff. If the rule reports but does not fix, omit `output`. When multiple errors appear in one file, all their fixes are applied in a single pass; `output` reflects the combined result.
+
+### Testing Suggestions
+
+Suggestions appear in editors as quick-fix options but are not applied by `--fix`. Test them with the `suggestions` array inside each error:
+
+```typescript
+{
+  code: 'a == b',
+  errors: [
+    {
+      messageId: 'useTripleEquals',
+      suggestions: [
+        {
+          messageId: 'replaceOperator',
+          data: { expected: '===', actual: '==' },
+          output: 'a === b',          // output after applying this suggestion
+        },
+      ],
+    },
+  ],
+},
+```
+
+### TypeScript-Aware RuleTester and Vitest Integration
+
+For rules that use `requiresTypeChecking: true`, use `@typescript-eslint/rule-tester` with a real tsconfig:
+
+```typescript
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { afterAll, describe, it } from 'vitest';
+
+// Wire into Vitest (or Jest — same API)
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: { project: './tsconfig.json', tsconfigRootDir: __dirname },
+  },
+});
+
+ruleTester.run('no-unnecessary-type-assertion', rule, {
+  valid: [`const x = 1 as number;`],
+  invalid: [
+    {
+      code: `const x = 3 as number;`,
+      errors: [{ messageId: 'unnecessaryAssertion' }],
+      output: `const x = 3;`,
+    },
+  ],
+});
+```
+
+---
+
+## ast-grep YAML Test Format
+
+ast-grep tests live in a `tests/` directory mirroring the `rules/` structure. Each test file is YAML with `valid` and `invalid` sections. For rules with fixes, add a `fixed` field.
+
+```yaml
+# tests/typescript/security/jwt-simple-noverify-typescript.yml
+id: jwt-simple-noverify-typescript
+valid:
+  - |
+    const jwt = require('jwt-simple');
+    jwt.decode(token, secret);          # no noverify flag — valid
+  - |
+    import jwt from 'jsonwebtoken';
+    jwt.verify(token, secret);          # different library — valid
+
+invalid:
+  - code: |
+      const jwt = require('jwt-simple');
+      jwt.decode(token, secret, true);
+  - code: |
+      console.log(x)
+    fixed: |
+      logger.info(x)
+```
+
+Run with `sg test` or `sg test --filter jwt`. The `sgconfig.yml` at the repo root must declare `testConfigs: [{ testDir: tests }]`.
+
+---
+
+## ts-morph Codemod Testing
+
+ts-morph transforms operate on a `Project` object. For testing, create an in-memory project — no disk I/O, no tsconfig required for simple cases.
+
+```typescript
+import { Project } from 'ts-morph';
+import { applyTransform } from '../src/my-transform';
+
+function createProject(source: string): Project {
+  const project = new Project({ useInMemoryFileSystem: true });
+  project.createSourceFile('test.ts', source);
+  return project;
+}
+
+it('adds private modifier to unused members', async () => {
+  const project = createProject(`class Foo { bar() {} private baz() { this.bar(); } }`);
+  await applyTransform(project);
+  expect(project.getSourceFileOrThrow('test.ts').getFullText()).toContain('private bar()');
+});
+
+it('does not modify already-private members', async () => {
+  const input = `class Foo { private bar() {} }`;
+  const project = createProject(input);
+  await applyTransform(project);
+  expect(project.getSourceFileOrThrow('test.ts').getFullText()).toBe(input);
+});
+```
+
+For transforms that require real type information, point to a real tsconfig. After the transform, check diagnostics directly:
+
+```typescript
+const project = new Project({ tsConfigFilePath: './tsconfig.test.json' });
+project.addSourceFileAtPath('./fixtures/input.ts');
+await applyTransform(project);
+const diagnostics = project.getPreEmitDiagnostics();
+expect(diagnostics.length).toBe(0);
+```
+
+---
+
+## Snapshot Testing
+
+Use snapshots when output is large and structure matters more than exact text. Avoid them when output is under 20 lines — explicit assertions catch regressions more precisely and make failures readable without opening a snapshot file.
+
+Snapshot pitfalls to avoid:
+- Snapshots updated on every change provide no protection — they become documentation, not tests
+- Whitespace differences cause false failures across OS and formatter versions
+- Large snapshots obscure what actually changed in a failing test
+
+For jscodeshift, prefer fixture files over snapshots. The `defineTest` utility already provides the fixture-based workflow that snapshots attempt to replicate, with the added benefit that fixture files are readable as standalone code.
+
+---
+
+## Idempotency Testing
+
+A transform is idempotent if applying it twice produces the same result as applying it once. The Rector book identifies idempotency as a required property of every rule. The test is mechanical:
+
+```typescript
+function assertIdempotent(transform: Transform, input: string): void {
+  const firstPass = transform(input);
+  const secondPass = transform(firstPass ?? input);
+  expect(secondPass).toEqual(firstPass ?? input);
+}
+
+it('is idempotent', () => {
+  assertIdempotent(myTransform, `var x = 1;`);
+  assertIdempotent(myTransform, `let x = 1;`);   // already transformed — no-op
+});
+```
+
+For jscodeshift, the second pass must return `null` when the file was already transformed. Include an `already-transformed` fixture in every fixture suite.
+
+Common causes of non-idempotency:
+- Adding an import without checking if it already exists
+- Wrapping a node without checking if it is already wrapped
+- Inserting a comment that the transform then detects as a signal to transform again
+
+---
+
+## Type Checking Validation
+
+Running `tsc --noEmit` after a transform is the strongest correctness check available. A transform that introduces type errors has broken the codebase even if all fixture tests pass.
+
+For jscodeshift transforms, write the output to a temp file and type-check it:
+
+```typescript
+import { execSync } from 'child_process';
+import { writeFileSync, unlinkSync } from 'fs';
+
+function assertTypeCorrect(source: string): void {
+  const tmp = '/tmp/transform-output.ts';
+  writeFileSync(tmp, source);
+  try {
+    execSync(`npx tsc --noEmit --strict ${tmp}`, { stdio: 'pipe' });
+  } catch (err: any) {
+    throw new Error(`Type errors in transform output:\n${err.stdout}`);
+  } finally {
+    unlinkSync(tmp);
+  }
+}
+
+it('produces type-correct output', () => assertTypeCorrect(applyTransform(input)));
+```
+
+For ts-morph transforms, use the project's diagnostics directly (shown in the ts-morph section above).
+
+---
+
+## Edge Case Test Catalog
+
+Every codemod should have fixtures covering these cases. Cases marked "no-op" should return `null` (jscodeshift) or the unchanged source.
+
+| Case | Description | Expected Behavior |
+|------|-------------|-------------------|
+| Empty file | File with no content | No-op |
+| Comments only | File with only block/line comments | No-op |
+| Already transformed | Output of a previous run | No-op (idempotency) |
+| Target pattern absent | File that does not contain the pattern | No-op |
+| Named import | `import { foo } from 'x'` | Transform |
+| Default import | `import foo from 'x'` | Transform |
+| Namespace import | `import * as foo from 'x'` | Transform |
+| Re-export | `export { foo } from 'x'` | Transform or no-op per rule |
+| TypeScript generics | `forwardRef<Ref, Props>(...)` | Transform with type params |
+| JSX | Pattern inside JSX attribute or child | Transform |
+| Template literals | Pattern inside `` `${expr}` `` | Transform |
+| Destructuring | `const { a, b } = obj` | Transform |
+| Spread | `{ ...rest }` or `[...items]` | Transform |
+| Optional chaining | `obj?.method?.()` | Transform |
+| Nested scope | Pattern inside nested function | Transform with scope awareness |
+| Class method | Pattern as class method body | Transform |
+| Arrow function | Pattern as arrow function body | Transform |
+| Async function | Pattern inside `async` function | Transform |
+| Multiple occurrences | Pattern appears 3+ times in one file | Transform all |
+| Mixed valid/invalid | Some occurrences match, some do not | Transform only matching |
+
+---
+
+## CI Integration
+
+Run codemod tests in CI the same way you run unit tests — they are unit tests. Add a TypeScript version matrix when the transform touches TypeScript-specific syntax, because the TypeScript AST changes between minor versions:
+
+```yaml
+strategy:
+  matrix:
+    node-version: [20, 22]
+    typescript-version: ['5.3', '5.4', '5.5']
+steps:
+  - run: npm ci
+  - run: npm install typescript@${{ matrix.typescript-version }}
+  - run: npm test
+  - run: npx tsc --noEmit   # type-check the transform itself
+```
+
+For ESLint plugins, test against each ESLint version declared as a peer dependency:
+
+```bash
+npm install eslint@8 && npm test
+npm install eslint@9 && npm test
+```
+
+Keep fixture files in version control. When a transform changes behavior, the fixture diff makes the change explicit and reviewable. Never auto-update fixtures in CI — treat fixture changes as intentional code changes requiring human review.

--- a/skills/ast-linter-codemod/references/ts-morph-patterns.md
+++ b/skills/ast-linter-codemod/references/ts-morph-patterns.md
@@ -1,0 +1,446 @@
+# ts-morph Patterns for Linters and Codemods
+
+Sources: dsherret/ts-morph v27 documentation, Syed (TypeScript Deep Dive), Rametta (TypeScript Compiler API), 2025-2026 production implementations
+
+ts-morph wraps the TypeScript Compiler API with a high-level, mutable API. The raw compiler API is read-only; ts-morph adds node tracking across edits, named navigation methods, and import management. Use it when you need type information alongside mutation — the combination that raw compiler API and jscodeshift each handle only half of.
+
+---
+
+## 1. Project Setup
+
+Create a `Project` from a tsconfig to inherit the same compiler options your codebase uses. This ensures type resolution matches what the TypeScript compiler sees.
+
+```typescript
+import { Project, SyntaxKind, Node } from "ts-morph";
+
+// From tsconfig — recommended for real projects
+const project = new Project({ tsConfigFilePath: "tsconfig.json" });
+
+// Manual options — useful for targeted scripts
+const project = new Project({
+  compilerOptions: { strict: true, target: ScriptTarget.ES2022 },
+  skipLoadingLibFiles: true,   // faster startup, no type info
+});
+
+// In-memory — ideal for testing codemods
+const project = new Project({ useInMemoryFileSystem: true });
+const sf = project.createSourceFile("test.ts", `const x: string = 42;`);
+```
+
+Add source files and save:
+
+```typescript
+project.addSourceFilesAtPaths("src/**/*.ts");
+project.addSourceFilesAtPaths(["src/**/*.ts", "!src/**/*.test.ts"]);
+const sf = project.getSourceFileOrThrow("src/index.ts"); // throws if missing
+
+await project.save(); // write all modified files atomically at the end
+```
+
+---
+
+## 2. Node Navigation
+
+Every node in ts-morph extends `Node<ts.Node>`. The two primary traversal strategies are kind-based search and the visitor pattern.
+
+**Kind-based search** — returns all matching descendants in document order:
+
+```typescript
+const calls = sf.getDescendantsOfKind(SyntaxKind.CallExpression);
+const first = sf.getFirstDescendantByKindOrThrow(SyntaxKind.ImportDeclaration);
+```
+
+**Visitor pattern** — use `forEachDescendant` when you need traversal control:
+
+```typescript
+node.forEachDescendant((node, traversal) => {
+  if (Node.isClassDeclaration(node)) traversal.skip();  // skip class internals
+  if (Node.isFunctionDeclaration(node)) traversal.stop(); // halt entirely
+  if (Node.isImportDeclaration(node)) return node;        // stop and return value
+});
+```
+
+**Type guards** narrow the node type without casting:
+
+```typescript
+if (Node.isCallExpression(node))          { /* node: CallExpression */ }
+if (Node.isPropertyAccessExpression(node)) { /* node: PropertyAccessExpression */ }
+if (Node.isIdentifier(node))              { /* node: Identifier */ }
+```
+
+**Parent and child navigation**: `node.getParent()`, `node.getParentOrThrow()`, `node.getParentIfKind(SyntaxKind.X)` (typed parent or undefined), `node.getChildren()` (all children including tokens), `node.forEachChild(cb)` (property children only).
+
+Position for violation reporting: `node.getStartLineNumber()` (1-indexed), `node.getStartColumn()` (0-indexed), `node.getSourceFile().getFilePath()`.
+
+---
+
+## 3. Type System Access
+
+ts-morph exposes the full TypeScript type checker through `node.getType()`. Type checks require `skipLoadingLibFiles: false` and a valid tsconfig.
+
+```typescript
+const type = variableDecl.getType();
+type.isString()       // string
+type.isAny()          // any
+type.isUnion()        // A | B
+type.isArray()        // T[]
+type.getText()        // "string | undefined"
+type.getUnionTypes()  // Type[] for union members
+
+// Assignability (ts-morph v22+)
+const stringType = project.getTypeChecker().getStringType();
+if (type.isAssignableTo(stringType)) { /* ... */ }
+```
+
+For linter rules that check return types or parameter types:
+
+```typescript
+// Find functions missing explicit return type annotation
+for (const fn of sf.getFunctions()) {
+  if (!fn.getReturnTypeNode()) {
+    // getReturnType() gives the inferred type; getReturnTypeNode() gives the annotation
+    report(fn, "Missing explicit return type");
+  }
+}
+```
+
+---
+
+## 4. Linter Pattern
+
+A ts-morph linter iterates source files, applies rule functions, and collects violations. Rules are pure functions: they receive a `SourceFile` and return an array of issues.
+
+```typescript
+interface Violation {
+  file: string;
+  line: number;
+  column: number;
+  message: string;
+  fix?: () => void;  // optional auto-fix closure
+}
+
+type Rule = (sf: SourceFile) => Violation[];
+```
+
+Runner — iterate source files, apply each rule, optionally apply fixes, then save once:
+
+```typescript
+async function lint(tsconfig: string, rules: Rule[], applyFixes = false) {
+  const project = new Project({ tsConfigFilePath: tsconfig });
+  const all: Violation[] = [];
+  for (const sf of project.getSourceFiles())
+    for (const rule of rules) {
+      const found = rule(sf);
+      all.push(...found);
+      if (applyFixes) found.forEach(v => v.fix?.());
+    }
+  if (applyFixes) await project.save();
+  return all;
+}
+```
+
+Example rule — no `console` calls:
+
+```typescript
+const noConsole: Rule = (sf) => {
+  const violations: Violation[] = [];
+  for (const call of sf.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+    const expr = call.getExpression();
+    if (Node.isPropertyAccessExpression(expr)) {
+      const obj = expr.getExpression();
+      if (Node.isIdentifier(obj) && obj.getText() === "console") {
+        violations.push({
+          file: sf.getFilePath(),
+          line: call.getStartLineNumber(),
+          column: call.getStartColumn(),
+          message: "Unexpected console statement",
+          fix: () => call.getParentIfKind(SyntaxKind.ExpressionStatement)?.remove(),
+        });
+      }
+    }
+  }
+  return violations;
+};
+```
+
+---
+
+## 5. Codemod Patterns
+
+The primary mutation operations:
+
+| Operation | API | Notes |
+|-----------|-----|-------|
+| Replace node text | `node.replaceWithText("new text")` | Returns new node; old node is forgotten |
+| Remove node | `node.remove()` | Removes node and surrounding whitespace |
+| Rename (cross-file) | `node.rename("newName")` | Updates all references in the project |
+| Add import | `sf.addImportDeclaration({...})` | Merges with existing if possible |
+| Remove import | `importDecl.remove()` | Or `namedImport.remove()` |
+| Set body | `fn.setBodyText("return 42;")` | Replaces entire function body |
+| Add statement | `fn.addStatements("doThing();")` | Appends to body |
+| Set declaration kind | `stmt.setDeclarationKind(VariableDeclarationKind.Const)` | var → const/let |
+
+**replaceWithText** is the workhorse for structural changes:
+
+```typescript
+// Wrap an object argument in a { where: ... } envelope
+const arg = callExpr.getArguments()[0];
+const original = arg.getText();           // "{ name: 'Lisa' }"
+arg.replaceWithText(`{ where: ${original} }`);
+// arg is now forgotten — do not use it again
+```
+
+**rename** propagates across all files in the project:
+
+```typescript
+classDecl.rename("NewClassName", {
+  renameInComments: true,
+  renameInStrings: true,
+});
+```
+
+**Low-level text operations** (`insertText`, `replaceText`) invalidate all previously navigated descendants. Re-navigate after using them.
+
+---
+
+## 6. The "Analyze Then Transform" Rule
+
+Mixing type queries and mutations in the same loop is the most common ts-morph performance mistake. Every mutation resets the type checker's internal cache. If you call `getType()` after a `remove()` in the same loop, the type checker rebuilds from scratch for each iteration.
+
+Collect first, transform second:
+
+```typescript
+// Collect nodes that need transformation
+const toRemove: ClassDeclaration[] = [];
+for (const sf of project.getSourceFiles()) {
+  for (const cls of sf.getClasses()) {
+    if (shouldRemove(cls)) toRemove.push(cls);  // type checks here
+  }
+}
+
+// Apply transformations after all analysis is complete
+for (const cls of toRemove) {
+  if (!cls.wasForgotten()) cls.remove();
+}
+```
+
+This pattern also applies within a single file. Gather all nodes matching your criteria, then mutate. The same principle appears in Angular's migration framework (Tsurge): a separate `analyze` phase produces a list of `Replacement[]` text spans, and a `migrate` phase applies them — never interleaved.
+
+---
+
+## 7. Node Forgetting
+
+When ts-morph mutates the AST, it marks affected nodes as "forgotten." Accessing a forgotten node throws. This is the most common runtime error in codemods.
+
+```typescript
+const param = callExpr.getFirstDescendantByKind(SyntaxKind.ObjectLiteralExpression);
+const text = param.getText();                    // capture text BEFORE mutation
+param.replaceWithText(`{ where: ${text} }`);
+// param.getText() here would throw — param is forgotten
+
+// Guard with wasForgotten() in loops
+for (const node of nodes) {
+  if (node.wasForgotten()) continue;
+  // safe to use node
+}
+```
+
+Release nodes you no longer need to reduce tracking overhead:
+
+```typescript
+cls.forget();  // stop tracking cls and all its descendants
+```
+
+---
+
+## 8. Import Management
+
+ts-morph provides high-level import helpers that handle the bookkeeping of adding, removing, and deduplicating imports.
+
+```typescript
+// Add a new import declaration
+sf.addImportDeclaration({
+  namedImports: ["useState", "useEffect"],
+  moduleSpecifier: "react",
+});
+
+// Add a named import to an existing declaration
+const reactImport = sf.getImportDeclaration("react");
+reactImport?.addNamedImport("useCallback");
+
+// Remove a specific named import
+const namedImport = reactImport?.getNamedImports()
+  .find(n => n.getName() === "forwardRef");
+namedImport?.remove();
+
+// Remove the entire import if it becomes empty
+if (reactImport?.getNamedImports().length === 0) {
+  reactImport.remove();
+}
+
+// Organize imports (equivalent to IDE "organize imports")
+sf.organizeImports();
+
+// Auto-add imports for identifiers that are used but not imported
+sf.fixMissingImports();
+```
+
+**Import detection before transformation** — always check what name a module was imported under before searching for usages. A codemod that assumes `forwardRef` is always named `forwardRef` will miss `import { forwardRef as fRef }`.
+
+```typescript
+const imp = sf.getImportDeclaration("react");
+const forwardRefName = imp?.getNamedImports()
+  .find(n => n.getName() === "forwardRef")
+  ?.getAliasNode()?.getText() ?? "forwardRef";
+// Now search for forwardRefName, not the literal string "forwardRef"
+```
+
+---
+
+## 9. Cross-File Operations
+
+`findReferencesAsNodes()` is ts-morph's most powerful feature for cross-file analysis. It uses the TypeScript language service to find every reference to a declaration across the entire project.
+
+```typescript
+// Find all usages of a class across all files
+const cls = sf.getClassOrThrow("UserService");
+const refs = cls.findReferencesAsNodes();
+
+for (const ref of refs) {
+  const refFile = ref.getSourceFile().getFilePath();
+  const line = ref.getStartLineNumber();
+  console.log(`${refFile}:${line}`);
+}
+```
+
+---
+
+## 10. Performance
+
+| Technique | When to Use |
+|-----------|-------------|
+| `skipLoadingLibFiles: true` | Analysis only, no type checking needed |
+| `skipFileDependencyResolution: true` | No cross-file type resolution needed |
+| Batch additions: `sf.addClasses([...])` | Adding multiple nodes at once |
+| `sf.transform(traversal => ...)` | Bulk text changes without type info |
+| `node.forget()` | Release nodes after use in large files |
+| Collect then mutate | Any loop mixing type queries and mutations |
+
+**Transform API** — for bulk changes where you do not need type information, the transform API avoids re-parsing between each change:
+
+```typescript
+import { ts } from "ts-morph";
+
+sf.transform(traversal => {
+  const node = traversal.visitChildren(); // visit children first
+  if (ts.isStringLiteral(node) && node.text.startsWith("old-")) {
+    return traversal.factory.createStringLiteral(
+      node.text.replace("old-", "new-")
+    );
+  }
+  return node;
+});
+// All previously wrapped descendants are forgotten after transform
+```
+
+---
+
+## 11. Complete Linter Example — Unused Exports
+
+This linter finds exported functions with no references outside their own file. It combines the linter pattern from section 4 with the cross-file reference API from section 9.
+
+```typescript
+import { Project } from "ts-morph";
+
+const project = new Project({ tsConfigFilePath: "tsconfig.json" });
+const violations: string[] = [];
+
+for (const sf of project.getSourceFiles()) {
+  for (const fn of sf.getFunctions()) {
+    if (!fn.isExported()) continue;
+    const externalRefs = fn.findReferencesAsNodes().filter(
+      ref => ref.getSourceFile().getFilePath() !== sf.getFilePath()
+    );
+    if (externalRefs.length === 0) {
+      violations.push(
+        `${sf.getFilePath()}:${fn.getStartLineNumber()} ` +
+        `'${fn.getName()}' exported but never imported`
+      );
+    }
+  }
+}
+
+violations.forEach(v => console.log(v));
+process.exit(violations.length > 0 ? 1 : 0);
+```
+
+Call `findReferencesAsNodes()` once per function, not once per reference. Filter by file path to distinguish internal from external usage.
+
+---
+
+## 12. Complete Codemod Example — API Rename
+
+This codemod migrates `OldClient` from `old-sdk` to `NewClient` from `new-sdk`. The three-phase structure — detect import, collect usages, transform — prevents the type-checker reset problem described in section 6.
+
+```typescript
+import { Project, SyntaxKind } from "ts-morph";
+
+const project = new Project({ tsConfigFilePath: "tsconfig.json" });
+
+for (const sf of project.getSourceFiles()) {
+  const oldImport = sf.getImportDeclaration("old-sdk");
+  if (!oldImport) continue;
+
+  const specifier = oldImport.getNamedImports()
+    .find(n => n.getName() === "OldClient");
+  if (!specifier) continue;
+
+  // Resolve local alias: handles `import { OldClient as OC }`
+  const localName = specifier.getAliasNode()?.getText() ?? "OldClient";
+
+  // Phase 1: collect before mutating
+  const toRename = sf.getDescendantsOfKind(SyntaxKind.Identifier)
+    .filter(id => id.getText() === localName);
+
+  // Phase 2: swap imports
+  specifier.remove();
+  if (oldImport.getNamedImports().length === 0) oldImport.remove();
+  sf.addImportDeclaration({ namedImports: ["NewClient"], moduleSpecifier: "new-sdk" });
+
+  // Phase 3: rename usages
+  for (const id of toRename) {
+    if (!id.wasForgotten()) id.replaceWithText("NewClient");
+  }
+}
+
+await project.save();
+```
+
+---
+
+## API Quick Reference
+
+| Task | API |
+|------|-----|
+| Create project | `new Project({ tsConfigFilePath })` |
+| Add files | `project.addSourceFilesAtPaths("src/**/*.ts")` |
+| Get all files | `project.getSourceFiles()` |
+| Find by kind | `node.getDescendantsOfKind(SyntaxKind.X)` |
+| Visitor traversal | `node.forEachDescendant((n, t) => { t.skip() })` |
+| Type guard | `Node.isCallExpression(node)` |
+| Get type | `node.getType()` |
+| Get line/col | `node.getStartLineNumber()`, `node.getStartColumn()` |
+| Replace node | `node.replaceWithText("new text")` |
+| Remove node | `node.remove()` |
+| Rename cross-file | `node.rename("newName")` |
+| Add import | `sf.addImportDeclaration({ namedImports, moduleSpecifier })` |
+| Find references | `node.findReferencesAsNodes()` |
+| Check forgotten | `node.wasForgotten()` |
+| Release node | `node.forget()` |
+| Organize imports | `sf.organizeImports()` |
+| Fix missing imports | `sf.fixMissingImports()` |
+| Bulk transform | `sf.transform(traversal => ...)` |
+| Save all changes | `await project.save()` |
+| Get diagnostics | `project.getPreEmitDiagnostics()` |
+
+Use https://ts-ast-viewer.com to explore the AST of any TypeScript snippet before writing a codemod. Paste code, identify the `SyntaxKind` values you need, then write the traversal.

--- a/skills/ast-linter-codemod/skills.json
+++ b/skills/ast-linter-codemod/skills.json
@@ -1,0 +1,16 @@
+{
+  "name": "@tank/ast-linter-codemod",
+  "version": "1.0.0",
+  "description": "Build custom linters with auto-fix, write codemods, and run large-scale code migrations using ts-morph, jscodeshift, ESLint custom rules, ast-grep, and Babel plugins. Covers Fixer API, Collection API, YAML rules, fixture testing, migration strategies, formatting preservation. Triggers: codemod, linter, custom lint rule, ESLint rule, auto-fix, ts-morph, jscodeshift, ast-grep, AST, code migration, Fixer API, RuleTester, babel plugin, recast, API rename, typed linting.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": ["**/*"],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

- Add `@tank/ast-linter-codemod` skill for building custom linters with auto-fix, writing codemods, and running large-scale code migrations
- Covers ts-morph, jscodeshift, ESLint custom rules, ast-grep, and Babel plugins
- 7 reference files (2,974 lines total) synthesized from 10+ authoritative sources including Crafting Interpreters, Babel Plugin Handbook, Rector, and production codemods from React, Next.js, and Angular

## Files

| File | Lines | Topic |
|------|-------|-------|
| `SKILL.md` | 166 | Tool selection, capabilities matrix, anti-patterns, failure map |
| `references/ast-fundamentals.md` | 440 | AST mental model, Visitor pattern, tool comparison |
| `references/ts-morph-patterns.md` | 446 | ts-morph linter/codemod patterns, type system |
| `references/eslint-custom-rules.md` | 449 | Fixer API, typed linting, RuleTester, plugin scaffold |
| `references/jscodeshift-codemods.md` | 428 | Collection API, formatting preservation, templates |
| `references/ast-grep-rules.md` | 406 | YAML rules, metavariables, fixes, agent integration |
| `references/migration-strategies.md` | 449 | Big Bang/Gradual strategies, Stripe/Pinterest cases |
| `references/testing-transforms.md` | 356 | Fixture testing, idempotency, edge case catalog |