### PR TITLE
feat(go-discord-bot): add Go Discord bot development skill

### DIFF
--- a/skills/go-discord-bot/SKILL.md
+++ b/skills/go-discord-bot/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: go-discord-bot
+description: |
+  Build Discord bots in Go using discordgo, arikawa, or disgo. Covers
+  library selection, project scaffolding, slash commands and handler
+  patterns, message components (buttons, select menus, modals), gateway
+  intents, state and database integration (pgx, entgo, Redis), voice
+  and audio (dgvoice, dca), goroutine safety, sharding, and deployment.
+  Synthesizes discordgo v0.29.0, arikawa v3.6.0, disgo docs, and
+  production patterns from YAGPDB, automuteus, CJ, ken, ops-bot-iii.
+
+  Trigger phrases: "discord bot go", "go discord", "discordgo",
+  "arikawa", "disgo", "golang discord bot", "slash command go",
+  "discord gateway go", "discord intents go", "discord voice go",
+  "discord music bot go", "discord embed go", "discord button go",
+  "discord modal go", "discord select menu go", "discord bot golang",
+  "dgvoice", "discord sharding go", "discord deployment go",
+  "discord bot docker go", "discord bot systemd go",
+  "go discord slash command", "discordgo handler",
+  "discordgo interaction"
+---
+
+# Go Discord Bot Development
+
+Build Discord bots in Go for simplicity and concurrency. The ecosystem
+centers on three libraries: **discordgo** (low-level, dominant),
+**arikawa** (typed, modular), and **disgo** (modern, API v10). Most
+bots use discordgo.
+
+## Core Philosophy
+
+1. **discordgo is the default** — Use discordgo for all new bots unless
+   you need typed snowflakes (arikawa) or API v10 (disgo). Largest
+   community, most examples, most Stack Overflow answers.
+2. **Slash commands first** — Prefer slash commands over message-based
+   commands. Message content requires the privileged MESSAGE_CONTENT
+   intent, which needs Discord verification at 100+ guilds.
+3. **Goroutine safety matters** — discordgo fires each handler in its
+   own goroutine. Protect shared state with `sync.RWMutex`, wrap handlers
+   with `recover()` because panics in goroutines are silent and fatal.
+4. **Respect the 3-second deadline** — Discord requires an interaction
+   response within 3 seconds. For slow operations, always defer first
+   with `InteractionResponseDeferredChannelMessageWithSource`, then edit.
+5. **Intents are permissions** — Only request gateway intents the bot
+   needs. Privileged intents (GUILD_MEMBERS, MESSAGE_CONTENT, PRESENCES)
+   require Discord Developer Portal approval at 100+ guilds.
+
+## Quick-Start
+
+### "I want to build a Discord bot from scratch"
+
+| Step | Action | Reference |
+|------|--------|-----------|
+| 1 | Choose library (discordgo recommended) | `references/library-selection.md` |
+| 2 | Scaffold project (go.mod, main.go, .env) | `references/project-setup.md` |
+| 3 | Define slash commands and handlers | `references/commands-and-interactions.md` |
+| 4 | Configure gateway intents | `references/event-handling.md` |
+| 5 | Add database and shared state | `references/state-and-database.md` |
+| 6 | Add voice support (if needed) | `references/voice-and-audio.md` |
+| 7 | Deploy with Docker or systemd | `references/deployment-and-ops.md` |
+
+### "I need to add a slash command"
+
+| Step | Action |
+|------|--------|
+| 1 | Define `*discordgo.ApplicationCommand` with name, description, options |
+| 2 | Add handler to `commandHandlers` map |
+| 3 | Register via `s.ApplicationCommandCreate` or `ApplicationCommandBulkOverwrite` |
+| 4 | Route in `InteractionCreate` handler by `i.ApplicationCommandData().Name` |
+-> See `references/commands-and-interactions.md`
+
+### "I need buttons, select menus, or modals"
+
+| Step | Action |
+|------|--------|
+| 1 | Build components with `discordgo.Button`, `discordgo.SelectMenu`, or `discordgo.TextInput` |
+| 2 | Wrap in `discordgo.ActionsRow`, send via `InteractionRespond` |
+| 3 | Handle clicks via `InteractionMessageComponent` or `InteractionModalSubmit` |
+| 4 | Route by `i.MessageComponentData().CustomID` |
+-> See `references/components-and-modals.md`
+
+### "I want to add voice/music support"
+
+| Step | Action |
+|------|--------|
+| 1 | Set `IntentGuildVoiceStates` intent |
+| 2 | Join channel with `s.ChannelVoiceJoin(guildID, channelID, false, true)` |
+| 3 | Encode audio to Opus via dgvoice/dca + ffmpeg |
+| 4 | Send frames via `vc.OpusSend <- opusFrame` |
+-> See `references/voice-and-audio.md`
+
+## Decision Trees
+
+### Library Selection
+
+| Signal | Use |
+|--------|-----|
+| New bot, want to ship fast | discordgo |
+| Need typed snowflakes, context.Context, pluggable state | arikawa |
+| Need Discord API v10 features | disgo |
+| Need chi-style interaction routing | disgo handler.Mux |
+| Need typed command routing with struct tags | arikawa cmdroute |
+
+### Database Selection
+
+| Scale | Use |
+|-------|-----|
+| Prototype / small bot | SQLite via database/sql |
+| Production / growing bot | PostgreSQL via pgxpool |
+| Type-safe ORM | entgo (code-generated) |
+| Multi-shard shared state | Redis (go-redis) |
+| No persistence needed | In-memory (sync.Map) |
+
+### Intent Selection
+
+| Feature | Required Intents |
+|---------|-----------------|
+| Slash commands only | `IntentsGuilds` (minimal) |
+| Basic guild events | `IntentsAllWithoutPrivileged` (default) |
+| Read message content | + `IntentMessageContent` (privileged) |
+| Welcome messages | + `IntentGuildMembers` (privileged) |
+| Voice bot | + `IntentGuildVoiceStates` |
+| Status tracking | + `IntentGuildPresences` (privileged) |
+
+## Anti-Patterns
+
+| Don't | Do Instead | Why |
+|-------|-----------|-----|
+| Use disgord | Use discordgo, arikawa, or disgo | disgord is archived, targets API v8 |
+| Request `IntentsAll` | Request only needed intents | Fails verification at 100+ guilds |
+| Block in event handlers | Use goroutines for slow work | Blocks all event processing if SyncEvents=true |
+| Ignore panics in handlers | Wrap with `recover()` + `debug.Stack()` | Panics in goroutines crash silently |
+| Respond after 3 seconds | Defer first, then edit response | Interaction expires, user sees error |
+| Use `sync.Mutex` on Bot struct fields | Use `sync.RWMutex` | Readers don't need to block each other |
+| Register guild commands in production | Use global commands or `BulkOverwrite` | Guild commands are for development only |
+| Skip interaction error responses | Always respond, even with error message | Silent failures confuse users |
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/library-selection.md` | discordgo vs arikawa vs disgo decision matrix, go.mod configs, companion packages, migration notes |
+| `references/project-setup.md` | Directory structure (simple and production), main.go bootstrapping, configuration, .env handling, Bot struct pattern |
+| `references/commands-and-interactions.md` | Slash commands, handler patterns (map dispatch, interface, cmdroute, ken), parameter types, autocomplete, subcommands, permissions, embeds |
+| `references/components-and-modals.md` | Buttons, select menus, modals, Components V2, component routing by CustomID, type assertions |
+| `references/event-handling.md` | Gateway intents (standard and privileged), event handler registration, common event types, state cache, interaction type routing |
+| `references/state-and-database.md` | Bot struct pattern, database integration (pgx, sqlx, entgo, GORM), Redis, in-memory state, background goroutines, context propagation |
+| `references/voice-and-audio.md` | discordgo VoiceConnection, OpusSend/OpusRecv, dgvoice/dca helpers, arikawa voice, ffmpeg pipeline, queue management |
+| `references/deployment-and-ops.md` | Docker multi-stage builds, systemd services, structured logging (slog/zap), error handling, graceful shutdown, goroutine safety, sharding, CI/CD |

--- a/skills/go-discord-bot/references/commands-and-interactions.md
+++ b/skills/go-discord-bot/references/commands-and-interactions.md
@@ -1,0 +1,445 @@
+# Commands and Interactions
+
+Sources: discordgo v0.29.0 examples, arikawa v3 cmdroute docs, ken framework, Discord API reference (2026), production bot analysis (YAGPDB, CJ, ops-bot-iii)
+
+
+## Slash Command Definition
+
+Every slash command is an `ApplicationCommand` struct registered with Discord's API. Discord stores the definition; your bot handles the resulting interaction events.
+
+```go
+var adminPerms int64 = discordgo.PermissionBanMembers
+var noDM bool = false
+
+var commands = []*discordgo.ApplicationCommand{
+    {Name: "ping", Description: "Responds with pong"},
+    {
+        Name:                     "ban",
+        Description:              "Ban a member from the server",
+        DefaultMemberPermissions: &adminPerms,
+        DMPermission:             &noDM,
+        Options: []*discordgo.ApplicationCommandOption{
+            {Type: discordgo.ApplicationCommandOptionUser, Name: "user", Description: "The user to ban", Required: true},
+            {Type: discordgo.ApplicationCommandOptionString, Name: "reason", Description: "Reason for the ban"},
+        },
+    },
+}
+```
+
+Register commands after `s.Open()`. Use `GuildID = ""` for global commands (up to 1-hour propagation); use a guild ID for instant registration during development. Prefer `ApplicationCommandBulkOverwrite` in production for atomic updates — it replaces all commands in one API call.
+
+### All 11 Option Types
+
+| Constant | Value | Go Type After Parsing |
+|---|---|---|
+| `ApplicationCommandOptionSubCommand` | 1 | — (routing only) |
+| `ApplicationCommandOptionSubCommandGroup` | 2 | — (routing only) |
+| `ApplicationCommandOptionString` | 3 | `string` |
+| `ApplicationCommandOptionInteger` | 4 | `int64` |
+| `ApplicationCommandOptionBoolean` | 5 | `bool` |
+| `ApplicationCommandOptionUser` | 6 | `*discordgo.User` |
+| `ApplicationCommandOptionChannel` | 7 | `*discordgo.Channel` |
+| `ApplicationCommandOptionRole` | 8 | `*discordgo.Role` |
+| `ApplicationCommandOptionMentionable` | 9 | `*discordgo.User` or `*discordgo.Role` |
+| `ApplicationCommandOptionNumber` | 10 | `float64` |
+| `ApplicationCommandOptionAttachment` | 11 | `*discordgo.MessageAttachment` |
+
+
+## Command Handler Patterns
+
+### Pattern 1: Map-Based Dispatch
+
+The dominant pattern across all official discordgo examples and most production bots. A `map[string]func` routes by command name; a single `AddHandler` call handles all interaction types via a type switch.
+
+```go
+var commandHandlers = map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
+    "ping": handlePing,
+    "ban":  handleBan,
+}
+
+s.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    switch i.Type {
+    case discordgo.InteractionApplicationCommand:
+        if h, ok := commandHandlers[i.ApplicationCommandData().Name]; ok {
+            h(s, i)
+        }
+    case discordgo.InteractionApplicationCommandAutocomplete:
+        if h, ok := autocompleteHandlers[i.ApplicationCommandData().Name]; ok {
+            h(s, i)
+        }
+    }
+})
+```
+
+Build an options map for named access inside handlers:
+
+```go
+func handleBan(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    data := i.ApplicationCommandData()
+    opts := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(data.Options))
+    for _, o := range data.Options { opts[o.Name] = o }
+
+    target := opts["user"].UserValue(s)
+    reason := "No reason provided"
+    if r, ok := opts["reason"]; ok { reason = r.StringValue() }
+
+    if err := s.GuildBanCreateWithReason(i.GuildID, target.ID, reason, 0); err != nil {
+        respondEphemeral(s, i, "Failed to ban: "+err.Error())
+        return
+    }
+    s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+        Type: discordgo.InteractionResponseChannelMessageWithSource,
+        Data: &discordgo.InteractionResponseData{
+            Content: fmt.Sprintf("Banned %s: %s", target.Username, reason),
+        },
+    })
+}
+```
+
+### Pattern 2: Interface-Based Commands
+
+Used by CJ, ops-bot-iii, and ken. Encapsulates definition and handler in one type, enabling self-registration and dependency injection.
+
+```go
+type Command interface {
+    Definition() *discordgo.ApplicationCommand
+    Handle(s *discordgo.Session, i *discordgo.InteractionCreate)
+}
+
+// Registry maps name → Command, exposes a single AddHandler-compatible func.
+type CommandRegistry struct{ commands map[string]Command }
+
+func (r *CommandRegistry) Register(cmd Command) { r.commands[cmd.Definition().Name] = cmd }
+
+func (r *CommandRegistry) Handler() func(*discordgo.Session, *discordgo.InteractionCreate) {
+    return func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+        if i.Type == discordgo.InteractionApplicationCommand {
+            if cmd, ok := r.commands[i.ApplicationCommandData().Name]; ok {
+                cmd.Handle(s, i)
+            }
+        }
+    }
+}
+```
+
+### Pattern 3: arikawa cmdroute
+
+arikawa's `cmdroute.Router` provides typed routing with struct-tag option unmarshaling and built-in middleware. Options unmarshal directly into structs via `data.Options.Unmarshal(&opts)`, eliminating manual option iteration.
+
+```go
+// Options struct — field names match Discord option names via `discord:` tags
+type BanOptions struct {
+    User   discord.UserID `discord:"user"`
+    Reason string         `discord:"reason"`
+}
+
+r := cmdroute.NewRouter()
+r.Use(cmdroute.Deferrable(s, cmdroute.DeferOpts{})) // auto-defer all commands
+
+r.AddFunc("ban", func(ctx context.Context, data cmdroute.CommandData) *api.InteractionResponseData {
+    var opts BanOptions
+    if err := data.Options.Unmarshal(&opts); err != nil {
+        return cmdroute.Error(err)
+    }
+    return &api.InteractionResponseData{Content: option.NewNullableString("Banned.")}
+})
+```
+
+### Pattern 4: ken Framework
+
+ken wraps discordgo with OOP-style commands, object pooling (safepool), and Before/After middleware hooks.
+
+```go
+type BanCommand struct{}
+
+func (c *BanCommand) Name() string        { return "ban" }
+func (c *BanCommand) Version() string     { return "1.0.0" }
+func (c *BanCommand) Description() string { return "Ban a member" }
+func (c *BanCommand) Options() []*discordgo.ApplicationCommandOption {
+    return []*discordgo.ApplicationCommandOption{
+        {Type: discordgo.ApplicationCommandOptionUser, Name: "user", Required: true},
+    }
+}
+func (c *BanCommand) Run(ctx ken.Context) error {
+    user := ctx.Options().Get("user").UserValue(ctx)
+    return ctx.RespondMessage("Banned: " + user.Username)
+}
+
+type AuthMiddleware struct{}
+
+func (m *AuthMiddleware) Before(ctx ken.Context) (bool, error) {
+    if !isAdmin(ctx.GetEvent().Member) {
+        return false, ctx.RespondError("Insufficient permissions", "Access Denied")
+    }
+    return true, nil
+}
+
+k, _ := ken.New(session, ken.Options{})
+k.RegisterMiddlewares(&AuthMiddleware{})
+k.Register(&BanCommand{})
+```
+
+
+## Parameter Types
+
+Retrieve option values using typed methods on `*discordgo.ApplicationCommandInteractionDataOption`:
+
+| Option Type | Method | Returns |
+|---|---|---|
+| String | `.StringValue()` | `string` |
+| Integer | `.IntValue()` | `int64` |
+| Boolean | `.BoolValue()` | `bool` |
+| Number | `.FloatValue()` | `float64` |
+| User | `.UserValue(s)` | `*discordgo.User` |
+| Channel | `.ChannelValue(s)` | `*discordgo.Channel` |
+| Role | `.RoleValue(s, guildID)` | `*discordgo.Role` |
+| Mentionable | `.UserValue(s)` or `.RoleValue(s, guildID)` | depends on resolved type |
+| Attachment | `data.Resolved.Attachments[id]` | `*discordgo.MessageAttachment` |
+
+
+## Autocomplete
+
+Autocomplete fires when a user types in an option marked `Autocomplete: true`. Respond within 3 seconds with up to 25 choices. The focused option has `opt.Focused == true`.
+
+```go
+// In the option definition: Autocomplete: true (omit Choices when using autocomplete)
+
+func handleDeployAutocomplete(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    data := i.ApplicationCommandData()
+    var query string
+    for _, opt := range data.Options {
+        if opt.Focused {
+            query = opt.StringValue()
+            break
+        }
+    }
+
+    all := []string{"production", "staging", "development", "preview"}
+    var choices []*discordgo.ApplicationCommandOptionChoice
+    for _, srv := range all {
+        if strings.Contains(srv, query) {
+            choices = append(choices, &discordgo.ApplicationCommandOptionChoice{Name: srv, Value: srv})
+        }
+    }
+
+    s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+        Type: discordgo.InteractionApplicationCommandAutocompleteResult,
+        Data: &discordgo.InteractionResponseData{Choices: choices},
+    })
+}
+```
+
+
+## Subcommands and Subcommand Groups
+
+Subcommands nest under a parent command. `data.Options[0]` is the selected subcommand; its own `Options` hold the subcommand's parameters.
+
+```go
+var deployCommand = &discordgo.ApplicationCommand{
+    Name: "deploy", Description: "Deployment commands",
+    Options: []*discordgo.ApplicationCommandOption{
+        {
+            Type: discordgo.ApplicationCommandOptionSubCommand,
+            Name: "start", Description: "Start a deployment",
+            Options: []*discordgo.ApplicationCommandOption{
+                {Type: discordgo.ApplicationCommandOptionString, Name: "env", Required: true},
+            },
+        },
+        {Type: discordgo.ApplicationCommandOptionSubCommand, Name: "rollback", Description: "Roll back"},
+    },
+}
+
+func handleDeploy(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    sub := i.ApplicationCommandData().Options[0]
+    switch sub.Name {
+    case "start":
+        handleDeployStart(s, i, sub.Options[0].StringValue())
+    case "rollback":
+        handleDeployRollback(s, i)
+    }
+}
+```
+
+For subcommand groups (two levels deep): `data.Options[0]` is the group, `group.Options[0]` is the subcommand, and `subCmd.Options` holds its parameters.
+
+
+## Permission Checks
+
+### DefaultMemberPermissions (Discord-native)
+
+Set `DefaultMemberPermissions` on the `ApplicationCommand` to let Discord enforce permissions before the interaction reaches your bot. Discord hides the command from users who lack the required permissions.
+
+```go
+var modPerms   int64 = discordgo.PermissionManageMessages | discordgo.PermissionKickMembers
+var adminPerms int64 = discordgo.PermissionAdministrator
+
+var kickCommand = &discordgo.ApplicationCommand{
+    Name:                     "kick",
+    Description:              "Kick a member",
+    DefaultMemberPermissions: &modPerms,
+}
+```
+
+Pass a pointer to `int64`. A value of `0` means no permissions required; `nil` inherits from integration settings.
+
+### Custom Permission Middleware (Go pattern)
+
+For role-based or database-driven checks, wrap handlers with a higher-order function. This composes cleanly with the map-dispatch pattern:
+
+```go
+type PermLevel int
+const (PermUser PermLevel = iota; PermMod; PermAdmin)
+
+func requirePerm(level PermLevel, h func(*discordgo.Session, *discordgo.InteractionCreate)) func(*discordgo.Session, *discordgo.InteractionCreate) {
+    return func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+        if i.Member == nil {
+            respondEphemeral(s, i, "Server-only command.")
+            return
+        }
+        if getUserPermLevel(s, i.GuildID, i.Member) < level {
+            respondEphemeral(s, i, "Insufficient permissions.")
+            return
+        }
+        h(s, i)
+    }
+}
+
+var commandHandlers = map[string]func(*discordgo.Session, *discordgo.InteractionCreate){
+    "ping": handlePing,
+    "ban":  requirePerm(PermMod, handleBan),
+    "nuke": requirePerm(PermAdmin, handleNuke),
+}
+```
+
+
+## Context Menu Commands
+
+Context menu commands appear when a user right-clicks a user or message. They have no options; the target is accessed via `data.TargetID` and `data.Resolved`.
+
+```go
+// Registration — Type 2 = User, Type 3 = Message:
+{Name: "Get User Info",   Type: discordgo.UserApplicationCommand}
+{Name: "Report Message",  Type: discordgo.MessageApplicationCommand}
+
+func handleUserInfo(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    data := i.ApplicationCommandData()
+    user := data.Resolved.Users[data.TargetID]
+    s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+        Type: discordgo.InteractionResponseChannelMessageWithSource,
+        Data: &discordgo.InteractionResponseData{
+            Content: fmt.Sprintf("User: %s (ID: %s)", user.Username, user.ID),
+            Flags:   discordgo.MessageFlagsEphemeral,
+        },
+    })
+}
+
+func handleReportMessage(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    msg := i.ApplicationCommandData().Resolved.Messages[i.ApplicationCommandData().TargetID]
+    // Forward to moderation channel, log to database, etc.
+    _ = msg
+}
+```
+
+
+## Embeds
+
+Build embeds via `discordgo.MessageEmbed` and pass them in `InteractionResponseData.Embeds`. Up to 10 embeds per message; `Color` is a 24-bit RGB integer.
+
+```go
+embed := &discordgo.MessageEmbed{
+    Title:     "User Information",
+    Color:     0x5865F2, // Discord blurple
+    Thumbnail: &discordgo.MessageEmbedThumbnail{URL: user.AvatarURL("256")},
+    Fields: []*discordgo.MessageEmbedField{
+        {Name: "Username", Value: user.Username, Inline: true},
+        {Name: "ID", Value: user.ID, Inline: true},
+    },
+    Footer:    &discordgo.MessageEmbedFooter{Text: "Requested via /info"},
+    Timestamp: time.Now().Format(time.RFC3339),
+}
+// Pass in response:
+Data: &discordgo.InteractionResponseData{Embeds: []*discordgo.MessageEmbed{embed}}
+```
+
+### Embed Field Limits
+
+| Field | Limit |
+|---|---|
+| Title | 256 chars |
+| Description | 4096 chars |
+| Fields per embed | 25 |
+| Field name / value | 256 / 1024 chars |
+| Total chars per embed | 6000 |
+| Embeds per message | 10 |
+
+
+## Responding to Interactions
+
+### Immediate Response (within 3 seconds)
+
+```go
+s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+    Type: discordgo.InteractionResponseChannelMessageWithSource,
+    Data: &discordgo.InteractionResponseData{Content: "Done!"},
+})
+```
+
+### Deferred Response (thinking... then followup)
+
+When the handler needs more than 3 seconds, acknowledge immediately then send the real response as a followup. The followup window extends to 15 minutes.
+
+```go
+s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+    Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+})
+go func() {
+    result, err := callExternalAPI()
+    if err != nil {
+        s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+            Content: "Failed: " + err.Error(), Flags: discordgo.MessageFlagsEphemeral,
+        })
+        return
+    }
+    s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{Content: result})
+}()
+```
+
+Spawning a goroutine after deferring is safe — the webhook token remains valid for 15 minutes.
+
+### Ephemeral Messages
+
+Set `Flags: discordgo.MessageFlagsEphemeral` on any `InteractionResponseData` or `WebhookParams` to make the message visible only to the invoking user. Ephemeral responses cannot be deleted by the bot after sending; use them for errors, confirmations, and sensitive output.
+
+### Followup Messages
+
+After any response (immediate or deferred), send, edit, or delete additional messages via the webhook token. The token is valid for 15 minutes.
+
+```go
+msg, _ := s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{Content: "Step 1."})
+s.FollowupMessageEdit(i.Interaction, msg.ID, &discordgo.WebhookEdit{Content: stringPtr("Step 2.")})
+s.FollowupMessageDelete(i.Interaction, msg.ID)
+```
+
+
+## Interaction Response Types
+
+| Constant | Value | Use Case |
+|---|---|---|
+| `InteractionResponsePong` | 1 | Health check ping |
+| `InteractionResponseChannelMessageWithSource` | 4 | Standard slash command response |
+| `InteractionResponseDeferredChannelMessageWithSource` | 5 | Acknowledge; followup later |
+| `InteractionResponseDeferredMessageUpdate` | 6 | Acknowledge component; update later |
+| `InteractionResponseUpdateMessage` | 7 | Edit original message (components) |
+| `InteractionApplicationCommandAutocompleteResult` | 8 | Return autocomplete choices |
+| `InteractionResponseModal` | 9 | Open a modal dialog |
+
+
+## The 3-Second Deadline
+
+Discord requires an interaction response within 3 seconds. Missing this deadline shows "This interaction failed" to the user.
+
+**Respond immediately** (`InteractionResponseChannelMessageWithSource`) for simple lookups, in-memory operations, and fast database reads.
+
+**Defer then followup** (`InteractionResponseDeferredChannelMessageWithSource`) for any handler that touches external services, performs writes, or has unpredictable latency. The defer is a fast HTTP acknowledgment; the followup window extends to 15 minutes.
+
+A practical rule: always defer for any command that makes an outbound network call. The cost is one extra round-trip; the benefit is eliminating the entire class of timeout failures.

--- a/skills/go-discord-bot/references/components-and-modals.md
+++ b/skills/go-discord-bot/references/components-and-modals.md
@@ -1,0 +1,420 @@
+# Components and Modals
+
+Sources: discordgo v0.29.0 components/modals examples, Discord API reference (2026), production bot patterns
+
+## Component Type Hierarchy
+
+All component types are integer constants in discordgo. Components V2 (types 9–19) require the `MessageFlagsIsComponentsV2` flag on the message.
+
+| Type | Constant | Value | Notes |
+|------|----------|-------|-------|
+| Actions Row | `ActionsRow` | 1 | Container for interactive components |
+| Button | `Button` | 2 | Clickable button, 5 per row |
+| String Select | `SelectMenu` | 3 | Dropdown with custom options |
+| Text Input | `TextInput` | 4 | Modal-only input field |
+| User Select | `UserSelect` | 5 | Auto-populated from guild members |
+| Role Select | `RoleSelect` | 6 | Auto-populated from guild roles |
+| Mentionable Select | `MentionableSelect` | 7 | Users and roles combined |
+| Channel Select | `ChannelSelect` | 8 | Auto-populated from guild channels |
+| Section | `Section` | 9 | Components V2: layout grouping |
+| Text Display | `TextDisplay` | 10 | Components V2: formatted text block |
+| Thumbnail | `Thumbnail` | 11 | Components V2: small image |
+| Media Gallery | `MediaGallery` | 12 | Components V2: image grid |
+| File | `File` | 13 | Components V2: file attachment |
+| Separator | `Separator` | 14 | Components V2: visual divider |
+| Content Inventory Entry | `ContentInventoryEntry` | 16 | Components V2: entitlement display |
+| Container | `Container` | 17 | Components V2: styled wrapper |
+| Input | `Input` | 18 | Components V2: standalone input |
+| Label | `Label` | 19 | Components V2: wraps TextInput in modals |
+
+## Buttons
+
+### Button Styles
+
+| Style | Constant | Value | Color | Use Case |
+|-------|----------|-------|-------|----------|
+| Primary | `ButtonStylePrimary` | 1 | Blurple | Main action |
+| Secondary | `ButtonStyleSecondary` | 2 | Grey | Alternative action |
+| Success | `ButtonStyleSuccess` | 3 | Green | Confirm, approve |
+| Danger | `ButtonStyleDanger` | 4 | Red | Destructive action |
+| Link | `ButtonStyleLink` | 5 | Grey + arrow | External URL, no CustomID |
+| Premium | `ButtonStylePremium` | 6 | — | SKU purchase, requires SKUID |
+
+Link buttons use `URL` instead of `CustomID` and do not generate an interaction event. Premium buttons use `SKUID` and also do not generate an interaction event.
+
+### Sending Buttons
+
+Buttons must be wrapped in an `ActionsRow`. Send the row as part of `InteractionResponseData.Components`.
+
+```go
+func handlePing(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+        Type: discordgo.InteractionResponseChannelMessageWithSource,
+        Data: &discordgo.InteractionResponseData{
+            Content: "Choose an action:",
+            Components: []discordgo.MessageComponent{
+                discordgo.ActionsRow{
+                    Components: []discordgo.MessageComponent{
+                        discordgo.Button{
+                            Label:    "Confirm",
+                            Style:    discordgo.ButtonStyleSuccess,
+                            CustomID: "confirm_action",
+                        },
+                        discordgo.Button{
+                            Label:    "Cancel",
+                            Style:    discordgo.ButtonStyleDanger,
+                            CustomID: "cancel_action",
+                        },
+                        discordgo.Button{
+                            Label: "Documentation",
+                            Style: discordgo.ButtonStyleLink,
+                            URL:   "https://discord.com/developers/docs",
+                        },
+                    },
+                },
+            },
+        },
+    })
+}
+```
+
+To disable a button at creation time, set `Disabled: true` on the `Button` struct.
+
+### Handling Button Clicks
+
+Button clicks arrive as `InteractionMessageComponent` interactions. Route by `CustomID` using a handler map:
+
+```go
+var componentHandlers = map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
+    "confirm_action": handleConfirm,
+    "cancel_action":  handleCancel,
+}
+
+s.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    if i.Type == discordgo.InteractionMessageComponent {
+        if h, ok := componentHandlers[i.MessageComponentData().CustomID]; ok {
+            h(s, i)
+        }
+    }
+})
+```
+
+## Select Menus
+
+### Five Select Menu Types
+
+| Type | Constant | Options Required | Returns |
+|------|----------|-----------------|---------|
+| String Select | `SelectMenu` | Yes — define manually | Selected string values |
+| User Select | `UserSelect` | No — auto-populated | User IDs |
+| Role Select | `RoleSelect` | No — auto-populated | Role IDs |
+| Mentionable Select | `MentionableSelect` | No — auto-populated | User or role IDs |
+| Channel Select | `ChannelSelect` | No — auto-populated | Channel IDs |
+
+### String Select Menu
+
+Define options explicitly. Each option has a `Label`, `Value`, and optional `Description` and `Default` flag.
+
+```go
+discordgo.ActionsRow{
+    Components: []discordgo.MessageComponent{
+        discordgo.SelectMenu{
+            CustomID:    "color_select",
+            Placeholder: "Choose a color",
+            MinValues:   discordgo.IntPtr(1),
+            MaxValues:   1,
+            Options: []discordgo.SelectMenuOption{
+                {
+                    Label:       "Red",
+                    Value:       "red",
+                    Description: "A warm color",
+                    Default:     false,
+                },
+                {
+                    Label: "Blue",
+                    Value: "blue",
+                },
+                {
+                    Label: "Green",
+                    Value: "green",
+                },
+            },
+        },
+    },
+}
+```
+
+`MinValues` takes a pointer to int. Use `discordgo.IntPtr(n)` or declare a local variable and pass its address.
+
+### Auto-Populated Select Menus
+
+User, Role, Mentionable, and Channel selects do not require an `Options` slice. Set `MenuType` and Discord populates choices from the guild automatically.
+
+```go
+// User select — no Options field needed
+discordgo.SelectMenu{
+    MenuType:    discordgo.UserSelectMenu,
+    CustomID:    "target_user",
+    Placeholder: "Select a user",
+    MaxValues:   1,
+}
+
+// Channel select with type filter
+discordgo.SelectMenu{
+    MenuType:     discordgo.ChannelSelectMenu,
+    CustomID:     "target_channel",
+    Placeholder:  "Select a text channel",
+    ChannelTypes: []discordgo.ChannelType{discordgo.ChannelTypeGuildText},
+}
+```
+
+Valid `MenuType` values: `discordgo.UserSelectMenu`, `discordgo.RoleSelectMenu`, `discordgo.MentionableSelectMenu`, `discordgo.ChannelSelectMenu`. The zero value is the string select.
+
+### Reading Selected Values
+
+All select menu interactions arrive as `InteractionMessageComponent`. The selected values are in `MessageComponentData().Values`, a `[]string`.
+
+```go
+func handleColorSelect(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    data := i.MessageComponentData()
+    if len(data.Values) == 0 {
+        return
+    }
+    selected := data.Values[0] // first selected value
+
+    s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+        Type: discordgo.InteractionResponseChannelMessageWithSource,
+        Data: &discordgo.InteractionResponseData{
+            Content: "You selected: " + selected,
+            Flags:   discordgo.MessageFlagsEphemeral,
+        },
+    })
+}
+```
+
+For multi-select menus (`MaxValues > 1`), iterate over `data.Values`. For User/Role/Channel selects, `data.Values` contains snowflake ID strings.
+
+## Modals
+
+### Opening a Modal
+
+Respond to a slash command or button click with `InteractionResponseModal`. Modals cannot be opened from another modal.
+
+```go
+func handleOpenModal(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+        Type: discordgo.InteractionResponseModal,
+        Data: &discordgo.InteractionResponseData{
+            CustomID: "feedback_modal",
+            Title:    "Submit Feedback",
+            Components: []discordgo.MessageComponent{
+                discordgo.ActionsRow{
+                    Components: []discordgo.MessageComponent{
+                        discordgo.TextInput{
+                            CustomID:    "subject",
+                            Label:       "Subject",
+                            Style:       discordgo.TextInputShort,
+                            Placeholder: "Brief summary",
+                            Required:    true,
+                            MaxLength:   100,
+                        },
+                    },
+                },
+                discordgo.ActionsRow{
+                    Components: []discordgo.MessageComponent{
+                        discordgo.TextInput{
+                            CustomID:    "body",
+                            Label:       "Details",
+                            Style:       discordgo.TextInputParagraph,
+                            Placeholder: "Describe your feedback in detail",
+                            Required:    false,
+                            MinLength:   10,
+                            MaxLength:   1000,
+                        },
+                    },
+                },
+            },
+        },
+    })
+}
+```
+
+Each `TextInput` must be in its own `ActionsRow`. A modal supports up to 5 rows, so up to 5 text inputs.
+
+### TextInput Styles
+
+| Style | Constant | Appearance | Use Case |
+|-------|----------|------------|----------|
+| Short | `TextInputShort` | Single line | Names, titles, short answers |
+| Paragraph | `TextInputParagraph` | Multi-line | Descriptions, messages, long text |
+
+Both styles support `MinLength`, `MaxLength`, `Placeholder`, `Value` (pre-filled text), and `Required`.
+
+### Components V2 with Label Wrapper
+
+When using Components V2 (flag `MessageFlagsIsComponentsV2`), wrap `TextInput` in a `Label` component instead of an `ActionsRow`. This applies to modal construction under the V2 system.
+
+```go
+// Components V2 modal structure
+discordgo.Label{
+    Components: []discordgo.MessageComponent{
+        discordgo.TextInput{
+            CustomID: "name",
+            Label:    "Your Name",
+            Style:    discordgo.TextInputShort,
+        },
+    },
+}
+```
+
+For standard (non-V2) modals, use `ActionsRow` wrappers as shown above.
+
+### Handling Modal Submissions
+
+Modal submissions arrive as `InteractionModalSubmit`. Extract field values by walking the `Components` tree with type assertions.
+
+```go
+func handleFeedbackModal(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    data := i.ModalSubmitData()
+
+    var subject, body string
+
+    for _, row := range data.Components {
+        actionsRow, ok := row.(*discordgo.ActionsRow)
+        if !ok {
+            continue
+        }
+        for _, component := range actionsRow.Components {
+            input, ok := component.(*discordgo.TextInput)
+            if !ok {
+                continue
+            }
+            switch input.CustomID {
+            case "subject":
+                subject = input.Value
+            case "body":
+                body = input.Value
+            }
+        }
+    }
+
+    s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+        Type: discordgo.InteractionResponseChannelMessageWithSource,
+        Data: &discordgo.InteractionResponseData{
+            Content: "Feedback received.\nSubject: " + subject + "\nDetails: " + body,
+            Flags:   discordgo.MessageFlagsEphemeral,
+        },
+    })
+}
+```
+
+### Modal Gotchas
+
+**Type assertions are required.** `data.Components` is `[]discordgo.MessageComponent` (an interface slice). Every element must be type-asserted before accessing fields. Skipping the `ok` check causes a panic on unexpected component types.
+
+**Components V2 flag changes the wrapper type.** If the modal was constructed with `MessageFlagsIsComponentsV2`, the row wrapper is `*discordgo.Label`, not `*discordgo.ActionsRow`. Assert accordingly.
+
+**Modal CustomID must match the handler key.** The `CustomID` on the `InteractionResponseData` (not on individual inputs) is what you route on in `InteractionModalSubmit` handling.
+
+**Modals cannot be opened from modals.** Attempting to respond to a modal submission with another modal returns an API error. Use a follow-up message instead.
+
+**Three-second deadline applies.** The initial `InteractionRespond` call must complete within 3 seconds of the interaction being created. For modals triggered by buttons, the button click starts the clock.
+
+## Component Interaction Routing
+
+### Separate Handler Maps Pattern
+
+Maintain distinct maps for commands, components, and modals. This keeps each concern isolated and makes adding new handlers straightforward.
+
+```go
+var (
+    commandHandlers = map[string]func(*discordgo.Session, *discordgo.InteractionCreate){
+        "feedback": handleOpenModal,
+        "ping":     handlePing,
+    }
+    componentHandlers = map[string]func(*discordgo.Session, *discordgo.InteractionCreate){
+        "confirm_action": handleConfirm,
+        "cancel_action":  handleCancel,
+        "color_select":   handleColorSelect,
+    }
+    modalHandlers = map[string]func(*discordgo.Session, *discordgo.InteractionCreate){
+        "feedback_modal": handleFeedbackModal,
+    }
+)
+
+s.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    switch i.Type {
+    case discordgo.InteractionApplicationCommand:
+        if h, ok := commandHandlers[i.ApplicationCommandData().Name]; ok {
+            h(s, i)
+        }
+    case discordgo.InteractionMessageComponent:
+        if h, ok := componentHandlers[i.MessageComponentData().CustomID]; ok {
+            h(s, i)
+        }
+    case discordgo.InteractionModalSubmit:
+        if h, ok := modalHandlers[i.ModalSubmitData().CustomID]; ok {
+            h(s, i)
+        }
+    }
+})
+```
+
+### Unified Switch Pattern
+
+For smaller bots, nested switches inside a single handler are readable without the map overhead. Replace the map lookups in the Separate Handler Maps example with `switch i.ApplicationCommandData().Name`, `switch i.MessageComponentData().CustomID`, and `switch i.ModalSubmitData().CustomID` blocks respectively.
+
+### CustomID Conventions
+
+CustomIDs are arbitrary strings up to 100 characters. Use them to encode routing information and state.
+
+**Prefix routing** — use colon-delimited segments to encode routing and state without exact-match maps:
+
+```go
+// CustomID: "ban:456789012345678901:987654321098765432"
+// Format:   "action:targetUserID:requestingUserID"
+parts := strings.SplitN(i.MessageComponentData().CustomID, ":", 3)
+customID := fmt.Sprintf("ban:%s:%s", targetUserID, requestingUserID)
+```
+
+**Namespacing** — prefix with the feature name (`feedback:submit`, `moderation:confirm_ban`) to avoid collisions across commands.
+
+Keep embedded data minimal. CustomIDs are not encrypted and are visible in client network traffic.
+
+## Updating Component Messages
+
+To replace the original message content and components after a button or select interaction, respond with `InteractionResponseUpdateMessage`.
+
+```go
+func handleConfirm(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+        Type: discordgo.InteractionResponseUpdateMessage,
+        Data: &discordgo.InteractionResponseData{
+            Content:    "Action confirmed. This cannot be undone.",
+            Components: []discordgo.MessageComponent{}, // empty = remove all components
+        },
+    })
+}
+```
+
+Passing an empty `Components` slice removes all buttons and selects from the message. This prevents double-submission without requiring a separate edit call.
+
+## Disabling Components After Use
+
+To keep the original message layout but prevent further interaction, respond with `InteractionResponseUpdateMessage` and rebuild the component tree with `Disabled: true` on each button or select. There is no partial update API — the full component tree must be resent. Read `i.Message.Components` to preserve existing labels and styles dynamically rather than hardcoding them.
+
+## Component Limits
+
+Discord enforces hard limits on component counts. Exceeding them returns a 400 error from the API.
+
+| Limit | Value |
+|-------|-------|
+| Buttons per ActionsRow | 5 |
+| Select menus per ActionsRow | 1 (cannot mix with buttons) |
+| ActionsRows per message | 5 |
+| TextInputs per modal | 5 (one per ActionsRow) |
+| Characters in CustomID | 100 |
+| Characters in button Label | 80 |
+| Options in a string select | 25 |
+| Characters in modal Title | 45 |
+| Characters in TextInput Value (max) | 4000 |

--- a/skills/go-discord-bot/references/deployment-and-ops.md
+++ b/skills/go-discord-bot/references/deployment-and-ops.md
@@ -1,0 +1,440 @@
+# Deployment and Operations
+
+Sources: discordgo v0.29.0 docs, YAGPDB deployment patterns, production bot analysis (2026), Go best practices
+
+## Docker Deployment
+
+### Multi-Stage Build (complete Dockerfile — Go builder + alpine)
+
+```dockerfile
+FROM golang:1.22-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+# CGO_ENABLED=0 = statically linked; -ldflags="-s -w" strips debug info (~30% smaller)
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /bot ./cmd/bot
+
+FROM alpine:3.19
+RUN apk --no-cache add ca-certificates tzdata && \
+    addgroup -S bot && adduser -S bot -G bot
+USER bot
+COPY --from=builder /bot /app/bot
+ENTRYPOINT ["/app/bot"]
+```
+
+### Alpine vs Scratch vs Distroless
+
+| Image | Size | Shell | CA Certs | Recommended For |
+|-------|------|-------|----------|-----------------|
+| Alpine | ~8 MB | Yes | Add manually | Development, debugging |
+| Scratch | ~0 MB | No | Copy manually | Minimal production |
+| Distroless (gcr.io/distroless/static) | ~2 MB | No | Included | Production default |
+
+Distroless is the recommended production choice: no shell reduces attack surface, CA certificates are bundled, non-root by default. For scratch, copy `/etc/ssl/certs/ca-certificates.crt` from the builder stage.
+
+### Docker Compose (bot + PostgreSQL + Redis)
+
+```yaml
+version: "3.9"
+services:
+  bot:
+    build: .
+    restart: unless-stopped
+    environment:
+      - DISCORD_TOKEN=${DISCORD_TOKEN}
+      - DATABASE_URL=postgres://bot:${DB_PASSWORD}@postgres:5432/botdb?sslmode=disable
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      postgres: { condition: service_healthy }
+    networks: [bot-net]
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment: { POSTGRES_USER: bot, POSTGRES_PASSWORD: "${DB_PASSWORD}", POSTGRES_DB: botdb }
+    volumes: [pgdata:/var/lib/postgresql/data]
+    healthcheck: { test: ["CMD-SHELL", "pg_isready -U bot"], interval: 10s, timeout: 5s, retries: 5 }
+    networks: [bot-net]
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes: [redisdata:/data]
+    networks: [bot-net]
+volumes: { pgdata: {}, redisdata: {} }
+networks: { bot-net: {} }
+```
+
+## systemd Service
+
+### Service File Template
+
+Place at `/etc/systemd/system/discord-bot.service`. Store secrets in `/etc/discord-bot/env` (mode 0600, owned by root).
+
+```ini
+[Unit]
+Description=Discord Bot
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=discord-bot
+WorkingDirectory=/opt/discord-bot
+ExecStart=/opt/discord-bot/bot
+Restart=on-failure
+RestartSec=5s
+EnvironmentFile=/etc/discord-bot/env
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ReadWritePaths=/opt/discord-bot/data
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=discord-bot
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Management Commands
+
+```bash
+sudo systemctl enable --now discord-bot
+sudo journalctl -u discord-bot -f        # follow logs
+sudo systemctl restart discord-bot       # after binary update
+```
+
+## Structured Logging
+
+### log/slog (Go 1.21+ stdlib — recommended)
+
+```go
+// JSON for production aggregators; NewTextHandler for development
+logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+slog.SetDefault(logger)
+slog.Info("bot starting", "version", version, "shard_id", shardID)
+slog.Error("command failed", "command", cmdName, "guild_id", guildID, "error", err)
+```
+
+### zap (high-performance structured logging)
+
+```go
+logger, _ := zap.NewProduction(); defer logger.Sync()
+logger.Info("bot starting", zap.String("version", version), zap.Int("shard_id", shardID))
+logger.Sugar().Infow("command executed", "command", name, "latency_ms", latency)
+```
+
+zap's zero-allocation design is 5-10x faster than slog. Use it when log throughput is a bottleneck (>10k events/sec).
+
+### logrus (popular, compatible)
+
+```go
+log.SetFormatter(&log.JSONFormatter{})
+log.WithFields(log.Fields{"guild_id": guildID, "command": cmdName}).Info("command executed")
+```
+
+logrus is in maintenance mode — prefer slog for new projects.
+
+### Logging Best Practices for Discord Bots
+
+Log at the interaction boundary, not inside every helper. Include guild ID, user ID, and command name on every entry. Never log message content — it may contain PII and violates Discord's developer policy.
+
+```go
+slog.Info("interaction handled", "command", i.ApplicationCommandData().Name,
+    "guild_id", i.GuildID, "user_id", i.Member.User.ID,
+    "duration_ms", time.Since(start).Milliseconds())
+```
+
+## Error Handling
+
+### discordgo RESTError (error codes, type assertion)
+
+Discord API errors return `*discordgo.RESTError`. Type-assert to inspect HTTP status and Discord error code.
+
+```go
+var restErr *discordgo.RESTError
+if errors.As(err, &restErr) {
+    slog.Error("discord api error", "status", restErr.Response.StatusCode, "code", restErr.Message.Code)
+}
+```
+
+Common codes: 10003 (unknown channel), 10008 (unknown message), 50013 (missing permissions), 50035 (invalid form body).
+
+### Always Respond to Interactions (even on error)
+
+Discord requires a response within 3 seconds. If the handler returns without responding, the user sees "This interaction failed." Send an ephemeral error rather than silently failing.
+
+```go
+func respondWithError(s *discordgo.Session, i *discordgo.InteractionCreate, msg string) {
+    s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+        Type: discordgo.InteractionResponseChannelMessageWithSource,
+        Data: &discordgo.InteractionResponseData{Content: msg, Flags: discordgo.MessageFlagsEphemeral}})
+}
+```
+
+For deferred interactions, use `FollowupMessageCreate` to deliver the error.
+
+### Safe Handler Wrapper with recover() (critical for goroutine safety)
+
+Handlers run in goroutines (`SyncEvents=false` default). A panic silently kills that goroutine — the interaction times out and the panic is invisible without recovery.
+
+```go
+func safeHandler(s *discordgo.Session, i *discordgo.InteractionCreate,
+    fn func(*discordgo.Session, *discordgo.InteractionCreate)) {
+    defer func() {
+        if r := recover(); r != nil {
+            slog.Error("handler panic", "panic", r, "stack", string(debug.Stack()),
+                "command", i.ApplicationCommandData().Name, "guild_id", i.GuildID)
+            respondWithError(s, i, "An internal error occurred.")
+        }
+    }()
+    fn(s, i)
+}
+// Wrap every dispatch point
+s.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    if h, ok := commandHandlers[i.ApplicationCommandData().Name]; ok {
+        safeHandler(s, i, h)
+    }
+})
+```
+
+Apply the same pattern to non-interaction handlers. A panic in a `MessageCreate` handler silently drops that event.
+
+### Custom Error Types
+
+```go
+type BotError struct {
+    Code    string
+    Message string // shown to user
+    Err     error  // internal cause, logged not shown
+}
+func (e *BotError) Error() string { return e.Message }
+func (e *BotError) Unwrap() error { return e.Err }
+```
+
+## Graceful Shutdown
+
+### Signal Handling (os.Signal, signal.Notify)
+
+Handle both `os.Interrupt` (Ctrl+C) and `syscall.SIGTERM` (Docker/systemd stop):
+
+```go
+stop := make(chan os.Signal, 1)
+signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+<-stop; slog.Info("shutting down"); cleanup(s); s.Close()
+```
+
+### Command Cleanup on Shutdown (guild commands)
+
+Guild-scoped commands persist across restarts. Delete them on shutdown during development; in production use `ApplicationCommandBulkOverwrite` at startup instead.
+
+```go
+for _, cmd := range registered {
+    s.ApplicationCommandDelete(s.State.User.ID, guildID, cmd.ID)
+}
+```
+
+### Context-Based Shutdown (arikawa pattern)
+
+arikawa propagates `context.Context` throughout. Cancel the root context to trigger shutdown across all components.
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+go func() {
+    stop := make(chan os.Signal, 1)
+    signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+    <-stop; cancel()
+}()
+if err := bot.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+    slog.Error("bot exited", "error", err); os.Exit(1)
+}
+```
+
+### WaitGroup for Plugin Cleanup (YAGPDB pattern)
+
+```go
+var wg sync.WaitGroup
+func startPlugin(ctx context.Context, p Plugin) {
+    wg.Add(1)
+    go func() { defer wg.Done(); p.Run(ctx); p.Stop() }()
+}
+// Shutdown: cancel() → wg.Wait() → s.Close()
+```
+
+## Goroutine Safety
+
+### Handlers Run in Goroutines (SyncEvents=false)
+
+discordgo dispatches each event to a new goroutine by default. Two `MessageCreate` events can execute simultaneously — any shared state must be protected. `SyncEvents=true` serializes all events; use only for debugging.
+
+### Panic Recovery (recover + debug.Stack)
+
+A panic in an unrecovered goroutine terminates the entire process. discordgo does not recover panics in handlers. Wrap every `go func()` call:
+
+```go
+go func() {
+    defer func() {
+        if r := recover(); r != nil {
+            slog.Error("goroutine panic", "panic", r, "stack", string(debug.Stack()))
+        }
+    }()
+    doWork()
+}()
+```
+
+### Shared State Protection (sync.RWMutex)
+
+```go
+type Cache struct {
+    mu     sync.RWMutex
+    guilds map[string]*GuildData
+}
+func (c *Cache) Get(id string) (*GuildData, bool) {
+    c.mu.RLock(); defer c.mu.RUnlock(); return c.guilds[id], c.guilds[id] != nil
+}
+func (c *Cache) Set(id string, data *GuildData) {
+    c.mu.Lock(); defer c.mu.Unlock(); c.guilds[id] = data
+}
+```
+
+Avoid holding locks across I/O operations.
+
+### Channel-Based Communication
+
+For serialized work (e.g., image generation queue), use a buffered channel:
+
+```go
+type Job struct{ Interaction *discordgo.InteractionCreate; Prompt string }
+queue := make(chan Job, 100)
+go func() { for job := range queue { sendResult(s, job.Interaction, processJob(job.Prompt)) } }()
+queue <- Job{Interaction: i, Prompt: prompt}
+```
+
+## Sharding
+
+### discordgo Built-In (ShardID, ShardCount)
+
+```go
+s, _ := discordgo.New("Bot " + token)
+s.ShardID = shardID        // 0-indexed
+s.ShardCount = totalShards // must match across all shards
+s.Open()
+```
+
+Each shard maintains its own gateway connection.
+
+### Multi-Process Sharding (YAGPDB dshardorchestrator)
+
+YAGPDB uses `dshardorchestrator` to coordinate shards across multiple processes. The orchestrator assigns shard IDs, monitors health, and restarts failed shards. Use this pattern for bots in thousands of guilds where a single process cannot handle all gateway traffic.
+
+### Shard Selection Formula ((guild_id >> 22) % total_shards)
+
+Discord assigns guilds to shards deterministically: `shard_id = (guild_id >> 22) % total_shards`. Use this to route guild-specific operations to the correct shard process.
+
+### When to Shard (2,500+ guilds)
+
+Discord requires sharding at 2,500 guilds. Request the recommended count from `/gateway/bot`:
+```go
+gw, _ := s.GatewayBot() // gw.Shards is Discord's recommendation
+```
+
+## Rate Limit Handling
+
+### Built-In Rate Limiter (per-bucket, global)
+
+discordgo manages rate limits automatically via per-endpoint buckets and a global atomic int64 counter (50 req/sec). When a bucket is exhausted, discordgo sleeps until reset. `ShouldRetryOnRateLimit` defaults to `true`.
+
+### Reaction Rate Limit (1/200ms hardcoded)
+
+Discord enforces a hardcoded 1 reaction per 200ms not reflected in standard headers. discordgo applies this internally. Space bulk reactions with a 250ms sleep.
+
+### ShouldRetryOnRateLimit
+```go
+s.ShouldRetryOnRateLimit = true // default
+s.MaxRestRetries = 3            // retries on 5xx and rate limits
+```
+Increase `MaxRestRetries` for critical operations (moderation logs). Decrease for latency-sensitive paths.
+
+## CI/CD (GitHub Actions)
+
+### Build and Test Workflow
+
+```yaml
+name: CI
+on: { push: { branches: [main] }, pull_request: {} }
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: "1.22", cache: true }
+      - run: go mod download && go vet ./...
+      - run: go test -race -coverprofile=coverage.out ./...
+      - run: CGO_ENABLED=0 go build -o /dev/null ./cmd/bot
+```
+
+### Docker Build and Push
+
+```yaml
+name: Docker
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions: { contents: read, packages: write }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with: { registry: ghcr.io, username: "${{ github.actor }}", password: "${{ secrets.GITHUB_TOKEN }}" }
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```
+
+## Environment Variable Checklist
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DISCORD_TOKEN` | Yes | Bot token from Discord Developer Portal |
+| `DISCORD_APP_ID` | Yes | Application ID for command registration |
+| `DISCORD_GUILD_ID` | Dev only | Guild ID for fast guild-scoped command registration |
+| `DATABASE_URL` | If using DB | PostgreSQL connection string |
+| `REDIS_URL` | If using Redis | Redis connection string |
+| `LOG_LEVEL` | No | `debug`, `info`, `warn`, `error` (default: `info`) |
+| `SHARD_ID` | If sharding | 0-indexed shard ID |
+| `SHARD_COUNT` | If sharding | Total number of shards |
+| `PORT` | If HTTP | Port for health check or webhook server |
+
+## Production Checklist
+
+- [ ] Token stored in environment variable or secrets manager, not in source
+- [ ] Multi-stage Docker build with non-root user
+- [ ] `restart: unless-stopped` in Compose or `Restart=on-failure` in systemd
+- [ ] Graceful shutdown handles both `SIGTERM` and `SIGINT`
+- [ ] All interaction handlers respond within 3 seconds or defer immediately
+- [ ] `recover()` wraps every handler and manually spawned goroutine
+- [ ] Shared state protected with `sync.RWMutex` or channel-based serialization
+- [ ] Structured logging with guild ID and user ID on every entry
+- [ ] No message content logged (PII / policy compliance)
+- [ ] `ShouldRetryOnRateLimit=true` (default — verify it has not been disabled)
+- [ ] Health check endpoint or liveness probe configured
+- [ ] Database migrations run before bot starts (not inside bot process)
+- [ ] `ApplicationCommandBulkOverwrite` used at startup instead of per-command registration
+- [ ] Shard count requested from `/gateway/bot` for bots approaching 2,500 guilds
+- [ ] CI pipeline runs `go vet` and `go test -race` on every pull request

