### PR TITLE
fix(ast-linter-codemod): bump to 1.0.1 to fix broken 1.0.0 publish

### DIFF
--- a/skills/ast-linter-codemod/skills.json
+++ b/skills/ast-linter-codemod/skills.json
@@ -1,6 +1,6 @@
 {
   "name": "@tank/ast-linter-codemod",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Build custom linters with auto-fix, write codemods, and run large-scale code migrations using ts-morph, jscodeshift, ESLint custom rules, ast-grep, and Babel plugins. Covers Fixer API, Collection API, YAML rules, fixture testing, migration strategies, formatting preservation. Triggers: codemod, linter, custom lint rule, ESLint rule, auto-fix, ts-morph, jscodeshift, ast-grep, AST, code migration, Fixer API, RuleTester, babel plugin, recast, API rename, typed linting.",
   "permissions": {
     "network": {


### PR DESCRIPTION
First publish uploaded metadata but failed on confirmation, leaving 1.0.0 in a broken state (visible in search but uninstallable). Bumps to 1.0.1 which is already published and verified installable.