### PR TITLE
feat(macos-cleanup): add macOS disk cleanup skill

### DIFF
--- a/skills/macos-cleanup/.tankignore
+++ b/skills/macos-cleanup/.tankignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.ruff_cache/
+.venv/

--- a/skills/macos-cleanup/SKILL.md
+++ b/skills/macos-cleanup/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: "@tank/macos-cleanup"
+description: |
+  macOS disk space recovery and system cleanup — a developer-focused
+  replacement for CCleaner. Analyzes disk usage, identifies space hogs
+  (caches, dev tool artifacts, stale dependencies, logs, Docker images),
+  and safely reclaims storage with risk-aware confirmation workflows.
+  Covers Xcode DerivedData/simulators, Homebrew, npm/yarn/pnpm/Bun caches,
+  pip/conda, Cargo/Rust targets, Go modules, Gradle, Docker (images +
+  build cache + VM disk), CocoaPods, JetBrains caches, VS Code caches,
+  browser caches, iOS backups, Time Machine snapshots, stale node_modules,
+  system logs, and large file discovery. Includes an analysis script that
+  scans all known targets and produces a prioritized cleanup report.
+
+  Trigger phrases: "disk cleanup", "free disk space", "clean up my mac",
+  "disk full", "running out of space", "storage full", "clear cache",
+  "clear caches", "delete caches", "clean caches", "clean storage",
+  "system cleanup", "mac cleanup", "ccleaner", "free up space",
+  "disk usage", "what's using space", "large files", "space hog",
+  "node_modules cleanup", "clean node_modules", "clean docker",
+  "docker disk space", "docker prune", "xcode cleanup", "DerivedData",
+  "brew cleanup", "npm cache", "pip cache", "cargo clean",
+  "clean dev tools", "reclaim space", "storage management",
+  "system data large", "other storage", "purge caches",
+  "Time Machine snapshots", "iOS backups", "stale dependencies"
+---
+
+# macOS Disk Cleanup
+
+Recover disk space on macOS by cleaning caches, dev tool artifacts, stale
+dependencies, logs, and other reclaimable storage. Developer-focused — knows
+where the real space hogs hide on a dev machine.
+
+## Core Philosophy
+
+1. **Analyze before deleting.** Always scan first. Show the user what's
+   consuming space and how much can be reclaimed before touching anything.
+2. **Risk-aware cleanup.** Categorize targets by risk (safe → low →
+   moderate → high). Clean safe items freely, require confirmation for
+   everything else.
+3. **Use built-in cleanup commands.** Prefer `brew cleanup`, `npm cache clean`,
+   `xcrun simctl delete unavailable` over raw `rm -rf`. Tools know their own
+   cleanup semantics better than we do.
+4. **Never touch user data.** Documents, Desktop, Pictures, credentials,
+   SSH keys, keychains, git repos — hands off. Always.
+5. **Report results.** After cleanup, show before/after disk space comparison.
+
+## Quick-Start
+
+### "My disk is full, help me clean up"
+
+| Step | Action |
+|------|--------|
+| 1 | Run `scripts/analyze-disk.sh` to scan all targets |
+| 2 | Review report — prioritize by size and risk |
+| 3 | Clean safe targets first (caches, logs, DerivedData) |
+| 4 | Present moderate targets for user confirmation |
+| 5 | Only mention high-risk targets if user asks |
+| 6 | Show before/after disk space comparison |
+
+### "Clean everything safe"
+
+Execute safe-tier cleanup in order:
+1. User caches (`rm -rf ~/Library/Caches/*`)
+2. User logs (`rm -rf ~/Library/Logs/*`)
+3. Xcode DerivedData (`rm -rf ~/Library/Developer/Xcode/DerivedData/*`)
+4. Simulator caches (`rm -rf ~/Library/Developer/CoreSimulator/Caches/*`)
+5. Homebrew (`brew cleanup --prune=all && brew autoremove`)
+6. npm/yarn/pip caches (`npm cache clean --force`, etc.)
+7. Diagnostic reports
+8. Saved Application State
+
+### "What's using all my space?"
+
+Run analysis only — no cleanup:
+```bash
+bash scripts/analyze-disk.sh
+```
+
+Or for machine-readable output:
+```bash
+bash scripts/analyze-disk.sh --json
+```
+
+## Cleanup Priority Order
+
+Targets ordered by typical space savings (highest ROI first):
+
+| Priority | Target | Typical Savings | Risk |
+|----------|--------|----------------|------|
+| 1 | Xcode DerivedData + simulators | 10-80 GB | Safe |
+| 2 | Docker images + build cache | 10-80 GB | Moderate |
+| 3 | Stale node_modules | 5-50 GB | Moderate |
+| 4 | Rust target/ directories | 5-50 GB | Moderate |
+| 5 | User caches (all apps) | 2-20 GB | Safe |
+| 6 | Homebrew cleanup | 1-8 GB | Safe |
+| 7 | Package manager caches | 3-15 GB | Safe |
+| 8 | Gradle/Maven caches | 3-13 GB | Safe |
+| 9 | iOS Device Support (old) | 2-30 GB | Low |
+| 10 | Trash | 0-50 GB | Moderate |
+| 11 | Logs & diagnostic reports | 0.5-5 GB | Safe |
+| 12 | iOS device backups | 5-100 GB | High |
+
+## Decision Trees
+
+### What to Clean Based on User Request
+
+| User Says | Action |
+|-----------|--------|
+| "Clean up my Mac" | Full scan → report → clean safe → confirm moderate |
+| "Clean caches" | User + system caches, browser caches, dev tool caches |
+| "Clean dev tools" | npm/pip/cargo/brew/xcode/docker/gradle caches only |
+| "What's using space?" | Analysis only, no cleanup |
+| "Clean Docker" | `docker system prune -a` (confirm first) |
+| "Clean Xcode" | DerivedData + simulators + old device support |
+| "Free up X GB" | Prioritized cleanup until target is reached |
+| "Clean everything" | Full cleanup including moderate-risk targets |
+
+### Docker Cleanup Levels
+
+| Level | Command | Cleans | Risk |
+|-------|---------|--------|------|
+| Light | `docker container prune && docker image prune` | Stopped containers + dangling images | Low |
+| Medium | `docker system prune -a` | All unused images + containers + networks | Moderate |
+| Heavy | `docker system prune -a --volumes` | Everything + volumes (data loss!) | High |
+
+Note: Docker Desktop's VM disk (`Docker.raw`) doesn't shrink after cleanup.
+To reclaim host disk space: Docker Desktop → Settings → Resources → reduce
+disk limit, or Troubleshoot → Clean/Purge Data.
+
+### Time Machine Local Snapshots
+
+If disk space wasn't freed after deletion, local TM snapshots may be holding
+references:
+```bash
+tmutil listlocalsnapshots /
+sudo tmutil deletelocalsnapshots <date>
+```
+
+## Safety Rules
+
+Never touch these paths:
+- `~/Documents`, `~/Desktop`, `~/Pictures`, `~/Music`, `~/Movies`
+- `~/Library/Keychains/`, `~/Library/Accounts/`
+- `~/.ssh/`, `~/.gnupg/`, `~/.aws/`, `~/.kube/`, `~/.config/gcloud/`
+- `/System/`, `/usr/`, `/bin/`, `/sbin/`
+- `~/.cargo/bin/` (installed Rust binaries, not cache)
+- Any `.git/` directory
+- `~/Library/Mail/` (use Mail.app for mail cleanup)
+- iCloud files (use `brctl evict` or Finder, never `rm`)
+
+See `references/safety-protocols.md` for detailed safety rules and
+confirmation flow patterns.
+
+## After Cleanup
+
+Always verify space was freed:
+```bash
+df -h /
+diskutil info / | grep -E "(Free|Available|Purgeable)"
+```
+
+If space wasn't freed, check Time Machine local snapshots (see above).
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/cleanup-targets.md` | Exhaustive list of cleanup targets with exact paths, commands, risk levels, and typical space savings for each category |
+| `references/safety-protocols.md` | Golden rules, confirmation flow patterns per risk level, paths to never touch, pre-cleanup checklist, recovery procedures |
+| `references/space-analysis.md` | Disk usage analysis techniques, scan/report/clean workflow, finding large files, stale node_modules/Rust targets, Docker analysis, recommended CLI tools |
+
+## Scripts
+
+| Script | Usage |
+|--------|-------|
+| `scripts/analyze-disk.sh` | Scans all known cleanup targets, reports sizes and risk levels. Flags: `--json` (JSON output), `--dev-only` (dev caches only), `--quick` (skip slow scans) |

--- a/skills/macos-cleanup/references/cleanup-targets.md
+++ b/skills/macos-cleanup/references/cleanup-targets.md
@@ -1,0 +1,369 @@
+# macOS Cleanup Targets
+
+Exhaustive reference of what can be safely cleaned on macOS, organized by
+category. Each target includes exact paths, commands, typical space savings,
+and risk level.
+
+## Risk Levels
+
+| Level | Meaning | Action |
+|-------|---------|--------|
+| Safe | Regenerated automatically, no data loss | Clean without asking |
+| Low | Unlikely to cause issues, minor convenience loss | List and confirm |
+| Moderate | May require re-login, re-download, or rebuild | Warn and confirm |
+| High | Potential data loss if user hasn't backed up | Explain risk, require explicit opt-in |
+
+## 1. System & User Caches
+
+Caches are the single biggest space waster on macOS. They regenerate
+automatically — cleaning them is always safe, just slow (apps rebuild on next
+launch).
+
+### User-Level Caches
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| User cache root | `~/Library/Caches/*` | Safe | 2-20 GB |
+| Specific app cache | `~/Library/Caches/com.app.name/` | Safe | varies |
+| Safari cache | `~/Library/Caches/com.apple.Safari/` | Safe | 0.5-3 GB |
+| Chrome cache | `~/Library/Caches/Google/Chrome/` | Safe | 0.5-5 GB |
+| Arc cache | `~/Library/Caches/company.thebrowser.Browser/` | Safe | 0.5-3 GB |
+| Firefox cache | `~/Library/Caches/Firefox/Profiles/*/cache2/` | Safe | 0.5-2 GB |
+| Slack cache | `~/Library/Caches/com.tinyspeck.slackmacgap/` | Safe | 0.2-2 GB |
+| Discord cache | `~/Library/Caches/com.hnc.Discord/` | Safe | 0.1-1 GB |
+| Spotify cache | `~/Library/Caches/com.spotify.client/` | Safe | 0.5-5 GB |
+| VS Code cache | `~/Library/Caches/com.microsoft.VSCode/` | Safe | 0.1-1 GB |
+
+```bash
+# Show total user cache size
+du -sh ~/Library/Caches 2>/dev/null
+
+# Clean all user caches (safe — apps rebuild them)
+rm -rf ~/Library/Caches/*
+
+# Clean specific app cache
+rm -rf ~/Library/Caches/com.apple.Safari/
+```
+
+### System-Level Caches
+
+| Target | Path | Risk | Notes |
+|--------|------|------|-------|
+| System cache | `/Library/Caches/*` | Low | Requires sudo, system rebuilds |
+| Font caches | `/System/Library/Caches/com.apple.FontRegistry/` | Low | SIP-protected on modern macOS |
+
+```bash
+# Show system cache size (requires sudo for accurate count)
+sudo du -sh /Library/Caches 2>/dev/null
+```
+
+## 2. Developer Tool Caches
+
+These are typically the largest space consumers on developer machines.
+
+### Xcode
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| DerivedData | `~/Library/Developer/Xcode/DerivedData/` | Safe | 5-50 GB |
+| Archives | `~/Library/Developer/Xcode/Archives/` | Moderate | 2-20 GB |
+| iOS DeviceSupport | `~/Library/Developer/Xcode/iOS DeviceSupport/` | Low | 2-30 GB |
+| watchOS DeviceSupport | `~/Library/Developer/Xcode/watchOS DeviceSupport/` | Low | 1-5 GB |
+| Old simulators | via `xcrun simctl` | Low | 5-30 GB |
+| CoreSimulator caches | `~/Library/Developer/CoreSimulator/Caches/` | Safe | 1-10 GB |
+| CoreSimulator devices | `~/Library/Developer/CoreSimulator/Devices/` | Moderate | 5-40 GB |
+| Previews cache | `~/Library/Developer/Xcode/UserData/Previews/` | Safe | 1-5 GB |
+
+```bash
+# DerivedData — always safe to nuke
+rm -rf ~/Library/Developer/Xcode/DerivedData/*
+
+# Old simulator runtimes
+xcrun simctl delete unavailable 2>/dev/null
+
+# Old iOS device support (keep latest 2 versions)
+ls -dt ~/Library/Developer/Xcode/iOS\ DeviceSupport/*/ 2>/dev/null | tail -n +3 | xargs rm -rf
+
+# Archives — user should review first (contains .ipa submissions)
+du -sh ~/Library/Developer/Xcode/Archives/ 2>/dev/null
+```
+
+### Homebrew
+
+| Target | Command | Risk | Typical Size |
+|--------|---------|------|-------------|
+| Old versions | `brew cleanup` | Safe | 0.5-5 GB |
+| Download cache | `brew cleanup -s` | Safe | 0.5-3 GB |
+| All caches | `brew cleanup --prune=all` | Safe | 1-8 GB |
+| Autoremove unused | `brew autoremove` | Low | varies |
+
+```bash
+brew cleanup --prune=all -s 2>/dev/null
+brew autoremove 2>/dev/null
+```
+
+### Node.js / JavaScript
+
+| Target | Path/Command | Risk | Typical Size |
+|--------|-------------|------|-------------|
+| npm cache | `npm cache clean --force` | Safe | 0.5-5 GB |
+| yarn cache | `yarn cache clean` | Safe | 0.5-5 GB |
+| pnpm store | `pnpm store prune` | Safe | 1-10 GB |
+| Stale node_modules | `find ~ -name node_modules -type d` | Moderate | 5-50 GB |
+| .npm cache dir | `~/.npm/_cacache/` | Safe | 0.5-3 GB |
+| Bun cache | `~/.bun/install/cache/` | Safe | 0.5-3 GB |
+
+```bash
+# npm
+npm cache clean --force 2>/dev/null
+
+# yarn (classic + berry)
+yarn cache clean 2>/dev/null
+
+# pnpm
+pnpm store prune 2>/dev/null
+
+# Find stale node_modules (not modified in 30+ days)
+find ~/dev -name node_modules -type d -maxdepth 4 -mtime +30 2>/dev/null
+
+# Bun cache
+rm -rf ~/.bun/install/cache/ 2>/dev/null
+```
+
+### Python
+
+| Target | Path/Command | Risk | Typical Size |
+|--------|-------------|------|-------------|
+| pip cache | `pip cache purge` | Safe | 0.5-3 GB |
+| pip cache dir | `~/Library/Caches/pip/` | Safe | 0.5-3 GB |
+| pyenv versions | `~/.pyenv/versions/` | Moderate | 1-5 GB |
+| __pycache__ dirs | scattered | Safe | varies |
+| .venv directories | scattered | Moderate | 1-10 GB |
+| conda pkgs | `~/miniconda3/pkgs/` or `~/anaconda3/pkgs/` | Safe | 2-10 GB |
+
+```bash
+pip cache purge 2>/dev/null
+pip3 cache purge 2>/dev/null
+conda clean --all -y 2>/dev/null
+```
+
+### Rust
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| Cargo registry | `~/.cargo/registry/` | Safe | 1-5 GB |
+| Cargo git | `~/.cargo/git/` | Safe | 0.5-2 GB |
+| Target dirs | `*/target/` | Moderate | 5-50 GB |
+
+```bash
+# Cargo cache cleanup (install cargo-cache first)
+cargo cache --autoclean 2>/dev/null
+# Or manual
+rm -rf ~/.cargo/registry/cache/ 2>/dev/null
+```
+
+### Go
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| Module cache | `~/go/pkg/mod/` | Safe | 1-5 GB |
+| Build cache | via `go clean -cache` | Safe | 0.5-3 GB |
+
+```bash
+go clean -cache 2>/dev/null
+go clean -modcache 2>/dev/null
+```
+
+### Docker
+
+| Target | Command | Risk | Typical Size |
+|--------|---------|------|-------------|
+| Stopped containers | `docker container prune` | Low | 0.1-1 GB |
+| Dangling images | `docker image prune` | Low | 1-10 GB |
+| All unused images | `docker image prune -a` | Moderate | 5-50 GB |
+| Build cache | `docker builder prune` | Low | 2-20 GB |
+| Volumes | `docker volume prune` | High | 1-20 GB |
+| Full system prune | `docker system prune -a --volumes` | High | 10-80 GB |
+| Docker Desktop VM | `~/Library/Containers/com.docker.docker/Data/vms/` | Moderate | 5-60 GB |
+
+```bash
+# Safe: remove stopped containers and dangling images
+docker container prune -f 2>/dev/null
+docker image prune -f 2>/dev/null
+docker builder prune -f 2>/dev/null
+
+# Aggressive: remove everything unused (will re-pull images)
+docker system prune -a -f 2>/dev/null
+
+# Nuclear: include volumes (DATA LOSS risk)
+docker system prune -a --volumes -f 2>/dev/null
+```
+
+### JetBrains IDEs
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| Caches | `~/Library/Caches/JetBrains/` | Safe | 1-5 GB |
+| Local history | `~/Library/Caches/JetBrains/*/LocalHistory/` | Moderate | 0.5-2 GB |
+| Logs | `~/Library/Logs/JetBrains/` | Safe | 0.1-1 GB |
+
+### Android Studio
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| Gradle cache | `~/.gradle/caches/` | Safe | 2-10 GB |
+| Gradle wrapper | `~/.gradle/wrapper/dists/` | Safe | 1-3 GB |
+| AVD images | `~/.android/avd/` | Moderate | 5-30 GB |
+| Android SDK | `~/Library/Android/sdk/` | High | 10-50 GB |
+
+```bash
+# Gradle cache cleanup
+rm -rf ~/.gradle/caches/ 2>/dev/null
+rm -rf ~/.gradle/wrapper/dists/ 2>/dev/null
+```
+
+### CocoaPods
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| Pods cache | `~/Library/Caches/CocoaPods/` | Safe | 0.5-3 GB |
+
+```bash
+pod cache clean --all 2>/dev/null
+```
+
+## 3. System Logs & Reports
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| User logs | `~/Library/Logs/` | Safe | 0.1-2 GB |
+| System logs | `/var/log/` | Low | 0.1-1 GB |
+| Diagnostic reports | `~/Library/Logs/DiagnosticReports/` | Safe | 0.01-0.5 GB |
+| Crash reports | `/Library/Logs/DiagnosticReports/` | Safe | 0.01-0.5 GB |
+| ASL logs | `/var/log/asl/` | Low | 0.01-0.2 GB |
+| System profiler | `~/Library/Logs/CoreSimulator/` | Safe | 0.1-1 GB |
+
+```bash
+# User logs
+rm -rf ~/Library/Logs/* 2>/dev/null
+
+# Diagnostic reports
+rm -rf ~/Library/Logs/DiagnosticReports/* 2>/dev/null
+rm -rf /Library/Logs/DiagnosticReports/* 2>/dev/null
+
+# Old system logs (keep recent)
+sudo rm -rf /var/log/*.gz 2>/dev/null
+```
+
+## 4. Trash
+
+```bash
+# Show Trash size
+du -sh ~/.Trash 2>/dev/null
+
+# Empty Trash
+rm -rf ~/.Trash/* 2>/dev/null
+```
+
+Typical: 0-50 GB depending on user behavior. Risk: Moderate (user chose to
+delete these, but might want to recover).
+
+## 5. iOS/Device Backups
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| iOS backups | `~/Library/Application Support/MobileSync/Backup/` | High | 5-100 GB |
+
+These are full device backups. Cleaning is HIGH risk — user loses backup data.
+Always list backups with dates first and let user decide.
+
+```bash
+# List iOS backups with sizes
+du -sh ~/Library/Application\ Support/MobileSync/Backup/*/ 2>/dev/null
+```
+
+## 6. Mail & Downloads
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| Mail downloads | `~/Library/Containers/com.apple.mail/Data/Library/Mail Downloads/` | Moderate | 0.1-5 GB |
+| Downloads folder | `~/Downloads/` | High | 1-30 GB |
+| Old DMGs | `~/Downloads/*.dmg` | Low | 0.5-5 GB |
+| Old ZIPs | `~/Downloads/*.zip` | Low | 0.5-5 GB |
+
+```bash
+# Find old DMGs in Downloads (older than 30 days)
+find ~/Downloads -name "*.dmg" -mtime +30 2>/dev/null
+
+# Find large files in Downloads
+find ~/Downloads -size +100M 2>/dev/null
+```
+
+## 7. Application Leftovers
+
+When apps are dragged to trash, they leave behind support files.
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| App support | `~/Library/Application Support/` | Moderate | varies |
+| Preferences | `~/Library/Preferences/` | Low | minimal |
+| Saved state | `~/Library/Saved Application State/` | Safe | 0.01-0.5 GB |
+| Containers | `~/Library/Containers/` | Moderate | varies |
+| Group Containers | `~/Library/Group Containers/` | Moderate | varies |
+
+Cleaning app leftovers requires checking which apps are still installed.
+Only remove support files for apps that no longer exist in /Applications.
+
+```bash
+# List Saved Application State (safe to clean)
+du -sh ~/Library/Saved\ Application\ State/ 2>/dev/null
+rm -rf ~/Library/Saved\ Application\ State/* 2>/dev/null
+```
+
+## 8. Language & Runtime Leftovers
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| Old Ruby gems | `~/.gem/` | Low | 0.1-1 GB |
+| rbenv versions | `~/.rbenv/versions/` | Moderate | 0.5-3 GB |
+| nvm node versions | `~/.nvm/versions/` | Moderate | 1-5 GB |
+| Old Java JDKs | `/Library/Java/JavaVirtualMachines/` | Moderate | 0.5-3 GB |
+| Composer cache | `~/.composer/cache/` | Safe | 0.1-1 GB |
+
+## 9. Cloud Storage Caches
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| Dropbox cache | `~/.dropbox/cache/` | Safe | 0.1-2 GB |
+| iCloud drive cache | `~/Library/Mobile Documents/` (evictable) | Low | varies |
+
+```bash
+# Dropbox cache
+rm -rf ~/.dropbox/cache/ 2>/dev/null
+```
+
+## 10. Miscellaneous
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| QuickLook thumbnails | `~/Library/Caches/com.apple.QuickLook.thumbnailcache/` | Safe | 0.01-0.5 GB |
+| Speech data | `~/Library/Caches/com.apple.SpeechRecognitionCore/` | Safe | 0.1-1 GB |
+| Siri analytics | `~/Library/Assistant/SiriAnalytics.db` | Safe | 0.01-0.1 GB |
+| CoreDuet knowledge | `~/Library/Application Support/Knowledge/` | Safe | 0.01-0.1 GB |
+
+## Priority Order for Maximum Impact
+
+When cleaning for space, target in this order (highest ROI first):
+
+1. **Xcode DerivedData + simulators** — 10-80 GB
+2. **Docker images + build cache** — 10-80 GB
+3. **node_modules (stale projects)** — 5-50 GB
+4. **User caches** — 2-20 GB
+5. **Rust target dirs** — 5-50 GB
+6. **iOS backups** — 5-100 GB (but high risk)
+7. **Homebrew cleanup** — 1-8 GB
+8. **Gradle/Android caches** — 3-13 GB
+9. **Package manager caches** (npm, pip, cargo) — 3-15 GB
+10. **Trash** — 0-50 GB
+11. **Logs** — 0.5-5 GB
+12. **Downloads (old DMGs/ZIPs)** — 0.5-5 GB

--- a/skills/macos-cleanup/references/safety-protocols.md
+++ b/skills/macos-cleanup/references/safety-protocols.md
@@ -1,0 +1,173 @@
+# Safety Protocols
+
+Rules and workflows for safely cleaning a macOS system without causing
+data loss, broken apps, or system instability.
+
+## Golden Rules
+
+1. **Analyze before deleting.** Always run the analysis script first to show
+   what will be cleaned and how much space will be freed. Never jump straight
+   to deletion.
+
+2. **Dry-run by default.** Every cleanup operation should first show what
+   WOULD be deleted, with sizes. Only proceed after user confirmation.
+
+3. **Never touch these without explicit user consent:**
+   - `~/Documents`, `~/Desktop`, `~/Pictures`, `~/Music`, `~/Movies`
+   - `~/Library/Keychains/` (passwords and certificates)
+   - `~/Library/Application Support/` (app data — not cache)
+   - `/System/` (SIP-protected, impossible anyway)
+   - `~/.ssh/`, `~/.gnupg/`, `~/.aws/`, `~/.kube/` (credentials)
+   - Any database files (.db, .sqlite) in app support directories
+   - Git repositories (.git directories)
+
+4. **Respect SIP.** System Integrity Protection blocks writes to system
+   directories. Never try to `sudo rm` anything under `/System/`.
+
+5. **Categorize by risk.** Group operations by risk level and present them
+   separately. Clean safe items first, warn for moderate, require explicit
+   opt-in for high-risk.
+
+## Confirmation Flow
+
+### For Safe Operations (risk: safe)
+
+Show summary and proceed:
+```
+Cache cleanup will free ~4.2 GB:
+  ~/Library/Caches/             3.8 GB  (app caches, auto-regenerate)
+  ~/Library/Logs/               0.4 GB  (old logs)
+
+Proceed? [Y/n]
+```
+
+### For Moderate Operations (risk: moderate)
+
+Show detailed breakdown with explanation:
+```
+The following require re-download or rebuild:
+  Xcode DerivedData               12.3 GB  (rebuild on next Xcode build)
+  3 stale node_modules dirs        4.1 GB  (run npm install to restore)
+    ~/dev/old-project/node_modules  (last modified 89 days ago)
+    ~/dev/archived/node_modules     (last modified 142 days ago)
+    ~/dev/test-app/node_modules     (last modified 67 days ago)
+
+Clean these? [y/N]
+```
+
+### For High-Risk Operations (risk: high)
+
+Require explicit acknowledgment:
+```
+WARNING: The following operations may cause DATA LOSS:
+
+  iOS device backups              28.4 GB
+    iPhone backup from 2024-03-15  14.2 GB
+    iPhone backup from 2023-11-20  14.2 GB
+
+  Docker volumes                   5.2 GB
+    postgres_data                  3.1 GB
+    redis_data                     2.1 GB
+
+These cannot be recovered after deletion.
+Type 'DELETE' to confirm, or press Enter to skip:
+```
+
+## What NOT to Clean
+
+These paths should NEVER be touched by the cleanup agent:
+
+| Path | Reason |
+|------|--------|
+| `~/Library/Keychains/` | Passwords, certificates, identity |
+| `~/Library/Accounts/` | System account credentials |
+| `~/.ssh/` | SSH keys — irrecoverable if lost |
+| `~/.gnupg/` | GPG keys — irrecoverable if lost |
+| `~/.aws/`, `~/.kube/`, `~/.config/gcloud/` | Cloud credentials |
+| `~/Library/Application Support/MobileSync/` | Only with HIGH-risk consent |
+| `/System/` | SIP-protected |
+| `/usr/` | System binaries |
+| `/bin/`, `/sbin/` | Core system tools |
+| `~/Library/Mail/` | Email data (not same as downloads) |
+| Any `.git/` directory | Version control history |
+| `*.keychain-db` | Keychain databases |
+| `~/.local/share/opencode/` | AI agent session data |
+
+## Pre-Cleanup Checklist
+
+Before running any cleanup:
+
+1. **Check available space first**: `df -h /` — if user has 50+ GB free,
+   aggressive cleanup may not be needed
+2. **Ensure no builds running**: Cleaning DerivedData during a build will
+   cause build failure
+3. **Check Docker containers**: Don't prune images that running containers
+   depend on
+4. **Verify Xcode is closed**: DerivedData cleanup works best with Xcode closed
+5. **Note Time Machine status**: If TM is running, cleanup will free space
+   on the next snapshot, not immediately
+
+## Recovery Procedures
+
+If something goes wrong:
+
+| Problem | Recovery |
+|---------|----------|
+| App won't launch after cache clean | Restart the app — it rebuilds cache on launch |
+| Xcode build fails after DerivedData clean | Clean build (Cmd+Shift+K), then rebuild |
+| Docker images missing | `docker pull <image>` to re-download |
+| npm packages missing | `cd <project> && npm install` |
+| Brew app broken | `brew reinstall <package>` |
+| Simulator missing | `xcode-select --install` or re-download via Xcode |
+| Python packages missing | `pip install -r requirements.txt` in the project |
+| Login items broken | Re-add from System Settings > General > Login Items |
+
+## Space Verification
+
+After cleanup, always verify space was actually freed:
+
+```bash
+# Check disk space
+df -h /
+
+# If space wasn't freed, check Time Machine local snapshots
+tmutil listlocalsnapshots /
+
+# Delete old TM snapshots if needed (requires sudo)
+sudo tmutil deletelocalsnapshots <date>
+```
+
+Time Machine snapshots are the most common reason "deleted files don't free
+space." The snapshot still references the data. Snapshots auto-expire, but
+if immediate space is needed, they can be manually deleted.
+
+## Purgeable Space
+
+macOS has a concept of "purgeable" space — storage that macOS will
+automatically free when needed (iCloud-optimized files, old Time Machine
+snapshots). The `df -h` output may differ from Finder's reported free space
+because Finder includes purgeable space as "available."
+
+```bash
+# Accurate space reading including purgeable
+diskutil info / | grep -E "(Free|Available|Purgeable)"
+```
+
+## Agent Behavior Rules
+
+When the agent is performing cleanup:
+
+1. **Always show a summary first** — total space that could be freed,
+   broken down by category and risk level
+2. **Ask permission per risk level** — don't batch safe and high-risk
+   items together
+3. **Show progress** — for large operations (like finding node_modules),
+   show what's being scanned
+4. **Report results** — after cleanup, show before/after space comparison
+5. **Suggest follow-ups** — if Docker or Xcode aren't cleaned because
+   they're high-impact, mention it
+6. **Don't touch what wasn't asked** — if user says "clean caches," don't
+   also clean Docker volumes
+7. **Prefer targeted over nuclear** — `brew cleanup` over `rm -rf $(brew --cache)`
+8. **Use built-in cleanup commands** when available — `brew cleanup`, `npm cache
+   clean`, `xcrun simctl delete unavailable` over raw `rm -rf`

--- a/skills/macos-cleanup/references/space-analysis.md
+++ b/skills/macos-cleanup/references/space-analysis.md
@@ -1,0 +1,227 @@
+# Space Analysis Techniques
+
+How to find where disk space is being consumed on macOS, identify the
+biggest offenders, and present actionable recommendations.
+
+## Quick Disk Overview
+
+```bash
+# Total disk usage and free space
+df -h /
+
+# Accurate reading with purgeable space
+diskutil info / | grep -E "(Total|Free|Available|Purgeable)"
+
+# Top-level home directory usage
+du -sh ~/*/ ~/.[!.]* 2>/dev/null | sort -hr | head -20
+```
+
+## The Scan → Report → Clean Workflow
+
+### Step 1: Scan
+
+Run the analysis script to discover all cleanup targets:
+
+```bash
+# The analyze-disk.sh script automates this
+# It checks every known cleanup target and reports sizes
+
+# Manual equivalent — scan key directories
+echo "=== User Caches ==="
+du -sh ~/Library/Caches 2>/dev/null
+
+echo "=== Logs ==="
+du -sh ~/Library/Logs 2>/dev/null
+
+echo "=== Xcode ==="
+du -sh ~/Library/Developer/Xcode/DerivedData 2>/dev/null
+du -sh ~/Library/Developer/Xcode/Archives 2>/dev/null
+du -sh ~/Library/Developer/Xcode/iOS\ DeviceSupport 2>/dev/null
+
+echo "=== Homebrew ==="
+brew cleanup --dry-run 2>/dev/null | tail -1
+
+echo "=== Docker ==="
+docker system df 2>/dev/null
+
+echo "=== Trash ==="
+du -sh ~/.Trash 2>/dev/null
+```
+
+### Step 2: Report
+
+Present findings as a categorized summary table:
+
+```
+macOS Disk Cleanup Report
+========================
+
+Disk: 494 GB total, 42 GB free (8.5%)
+
+Category                         Size     Risk     
+─────────────────────────────────────────────────────
+Xcode DerivedData               18.2 GB   Safe     
+Docker images (unused)          12.4 GB   Moderate 
+User Caches                      8.3 GB   Safe     
+Stale node_modules (4 dirs)      6.1 GB   Moderate 
+Trash                            4.8 GB   Moderate 
+npm/yarn/pnpm cache              3.2 GB   Safe     
+Homebrew old versions            2.1 GB   Safe     
+iOS Device Support (old)         1.8 GB   Low      
+Logs & diagnostics               0.9 GB   Safe     
+pip cache                        0.7 GB   Safe     
+─────────────────────────────────────────────────────
+Total reclaimable:              58.5 GB
+
+Safe to clean now:              34.4 GB
+Needs confirmation:             24.1 GB
+```
+
+### Step 3: Clean
+
+Execute cleanup in risk-level order:
+1. Clean all Safe targets (no confirmation needed)
+2. Present Moderate targets, ask for confirmation
+3. Present High-risk targets only if specifically asked
+
+## Finding Large Files
+
+```bash
+# Find files larger than 500 MB anywhere in home
+find ~ -type f -size +500M -not -path "*/Library/*" 2>/dev/null | \
+  while read f; do echo "$(du -sh "$f" 2>/dev/null)"; done | sort -hr
+
+# Find files larger than 1 GB anywhere
+find ~ -type f -size +1G 2>/dev/null | \
+  while read f; do echo "$(du -sh "$f" 2>/dev/null)"; done | sort -hr
+
+# Top 20 largest files in home
+find ~ -type f 2>/dev/null | xargs du -s 2>/dev/null | sort -rn | head -20 | \
+  while read size file; do echo "$(du -sh "$file" 2>/dev/null)"; done
+```
+
+## Finding Large Directories
+
+```bash
+# Top 20 largest directories under home (depth 3)
+du -d 3 ~ 2>/dev/null | sort -rn | head -20 | \
+  while read size dir; do echo "$(du -sh "$dir" 2>/dev/null)"; done
+
+# Just Library subdirectories
+du -sh ~/Library/*/ 2>/dev/null | sort -hr | head -20
+```
+
+## Finding Stale node_modules
+
+Node modules in projects you haven't touched in weeks are pure waste.
+
+```bash
+# Find node_modules directories, show parent project and last modified
+find ~/dev -name node_modules -type d -maxdepth 4 2>/dev/null | while read dir; do
+  project_dir=$(dirname "$dir")
+  size=$(du -sh "$dir" 2>/dev/null | cut -f1)
+  last_modified=$(stat -f "%Sm" -t "%Y-%m-%d" "$dir" 2>/dev/null)
+  echo "$size  $last_modified  $project_dir"
+done | sort -hr
+```
+
+To clean, the user can `rm -rf` individual node_modules directories.
+The project will need `npm install` (or equivalent) to restore them.
+
+## Finding Stale Rust target/ Directories
+
+```bash
+find ~/dev -name target -type d -maxdepth 4 2>/dev/null | while read dir; do
+  # Check if parent has a Cargo.toml
+  if [ -f "$(dirname "$dir")/Cargo.toml" ]; then
+    project_dir=$(dirname "$dir")
+    size=$(du -sh "$dir" 2>/dev/null | cut -f1)
+    last_modified=$(stat -f "%Sm" -t "%Y-%m-%d" "$dir" 2>/dev/null)
+    echo "$size  $last_modified  $project_dir"
+  fi
+done | sort -hr
+```
+
+## Docker Space Analysis
+
+```bash
+# Docker's own space report
+docker system df -v 2>/dev/null
+
+# Docker Desktop VM disk image (the real space consumer)
+du -sh ~/Library/Containers/com.docker.docker/Data/vms/ 2>/dev/null
+
+# Orbstack (Docker alternative)
+du -sh ~/Library/Group\ Containers/*.orbstack/ 2>/dev/null
+```
+
+Docker Desktop's VM disk image only shrinks when you do a factory reset or
+use `docker system prune`. Even after deleting images, the VM file stays
+the same size.
+
+## Time Machine Snapshots
+
+Local TM snapshots can consume significant space invisibly:
+
+```bash
+# List local snapshots
+tmutil listlocalsnapshots /
+
+# Show snapshot sizes (requires sudo)
+sudo tmutil listlocalsnapshots / | while read snap; do
+  echo "$snap"
+done
+
+# Delete specific snapshot
+sudo tmutil deletelocalsnapshots <YYYY-MM-DD-HHMMSS>
+
+# Delete all local snapshots (aggressive)
+for snap in $(tmutil listlocalsnapshots / | cut -d. -f4); do
+  sudo tmutil deletelocalsnapshots "$snap"
+done
+```
+
+## Recommended CLI Tools
+
+These are established tools the agent can suggest for interactive
+space exploration:
+
+| Tool | Install | Description |
+|------|---------|-------------|
+| `ncdu` | `brew install ncdu` | Interactive terminal disk analyzer |
+| `dust` | `brew install dust` | Rust-based `du` replacement with visual bars |
+| `duf` | `brew install duf` | Modern `df` replacement with better output |
+| `gdu` | `brew install gdu` | Fast disk usage analyzer with TUI |
+
+These are for user reference only — the agent should use its own scripts
+and `du`/`find` commands rather than depending on these being installed.
+
+## Volume-Specific Paths
+
+macOS mounts the data volume separately. Space calculations should consider:
+
+```bash
+# System volume (read-only on modern macOS)
+df -h /System/Volumes/Data
+
+# Same as root on APFS
+df -h /
+```
+
+On APFS, `/` and `/System/Volumes/Data` share the same container, so
+free space is the same regardless of which you query.
+
+## Interpreting macOS Storage
+
+Finder's "About This Mac" storage display categories:
+
+| Category | Includes | Agent can clean? |
+|----------|----------|------------------|
+| Apps | /Applications, ~/Applications | No (user decision) |
+| Documents | ~/Documents, ~/Desktop, etc. | No (user data) |
+| System Data | Caches, logs, TM snapshots | Yes (caches, logs) |
+| macOS | /System | No (SIP-protected) |
+| Other | Everything else | Depends on content |
+
+"System Data" and "Other" are the categories most inflated by cleanable
+content (caches, dev tool artifacts, Docker images).

--- a/skills/macos-cleanup/scripts/analyze-disk.sh
+++ b/skills/macos-cleanup/scripts/analyze-disk.sh
@@ -1,0 +1,424 @@
+#!/usr/bin/env bash
+# macOS Disk Cleanup Analyzer
+# Scans known cleanup targets and reports sizes with risk levels.
+# Output: structured text report suitable for agent consumption.
+#
+# Usage: bash analyze-disk.sh [--json] [--dev-only] [--quick]
+#   --json      Output as JSON instead of table
+#   --dev-only  Only scan developer tool caches
+#   --quick     Skip slow scans (stale node_modules, large file search)
+
+set -euo pipefail
+
+# Parse arguments
+JSON_OUTPUT=false
+DEV_ONLY=false
+QUICK=false
+for arg in "$@"; do
+  case "$arg" in
+    --json) JSON_OUTPUT=true ;;
+    --dev-only) DEV_ONLY=true ;;
+    --quick) QUICK=true ;;
+  esac
+done
+
+# Helper: get directory size in bytes, return "0" if doesn't exist
+dir_size_bytes() {
+  local path="$1"
+  if [ -d "$path" ]; then
+    du -sk "$path" 2>/dev/null | awk '{print $1 * 1024}' || echo "0"
+  else
+    echo "0"
+  fi
+}
+
+# Helper: get directory size human-readable
+dir_size_human() {
+  local path="$1"
+  if [ -d "$path" ]; then
+    du -sh "$path" 2>/dev/null | cut -f1 || echo "0B"
+  else
+    echo "0B"
+  fi
+}
+
+# Helper: format bytes to human-readable
+format_bytes() {
+  local bytes=$1
+  if [ "$bytes" -ge 1073741824 ]; then
+    echo "$(echo "scale=1; $bytes / 1073741824" | bc) GB"
+  elif [ "$bytes" -ge 1048576 ]; then
+    echo "$(echo "scale=1; $bytes / 1048576" | bc) MB"
+  elif [ "$bytes" -ge 1024 ]; then
+    echo "$(echo "scale=0; $bytes / 1024" | bc) KB"
+  else
+    echo "${bytes} B"
+  fi
+}
+
+# Collect disk info
+DISK_TOTAL=$(diskutil info / 2>/dev/null | grep "Container Total Space" | awk -F'(' '{print $2}' | awk '{print $1}' || echo "0")
+DISK_FREE=$(diskutil info / 2>/dev/null | grep "Container Free Space" | awk -F'(' '{print $2}' | awk '{print $1}' || echo "0")
+DISK_FREE_HUMAN=$(df -h / 2>/dev/null | tail -1 | awk '{print $4}')
+DISK_TOTAL_HUMAN=$(df -h / 2>/dev/null | tail -1 | awk '{print $2}')
+DISK_USED_PCT=$(df -h / 2>/dev/null | tail -1 | awk '{print $5}')
+
+# Results array (category|size_bytes|size_human|risk|path)
+declare -a RESULTS=()
+
+add_result() {
+  local category="$1" size_bytes="$2" size_human="$3" risk="$4" path="$5"
+  if [ "$size_bytes" -gt 0 ] 2>/dev/null; then
+    RESULTS+=("${category}|${size_bytes}|${size_human}|${risk}|${path}")
+  fi
+}
+
+echo "Scanning macOS disk for cleanup targets..." >&2
+
+# === CACHES ===
+if [ "$DEV_ONLY" = false ]; then
+  echo "  Scanning user caches..." >&2
+  bytes=$(dir_size_bytes ~/Library/Caches)
+  human=$(dir_size_human ~/Library/Caches)
+  add_result "User Caches" "$bytes" "$human" "safe" "~/Library/Caches/"
+
+  echo "  Scanning logs..." >&2
+  bytes=$(dir_size_bytes ~/Library/Logs)
+  human=$(dir_size_human ~/Library/Logs)
+  add_result "User Logs" "$bytes" "$human" "safe" "~/Library/Logs/"
+
+  # Diagnostic reports
+  bytes=$(dir_size_bytes ~/Library/Logs/DiagnosticReports)
+  human=$(dir_size_human ~/Library/Logs/DiagnosticReports)
+  add_result "Diagnostic Reports" "$bytes" "$human" "safe" "~/Library/Logs/DiagnosticReports/"
+
+  # Trash
+  echo "  Scanning Trash..." >&2
+  bytes=$(dir_size_bytes ~/.Trash)
+  human=$(dir_size_human ~/.Trash)
+  add_result "Trash" "$bytes" "$human" "moderate" "~/.Trash/"
+
+  # Saved Application State
+  bytes=$(dir_size_bytes ~/Library/Saved\ Application\ State)
+  human=$(dir_size_human ~/Library/Saved\ Application\ State)
+  add_result "Saved App State" "$bytes" "$human" "safe" "~/Library/Saved Application State/"
+
+  # Downloads (old DMGs/ZIPs)
+  echo "  Scanning Downloads..." >&2
+  if [ -d ~/Downloads ]; then
+    dmg_bytes=$(find ~/Downloads -name "*.dmg" -mtime +30 -exec stat -f%z {} \; 2>/dev/null | awk '{s+=$1}END{print s+0}')
+    zip_bytes=$(find ~/Downloads -name "*.zip" -mtime +30 -exec stat -f%z {} \; 2>/dev/null | awk '{s+=$1}END{print s+0}')
+    old_dl_bytes=$((dmg_bytes + zip_bytes))
+    if [ "$old_dl_bytes" -gt 0 ]; then
+      old_dl_human=$(format_bytes "$old_dl_bytes")
+      add_result "Old Downloads (DMG/ZIP >30d)" "$old_dl_bytes" "$old_dl_human" "low" "~/Downloads/*.{dmg,zip}"
+    fi
+  fi
+
+  # iOS backups
+  echo "  Scanning iOS backups..." >&2
+  bytes=$(dir_size_bytes ~/Library/Application\ Support/MobileSync/Backup)
+  human=$(dir_size_human ~/Library/Application\ Support/MobileSync/Backup)
+  add_result "iOS Device Backups" "$bytes" "$human" "high" "~/Library/Application Support/MobileSync/Backup/"
+
+  # Mail downloads
+  bytes=$(dir_size_bytes ~/Library/Containers/com.apple.mail/Data/Library/Mail\ Downloads)
+  human=$(dir_size_human ~/Library/Containers/com.apple.mail/Data/Library/Mail\ Downloads)
+  add_result "Mail Downloads" "$bytes" "$human" "moderate" "~/Library/Containers/com.apple.mail/.../Mail Downloads/"
+fi
+
+# === DEVELOPER TOOLS ===
+
+# Xcode
+echo "  Scanning Xcode..." >&2
+bytes=$(dir_size_bytes ~/Library/Developer/Xcode/DerivedData)
+human=$(dir_size_human ~/Library/Developer/Xcode/DerivedData)
+add_result "Xcode DerivedData" "$bytes" "$human" "safe" "~/Library/Developer/Xcode/DerivedData/"
+
+bytes=$(dir_size_bytes ~/Library/Developer/Xcode/Archives)
+human=$(dir_size_human ~/Library/Developer/Xcode/Archives)
+add_result "Xcode Archives" "$bytes" "$human" "moderate" "~/Library/Developer/Xcode/Archives/"
+
+bytes=$(dir_size_bytes ~/Library/Developer/Xcode/iOS\ DeviceSupport)
+human=$(dir_size_human ~/Library/Developer/Xcode/iOS\ DeviceSupport)
+add_result "iOS Device Support" "$bytes" "$human" "low" "~/Library/Developer/Xcode/iOS DeviceSupport/"
+
+bytes=$(dir_size_bytes ~/Library/Developer/CoreSimulator/Devices)
+human=$(dir_size_human ~/Library/Developer/CoreSimulator/Devices)
+add_result "Simulator Devices" "$bytes" "$human" "moderate" "~/Library/Developer/CoreSimulator/Devices/"
+
+bytes=$(dir_size_bytes ~/Library/Developer/CoreSimulator/Caches)
+human=$(dir_size_human ~/Library/Developer/CoreSimulator/Caches)
+add_result "Simulator Caches" "$bytes" "$human" "safe" "~/Library/Developer/CoreSimulator/Caches/"
+
+bytes=$(dir_size_bytes ~/Library/Caches/com.apple.dt.Xcode)
+human=$(dir_size_human ~/Library/Caches/com.apple.dt.Xcode)
+add_result "Xcode App Cache" "$bytes" "$human" "safe" "~/Library/Caches/com.apple.dt.Xcode/"
+
+# Homebrew
+echo "  Scanning Homebrew..." >&2
+if command -v brew &>/dev/null; then
+  brew_cache=$(brew --cache 2>/dev/null || echo "")
+  if [ -n "$brew_cache" ] && [ -d "$brew_cache" ]; then
+    bytes=$(dir_size_bytes "$brew_cache")
+    human=$(dir_size_human "$brew_cache")
+    add_result "Homebrew Cache" "$bytes" "$human" "safe" "$brew_cache"
+  fi
+fi
+
+# npm
+echo "  Scanning package manager caches..." >&2
+bytes=$(dir_size_bytes ~/.npm)
+human=$(dir_size_human ~/.npm)
+add_result "npm Cache" "$bytes" "$human" "safe" "~/.npm/"
+
+# yarn
+bytes=$(dir_size_bytes ~/Library/Caches/Yarn)
+human=$(dir_size_human ~/Library/Caches/Yarn)
+add_result "Yarn Cache" "$bytes" "$human" "safe" "~/Library/Caches/Yarn/"
+
+# pnpm
+if command -v pnpm &>/dev/null; then
+  pnpm_store=$(pnpm store path 2>/dev/null || echo "")
+  if [ -n "$pnpm_store" ] && [ -d "$pnpm_store" ]; then
+    bytes=$(dir_size_bytes "$pnpm_store")
+    human=$(dir_size_human "$pnpm_store")
+    add_result "pnpm Store" "$bytes" "$human" "safe" "$pnpm_store"
+  fi
+fi
+
+# Bun
+bytes=$(dir_size_bytes ~/.bun/install/cache)
+human=$(dir_size_human ~/.bun/install/cache)
+add_result "Bun Cache" "$bytes" "$human" "safe" "~/.bun/install/cache/"
+
+# pip
+bytes=$(dir_size_bytes ~/Library/Caches/pip)
+human=$(dir_size_human ~/Library/Caches/pip)
+add_result "pip Cache" "$bytes" "$human" "safe" "~/Library/Caches/pip/"
+
+# conda
+for conda_dir in ~/miniconda3/pkgs ~/anaconda3/pkgs ~/miniforge3/pkgs; do
+  if [ -d "$conda_dir" ]; then
+    bytes=$(dir_size_bytes "$conda_dir")
+    human=$(dir_size_human "$conda_dir")
+    add_result "Conda Package Cache" "$bytes" "$human" "safe" "$conda_dir"
+  fi
+done
+
+# Cargo (Rust)
+echo "  Scanning Rust/Cargo..." >&2
+cargo_total=0
+for cargo_sub in ~/.cargo/registry/cache ~/.cargo/registry/src ~/.cargo/git/checkouts; do
+  if [ -d "$cargo_sub" ]; then
+    sub_bytes=$(dir_size_bytes "$cargo_sub")
+    cargo_total=$((cargo_total + sub_bytes))
+  fi
+done
+if [ "$cargo_total" -gt 0 ]; then
+  cargo_human=$(format_bytes "$cargo_total")
+  add_result "Cargo Cache" "$cargo_total" "$cargo_human" "safe" "~/.cargo/registry/ + ~/.cargo/git/"
+fi
+
+# Go
+echo "  Scanning Go..." >&2
+bytes=$(dir_size_bytes ~/go/pkg/mod)
+human=$(dir_size_human ~/go/pkg/mod)
+add_result "Go Module Cache" "$bytes" "$human" "safe" "~/go/pkg/mod/"
+
+go_build_cache="${HOME}/.cache/go-build"
+if [ -d "$go_build_cache" ]; then
+  bytes=$(dir_size_bytes "$go_build_cache")
+  human=$(dir_size_human "$go_build_cache")
+  add_result "Go Build Cache" "$bytes" "$human" "safe" "$go_build_cache"
+fi
+
+# Gradle
+bytes=$(dir_size_bytes ~/.gradle/caches)
+human=$(dir_size_human ~/.gradle/caches)
+add_result "Gradle Cache" "$bytes" "$human" "safe" "~/.gradle/caches/"
+
+bytes=$(dir_size_bytes ~/.gradle/wrapper/dists)
+human=$(dir_size_human ~/.gradle/wrapper/dists)
+add_result "Gradle Wrapper Dists" "$bytes" "$human" "safe" "~/.gradle/wrapper/dists/"
+
+# Maven
+bytes=$(dir_size_bytes ~/.m2/repository)
+human=$(dir_size_human ~/.m2/repository)
+add_result "Maven Local Repo" "$bytes" "$human" "safe" "~/.m2/repository/"
+
+# CocoaPods
+bytes=$(dir_size_bytes ~/Library/Caches/CocoaPods)
+human=$(dir_size_human ~/Library/Caches/CocoaPods)
+add_result "CocoaPods Cache" "$bytes" "$human" "safe" "~/Library/Caches/CocoaPods/"
+
+# Docker
+echo "  Scanning Docker..." >&2
+docker_raw="$HOME/Library/Containers/com.docker.docker/Data/vms/0/data/Docker.raw"
+if [ -f "$docker_raw" ]; then
+  bytes=$(stat -f%z "$docker_raw" 2>/dev/null || echo "0")
+  human=$(format_bytes "$bytes")
+  add_result "Docker Desktop VM Disk" "$bytes" "$human" "moderate" "$docker_raw"
+fi
+
+# JetBrains
+bytes=$(dir_size_bytes ~/Library/Caches/JetBrains)
+human=$(dir_size_human ~/Library/Caches/JetBrains)
+add_result "JetBrains Caches" "$bytes" "$human" "safe" "~/Library/Caches/JetBrains/"
+
+bytes=$(dir_size_bytes ~/Library/Logs/JetBrains)
+human=$(dir_size_human ~/Library/Logs/JetBrains)
+add_result "JetBrains Logs" "$bytes" "$human" "safe" "~/Library/Logs/JetBrains/"
+
+# VS Code
+vscode_cache_total=0
+for vsc_dir in \
+  ~/Library/Application\ Support/Code/Cache \
+  ~/Library/Application\ Support/Code/CachedData \
+  ~/Library/Application\ Support/Code/CachedExtensions \
+  ~/Library/Application\ Support/Code/CachedExtensionVSIXs \
+  ~/Library/Application\ Support/Code/logs; do
+  if [ -d "$vsc_dir" ]; then
+    sub_bytes=$(dir_size_bytes "$vsc_dir")
+    vscode_cache_total=$((vscode_cache_total + sub_bytes))
+  fi
+done
+if [ "$vscode_cache_total" -gt 0 ]; then
+  vsc_human=$(format_bytes "$vscode_cache_total")
+  add_result "VS Code Caches" "$vscode_cache_total" "$vsc_human" "safe" "~/Library/Application Support/Code/Cache*"
+fi
+
+# Stale node_modules (slow scan)
+if [ "$QUICK" = false ]; then
+  echo "  Scanning for stale node_modules (this may take a moment)..." >&2
+  stale_nm_bytes=0
+  stale_nm_count=0
+  # Search common dev directories
+  for search_dir in ~/dev ~/projects ~/code ~/src ~/work ~/repos; do
+    if [ -d "$search_dir" ]; then
+      while IFS= read -r nm_dir; do
+        nm_bytes=$(dir_size_bytes "$nm_dir")
+        stale_nm_bytes=$((stale_nm_bytes + nm_bytes))
+        stale_nm_count=$((stale_nm_count + 1))
+      done < <(find "$search_dir" -name node_modules -type d -maxdepth 5 -mtime +30 -prune 2>/dev/null)
+    fi
+  done
+  if [ "$stale_nm_bytes" -gt 0 ]; then
+    stale_nm_human=$(format_bytes "$stale_nm_bytes")
+    add_result "Stale node_modules (${stale_nm_count} dirs, >30d)" "$stale_nm_bytes" "$stale_nm_human" "moderate" "various ~/dev/**/node_modules"
+  fi
+
+  # Stale Rust target/ dirs
+  echo "  Scanning for stale Rust target/ dirs..." >&2
+  stale_target_bytes=0
+  stale_target_count=0
+  for search_dir in ~/dev ~/projects ~/code ~/src ~/work ~/repos; do
+    if [ -d "$search_dir" ]; then
+      while IFS= read -r t_dir; do
+        if [ -f "$(dirname "$t_dir")/Cargo.toml" ]; then
+          t_bytes=$(dir_size_bytes "$t_dir")
+          stale_target_bytes=$((stale_target_bytes + t_bytes))
+          stale_target_count=$((stale_target_count + 1))
+        fi
+      done < <(find "$search_dir" -name target -type d -maxdepth 5 -mtime +30 -prune 2>/dev/null)
+    fi
+  done
+  if [ "$stale_target_bytes" -gt 0 ]; then
+    stale_target_human=$(format_bytes "$stale_target_bytes")
+    add_result "Stale Rust target/ (${stale_target_count} dirs, >30d)" "$stale_target_bytes" "$stale_target_human" "moderate" "various ~/dev/**/target"
+  fi
+fi
+
+# Dropbox cache
+bytes=$(dir_size_bytes ~/.dropbox/cache)
+human=$(dir_size_human ~/.dropbox/cache)
+add_result "Dropbox Cache" "$bytes" "$human" "safe" "~/.dropbox/cache/"
+
+# Swift Package Manager
+bytes=$(dir_size_bytes ~/Library/Caches/org.swift.swiftpm)
+human=$(dir_size_human ~/Library/Caches/org.swift.swiftpm)
+add_result "Swift PM Cache" "$bytes" "$human" "safe" "~/Library/Caches/org.swift.swiftpm/"
+
+# Flutter/Dart
+bytes=$(dir_size_bytes ~/.pub-cache)
+human=$(dir_size_human ~/.pub-cache)
+add_result "Flutter/Dart pub-cache" "$bytes" "$human" "safe" "~/.pub-cache/"
+
+# Composer (PHP)
+bytes=$(dir_size_bytes ~/.composer/cache)
+human=$(dir_size_human ~/.composer/cache)
+add_result "Composer Cache" "$bytes" "$human" "safe" "~/.composer/cache/"
+
+echo "  Scan complete." >&2
+
+# === OUTPUT ===
+
+if [ "$JSON_OUTPUT" = true ]; then
+  echo "{"
+  echo "  \"disk\": {"
+  echo "    \"total\": \"$DISK_TOTAL_HUMAN\","
+  echo "    \"free\": \"$DISK_FREE_HUMAN\","
+  echo "    \"used_pct\": \"$DISK_USED_PCT\""
+  echo "  },"
+  echo "  \"targets\": ["
+  first=true
+  # Sort by size descending
+  IFS=$'\n' sorted=($(for r in "${RESULTS[@]}"; do echo "$r"; done | sort -t'|' -k2 -rn))
+  for result in "${sorted[@]}"; do
+    IFS='|' read -r category size_bytes size_human risk path <<< "$result"
+    if [ "$first" = true ]; then
+      first=false
+    else
+      echo ","
+    fi
+    printf '    {"category": "%s", "size_bytes": %s, "size_human": "%s", "risk": "%s", "path": "%s"}' \
+      "$category" "$size_bytes" "$size_human" "$risk" "$path"
+  done
+  echo ""
+  echo "  ]"
+  echo "}"
+else
+  echo ""
+  echo "macOS Disk Cleanup Report"
+  echo "========================"
+  echo ""
+  echo "Disk: ${DISK_TOTAL_HUMAN} total, ${DISK_FREE_HUMAN} free (${DISK_USED_PCT} used)"
+  echo ""
+
+  # Calculate totals by risk
+  safe_total=0
+  moderate_total=0
+  high_total=0
+  low_total=0
+  grand_total=0
+
+  printf "%-45s %10s   %-10s\n" "Category" "Size" "Risk"
+  printf "%-45s %10s   %-10s\n" "─────────────────────────────────────────────" "──────────" "──────────"
+
+  # Sort by size descending
+  IFS=$'\n' sorted=($(for r in "${RESULTS[@]}"; do echo "$r"; done | sort -t'|' -k2 -rn))
+  for result in "${sorted[@]}"; do
+    IFS='|' read -r category size_bytes size_human risk path <<< "$result"
+    # Skip items under 10 MB
+    if [ "$size_bytes" -lt 10485760 ] 2>/dev/null; then
+      continue
+    fi
+    printf "%-45s %10s   %-10s\n" "$category" "$size_human" "$risk"
+    grand_total=$((grand_total + size_bytes))
+    case "$risk" in
+      safe) safe_total=$((safe_total + size_bytes)) ;;
+      low) low_total=$((low_total + size_bytes)) ;;
+      moderate) moderate_total=$((moderate_total + size_bytes)) ;;
+      high) high_total=$((high_total + size_bytes)) ;;
+    esac
+  done
+
+  echo ""
+  printf "%-45s %10s\n" "─────────────────────────────────────────────" "──────────"
+  printf "%-45s %10s\n" "Total reclaimable" "$(format_bytes $grand_total)"
+  echo ""
+  printf "  %-43s %10s\n" "Safe to clean now" "$(format_bytes $safe_total)"
+  printf "  %-43s %10s\n" "Low risk (confirm)" "$(format_bytes $low_total)"
+  printf "  %-43s %10s\n" "Moderate risk (review first)" "$(format_bytes $moderate_total)"
+  printf "  %-43s %10s\n" "High risk (explicit opt-in only)" "$(format_bytes $high_total)"
+fi