--- a/skills/go-discord-bot/references/event-handling.md
+++ b/skills/go-discord-bot/references/event-handling.md
@@ -1,0 +1,376 @@
+# Event Handling
+
+Sources: discordgo v0.29.0 docs, arikawa v3 gateway docs, Discord API reference (2026), YAGPDB event system analysis
+
+---
+
+## Gateway Intents
+
+Intents are bitmask flags that tell Discord which events to send. Declare them before `s.Open()`. Undeclared intents result in silently dropped events.
+
+### Standard Intents (Non-Privileged)
+
+| Intent | Bit | Key Events |
+|--------|-----|------------|
+| `IntentsGuilds` | `1<<0` | GuildCreate/Update/Delete, Channel/Role CRUD |
+| `IntentsGuildBans` | `1<<2` | GuildBanAdd, GuildBanRemove |
+| `IntentsGuildEmojis` | `1<<3` | GuildEmojisUpdate |
+| `IntentsGuildWebhooks` | `1<<5` | WebhooksUpdate |
+| `IntentsGuildInvites` | `1<<6` | InviteCreate, InviteDelete |
+| `IntentsGuildVoiceStates` | `1<<7` | VoiceStateUpdate |
+| `IntentsGuildMessages` | `1<<9` | MessageCreate, MessageUpdate, MessageDelete |
+| `IntentsGuildMessageReactions` | `1<<10` | MessageReactionAdd/Remove/RemoveAll |
+| `IntentsGuildMessageTyping` | `1<<11` | TypingStart (guilds) |
+| `IntentsDirectMessages` | `1<<12` | MessageCreate/Update/Delete (DMs) |
+| `IntentsDirectMessageReactions` | `1<<13` | MessageReactionAdd/Remove (DMs) |
+| `IntentsGuildScheduledEvents` | `1<<16` | GuildScheduledEventCreate/Update/Delete |
+| `IntentsAutoModerationConfiguration` | `1<<20` | AutoModerationRuleCreate/Update/Delete |
+| `IntentsAutoModerationExecution` | `1<<21` | AutoModerationActionExecution |
+| `IntentsGuildMessagePolls` | `1<<24` | MessagePollVoteAdd/Remove (guilds) |
+| `IntentsDirectMessagePolls` | `1<<25` | MessagePollVoteAdd/Remove (DMs) |
+
+### Privileged Intents
+
+Three intents require explicit enablement in the Discord Developer Portal. Bots in 100+ guilds must pass a verification review before these intents are granted.
+
+| Intent | Bit | Unlocks | Verification |
+|--------|-----|---------|--------------|
+| `IntentsGuildMembers` | `1<<1` | GuildMemberAdd/Update/Remove | Yes (100+ guilds) |
+| `IntentsGuildPresences` | `1<<8` | PresenceUpdate | Yes (100+ guilds) |
+| `IntentsMessageContent` | `1<<15` | `Message.Content`, `.Attachments`, `.Embeds` in guild messages | Yes (100+ guilds) |
+
+**MessageContent is the most commonly missed privileged intent.** Without it, `Message.Content` is an empty string for all guild messages. Slash commands and interactions are unaffected — they do not require MessageContent. Enable privileged intents at: Discord Developer Portal → your app → Bot → Privileged Gateway Intents.
+
+### Convenience Bundles
+
+| Constant | Includes |
+|----------|----------|
+| `IntentsAllWithoutPrivileged` | All non-privileged intents (default for `New()`) |
+| `IntentsAll` | All intents including all three privileged |
+| `IntentsNone` | No intents — only interaction events reach the bot |
+
+`IntentsNone` is appropriate for interaction-only bots (slash commands, buttons, modals) that never read message content.
+
+### Setting Intents
+
+Set intents on `s.Identify.Intents` before `s.Open()`. Combine with bitwise OR.
+
+```go
+s, _ := discordgo.New("Bot " + os.Getenv("DISCORD_TOKEN"))
+s.Identify.Intents = discordgo.IntentsGuilds |
+    discordgo.IntentsGuildMessages |
+    discordgo.IntentsMessageContent // privileged — must be enabled in portal
+s.AddHandler(onReady)
+if err := s.Open(); err != nil {
+    log.Fatal(err)
+}
+```
+
+### Intent Selection Guide
+
+| Feature | Required Intents |
+|---------|-----------------|
+| Read message text (prefix commands, moderation) | `IntentsGuildMessages` + `IntentsMessageContent` (privileged) |
+| Slash commands / buttons / modals only | `IntentsNone` or `IntentsGuilds` |
+| Track voice channel membership | `IntentsGuildVoiceStates` |
+| Welcome new members | `IntentsGuildMembers` (privileged) |
+| User presence / status | `IntentsGuildPresences` (privileged) |
+| Emoji reactions | `IntentsGuildMessageReactions` |
+| DM support | `IntentsDirectMessages` |
+
+---
+
+## Event Handler Registration
+
+### AddHandler
+
+`AddHandler` uses reflection to match the function signature to the correct event type. The second parameter's concrete type determines which event triggers the handler. Returns a removal function.
+
+```go
+remove := s.AddHandler(func(s *discordgo.Session, m *discordgo.MessageCreate) {
+    if m.Author.Bot {
+        return
+    }
+    log.Printf("message from %s: %s", m.Author.Username, m.Content)
+})
+// remove() unregisters the handler
+```
+
+Multiple handlers for the same event type are all called in registration order.
+
+### AddHandlerOnce
+
+Fires exactly once, then auto-removes. Use for one-time initialization that depends on gateway state (e.g., registering commands after `State.User.ID` is populated):
+
+```go
+s.AddHandlerOnce(func(s *discordgo.Session, r *discordgo.Ready) {
+    registerCommands(s)
+})
+```
+
+### Handler Removal
+
+`AddHandler` returns a zero-argument removal function. Call it to unregister. Supports self-removal:
+
+```go
+var remove func()
+remove = s.AddHandler(func(s *discordgo.Session, m *discordgo.MessageCreate) {
+    if m.Content == "stop" {
+        remove()
+    }
+})
+```
+
+### SyncEvents
+
+`s.SyncEvents` controls handler concurrency:
+
+- `false` (default): each handler runs in a new goroutine. Protect shared state with `sync.Mutex`. Panics are silent — wrap with `recover()`.
+- `true`: handlers run sequentially in the gateway receive loop. A slow handler blocks all event processing.
+
+Never set `SyncEvents = true` in production. It exists for testing only. Wrap handler bodies with `recover()` to surface panics that would otherwise be silently dropped:
+
+```go
+func safe[E any](fn func(*discordgo.Session, E)) func(*discordgo.Session, E) {
+    return func(s *discordgo.Session, e E) {
+        defer func() {
+            if r := recover(); r != nil {
+                log.Printf("panic in handler: %v", r)
+            }
+        }()
+        fn(s, e)
+    }
+}
+```
+
+---
+
+## Common Event Types
+
+| Event Type | Struct | Trigger |
+|------------|--------|---------|
+| `Ready` | `*discordgo.Ready` | Bot connects; contains initial guild list and session ID |
+| `Resumed` | `*discordgo.Resumed` | Session resumes after disconnect |
+| `MessageCreate` | `*discordgo.MessageCreate` | New message in any subscribed channel |
+| `MessageUpdate` | `*discordgo.MessageUpdate` | Message edited; `Content` may be empty if not cached |
+| `MessageDelete` | `*discordgo.MessageDelete` | Message deleted; only ID available if not cached |
+| `InteractionCreate` | `*discordgo.InteractionCreate` | Slash command, button, select menu, modal, autocomplete |
+| `GuildCreate` | `*discordgo.GuildCreate` | Bot joins a guild, or guild becomes available on startup |
+| `GuildDelete` | `*discordgo.GuildDelete` | Bot removed from guild, or guild goes unavailable |
+| `GuildMemberAdd` | `*discordgo.GuildMemberAdd` | User joins a guild (requires `IntentsGuildMembers`) |
+| `GuildMemberRemove` | `*discordgo.GuildMemberRemove` | User leaves or is kicked/banned |
+| `GuildMemberUpdate` | `*discordgo.GuildMemberUpdate` | Member roles, nickname, or timeout changes |
+| `VoiceStateUpdate` | `*discordgo.VoiceStateUpdate` | User joins, moves, or leaves a voice channel |
+| `PresenceUpdate` | `*discordgo.PresenceUpdate` | User status or activity changes (requires `IntentsGuildPresences`) |
+| `ChannelCreate` | `*discordgo.ChannelCreate` | New channel created in a guild |
+| `GuildBanAdd` | `*discordgo.GuildBanAdd` | User banned from guild |
+
+### Ready, MessageCreate, GuildCreate, VoiceStateUpdate, GuildMemberAdd, PresenceUpdate
+
+```go
+// Ready — fires once per connection (not on resume)
+s.AddHandler(func(s *discordgo.Session, r *discordgo.Ready) {
+    log.Printf("connected as %s (session %s)", r.User.String(), r.SessionID)
+})
+
+// MessageCreate — Content is empty without IntentsMessageContent (privileged)
+s.AddHandler(func(s *discordgo.Session, m *discordgo.MessageCreate) {
+    if m.Author == nil || m.Author.Bot {
+        return
+    }
+    if m.Content == "ping" {
+        s.ChannelMessageSend(m.ChannelID, "pong")
+    }
+})
+
+// GuildCreate — fires on startup for each existing guild and on new joins
+s.AddHandler(func(s *discordgo.Session, g *discordgo.GuildCreate) {
+    if g.Guild.Unavailable {
+        return // outage, not a real join
+    }
+    log.Printf("guild available: %s", g.Guild.Name)
+})
+
+// VoiceStateUpdate — ChannelID="" means user left voice
+s.AddHandler(func(s *discordgo.Session, v *discordgo.VoiceStateUpdate) {
+    if v.ChannelID == "" {
+        log.Printf("user %s left voice", v.UserID)
+    } else {
+        log.Printf("user %s joined channel %s", v.UserID, v.ChannelID)
+    }
+})
+
+// GuildMemberAdd — requires IntentsGuildMembers (privileged)
+s.AddHandler(func(s *discordgo.Session, m *discordgo.GuildMemberAdd) {
+    s.ChannelMessageSend(welcomeChannelID, fmt.Sprintf("Welcome, <@%s>!", m.User.ID))
+})
+
+// PresenceUpdate — requires IntentsGuildPresences (privileged); fires very frequently
+s.AddHandler(func(s *discordgo.Session, p *discordgo.PresenceUpdate) {
+    log.Printf("user %s status: %s", p.User.ID, p.Status)
+})
+```
+
+---
+
+## Interaction Type Routing
+
+All interactions arrive through a single `InteractionCreate` event. Route by `i.Type` before dispatching.
+
+### The Master Switch Pattern
+
+Four interaction types require distinct handling:
+
+| Type Constant | Value | Data Accessor |
+|---------------|-------|---------------|
+| `InteractionApplicationCommand` | 2 | `i.ApplicationCommandData()` |
+| `InteractionMessageComponent` | 3 | `i.MessageComponentData()` |
+| `InteractionApplicationCommandAutocomplete` | 4 | `i.ApplicationCommandData()` |
+| `InteractionModalSubmit` | 5 | `i.ModalSubmitData()` |
+
+### Complete Routing Example
+
+```go
+var commandHandlers = map[string]func(*discordgo.Session, *discordgo.InteractionCreate){
+    "ping": handlePing,
+    "ban":  handleBan,
+}
+
+var componentHandlers = map[string]func(*discordgo.Session, *discordgo.InteractionCreate){
+    "confirm-ban": handleConfirmBan,
+    "cancel":      handleCancel,
+}
+
+s.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    switch i.Type {
+    case discordgo.InteractionApplicationCommand:
+        name := i.ApplicationCommandData().Name
+        if h, ok := commandHandlers[name]; ok {
+            h(s, i)
+        }
+
+    case discordgo.InteractionMessageComponent:
+        // CustomID may encode state: "confirm-ban:123456789"
+        parts := strings.SplitN(i.MessageComponentData().CustomID, ":", 2)
+        if h, ok := componentHandlers[parts[0]]; ok {
+            h(s, i)
+        }
+
+    case discordgo.InteractionModalSubmit:
+        data := i.ModalSubmitData()
+        if data.CustomID == "feedback-modal" {
+            handleFeedbackModal(s, i, data)
+        }
+
+    case discordgo.InteractionApplicationCommandAutocomplete:
+        choices := generateChoices(i.ApplicationCommandData())
+        s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+            Type: discordgo.InteractionApplicationCommandAutocompleteResult,
+            Data: &discordgo.InteractionResponseData{Choices: choices},
+        })
+    }
+})
+```
+
+---
+
+## discordgo State Cache
+
+discordgo maintains an in-memory cache populated from gateway events. Enabled by default (`StateEnabled = true`).
+
+### What's Cached
+
+| Object | Populated By |
+|--------|-------------|
+| Guilds | GuildCreate, GuildUpdate, GuildDelete |
+| Channels | GuildCreate, ChannelCreate/Update/Delete |
+| Members | GuildCreate, GuildMemberAdd/Update/Remove |
+| Roles | GuildCreate, GuildRoleCreate/Update/Delete |
+| Voice states | VoiceStateUpdate |
+| Messages | MessageCreate/Update/Delete (up to `MaxMessageCount` per channel) |
+
+### Accessing State
+
+```go
+me := s.State.User // available after Ready
+
+// All accessors return (T, error); error = not in cache → fall back to REST
+guild, err := s.State.Guild(guildID)
+if err != nil {
+    guild, err = s.Guild(guildID)
+}
+channel, _ := s.State.Channel(channelID)
+member, _ := s.State.Member(guildID, userID)
+vs, _ := s.State.VoiceState(guildID, userID)
+```
+
+### State Configuration
+
+```go
+s.State.MaxMessageCount = 100   // per channel (default: 0 = disabled)
+s.State.TrackMembers = true     // default: true
+s.State.TrackPresences = false  // default: false — high memory cost
+```
+
+### Limitations
+
+The cache is in-memory and per-process. Multi-shard bots need a shared store (Redis, database) for cross-shard lookups. Multiple bot instances do not share state. For large guilds, disable `TrackMembers` and fetch members on demand to control memory usage.
+
+---
+
+## arikawa Event System
+
+arikawa provides a typed event system that eliminates reflection-based dispatch.
+
+### Typed Events
+
+Handlers receive concrete types from the `gateway` package — compile-time safety, no interface{} dispatch:
+
+```go
+s.AddHandler(func(e *gateway.MessageCreateEvent) {
+    fmt.Println(e.Content)
+})
+```
+
+### PreHandler
+
+Intercepts events before the state cache is updated. Use for diffing old vs. new state:
+
+```go
+s.PreHandler.AddSyncHandler(func(e *gateway.GuildMemberUpdateEvent) {
+    old, _ := s.Cabinet.Member(e.GuildID, e.User.ID)
+    log.Printf("roles changing: %v → %v", old.RoleIDs, e.RoleIDs)
+})
+```
+
+### AddIntents Helper
+
+Accumulate intents incrementally: `s.AddIntents(gateway.IntentGuilds)`, `s.AddIntents(gateway.IntentMessageContent)`, etc.
+
+---
+
+## Setting Bot Presence and Activity
+
+```go
+s.AddHandler(func(s *discordgo.Session, r *discordgo.Ready) {
+    s.UpdateStatusComplex(discordgo.UpdateStatusData{
+        Status: "online", // online, idle, dnd, invisible
+        Activities: []*discordgo.Activity{{
+            Name: "/help",
+            Type: discordgo.ActivityTypeListening, // Playing=0, Listening=2, Watching=3, Competing=5
+        }},
+    })
+})
+// Rate-limited to 5 updates per 20 seconds
+```
+
+---
+
+## YAGPDB Custom Event System
+
+YAGPDB implements a code-generated event dispatch system for large-scale bots. Key patterns:
+
+- **Code generation**: dispatch tables generated from a schema — no reflection overhead at runtime
+- **Plugin interface**: each plugin implements `func(evt *EventData) error` rather than ad-hoc handlers
+- **Shard orchestrator**: events distributed across shards; each shard process handles a subset of guilds
+- **Buffered dispatch**: per-plugin channels decouple event ingestion from processing, preventing slow plugins from blocking the gateway receive loop

