### PR TITLE
fix(go-discord-bot): trim description to fit 500 char limit

### DIFF
--- a/skills/go-discord-bot/skills.json
+++ b/skills/go-discord-bot/skills.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/go-discord-bot",
   "version": "1.0.0",
-  "description": "Build Discord bots in Go using discordgo, arikawa, or disgo. Covers library selection, project scaffolding, slash commands and handler patterns (map dispatch, interface-based, cmdroute), message components (buttons, select menus, modals), embeds, gateway intents, event handling, state management, database integration (pgx, sqlx, entgo, GORM), voice and audio (dgvoice, dca), goroutine safety, graceful shutdown, sharding, and deployment (Docker, systemd). Synthesizes discordgo v0.29.0 docs, arikawa v3 docs, disgo docs, Discord API reference (2026), and production patterns from YAGPDB, automuteus, CJ, and ken. Triggers: discord bot go, go discord, discordgo, arikawa, disgo, golang discord bot, slash command go, discord gateway go, discord intents go, discord voice go, discord music bot go, discord embed go, discord button go, discord modal go, discord select menu go, discord bot golang, dgvoice, discord sharding go, discord deployment go, discord bot docker go",
+  "description": "Build Discord bots in Go with discordgo, arikawa, or disgo. Covers slash commands, handler patterns, components, embeds, intents, events, state, database (pgx, entgo), voice (dgvoice, dca), goroutine safety, sharding, deployment. Triggers: discord bot go, discordgo, arikawa, disgo, golang discord bot, slash command go, discord gateway go, discord voice go, discord embed go, discord button go, discord modal go, discord bot docker go, dgvoice, discord sharding go.",
   "permissions": {
     "network": {
       "outbound": []


### PR DESCRIPTION
Trims skills.json description from 971 to 466 chars to pass Tank publish validation (max 500).