--- a/skills/macos-cleanup/skills.json
+++ b/skills/macos-cleanup/skills.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/macos-cleanup",
+  "version": "1.0.0",
+  "description": "macOS disk space recovery and system cleanup for developers. Scans and cleans caches, Xcode DerivedData, Docker images, stale node_modules, Homebrew, npm/pip/cargo caches, logs, iOS backups, and more. Risk-aware with dry-run analysis. Triggers: disk cleanup, free disk space, clean up my mac, disk full, running out of space, clear cache, clean storage, ccleaner, node_modules cleanup, docker disk space, xcode cleanup, DerivedData, brew cleanup, npm cache, pip cache, cargo clean, reclaim space, system data large, other storage, purge caches.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary
- Adds `@tank/macos-cleanup` skill — a developer-focused macOS disk space recovery tool (CCleaner replacement)
- Covers 30+ cleanup targets: Xcode DerivedData, Docker, Homebrew, npm/yarn/pnpm/Bun, pip/conda, Cargo/Rust, Go, Gradle/Maven, CocoaPods, JetBrains, VS Code, browser caches, iOS backups, Time Machine snapshots, and more
- Includes `analyze-disk.sh` script that scans all targets and produces a prioritized report with risk levels
- Risk-aware confirmation workflow (safe/low/moderate/high) with explicit never-touch paths for safety