--- a/skills/go-discord-bot/references/library-selection.md
+++ b/skills/go-discord-bot/references/library-selection.md
@@ -1,0 +1,380 @@
+# Library Selection
+
+Sources: discordgo v0.29.0 docs, arikawa v3.6.0 docs, disgo docs, Discord API reference (2026), production bot analysis (YAGPDB, discordo, disgolink)
+
+The Go Discord ecosystem has three actively maintained libraries. Each targets a different point on the simplicity-vs-safety spectrum. Choose once at project start — migration is painful.
+
+## The Three Libraries
+
+### discordgo
+
+The oldest and most popular Go Discord library. Import path: `github.com/bwmarrin/discordgo`.
+
+discordgo wraps the Discord API as a single `Session` struct. All REST calls, gateway management, state caching, and voice connections live on this one type. The design is intentionally flat: no sub-packages, no interfaces to implement, no routing abstractions. You register handlers with `AddHandler`, which uses reflection to match your function signature to an event type.
+
+**Critical gotcha:** discordgo targets Discord API **v9**, not v10. The `APIVersion` constant in `endpoints.go` is `"9"`. You can override it, but the library is not tested against v10 and some v10-only features (forum channels, message polls, updated permission model) may behave incorrectly. If your bot requires v10 features, use disgo instead.
+
+Voice support is mature. `ChannelVoiceJoin` returns a `*VoiceConnection` with `OpusSend` and `OpusRecv` channels. The companion libraries `dgVoice` (ffmpeg pipeline) and `dca` (Opus encoding) are widely used and well-documented.
+
+Rate limiting is fully automatic. Per-endpoint token buckets and a global rate limit are managed transparently. `ShouldRetryOnRateLimit` defaults to `true`.
+
+**Weaknesses:** No `context.Context` support anywhere in the API. Handlers run in separate goroutines by default (`SyncEvents=false`), so shared state requires explicit synchronization. Panics inside handlers are silent unless you wrap them with `recover()`. The lack of typed IDs means passing a `string` where a channel ID is expected compiles without error.
+
+**Best for:** Bots where community examples matter, teams new to Discord bots, projects that need mature voice support, and cases where the large body of existing discordgo tutorials is an asset.
+
+### arikawa
+
+A modular, type-safe library. Import path: `github.com/diamondburned/arikawa/v3`.
+
+arikawa splits functionality across focused packages rather than concentrating everything in one struct. Each package has a narrow responsibility and can be used independently. The library targets Discord API **v9** but is more current on v9 features than discordgo.
+
+The defining feature is typed Snowflakes. Instead of bare `string` or `uint64`, arikawa defines `discord.ChannelID`, `discord.UserID`, `discord.GuildID`, and so on. Passing the wrong ID type is a compile-time error. This eliminates an entire class of runtime bugs common in large bots.
+
+`cmdroute.Router` provides built-in slash command routing with middleware support. Options are unmarshaled into structs via field tags rather than manual `GetByName` calls. `cmdroute.Deferrable` wraps a handler to automatically send a deferred response if the handler takes longer than 2.5 seconds.
+
+`context.Context` is threaded through the entire API. Every REST call accepts a context, enabling proper timeout and cancellation handling.
+
+The state package is pluggable. The default in-memory state can be replaced with a Redis-backed implementation or a custom store, which matters for sharded bots that need shared state across processes.
+
+arikawa can run as a gateway bot or as an HTTP webhook server (for interactions-only bots that do not need a persistent gateway connection).
+
+**Weaknesses:** Smaller community than discordgo. Fewer tutorials and Stack Overflow answers. The modular package structure has a steeper initial learning curve.
+
+**Best for:** Bots where compile-time correctness matters, teams comfortable with Go idioms, projects that need pluggable state for sharding, and bots that may need to switch between gateway and webhook modes.
+
+### disgo
+
+The only Go library targeting Discord API **v10**. Import path: `github.com/disgoorg/disgo`.
+
+disgo is the newest of the three. It was built specifically to support v10 features: forum channels, the updated permission system, message polls, and the revised interaction model. If your bot depends on any v10-only API surface, disgo is the correct choice.
+
+The interaction routing model is inspired by chi. A `handler.Mux` routes slash commands and component interactions by path. Component custom IDs support variable segments (`/ticket/{id}/close`), which eliminates the manual string parsing that discordgo and arikawa bots typically implement. Middleware is composed functionally.
+
+The architecture is modular: REST, gateway, sharding, and voice are separate modules that can be composed as needed. This makes it straightforward to build bots that use only REST (no gateway) or that add sharding later without restructuring.
+
+**Weaknesses:** Smallest community of the three. Fewer production examples. Some APIs are still stabilizing as v10 features are added.
+
+**Best for:** Bots that require Discord API v10 features, projects starting fresh that want the most current API surface, and teams that prefer chi-style routing for interactions.
+
+---
+
+## Decision Matrix
+
+| Factor | discordgo | arikawa | disgo |
+|--------|-----------|---------|-------|
+| GitHub stars (Mar 2026) | 5,829 | 579 | 516 |
+| Discord API version | v9 | v9 | v10 |
+| Maintenance status | Active | Active | Active |
+| Voice support | v1 (mature) | v4 | v4 |
+| Type-safe IDs | No | Yes | Partial |
+| context.Context support | No | Yes | Yes |
+| Built-in command routing | No | Yes (cmdroute) | Yes (handler.Mux) |
+| Middleware support | No (use ken) | Yes | Yes |
+| Pluggable state | No | Yes | No |
+| HTTP webhook mode | No | Yes | Yes |
+| Community examples | Extensive | Moderate | Limited |
+| Forum channels (v10) | Partial | Partial | Full |
+| Variable component IDs | Manual | Manual | Yes (/path/{var}) |
+| Production bots using it | YAGPDB, many | discordo | disgolink |
+
+---
+
+## Quick Decision
+
+Start here and follow the branches:
+
+```
+Does your bot require Discord API v10 features?
+  (forum channels, updated permissions, message polls)
+  YES → disgo
+  NO  → continue
+
+Do you need pluggable state for multi-process sharding?
+  YES → arikawa
+  NO  → continue
+
+Do you need context.Context for timeout/cancellation?
+  YES → arikawa
+  NO  → continue
+
+Is compile-time ID type safety important to your team?
+  YES → arikawa
+  NO  → continue
+
+Do you want the largest community and most tutorials?
+  YES → discordgo
+  NO  → arikawa (better defaults, worth the smaller community)
+```
+
+Default recommendation for new projects with no special requirements: **discordgo** if the team is new to Discord bots (community support matters), **arikawa** if the team is experienced with Go (better idioms, safer defaults).
+
+---
+
+## go.mod Configuration
+
+### discordgo
+
+```go
+module github.com/yourorg/yourbot
+
+go 1.22
+
+require (
+    github.com/bwmarrin/discordgo v0.29.0
+)
+```
+
+For voice with ffmpeg pipeline:
+
+```go
+require (
+    github.com/bwmarrin/discordgo v0.29.0
+    github.com/bwmarrin/dgvoice v0.0.0-20210225172318-caaac756e02e
+    github.com/jonas747/dca v0.0.0-20210930103944-155f5e5f0cc7
+)
+```
+
+### arikawa
+
+```go
+module github.com/yourorg/yourbot
+
+go 1.22
+
+require (
+    github.com/diamondburned/arikawa/v3 v3.6.0
+)
+```
+
+arikawa bundles all sub-packages in a single module. You do not need separate imports for `api`, `gateway`, or `state` — they are all under `v3`.
+
+### disgo
+
+```go
+module github.com/yourorg/yourbot
+
+go 1.22
+
+require (
+    github.com/disgoorg/disgo v0.18.14
+    github.com/disgoorg/snowflake/v2 v2.0.3
+)
+```
+
+disgo uses `github.com/disgoorg/snowflake/v2` for its ID types. This is a separate module and must be listed explicitly.
+
+---
+
+## discordgo Feature Flags and Configuration
+
+Set these on the `Session` before calling `Open()`. Changing them after the gateway connects has no effect.
+
+```go
+s, err := discordgo.New("Bot " + token)
+
+// Gateway intents — required for most events
+// IntentsAllWithoutPrivileged is the default
+s.Identify.Intents = discordgo.IntentsGuilds |
+    discordgo.IntentsGuildMessages |
+    discordgo.IntentsGuildVoiceStates
+
+// Privileged intents — must be enabled in Developer Portal
+s.Identify.Intents |= discordgo.IntentsGuildMembers    // member join/leave
+s.Identify.Intents |= discordgo.IntentsMessageContent  // message body text
+
+// Sharding
+s.ShardID = 0
+s.ShardCount = 4
+
+// State cache — enabled by default
+s.StateEnabled = true
+
+// Sync event handlers (run sequentially, not in goroutines)
+// Use only for debugging — hurts throughput
+s.SyncEvents = false
+
+// Compression for gateway payloads
+s.Compress = true
+
+// Retry behavior
+s.ShouldReconnectOnError = true
+s.ShouldRetryOnRateLimit = true
+s.MaxRestRetries = 3
+```
+
+**Intent reference:**
+
+| Intent constant | Bit | Privileged |
+|----------------|-----|-----------|
+| `IntentsGuilds` | 1<<0 | No |
+| `IntentsGuildMembers` | 1<<1 | Yes |
+| `IntentsGuildPresences` | 1<<8 | Yes |
+| `IntentsGuildMessages` | 1<<9 | No |
+| `IntentsMessageContent` | 1<<15 | Yes |
+| `IntentsGuildVoiceStates` | 1<<7 | No |
+| `IntentsDirectMessages` | 1<<12 | No |
+
+Privileged intents require explicit enablement in the Discord Developer Portal under your application's Bot settings. Requesting them without portal approval causes the gateway connection to fail.
+
+---
+
+## arikawa Package Architecture
+
+arikawa is organized into focused packages. Understanding the boundaries helps you import only what you need.
+
+```
+github.com/diamondburned/arikawa/v3/
+├── api/          REST API client — all HTTP calls to Discord
+├── gateway/      Gateway client — WebSocket connection and event dispatch
+├── session/      Combines api + gateway into a usable bot session
+├── state/        In-memory cache built on top of session
+├── voice/        Voice gateway and UDP audio transport
+├── discord/      Types — all Discord objects, typed Snowflakes
+├── utils/
+│   ├── json/     JSON helpers
+│   ├── ws/       WebSocket abstraction
+│   └── httputil/ HTTP client utilities
+└── app/
+    └── cmdroute/ Slash command router with middleware
+```
+
+**Typical import pattern for a full bot:**
+
+```go
+import (
+    "github.com/diamondburned/arikawa/v3/state"
+    "github.com/diamondburned/arikawa/v3/discord"
+    "github.com/diamondburned/arikawa/v3/app/cmdroute"
+    "github.com/diamondburned/arikawa/v3/api"
+)
+```
+
+Use `state.New` rather than `session.New` for most bots — the state package wraps session and adds the in-memory cache. Use `session.New` only when you are providing your own state backend.
+
+The `discord` package is the type layer. `discord.ChannelID`, `discord.UserID`, `discord.GuildID`, `discord.RoleID`, and `discord.MessageID` are distinct types backed by `uint64`. They do not convert implicitly, which is the point.
+
+`cmdroute.Router` handles slash command dispatch:
+
+```go
+r := cmdroute.NewRouter()
+r.Use(cmdroute.Deferrable(state, cmdroute.DeferOpts{}))
+r.AddFunc("ping", handlePing)
+r.Sub("admin", func(r *cmdroute.Router) {
+    r.AddFunc("ban", handleBan)
+})
+state.AddInteractionHandler(r)
+```
+
+---
+
+## disgo Module Architecture
+
+disgo separates concerns into distinct top-level packages within the module:
+
+```
+github.com/disgoorg/disgo/
+├── bot/          Bot client — entry point, combines all modules
+├── discord/      Types — all Discord v10 objects
+├── rest/         REST API client
+├── gateway/      Gateway client and shard manager
+├── sharding/     Multi-shard manager
+├── voice/        Voice gateway and UDP transport
+├── handler/      Interaction routing (Mux, middleware)
+└── cache/        In-memory cache with configurable policies
+```
+
+**Entry point:**
+
+```go
+import "github.com/disgoorg/disgo/bot"
+
+client, err := disgo.New(token,
+    bot.WithGatewayConfigOpts(
+        gateway.WithIntents(gateway.IntentGuilds, gateway.IntentGuildMessages),
+    ),
+    bot.WithCacheConfigOpts(
+        cache.WithCaches(cache.FlagGuilds, cache.FlagChannels),
+    ),
+)
+```
+
+The `handler.Mux` routes interactions by command name or component custom ID:
+
+```go
+mux := handler.New()
+mux.Command("/ping", handlePing)
+mux.Component("/ticket/{id}/close", handleTicketClose)
+mux.Autocomplete("/search", handleSearchAutocomplete)
+client.AddEventListeners(mux)
+```
+
+Variable segments in component custom IDs (`{id}`) are extracted and available in the handler context, eliminating the manual `strings.Split` parsing that other libraries require.
+
+---
+
+## Common Companion Packages
+
+These packages appear consistently across production Go Discord bots regardless of which Discord library is used.
+
+| Category | Package | Notes |
+|----------|---------|-------|
+| Structured logging | `go.uber.org/zap` | Used by YAGPDB, ops-bot-iii; fast, structured |
+| Structured logging | `github.com/rs/zerolog` | Zero-allocation; common in smaller bots |
+| Configuration | `github.com/spf13/viper` | YAML/env/flags; hot-reload via fsnotify |
+| Configuration | `github.com/joho/godotenv` | `.env` file loading for local dev |
+| PostgreSQL | `github.com/jackc/pgx/v5` | Preferred over `database/sql` for Postgres |
+| PostgreSQL ORM | `github.com/volatiletech/sqlboiler` | Code-generated from schema; used by YAGPDB |
+| Type-safe ORM | `entgo.io/ent` | Code-generated graph ORM; used by ops-bot-iii |
+| Redis | `github.com/mediocregopher/radix/v4` | Used by YAGPDB for caching and pub/sub |
+| SQLite | `github.com/mattn/go-sqlite3` | CGo; or `modernc.org/sqlite` for pure Go |
+| Testing | `github.com/stretchr/testify` | Assert/require; standard across all bots |
+| Metrics | `github.com/prometheus/client_golang` | Prometheus metrics; used by YAGPDB |
+| APM | `gopkg.in/DataDog/dd-trace-go.v1` | DataDog tracing; used by ops-bot-iii |
+| Opus encoding | `github.com/jonas747/dca` | Opus encoding for discordgo voice |
+| Voice pipeline | `github.com/bwmarrin/dgvoice` | ffmpeg pipeline for discordgo |
+
+---
+
+## Migration Notes
+
+### discordgo → arikawa
+
+The conceptual shift is from a single `*Session` to composed packages. The `state.State` type is the closest equivalent to `discordgo.Session`.
+
+| discordgo | arikawa equivalent |
+|-----------|-------------------|
+| `discordgo.New(token)` | `state.New("Bot " + token)` |
+| `s.AddHandler(fn)` | `s.AddHandler(fn)` (same pattern) |
+| `s.Open()` | `s.Connect(ctx)` |
+| `s.Close()` | `s.Close()` |
+| `s.ChannelMessage(cID, mID)` | `s.Message(channelID, messageID)` |
+| `s.GuildRoles(gID)` | `s.Roles(guildID)` |
+| `i.ApplicationCommandData().Name` | `e.Data.Name` (typed) |
+| `i.ApplicationCommandData().Options` | `e.Data.Options` (unmarshal to struct) |
+| `string` channel/user IDs | `discord.ChannelID`, `discord.UserID` |
+
+The largest migration effort is converting bare string IDs to typed Snowflakes. This is mechanical but touches every database query, every REST call, and every event handler that reads IDs.
+
+Event handler signatures change. discordgo uses `func(s *discordgo.Session, e *discordgo.MessageCreate)`. arikawa uses `func(*gateway.MessageCreateEvent)` — the session is not passed; use a closure to capture it.
+
+### discordgo → disgo
+
+disgo's `bot.Client` replaces `discordgo.Session`. The gateway intent system uses the same bit values but different constant names.
+
+| discordgo | disgo equivalent |
+|-----------|-----------------|
+| `discordgo.New(token)` | `disgo.New(token, ...)` |
+| `s.Identify.Intents = ...` | `gateway.WithIntents(...)` option |
+| `s.AddHandler(fn)` | `client.AddEventListeners(fn)` |
+| `s.Open()` | `client.OpenGateway(ctx)` |
+| `s.Close()` | `client.Close(ctx)` |
+| Manual custom ID parsing | `mux.Component("/path/{var}", fn)` |
+| `s.ApplicationCommandCreate(...)` | `client.Rest().CreateApplicationCommand(...)` |
+
+The interaction routing model changes substantially. discordgo bots typically use a map dispatch pattern (`commandHandlers[name](s, i)`). disgo bots use the `handler.Mux` with path-based routing. Rewriting the interaction layer is the bulk of the migration work.
+
+---
+
+## disgord Is Archived
+
+`github.com/andersfylling/disgord` has not received meaningful updates in over a year and is effectively unmaintained. The repository is archived. Do not start new projects with disgord. If you are maintaining an existing disgord bot, plan a migration to discordgo, arikawa, or disgo. The API surface is different enough from all three that migration requires a rewrite of the bot layer, not a find-and-replace.

--- a/skills/go-discord-bot/references/project-setup.md
+++ b/skills/go-discord-bot/references/project-setup.md
@@ -1,0 +1,415 @@
+# Project Setup and Structure
+
+Sources: discordgo examples, YAGPDB architecture, CJ bot, ops-bot-iii patterns, production bot analysis (2026)
+
+## Project Structure Patterns
+
+### Simple Bot (single main.go + packages)
+
+Use for bots with fewer than ~10 commands and no external services.
+
+```
+mybot/
+├── main.go          # session setup, graceful shutdown
+├── commands.go      # command definitions and handlers
+├── handlers.go      # event handlers (Ready, GuildCreate, etc.)
+├── config.go        # config struct and loader
+├── go.mod
+└── .env
+```
+
+All code lives in `package main`. `main.go` owns the session lifecycle. `commands.go` holds the command map and handler functions.
+
+### Production Bot (cmd/internal layout)
+
+Use when the bot has a database, multiple subsystems, or multiple developers.
+
+```
+mybot/
+├── cmd/
+│   └── bot/
+│       └── main.go          # thin entry point: load config, wire deps, run
+├── internal/
+│   ├── bot/
+│   │   └── bot.go           # Bot struct, Start/Stop, handler registration
+│   ├── commands/
+│   │   ├── general.go
+│   │   ├── moderation.go
+│   │   └── registry.go      # command map, bulk registration
+│   ├── handlers/
+│   │   └── events.go
+│   ├── database/
+│   │   └── db.go
+│   └── config/
+│       └── config.go
+├── migrations/
+├── go.mod
+└── .env
+```
+
+`cmd/bot/main.go` is intentionally thin — load config, construct dependencies, call `bot.Start()`. The `internal/` boundary prevents external packages from importing bot internals.
+
+### Plugin-Based Bot (YAGPDB-style)
+
+Use for large bots where features must be independently toggled. Each plugin implements a `Plugin` interface and registers itself via `init()`. `main.go` imports plugin packages for side effects only.
+
+```
+mybot/
+├── cmd/bot/main.go          # imports plugins to trigger init()
+├── bot/bot.go               # core session, plugin registry
+├── common/plugin.go         # Plugin interface: BotInitHandler, BotStopperHandler
+└── plugins/
+    ├── moderation/
+    ├── music/
+    └── logging/
+```
+
+Prefer `cmd/internal` until you have 5+ independent feature areas.
+
+## main.go Bootstrapping
+
+### Minimal Example (complete working bot in ~40 lines)
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func main() {
+	token := os.Getenv("DISCORD_TOKEN")
+	if token == "" {
+		fmt.Fprintln(os.Stderr, "DISCORD_TOKEN not set")
+		os.Exit(1)
+	}
+
+	s, err := discordgo.New("Bot " + token)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "creating session: %v\n", err)
+		os.Exit(1)
+	}
+
+	s.Identify.Intents = discordgo.IntentsGuilds | discordgo.IntentsGuildMessages
+
+	s.AddHandler(func(s *discordgo.Session, r *discordgo.Ready) {
+		fmt.Printf("Logged in as %s\n", r.User.String())
+	})
+
+	s.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+		if i.ApplicationCommandData().Name == "ping" {
+			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{Content: "Pong!"},
+			})
+		}
+	})
+
+	if err = s.Open(); err != nil {
+		fmt.Fprintf(os.Stderr, "opening connection: %v\n", err)
+		os.Exit(1)
+	}
+	defer s.Close()
+
+	s.ApplicationCommandCreate(s.State.User.ID, "", &discordgo.ApplicationCommand{
+		Name: "ping", Description: "Responds with Pong!",
+	})
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+	<-stop
+}
+```
+
+Note the `"Bot "` prefix on the token — discordgo requires it. Call `s.Open()` before registering commands so `s.State.User.ID` is populated.
+
+### Production Example (with config, logging, graceful shutdown)
+
+```go
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/joho/godotenv"
+	"mybot/internal/bot"
+	"mybot/internal/config"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+
+	if err := godotenv.Load(); err != nil {
+		slog.Info("no .env file, using environment variables")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		slog.Error("loading config", "error", err)
+		os.Exit(1)
+	}
+
+	b, err := bot.New(cfg, logger)
+	if err != nil {
+		slog.Error("creating bot", "error", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	if err := b.Start(ctx); err != nil {
+		slog.Error("starting bot", "error", err)
+		os.Exit(1)
+	}
+
+	<-ctx.Done()
+	slog.Info("shutdown signal received")
+	b.Stop()
+}
+```
+
+`signal.NotifyContext` (Go 1.16+) is cleaner than the manual channel pattern. `b.Start(ctx)` opens the session and registers commands. `b.Stop()` deregisters guild commands and closes the session.
+
+## go.mod Setup
+
+```bash
+go mod init github.com/yourname/mybot
+go get github.com/bwmarrin/discordgo@latest
+go get github.com/joho/godotenv@latest
+```
+
+```
+module github.com/yourname/mybot
+
+go 1.22
+
+require (
+    github.com/bwmarrin/discordgo v0.28.1
+    github.com/joho/godotenv v1.5.1
+    github.com/spf13/viper v1.19.0       // optional: YAML config + hot-reload
+    github.com/caarlos0/env/v11 v11.2.2  // optional: struct tag env parsing
+)
+```
+
+Pin discordgo to a specific version in production. The library does not follow strict semver and breaking changes occasionally appear in minor releases.
+
+## Configuration Management
+
+### Environment Variables (os.Getenv, caarlos0/env)
+
+For structured config with validation, use `caarlos0/env`:
+
+```go
+type Config struct {
+    Token       string `env:"DISCORD_TOKEN,required"`
+    GuildID     string `env:"DISCORD_GUILD_ID"`           // empty = global commands
+    DatabaseURL string `env:"DATABASE_URL,required"`
+    LogLevel    string `env:"LOG_LEVEL"    envDefault:"info"`
+}
+
+func Load() (*Config, error) {
+    cfg := &Config{}
+    if err := env.Parse(cfg); err != nil {
+        return nil, fmt.Errorf("parsing config: %w", err)
+    }
+    return cfg, nil
+}
+```
+
+The `required` tag causes `env.Parse` to return an error if the variable is unset, surfacing misconfiguration at startup.
+
+### Viper Config (YAML + hot-reload pattern from ops-bot-iii)
+
+ops-bot-iii uses Viper with fsnotify to reload configuration without restarting the bot — useful for feature flags and rate limits.
+
+```go
+viper.SetConfigName("config")
+viper.SetConfigType("yaml")
+viper.AddConfigPath(".")
+viper.AutomaticEnv() // env vars override YAML values
+viper.ReadInConfig()
+
+viper.OnConfigChange(func(e fsnotify.Event) {
+    slog.Info("config reloaded", "file", e.Name)
+})
+viper.WatchConfig()
+```
+
+### Config Struct Pattern
+
+Expose configuration as a typed struct regardless of the loading mechanism:
+
+```go
+type Config struct {
+    Discord  DiscordConfig
+    Database DatabaseConfig
+    Features FeatureFlags
+}
+
+type DiscordConfig struct {
+    Token   string
+    GuildID string // empty = global command registration
+    AppID   string // populated from session after Open()
+}
+```
+
+Pass `*Config` into the `Bot` struct constructor. Avoid global config variables — they make testing difficult and obscure dependencies.
+
+## .env Handling (godotenv)
+
+```bash
+# .env — never commit this file
+DISCORD_TOKEN=Bot_your_token_here
+DISCORD_GUILD_ID=123456789012345678
+DATABASE_URL=postgres://localhost/mybot_dev?sslmode=disable
+LOG_LEVEL=debug
+```
+
+`godotenv.Load()` does not overwrite variables already set in the environment, so production deployments that inject secrets via the environment work without modification.
+
+Commit a `.env.example` with placeholder values to document required variables.
+
+## .gitignore Template
+
+```gitignore
+.env
+*.env
+config.local.yaml
+/mybot
+/bin/
+*.test
+*.out
+.idea/
+.vscode/
+.DS_Store
+```
+
+## Bot Struct Pattern (dependency injection)
+
+The `Bot` struct is the central dependency container. Inject all external dependencies through the constructor.
+
+```go
+type Bot struct {
+    session  *discordgo.Session
+    db       *database.DB
+    cfg      *config.Config
+    logger   *slog.Logger
+    commands []*discordgo.ApplicationCommand // track for cleanup
+}
+
+func New(cfg *config.Config, db *database.DB, logger *slog.Logger) (*Bot, error) {
+    s, err := discordgo.New("Bot " + cfg.Discord.Token)
+    if err != nil {
+        return nil, fmt.Errorf("creating session: %w", err)
+    }
+    s.Identify.Intents = discordgo.IntentsGuilds |
+        discordgo.IntentsGuildMessages |
+        discordgo.IntentsGuildMembers
+
+    b := &Bot{session: s, db: db, cfg: cfg, logger: logger}
+    b.session.AddHandler(b.onReady)
+    b.session.AddHandler(b.onInteractionCreate)
+    return b, nil
+}
+
+func (b *Bot) onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    switch i.Type {
+    case discordgo.InteractionApplicationCommand:
+        b.handleCommand(s, i)
+    case discordgo.InteractionMessageComponent:
+        b.handleComponent(s, i)
+    case discordgo.InteractionModalSubmit:
+        b.handleModal(s, i)
+    }
+}
+```
+
+Handler methods on `Bot` access all injected dependencies without global state.
+
+## Command Registration Strategies
+
+### Guild Commands (instant, for development)
+
+Guild commands appear immediately and are only visible in the specified guild. Use during development to avoid propagation delay.
+
+```go
+registered, err := b.session.ApplicationCommandCreate(
+    b.cfg.Discord.AppID,
+    b.cfg.Discord.GuildID, // dev server ID
+    cmd,
+)
+```
+
+Delete guild commands on shutdown to keep the command list clean:
+
+```go
+func (b *Bot) deregisterCommands() {
+    for _, cmd := range b.commands {
+        b.session.ApplicationCommandDelete(b.cfg.Discord.AppID, b.cfg.Discord.GuildID, cmd.ID)
+    }
+}
+```
+
+### Global Commands (up to 1hr propagation, for production)
+
+Pass an empty string as the guild ID for global registration:
+
+```go
+registered, err := b.session.ApplicationCommandCreate(b.cfg.Discord.AppID, "", cmd)
+```
+
+Discord caches global commands for up to one hour. Do not delete and re-register global commands on every restart — this wastes API quota and causes commands to disappear temporarily. Register global commands once during deployment, not at runtime.
+
+Switch between guild and global registration via config: set `GuildID` to your dev server in development, leave it empty in production.
+
+### ApplicationCommandBulkOverwrite (atomic, recommended)
+
+`ApplicationCommandBulkOverwrite` replaces all commands in a single API call. It is atomic — the old set is replaced by the new set with no intermediate state. CJ bot uses this pattern for reliable deployments.
+
+```go
+func (b *Bot) registerCommands() error {
+    registered, err := b.session.ApplicationCommandBulkOverwrite(
+        b.cfg.Discord.AppID,
+        b.cfg.Discord.GuildID, // empty for global
+        commandDefinitions,
+    )
+    if err != nil {
+        return fmt.Errorf("bulk registering commands: %w", err)
+    }
+    b.commands = registered
+    b.logger.Info("commands registered", "count", len(registered))
+    return nil
+}
+```
+
+Prefer `BulkOverwrite` over individual `ApplicationCommandCreate` calls in all cases. It handles additions, updates, and deletions in one round trip and avoids partial registration failures.
+
+For global commands in production, run `BulkOverwrite` once during deployment via a separate `cmd/register/main.go` binary rather than on every bot startup:
+
+```go
+// cmd/register/main.go — run once during deployment, not on every start
+func main() {
+    godotenv.Load()
+    s, _ := discordgo.New("Bot " + os.Getenv("DISCORD_TOKEN"))
+    s.Open()
+    defer s.Close()
+
+    registered, err := s.ApplicationCommandBulkOverwrite(s.State.User.ID, "", commands.Definitions)
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "registering commands: %v\n", err)
+        os.Exit(1)
+    }
+    fmt.Printf("registered %d commands\n", len(registered))
+}
+```

--- a/skills/go-discord-bot/references/state-and-database.md
+++ b/skills/go-discord-bot/references/state-and-database.md
@@ -1,0 +1,420 @@
+# State and Database
+
+Sources: discordgo v0.29.0 docs, YAGPDB architecture, automuteus patterns, ops-bot-iii (entgo), SD bot (repositories), production bot analysis (2026)
+
+## The Bot Struct Pattern
+
+Handlers registered with `discordgo.AddHandler` receive only `*discordgo.Session` and the event. To access databases, caches, loggers, or config, close over a struct that holds all dependencies — the universal pattern across every production Go Discord bot.
+
+### Basic Bot Struct (Session, Config)
+
+For simple bots, two fields suffice: `session *discordgo.Session` and `config *Config`. Register handlers as methods on the struct so the config is accessible via the receiver.
+
+### Production Bot Struct (Session, DB Pool, Redis, Logger, Config)
+
+```go
+type Bot struct {
+    session  *discordgo.Session
+    db       *pgxpool.Pool
+    redis    *redis.Client
+    log      *slog.Logger
+    config   *Config
+    cache    *cache.Cache   // go-cache for in-memory TTL
+    mu       sync.RWMutex  // guards mutable fields below
+    guilds   map[string]*GuildState
+    commands map[string]CommandHandler
+    queue    chan *WorkItem // buffered work queue (SD bot pattern)
+}
+```
+
+Fields set once at startup (session, db, redis, log, config) need no lock. `mu` guards only fields written after construction.
+
+### Dependency Injection via Constructor
+
+```go
+func New(cfg *Config, log *slog.Logger) (*Bot, error) {
+    s, err := discordgo.New("Bot " + cfg.Token)
+    if err != nil { return nil, fmt.Errorf("create session: %w", err) }
+    pool, err := NewPool(context.Background(), cfg.DatabaseURL)
+    if err != nil { return nil, err }
+    rdb := redis.NewClient(&redis.Options{Addr: cfg.RedisAddr})
+    if err := rdb.Ping(context.Background()).Err(); err != nil {
+        return nil, fmt.Errorf("ping redis: %w", err)
+    }
+    b := &Bot{
+        session: s, db: pool, redis: rdb, log: log, config: cfg,
+        cache: cache.New(5*time.Minute, 10*time.Minute),
+        guilds: make(map[string]*GuildState),
+        commands: registerCommands(),
+        queue: make(chan *WorkItem, 50),
+    }
+    s.AddHandler(b.onInteractionCreate)
+    s.AddHandler(b.onGuildCreate)
+    s.Identify.Intents = discordgo.IntentsGuilds | discordgo.IntentsGuildMessages
+    return b, nil
+}
+```
+
+### Accessing State in Handlers
+
+Register methods, not standalone functions. The method receiver carries all dependencies without globals.
+
+```go
+func (b *Bot) onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    if i.Type != discordgo.InteractionApplicationCommand {
+        return
+    }
+    handler, ok := b.commands[i.ApplicationCommandData().Name]
+    if !ok { return }
+    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+    defer cancel()
+    if err := handler(ctx, s, i); err != nil {
+        b.log.Error("command error", "err", err)
+    }
+}
+```
+
+## Database Integration
+
+### database/sql + pgx (PostgreSQL)
+
+Use `pgx/v5` as the driver with the standard `database/sql` interface for portability across ORMs and tools. For direct pgx usage without `database/sql`, use `pgxpool` (see Connection Pool Setup).
+
+```go
+import _ "github.com/jackc/pgx/v5/stdlib"
+
+db, err := sql.Open("pgx", os.Getenv("DATABASE_URL"))
+db.SetMaxOpenConns(25)
+db.SetMaxIdleConns(5)
+db.SetConnMaxLifetime(5 * time.Minute)
+```
+
+### sqlx (Named Queries, Struct Scanning)
+
+`sqlx` wraps `database/sql` and adds struct scanning and named parameters — the lightest upgrade from raw SQL.
+
+```go
+type GuildConfig struct {
+    GuildID string `db:"guild_id"`
+    Prefix  string `db:"prefix"`
+    Enabled bool   `db:"enabled"`
+}
+
+// GetContext scans a single row into a struct
+var cfg GuildConfig
+err := b.sqlx.GetContext(ctx, &cfg,
+    `SELECT guild_id, prefix, enabled FROM guild_configs WHERE guild_id = $1`, guildID)
+if errors.Is(err, sql.ErrNoRows) {
+    return nil, ErrNotFound
+}
+
+// NamedExecContext maps struct fields to :param placeholders
+_, err = b.sqlx.NamedExecContext(ctx, `
+    INSERT INTO guild_configs (guild_id, prefix, enabled)
+    VALUES (:guild_id, :prefix, :enabled)
+    ON CONFLICT (guild_id) DO UPDATE SET prefix = EXCLUDED.prefix
+`, cfg)
+```
+
+### GORM (Full ORM)
+
+GORM suits bots that want ActiveRecord-style queries. Avoid `AutoMigrate` in production; use golang-migrate instead.
+
+```go
+type Warning struct {
+    gorm.Model
+    GuildID string `gorm:"index;not null"`
+    UserID  string `gorm:"index;not null"`
+    Reason  string
+}
+
+db, _ := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+var warnings []Warning
+db.WithContext(ctx).Where("guild_id = ? AND user_id = ?", guildID, userID).Find(&warnings)
+```
+
+### entgo (Code-Generated Type-Safe ORM — ops-bot-iii Pattern)
+
+`ent` generates a full type-safe client from schema definitions. ops-bot-iii uses this for compile-time query safety. Define fields in `ent/schema/`, run `go generate ./ent/...`, then store the generated client on the Bot struct as `b.ent`.
+
+```go
+warnings, err := b.ent.Warning.
+    Query().
+    Where(warning.GuildID(guildID), warning.UserID(userID)).
+    All(ctx)
+```
+
+### sqlboiler (Code-Gen ORM — YAGPDB Pattern)
+
+YAGPDB generates models from an existing database schema. The workflow is schema-first: write migrations, then regenerate with `sqlboiler psql --output internal/models`. Zero-reflection queries; the schema is the source of truth.
+
+```go
+guilds, err := models.Guilds(
+    models.GuildWhere.OwnerID.EQ(userID),
+    qm.Limit(10),
+).All(ctx, db)
+```
+
+### SQLite for Prototypes
+
+For single-server bots or local development, `modernc.org/sqlite` (pure Go, no CGO) is the simplest option. Enable WAL mode for concurrent reads; switch to PostgreSQL before deploying to multiple servers.
+
+```go
+import _ "modernc.org/sqlite"
+db, err := sql.Open("sqlite", "bot.db?_journal=WAL&_timeout=5000")
+```
+
+## Connection Pool Setup (pgxpool)
+
+`pgxpool` handles connection lifecycle, health checks, and context cancellation. Close on shutdown: `defer b.db.Close()`.
+
+```go
+func NewPool(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
+    cfg, err := pgxpool.ParseConfig(dsn)
+    if err != nil { return nil, fmt.Errorf("parse dsn: %w", err) }
+    cfg.MaxConns = 20
+    cfg.MinConns = 2
+    cfg.MaxConnLifetime = 30 * time.Minute
+    cfg.MaxConnIdleTime = 5 * time.Minute
+    cfg.ConnConfig.ConnectTimeout = 5 * time.Second
+    pool, err := pgxpool.NewWithConfig(ctx, cfg)
+    if err != nil { return nil, fmt.Errorf("create pool: %w", err) }
+    pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+    defer cancel()
+    return pool, pool.Ping(pingCtx)
+}
+
+## Migration Patterns
+
+### golang-migrate
+
+Run migrations programmatically at startup. Name files `000001_create_guilds.up.sql` / `000001_create_guilds.down.sql`.
+
+```go
+m, err := migrate.New("file://migrations", dsn)
+if err != nil {
+    return err
+}
+if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+    return fmt.Errorf("migrate: %w", err)
+}
+```
+
+### Atlas
+
+Atlas provides schema diffing and declarative migrations. Define the target schema in HCL or SQL, generate migration files with `atlas migrate diff --env local`. Integrates with entgo via `entc.WithAtlas(true)`.
+
+## Redis Integration
+
+### go-redis for Caching and Session State
+
+```go
+rdb := redis.NewClient(&redis.Options{
+    Addr: cfg.RedisAddr, DialTimeout: 3 * time.Second, PoolSize: 10,
+})
+
+// Set with TTL
+data, _ := json.Marshal(cfg)
+b.redis.Set(ctx, "guild:"+cfg.GuildID+":config", data, 10*time.Minute)
+
+// Get with miss detection
+data, err := b.redis.Get(ctx, "guild:"+guildID+":config").Bytes()
+if errors.Is(err, redis.Nil) {
+    return nil, ErrCacheMiss
+}
+var cfg GuildConfig
+json.Unmarshal(data, &cfg)
+```
+
+### Distributed Locking (redislock)
+
+Prevent duplicate processing when multiple bot instances handle the same event. `redislock.ErrNotObtained` means another instance holds the lock — return nil and skip.
+
+```go
+locker := redislock.New(b.redis)
+
+lock, err := locker.Obtain(ctx, "lock:"+key, 30*time.Second, nil)
+if errors.Is(err, redislock.ErrNotObtained) {
+    return nil
+}
+defer lock.Release(ctx)
+```
+
+### Multi-Shard State via Redis
+
+When running multiple shards as separate processes (YAGPDB pattern), store shared state in Redis rather than in-process maps. Use `Incr` for atomic counters and `Publish`/`Subscribe` for cross-shard event fanout.
+
+## In-Memory State
+
+### sync.Map for Concurrent Collections
+
+`sync.Map` suits collections with many concurrent readers and infrequent writes, such as active voice connections or per-guild rate limiters. For frequent writes, a plain `map` protected by `sync.RWMutex` is faster.
+
+```go
+b.voiceConns.Store(guildID, vc)
+v, ok := b.voiceConns.Load(guildID)
+if ok {
+    vc := v.(*discordgo.VoiceConnection)
+    _ = vc
+}
+```
+
+### sync.RWMutex for Bot Struct Fields
+
+```go
+func (b *Bot) SetGuildState(guildID string, state *GuildState) {
+    b.mu.Lock(); defer b.mu.Unlock()
+    b.guilds[guildID] = state
+}
+func (b *Bot) GetGuildState(guildID string) (*GuildState, bool) {
+    b.mu.RLock(); defer b.mu.RUnlock()
+    return b.guilds[guildID], b.guilds[guildID] != nil
+}
+```
+
+Never hold a lock while calling discordgo API methods — those make HTTP requests and will block other goroutines.
+
+### go-cache for TTL-Based Caching
+
+`github.com/patrickmn/go-cache` provides an in-process cache with per-item TTL and background eviction. Use it as an L1 cache in front of Redis or the database. Init with `cache.New(defaultTTL, cleanupInterval)`.
+
+```go
+if v, found := b.cache.Get("guild:" + guildID); found {
+    return v.(*GuildConfig), nil
+}
+cfg, err := b.GetGuildConfig(ctx, guildID)
+if err == nil {
+    b.cache.Set("guild:"+guildID, cfg, cache.DefaultExpiration)
+}
+return cfg, err
+```
+
+## Background Goroutines
+
+All background goroutines follow the same pattern: receive a `context.Context`, select on `ctx.Done()` to exit, and use a ticker or channel for work. Call them after `session.Open()`.
+
+### Status Rotation
+
+```go
+func (b *Bot) startStatusRotation(ctx context.Context) {
+    statuses := []string{"with Go", "/help", "over 42 servers"}
+    ticker := time.NewTicker(30 * time.Second)
+    go func() {
+        defer ticker.Stop()
+        for i := 0; ; i++ {
+            select {
+            case <-ctx.Done():
+                return
+            case <-ticker.C:
+                b.session.UpdateGameStatus(0, statuses[i%len(statuses)])
+            }
+        }
+    }()
+}
+```
+
+### Periodic Cleanup Tasks
+
+Same ticker pattern as status rotation. Replace `UpdateGameStatus` with the cleanup call and set the interval to `1 * time.Hour`.
+
+### Scheduled Tasks with Auto-Restart (ops-bot-iii Pattern)
+
+ops-bot-iii wraps each scheduled task in a restart loop so a panic or error does not kill the goroutine permanently.
+
+```go
+func runWithRestart(ctx context.Context, log *slog.Logger, name string, fn func(context.Context) error) {
+    go func() {
+        for {
+            if err := fn(ctx); err != nil {
+                log.Error("task exited", "task", name, "err", err)
+            }
+            select {
+            case <-ctx.Done():
+                return
+            case <-time.After(5 * time.Second):
+            }
+        }
+    }()
+}
+
+runWithRestart(ctx, b.log, "cleanup", b.cleanupLoop)
+runWithRestart(ctx, b.log, "metrics", b.metricsLoop)
+```
+
+### Channel-Based Work Queues (SD Bot Pattern)
+
+The Stable Diffusion Discord bot uses a buffered channel so slow operations (image generation, LLM calls) are processed serially while the interaction handler returns immediately.
+
+```go
+// Worker goroutine — started once at bot startup
+func (b *Bot) startWorker(ctx context.Context) {
+    go func() {
+        for {
+            select {
+            case <-ctx.Done():
+                return
+            case item := <-b.queue:
+                b.processItem(item)
+            }
+        }
+    }()
+}
+
+// Handler — defers, enqueues, returns
+func (b *Bot) onGenerateCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+        Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+    })
+    select {
+    case b.queue <- &WorkItem{Interaction: i}:
+    default:
+        s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{Content: "Queue is full."})
+    }
+}
+```
+
+The `select` default case rejects overflow without blocking. Size the buffer to the maximum acceptable backlog.
+
+## Context Propagation
+
+### discordgo Has No Context (Workaround with Goroutine + Timeout)
+
+discordgo handlers receive no `context.Context`. Create a timeout context at the handler boundary and pass it into all downstream calls. For long-running operations, defer first, then do the work in a goroutine with its own context.
+
+```go
+// Short command — create context at handler boundary
+func (b *Bot) onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+    defer cancel()
+    cfg, _ := b.GetGuildConfigCached(ctx, i.GuildID) // ctx flows to db/redis
+    _ = cfg
+}
+
+// Slow command — defer, then goroutine with its own context
+func (b *Bot) handleSlowCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+    s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+        Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+    })
+    go func() {
+        ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+        defer cancel()
+        result, err := b.doSlowWork(ctx)
+        if err != nil {
+            result = "Something went wrong."
+        }
+        s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{Content: result})
+    }()
+}
+```
+
+### arikawa Is Context-First
+
+If context propagation is a hard requirement, arikawa passes `context.Context` through its entire API surface — every handler, REST call, and state query accepts a context. No workaround needed.
+
+```go
+func (b *Bot) onMessage(ctx context.Context, e *gateway.MessageCreateEvent) {
+    cfg, _ := b.db.GetGuildConfig(ctx, e.GuildID.String()) // ctx flows naturally
+    _ = cfg
+}
+```
+Choose arikawa when building bots that require strict timeout budgets or OpenTelemetry tracing across all operations.

--- a/skills/go-discord-bot/references/voice-and-audio.md
+++ b/skills/go-discord-bot/references/voice-and-audio.md
@@ -1,0 +1,380 @@
+# Voice and Audio
+
+Sources: discordgo v0.29.0 voice docs, dgvoice helper library, dca encoding tool, arikawa v3 voice package, Discord voice API reference (2026)
+
+## Voice Support Overview
+
+Discord voice uses a separate UDP connection alongside the WebSocket gateway. The bot joins a voice channel, negotiates an encryption key, and streams Opus-encoded audio frames over UDP.
+
+### Library Voice Capabilities
+
+| Feature | discordgo | arikawa | disgo |
+|---|---|---|---|
+| Voice protocol | v1 (XSalsa20) | v4 (AES-GCM) | v4 (AES-GCM) |
+| Send audio | Yes | Yes | Yes |
+| Receive audio | Yes (unofficial) | Yes (unofficial) | Limited |
+| Helper libraries | dgvoice, dca | Built-in | Built-in |
+| Context support | No | Yes | Yes |
+
+discordgo uses the older v1 voice protocol (XSalsa20). arikawa and disgo implement v4 (AES-GCM). Both work with current Discord infrastructure; v4 is the forward-looking standard.
+
+## discordgo Voice
+
+### Required Intent
+
+Register `IntentGuildVoiceStates` before opening the session. Without it, the gateway does not deliver `VoiceStateUpdate` events and voice channel joins fail silently. This intent is not included in `IntentsAllWithoutPrivileged`, so add it explicitly.
+
+```go
+s.Identify.Intents = discordgo.IntentsGuilds |
+    discordgo.IntentGuildVoiceStates |
+    discordgo.IntentsGuildMessages
+```
+
+### VoiceConnection Struct
+
+`*discordgo.VoiceConnection` is the handle returned by `ChannelVoiceJoin`. The two key exported channels are `OpusSend chan []byte` (write Opus frames to play audio) and `OpusRecv chan *Packet` (read incoming Opus frames). `OpusSend` is buffered (capacity 2) — sending faster than real-time causes frames to drop. `OpusRecv` is nil when `deaf=true`.
+
+### Joining a Voice Channel
+
+```go
+// mute=false, deaf=true disables receive; set deaf=false to receive audio
+vc, err := s.ChannelVoiceJoin(guildID, channelID, false, true)
+if err != nil {
+    return fmt.Errorf("join voice: %w", err)
+}
+```
+
+`ChannelVoiceJoin` blocks until the connection is ready. It stores the connection in `s.VoiceConnections[guildID]`, so only one voice connection per guild is possible.
+
+### Leaving a Voice Channel
+
+Call `vc.Disconnect()` to send the leave payload, close the UDP connection, and remove the entry from `s.VoiceConnections`. Defer it immediately after a successful join.
+
+## Sending Audio
+
+### Opus Frame Format
+
+Discord requires Opus at 48,000 Hz, stereo, 20 ms per frame (960 samples per channel). Each value sent to `OpusSend` must be exactly one 20 ms Opus packet.
+
+### Speaking State
+
+Signal speaking state before sending frames and clear it after:
+
+```go
+vc.Speaking(true)
+// ... send frames ...
+vc.Speaking(false)
+```
+
+Omitting `Speaking(true)` makes audio inaudible. Omitting `Speaking(false)` leaves the voice indicator active in the Discord UI.
+
+### Direct Opus Send
+
+```go
+for _, frame := range opusFrames {
+    vc.OpusSend <- frame
+}
+```
+
+Use this when you already have Opus-encoded data (e.g., from a `.dca` file).
+
+### Using dgvoice Helper
+
+`github.com/bwmarrin/dgvoice` wraps ffmpeg into a convenience function:
+
+```go
+stop := make(chan bool)
+dgvoice.PlayAudioFile(vc, "audio.mp3", stop)
+// send on stop to interrupt playback
+```
+
+dgvoice spawns ffmpeg, pipes PCM through an Opus encoder, writes frames to `OpusSend`, and handles `Speaking` state internally.
+
+### Using dca
+
+`github.com/jonas747/dca` provides Discord-optimized encoding and a streaming API. It also reads pre-encoded `.dca` files, skipping encoding and reducing CPU usage:
+
+```go
+opts := dca.StdEncodeOptions
+opts.RawOutput = true
+opts.Bitrate = 96
+enc, err := dca.EncodeFile("audio.mp3", opts)
+if err != nil { return err }
+defer enc.Cleanup()
+done := make(chan error)
+dca.NewStream(enc, vc, done)
+if err := <-done; err != nil && err != io.EOF {
+    return fmt.Errorf("stream: %w", err)
+}
+```
+
+### Playing Audio Files
+
+Combine join, encode, and stream:
+
+```go
+func playFile(s *discordgo.Session, guildID, channelID, filePath string) error {
+    vc, err := s.ChannelVoiceJoin(guildID, channelID, false, true)
+    if err != nil { return fmt.Errorf("join: %w", err) }
+    defer vc.Disconnect()
+    enc, err := dca.EncodeFile(filePath, dca.StdEncodeOptions)
+    if err != nil { return fmt.Errorf("encode: %w", err) }
+    defer enc.Cleanup()
+    done := make(chan error)
+    dca.NewStream(enc, vc, done)
+    if err := <-done; err != nil && err != io.EOF { return fmt.Errorf("stream: %w", err) }
+    return nil
+}
+```
+
+### Playing from URL/YouTube
+
+Use yt-dlp to extract a stream URL, then pass it to dca:
+
+```go
+out, err := exec.Command("yt-dlp", "-f", "bestaudio", "-g", url).Output()
+if err != nil {
+    return fmt.Errorf("yt-dlp: %w", err)
+}
+enc, err := dca.EncodeFile(strings.TrimSpace(string(out)), dca.StdEncodeOptions)
+// ... stream as above ...
+```
+
+yt-dlp must be installed on the host. The `-g` flag returns the direct stream URL without downloading. ffmpeg (called internally by dca) handles the HTTP stream.
+
+## Receiving Audio
+
+### OpusRecv Channel
+
+When `deaf=false`, incoming audio arrives on `vc.OpusRecv` as `*discordgo.Packet` values. Each packet carries `SSRC` (speaker identifier), `Sequence` (ordering), `Timestamp` (RTP), and `Opus` (raw frame bytes).
+
+```go
+go func() {
+    for p := range vc.OpusRecv {
+        processPacket(p) // p.SSRC, p.Opus, p.Sequence
+    }
+}()
+```
+
+### Mapping SSRC to Users
+
+Discord does not include user IDs in audio packets. Map SSRC values to users via `VoiceSpeakingUpdate` events:
+
+```go
+ssrcToUser := make(map[uint32]string)
+var mu sync.RWMutex
+s.AddHandler(func(vc *discordgo.VoiceConnection, vs *discordgo.VoiceSpeakingUpdate) {
+    mu.Lock(); ssrcToUser[uint32(vs.SSRC)] = vs.UserID; mu.Unlock()
+})
+```
+
+### Recording to File
+
+Write length-prefixed Opus frames to disk:
+
+```go
+for p := range vc.OpusRecv {
+    binary.Write(f, binary.LittleEndian, int16(len(p.Opus)))
+    f.Write(p.Opus)
+}
+// Decode later: ffmpeg -f s16le -ar 48000 -ac 2 -i recorded.raw output.mp3
+```
+
+### Voice Receive Limitations
+
+Voice receive is not officially supported by Discord or discordgo. Key constraints:
+
+- Packets arrive mixed from all speakers; separation requires per-SSRC buffering.
+- Silence packets (comfort noise) have `len(p.Opus) == 3`; filter them before decoding.
+- Packet loss and reordering are common; use `p.Sequence` to detect gaps.
+- Discord may change the voice protocol without notice, breaking receive.
+
+## arikawa Voice
+
+### voice.NewSession Setup
+
+```go
+s, _ := state.New("Bot " + token)
+vs, err := voice.NewSession(s)
+```
+
+arikawa uses v4 voice protocol with AES-GCM encryption.
+
+### JoinChannel with Context
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+defer cancel()
+if err := vs.JoinChannel(ctx, guildID, channelID, false, true); err != nil {
+    return fmt.Errorf("join: %w", err)
+}
+defer vs.Leave(context.Background())
+```
+
+Context propagation allows cancellation and timeout on the join handshake — an advantage over discordgo.
+
+### UDP Dialer Configuration
+
+Override the UDP dialer for custom network settings or timeouts:
+
+```go
+vs.SetUDPDialer(func(ctx context.Context, network, addr string) (net.Conn, error) {
+    return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, addr)
+})
+```
+
+### Streaming via ffmpeg
+
+```go
+ffmpeg := exec.CommandContext(ctx, "ffmpeg", "-i", filePath,
+    "-f", "s16le", "-ar", "48000", "-ac", "2", "pipe:1")
+stdout, _ := ffmpeg.StdoutPipe()
+ffmpeg.Start()
+
+enc, _ := opus.NewEncoder(48000, 2, opus.AppAudio)
+buf := make([]int16, 960*2)
+for {
+    if err := binary.Read(stdout, binary.LittleEndian, buf); err != nil { break }
+    frame, _ := enc.Encode(buf, 960, 960*2*2)
+    vs.WriteCtx(ctx, frame)
+}
+```
+
+## Queue Management
+
+### Simple Slice Queue
+
+A mutex-protected slice works for simple bots:
+
+```go
+type Queue struct{ mu sync.Mutex; items []string }
+func (q *Queue) Add(s string) { q.mu.Lock(); q.items = append(q.items, s); q.mu.Unlock() }
+func (q *Queue) Next() (string, bool) {
+    q.mu.Lock(); defer q.mu.Unlock()
+    if len(q.items) == 0 { return "", false }
+    s := q.items[0]; q.items = q.items[1:]; return s, true
+}
+```
+
+### Channel-Based Queue
+
+A channel-based queue decouples command handlers from the playback goroutine:
+
+```go
+type Player struct{ queue chan string; skip, stop chan struct{} }
+
+func (p *Player) Run(vc *discordgo.VoiceConnection) {
+    for {
+        select {
+        case url := <-p.queue: p.play(vc, url)
+        case <-p.stop: return
+        }
+    }
+}
+```
+
+### Skip, Stop, Pause, Resume
+
+```go
+func (p *Player) Skip() { select { case p.skip <- struct{}{}: default: } }
+func (p *Player) Stop() { close(p.stop) }
+
+var paused atomic.Bool // Pause/Resume: checked in the send loop
+
+func sendLoop(vc *discordgo.VoiceConnection, frames [][]byte, skip <-chan struct{}) {
+    for _, frame := range frames {
+        for paused.Load() { time.Sleep(20 * time.Millisecond) }
+        select {
+        case vc.OpusSend <- frame:
+        case <-skip: return
+        }
+    }
+}
+```
+
+## Audio Encoding
+
+### Opus Codec Requirements
+
+| Parameter | Value |
+|---|---|
+| Sample rate | 48,000 Hz |
+| Channels | 2 (stereo) |
+| Frame size | 960 samples (20 ms) |
+| Bitrate | 8–128 kbps (96 kbps recommended) |
+
+### ffmpeg Pipeline (PCM → Opus)
+
+Convert any audio format to raw PCM for Opus encoding: `ffmpeg -i input.mp3 -f s16le -ar 48000 -ac 2 pipe:1`. Flags: `-f s16le` (signed 16-bit PCM), `-ar 48000` (resample), `-ac 2` (stereo), `pipe:1` (stdout for piping).
+
+### gopus for Direct Encoding
+
+`github.com/hraban/opus` wraps libopus (requires `libopus-dev` or `brew install opus`):
+
+```go
+enc, _ := opus.NewEncoder(48000, 2, opus.AppAudio)
+enc.SetBitrate(96000)
+pcm := make([]int16, 960*2) // fill from ffmpeg stdout
+buf := make([]byte, 1000)
+n, _ := enc.Encode(pcm, buf)
+vc.OpusSend <- buf[:n]
+```
+
+## Common Voice Bot Patterns
+
+### Auto-Disconnect on Empty Channel
+
+```go
+s.AddHandler(func(s *discordgo.Session, vsu *discordgo.VoiceStateUpdate) {
+    vc, ok := s.VoiceConnections[vsu.GuildID]
+    if !ok { return }
+    guild, _ := s.State.Guild(vsu.GuildID)
+    count := 0
+    for _, vs := range guild.VoiceStates {
+        if vs.ChannelID == vc.ChannelID && vs.UserID != s.State.User.ID { count++ }
+    }
+    if count == 0 { vc.Disconnect() }
+})
+```
+
+### Volume Control
+
+Apply a gain multiplier to PCM samples before encoding. Clamp to int16 range to prevent overflow. `volume=1.0` is unity gain; `0.5` is half volume:
+
+```go
+func applyVolume(pcm []int16, volume float32) {
+    for i, s := range pcm {
+        v := float32(s) * volume
+        if v > 32767 { v = 32767 } else if v < -32768 { v = -32768 }
+        pcm[i] = int16(v)
+    }
+}
+```
+
+### Audio Mixing
+
+Sum PCM streams and clamp. Divide by stream count to avoid clipping when mixing more than two sources:
+
+```go
+func mixPCM(streams [][]int16) []int16 {
+    out := make([]int16, len(streams[0]))
+    for i := range out {
+        var sum int32
+        for _, s := range streams { sum += int32(s[i]) }
+        if sum > 32767 { sum = 32767 } else if sum < -32768 { sum = -32768 }
+        out[i] = int16(sum)
+    }
+    return out
+}
+```
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|---|---|---|
+| Sending frames without `Speaking(true)` | Audio is inaudible; Discord drops frames | Call `vc.Speaking(true)` before the first frame |
+| Not deferring `vc.Disconnect()` | Voice connection leaks; bot stays in channel | Defer `vc.Disconnect()` immediately after join |
+| Sending frames faster than real-time | `OpusSend` buffer fills, frames drop | Pace sends at 20 ms intervals or use dca's stream |
+| Ignoring `OpusSend` capacity | Goroutine blocks indefinitely on full channel | Use `select` with a `stop` channel |
+| Decoding audio in the send goroutine | CPU spike causes frame timing jitter | Decode ahead or use a separate encoder goroutine |
+| Reading `OpusRecv` with `deaf=true` | `OpusRecv` is nil; nil channel blocks forever | Set `deaf=false` when receive is needed |

--- a/skills/go-discord-bot/skills.json
+++ b/skills/go-discord-bot/skills.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/go-discord-bot",
+  "version": "1.0.0",
+  "description": "Build Discord bots in Go using discordgo, arikawa, or disgo. Covers library selection, project scaffolding, slash commands and handler patterns (map dispatch, interface-based, cmdroute), message components (buttons, select menus, modals), embeds, gateway intents, event handling, state management, database integration (pgx, sqlx, entgo, GORM), voice and audio (dgvoice, dca), goroutine safety, graceful shutdown, sharding, and deployment (Docker, systemd). Synthesizes discordgo v0.29.0 docs, arikawa v3 docs, disgo docs, Discord API reference (2026), and production patterns from YAGPDB, automuteus, CJ, and ken. Triggers: discord bot go, go discord, discordgo, arikawa, disgo, golang discord bot, slash command go, discord gateway go, discord intents go, discord voice go, discord music bot go, discord embed go, discord button go, discord modal go, discord select menu go, discord bot golang, dgvoice, discord sharding go, discord deployment go, discord bot docker go",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary
- New Tank skill for building Discord bots in Go (discordgo, arikawa, disgo)
- 8 reference files covering library selection, project setup, commands/interactions, components/modals, event handling, state/database, voice/audio, and deployment/ops
- Synthesized from discordgo v0.29.0 docs, production bot analysis (YAGPDB, automuteus, CJ, ken, ops-bot-iii), and Discord API reference

## Validation
- `quick_validate.py` passes with all checks green
- SKILL.md: 151 lines (limit 200), description 976 chars (limit 1024)
- All 8 references within 250-450 line bounds
- No YAML frontmatter in reference files
- 24 trigger phrases in description