### PR TITLE
feat(macos-maintenance): add macOS health check and maintenance skill

### DIFF
--- a/skills/macos-maintenance/.tankignore
+++ b/skills/macos-maintenance/.tankignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.ruff_cache/
+.venv/

--- a/skills/macos-maintenance/SKILL.md
+++ b/skills/macos-maintenance/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: "@tank/macos-maintenance"
+description: |
+  macOS system health checks, security auditing, and periodic maintenance.
+  Diagnoses disk SMART status, battery health, memory pressure, CPU thermals,
+  security posture (SIP, Gatekeeper, FileVault, firewall, XProtect), pending
+  updates, Time Machine backups, network issues, launch daemon cruft, and
+  macOS periodic maintenance scripts. Includes a system checkup script that
+  produces a scored health report. Companion to @tank/macos-cleanup (space
+  recovery) — this skill focuses on system health, not disk space.
+
+  Trigger phrases: "mac health check", "system checkup", "is my mac ok",
+  "mac maintenance", "system maintenance", "mac running slow", "check SIP",
+  "check FileVault", "check Gatekeeper", "battery health", "battery cycle",
+  "SMART status", "disk health", "memory pressure", "mac security audit",
+  "firewall status", "mac diagnostics", "periodic maintenance", "flush DNS",
+  "rebuild spotlight", "rebuild launch services", "login items", "startup items",
+  "launch agents", "launch daemons", "Wi-Fi issues", "network diagnostics",
+  "mac updates", "brew outdated", "softwareupdate", "Time Machine status",
+  "mac slow", "fan loud", "mac hot", "system check", "OnyX", "mac tune up",
+  "kernel extensions", "system extensions", "mac security check"
+---
+
+# macOS Maintenance
+
+System health checks, security auditing, and periodic maintenance for macOS.
+Keeps your Mac healthy, secure, and performant — the diagnostic counterpart
+to `@tank/macos-cleanup` (which handles disk space recovery).
+
+## Core Philosophy
+
+1. **Diagnose before fixing.** Run the checkup script first. Understand the
+   state of the system before changing anything.
+2. **Scored health reports.** Every check is PASS/WARN/FAIL. Users see a
+   clear scorecard, not a wall of terminal output.
+3. **Security by default.** SIP, Gatekeeper, FileVault, and firewall should
+   all be enabled. Flag anything that's off.
+4. **Non-destructive.** Diagnostics are read-only. Maintenance actions
+   (flush DNS, rebuild Spotlight, run periodic scripts) are safe and
+   idempotent — running them extra times causes no harm.
+5. **Know when to restart.** Many issues resolve with a restart. Check uptime
+   and recommend restart when >30 days.
+
+## Quick-Start
+
+### "Is my Mac OK?" / "Run a health check"
+
+```bash
+bash scripts/system-checkup.sh
+```
+
+The script checks security, disk, battery, memory, uptime, updates,
+maintenance scripts, and Time Machine. Outputs a scored report.
+
+Flags:
+- `--json` — machine-readable output
+- `--quick` — skip slow checks (software updates)
+- `--security-only` — only run security posture checks
+
+### "My Mac is running slow"
+
+| Step | Check | Command |
+|------|-------|---------|
+| 1 | Memory pressure | `memory_pressure` |
+| 2 | CPU hogs | `ps aux --sort=-%cpu \| head -11` |
+| 3 | Disk space | `df -h /` (needs >10% free) |
+| 4 | Swap usage | `sysctl vm.swapusage` |
+| 5 | Uptime | `uptime` (restart if >30 days) |
+| 6 | Spotlight indexing | `mdutil -s /` |
+| 7 | Restart | Fixes most transient issues |
+
+### "Run security audit"
+
+```bash
+bash scripts/system-checkup.sh --security-only
+```
+
+Or the agent can check manually — see `references/security-posture.md`
+for the full scorecard.
+
+### "Run periodic maintenance"
+
+```bash
+sudo periodic daily weekly monthly
+```
+
+Safe and idempotent. Rotates logs, rebuilds system databases. Should be
+done if the Mac sleeps through scheduled run times (common for laptops).
+
+## Decision Trees
+
+### What to Check Based on Symptom
+
+| Symptom | First Check | Then |
+|---------|-------------|------|
+| Mac is slow | Memory + CPU | Disk space, uptime, Spotlight |
+| Fan is loud | CPU usage | Thermal state, runaway processes |
+| Battery drains fast | `pmset -g assertions` | Activity Monitor Energy, cycle count |
+| Wi-Fi issues | Signal strength (RSSI) | DNS, DHCP renewal |
+| Apps crash | Disk space, memory | Crash logs in DiagnosticReports |
+| Can't install updates | Disk space (need ~15 GB) | SIP status, time/date |
+| Search broken | Spotlight index status | Rebuild: `sudo mdutil -E /` |
+| Wrong app opens files | Launch Services DB | Rebuild: `lsregister -kill -r ...` |
+| Login is slow | Login items count | Launch agent audit |
+
+### Security Issue Priority
+
+| Issue | Severity | Action |
+|-------|----------|--------|
+| SIP disabled | Critical | Re-enable from Recovery Mode |
+| FileVault off | High | Enable in System Settings |
+| Gatekeeper off | High | `sudo spctl --master-enable` |
+| Firewall off | Medium | Enable via `socketfilterfw` |
+| Auto-updates off | Medium | Enable in System Settings |
+| Remote Login on | Low | Disable if not needed |
+
+### Maintenance Frequency
+
+| Task | Frequency | When |
+|------|-----------|------|
+| macOS updates | Weekly | `softwareupdate -l` |
+| Homebrew update | Weekly | `brew update && brew upgrade` |
+| Periodic scripts | Auto (or force monthly) | `sudo periodic daily weekly monthly` |
+| Security audit | Quarterly | `system-checkup.sh --security-only` |
+| Full health check | Quarterly | `system-checkup.sh` |
+| SMART disk check | Quarterly | `diskutil info disk0 \| grep SMART` |
+| Battery check | Monthly (laptops) | `system_profiler SPPowerDataType` |
+| Login items audit | Quarterly | Review ~/Library/LaunchAgents/ |
+| Flush DNS | As needed | After VPN/DNS issues |
+| Rebuild Spotlight | As needed | When search is broken |
+
+## Common Fix Commands
+
+```bash
+# Flush DNS
+sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
+
+# Rebuild Launch Services (fixes "Open With" duplicates)
+/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -kill -r -domain local -domain system -domain user && killall Finder
+
+# Rebuild Spotlight
+sudo mdutil -E /
+
+# Force periodic maintenance
+sudo periodic daily weekly monthly
+
+# Renew DHCP lease
+sudo ipconfig set en0 DHCP
+
+# Enable firewall
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on
+
+# Check for macOS updates
+softwareupdate -l
+```
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/health-checks.md` | Disk SMART, battery cycle/condition, memory pressure/swap, CPU/thermal, uptime, Time Machine, Spotlight — with commands, thresholds, and fix procedures |
+| `references/security-posture.md` | SIP, Gatekeeper, FileVault, firewall, XProtect/MRT, remote access, auto-updates, login items audit, privacy settings — with full security scorecard |
+| `references/maintenance-tasks.md` | Periodic scripts, DNS flush, Launch Services rebuild, Spotlight rebuild, NVRAM/SMC reset, launch daemon audit, app updates, maintenance schedule, troubleshooting guides |
+| `references/network-diagnostics.md` | Connectivity tests, DNS diagnostics, Wi-Fi signal/channel analysis, port testing, VPN status, proxy settings, network performance, network reset procedure |
+
+## Scripts
+
+| Script | Usage |
+|--------|-------|
+| `scripts/system-checkup.sh` | Full system health report with scored results. Flags: `--json`, `--quick`, `--security-only` |

--- a/skills/macos-maintenance/references/health-checks.md
+++ b/skills/macos-maintenance/references/health-checks.md
@@ -1,0 +1,263 @@
+# System Health Checks
+
+Hardware and OS-level diagnostics for macOS. Each check includes the command,
+how to interpret results, and what to do when something is wrong.
+
+## Disk Health
+
+### APFS Container & Volume Status
+
+```bash
+# Quick volume verification (non-destructive, no unmount needed)
+diskutil verifyVolume /
+
+# Full APFS container check
+diskutil apfs list
+
+# Verify the data volume specifically
+diskutil verifyVolume disk3s5  # adjust to your volume identifier
+
+# Run First Aid via Disk Utility CLI (may need recovery mode for boot disk)
+diskutil repairVolume /
+```
+
+**Interpreting results:**
+- "The volume X appears to be OK" — healthy
+- "Storage system check exit code is 0" — healthy
+- Any "invalid" or "error" message — run First Aid from Recovery Mode
+  (restart holding Cmd+R, open Disk Utility, run First Aid on the container)
+
+### SMART Status (SSD/HDD Health)
+
+```bash
+# Built-in quick check
+diskutil info disk0 | grep "SMART Status"
+# Expected: "SMART Status: Verified" — healthy
+# "SMART Status: Failing" — drive replacement needed urgently
+
+# Detailed SMART data (requires smartmontools)
+# brew install smartmontools
+sudo smartctl -a /dev/disk0
+
+# Key SMART attributes for SSDs:
+#   Percentage Used: should be under 80%
+#   Available Spare: should be above 10%
+#   Media Errors: should be 0
+#   Data Units Written: informational (wear indicator)
+```
+
+**Health thresholds:**
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| SMART Status | Verified | — | Failing |
+| Percentage Used | <50% | 50-80% | >80% |
+| Available Spare | >50% | 10-50% | <10% |
+| Media Errors | 0 | 1-5 | >5 |
+
+### Disk Space
+
+```bash
+# Human-readable overview
+df -h /
+
+# Accurate with purgeable space
+diskutil info / | grep -E "(Total|Free|Available|Purgeable)"
+
+# Percentage used
+df -h / | tail -1 | awk '{print $5}'
+```
+
+**Thresholds:**
+- <70% used — healthy
+- 70-85% used — monitor, consider cleanup
+- 85-95% used — cleanup needed, performance may degrade
+- >95% used — critical, macOS needs ~10% free for swap/updates
+
+## Battery Health (Laptops)
+
+```bash
+# Full battery report
+system_profiler SPPowerDataType
+
+# Key values via ioreg
+ioreg -l -w0 | grep -E '"(MaxCapacity|DesignCapacity|CycleCount|BatteryHealth)"'
+
+# Quick cycle count
+system_profiler SPPowerDataType | grep "Cycle Count"
+
+# Battery condition
+system_profiler SPPowerDataType | grep "Condition"
+
+# Current charge percentage
+pmset -g batt
+```
+
+**Interpreting battery health:**
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| Condition | Normal | — | Service Recommended / Replace |
+| Cycle Count | <500 | 500-800 | >1000 |
+| Max Capacity % | >80% | 60-80% | <60% |
+
+Apple considers batteries consumed at 1000 cycles or <80% capacity.
+
+**Battery drain diagnostics:**
+```bash
+# Check what's preventing sleep
+pmset -g assertions
+
+# Check wake reasons (why did it wake from sleep?)
+pmset -g log | grep -E "Wake from|DarkWake" | tail -20
+
+# Power-hungry processes
+top -l 1 -o cpu -n 10 | tail -11
+
+# Apps preventing sleep
+pmset -g assertions | grep -A1 "PreventUserIdleSystemSleep"
+```
+
+## Memory Health
+
+```bash
+# Memory pressure (the most useful single check)
+memory_pressure
+# "The system has X% memory available"
+# Below 20% = system is under pressure
+
+# Detailed VM stats
+vm_stat
+# Key: "Pages free" and "Pages speculative" = available
+# "Pageouts" > 0 means swapping occurred (not always bad on Apple Silicon)
+
+# Swap usage
+sysctl vm.swapusage
+# If swap used is > 0 and growing, system is memory-constrained
+
+# Physical RAM
+sysctl hw.memsize | awk '{print $2/1073741824 " GB"}'
+
+# Top memory consumers
+ps aux --sort=-%mem | head -11
+```
+
+**Thresholds:**
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| Memory available | >40% | 20-40% | <20% |
+| Swap used | 0-1 GB | 1-4 GB | >4 GB |
+| Memory pressure | green | yellow | red |
+
+**Swap on Apple Silicon:** Small amounts of swap usage are normal on Apple
+Silicon Macs due to unified memory architecture. macOS aggressively uses
+swap as a performance optimization, not just as emergency overflow.
+
+## CPU & Thermal
+
+```bash
+# Load averages (1, 5, 15 minutes)
+sysctl -n vm.loadavg
+# Or
+uptime
+
+# CPU usage by process (top 10)
+ps aux --sort=-%cpu | head -11
+
+# Thermal state (Apple Silicon)
+sudo powermetrics --samplers smc -i 1 -n 1 2>/dev/null | grep -i "thermal"
+
+# CPU throttling check
+sudo powermetrics --samplers cpu_power -i 1000 -n 1 2>/dev/null | head -30
+
+# Fan speed (Intel Macs, or with iStats)
+# brew install iStats (Ruby gem: gem install iStats)
+# istats fan speed
+```
+
+**Interpreting load averages:**
+- Load / number of cores < 1.0 — system is idle
+- Load / number of cores = 1.0-2.0 — moderate load
+- Load / number of cores > 2.0 — system is overloaded
+
+Get core count: `sysctl -n hw.ncpu`
+
+**Finding runaway processes:**
+```bash
+# Processes using >50% CPU
+ps aux | awk '$3 > 50.0 {print $0}'
+
+# Processes using >1 GB memory
+ps aux | awk '$6 > 1048576 {print $0}'
+
+# WindowServer CPU (if high, GPU/display issue)
+ps aux | grep WindowServer | grep -v grep
+```
+
+## System Uptime & Restart History
+
+```bash
+# Current uptime
+uptime
+
+# Last reboot
+last reboot | head -5
+
+# Last shutdown
+last shutdown | head -5
+
+# Kernel panics (crashes)
+ls -la /Library/Logs/DiagnosticReports/*.panic 2>/dev/null
+ls -la ~/Library/Logs/DiagnosticReports/*.panic 2>/dev/null
+```
+
+Macs should be restarted at least every few weeks. Extended uptime (30+ days)
+can lead to memory leaks in long-running processes and stale system caches.
+
+## Time Machine Status
+
+```bash
+# Backup status
+tmutil status
+
+# Last backup date
+tmutil latestbackup
+
+# Backup destination info
+tmutil destinationinfo
+
+# List local snapshots (consume disk space)
+tmutil listlocalsnapshots /
+
+# Machine directory info
+tmutil machinedirectory 2>/dev/null
+```
+
+**Health checks:**
+- Last backup > 24 hours ago — warning (if TM is configured)
+- Last backup > 7 days ago — critical
+- No backup destination configured — security risk
+
+## Spotlight Index Health
+
+```bash
+# Index status
+mdutil -s /
+
+# Check if indexing is currently running
+mdutil -s / | grep "Indexing"
+# "Indexing enabled." + not actively indexing = healthy
+# "Indexing disabled." = might need re-enabling
+
+# Rebuild if search is broken (takes 10-60 min)
+sudo mdutil -E /
+
+# Check Spotlight CPU usage (should be low when idle)
+ps aux | grep mds | grep -v grep
+```
+
+**When to rebuild Spotlight:**
+- Search returns no results or wrong results
+- `mds_stores` consuming high CPU persistently
+- After major OS upgrade

--- a/skills/macos-maintenance/references/maintenance-tasks.md
+++ b/skills/macos-maintenance/references/maintenance-tasks.md
@@ -1,0 +1,256 @@
+# Maintenance Tasks
+
+Periodic maintenance operations that keep macOS running smoothly. Includes
+tasks macOS handles automatically and tasks that need manual intervention.
+
+## macOS Built-in Periodic Scripts
+
+macOS runs three maintenance scripts automatically:
+- **daily** — rotates system logs, removes old temp files
+- **weekly** — rebuilds `locate` and `whatis` databases
+- **monthly** — rotates additional logs, cleans up old accounting data
+
+```bash
+# Check when they last ran
+ls -la /var/log/*.out 2>/dev/null
+# daily.out, weekly.out, monthly.out
+# Compare dates — if laptop sleeps through scheduled times, they get skipped
+
+# Force-run all periodic scripts (safe, takes 1-2 minutes)
+sudo periodic daily weekly monthly
+
+# Run individually
+sudo periodic daily
+sudo periodic weekly
+sudo periodic monthly
+```
+
+**When to force-run:**
+- If the Mac was sleeping/off at scheduled run times
+- After extended travel (laptop closed for days)
+- If `daily.out` is more than 3 days old
+- Monthly scripts haven't run in 30+ days
+
+These scripts are safe and idempotent — running them extra times causes no harm.
+
+## DNS Cache Flush
+
+```bash
+# Flush DNS cache (useful when DNS is stale or domains don't resolve)
+sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
+
+# Verify
+dscacheutil -q host -a name google.com
+```
+
+**When to flush:**
+- After changing DNS servers
+- After VPN connect/disconnect issues
+- When websites fail to load but internet works
+- After editing `/etc/hosts`
+
+## Rebuild Launch Services Database
+
+The Launch Services database maps file types to applications. Corruption
+causes "Open With" to show duplicates or wrong apps.
+
+```bash
+# Rebuild Launch Services database
+/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -kill -r -domain local -domain system -domain user
+
+# Then restart Finder
+killall Finder
+```
+
+**When to rebuild:**
+- Duplicate entries in "Open With" context menu
+- Wrong app opens for a file type
+- App icons showing as generic white document
+
+## Rebuild Spotlight Index
+
+```bash
+# Disable then re-enable to force full re-index
+sudo mdutil -E /
+
+# Check progress
+mdutil -s /
+
+# Alternatively, add then remove from Privacy list
+# System Settings → Spotlight → Privacy → add "/" → remove "/"
+```
+
+**When to rebuild:**
+- Search returns no/wrong results
+- `mds_stores` process using high CPU for extended periods
+- After OS upgrade or migration
+
+Rebuilding takes 10-60 minutes depending on disk size. Mac may feel
+sluggish during indexing.
+
+## Reset NVRAM/PRAM
+
+**Intel Macs:**
+Restart and hold Cmd+Option+P+R for 20 seconds.
+
+**Apple Silicon:**
+NVRAM resets automatically during a normal restart. No manual reset needed.
+
+NVRAM stores: display resolution, startup disk, time zone, volume, kernel
+panic info. Reset when display/sound/startup issues occur.
+
+## Reset SMC
+
+**Intel Macs:**
+1. Shut down
+2. Hold Control+Shift+Option+Power for 10 seconds
+3. Release and power on
+
+**Apple Silicon:**
+No SMC — shut down for 30 seconds and restart.
+
+SMC controls: fans, thermal management, battery charging, LED indicators,
+power button behavior. Reset when fans run high, battery doesn't charge,
+or sleep/wake fails.
+
+## Launch Daemon/Agent Audit
+
+```bash
+# All non-Apple launch agents (user)
+ls ~/Library/LaunchAgents/ 2>/dev/null | grep -v "com.apple"
+
+# All non-Apple launch agents (system)
+ls /Library/LaunchAgents/ 2>/dev/null | grep -v "com.apple"
+
+# All non-Apple launch daemons
+ls /Library/LaunchDaemons/ 2>/dev/null | grep -v "com.apple"
+
+# Check if a specific agent/daemon is loaded
+launchctl list | grep "com.example"
+
+# Get details about a launchd job
+launchctl print system/com.example.daemon
+
+# Disable a launch agent (persists across restarts)
+launchctl disable user/$(id -u)/com.example.agent
+
+# Unload immediately
+launchctl bootout gui/$(id -u)/com.example.agent
+```
+
+**Common safe-to-remove items** (if you don't use the app):
+- `com.adobe.AdobeCreativeCloud` — Creative Cloud auto-launcher
+- `com.spotify.webhelper` — Spotify web player helper
+- `com.google.keystone.*` — Google updater
+- `com.microsoft.update.*` — Microsoft AutoUpdate
+
+**Never remove:**
+- Anything starting with `com.apple.`
+- Items you're not sure about — research first
+
+## Kernel Extension Audit (Intel/Transition)
+
+```bash
+# List loaded kexts
+kextstat | grep -v com.apple
+
+# System Extensions (modern replacement for kexts)
+systemextensionsctl list
+```
+
+On Apple Silicon, third-party kernel extensions are largely deprecated.
+System Extensions are the modern replacement and run in user space.
+
+**Common legitimate non-Apple kexts:**
+- VirtualBox, VMware, Parallels — virtualization
+- Little Snitch — network firewall
+- Wireshark — packet capture
+
+## App Update Checks
+
+```bash
+# macOS software updates
+softwareupdate -l
+
+# Homebrew outdated packages
+brew outdated
+
+# Homebrew cask (GUI app) updates
+brew outdated --cask
+
+# npm global packages
+npm outdated -g 2>/dev/null
+
+# pip packages
+pip list --outdated 2>/dev/null
+```
+
+## Recommended Maintenance Schedule
+
+### Weekly
+- Check for macOS updates (`softwareupdate -l`)
+- Run `brew update && brew upgrade && brew cleanup`
+- Empty Trash if large
+
+### Monthly
+- Force periodic scripts (`sudo periodic daily weekly monthly`)
+- Check disk space (`df -h /`)
+- Review login items
+- Check battery health (laptops)
+- Run `brew autoremove`
+
+### Quarterly
+- Full security audit (run the security scorecard)
+- Check SMART disk status
+- Review launch agents/daemons for cruft
+- Check Time Machine backup health
+- Review large files and disk usage
+- Update dev tool caches (consider cleanup)
+
+### Annually
+- Full system backup before OS upgrade
+- Review system extensions
+- Audit installed applications (remove unused)
+- Check FileVault recovery key is accessible
+
+## Troubleshooting Common Issues
+
+### Mac Running Slow
+
+1. Check memory pressure: `memory_pressure`
+2. Check CPU: `top -l 1 -o cpu -n 5`
+3. Check disk space: `df -h /` (needs >10% free)
+4. Check swap: `sysctl vm.swapusage`
+5. Check uptime: `uptime` (restart if >30 days)
+6. Check for runaway processes: `ps aux | awk '$3 > 50'`
+7. Check Spotlight indexing: `mdutil -s /`
+8. Consider restart (fixes most transient issues)
+
+### Fan Running Loud
+
+1. Check CPU usage: `top -l 1 -o cpu -n 5`
+2. Kill runaway process if found
+3. Check thermal state: `sudo powermetrics --samplers smc -i 1 -n 1`
+4. Reset SMC (Intel) or restart (Apple Silicon)
+5. Clean vents with compressed air
+6. Check ambient temperature
+
+### Wi-Fi Issues
+
+See `references/network-diagnostics.md` for detailed Wi-Fi troubleshooting.
+
+Quick fixes:
+1. Turn Wi-Fi off and on
+2. Forget and re-join network
+3. Flush DNS: `sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder`
+4. Renew DHCP: `sudo ipconfig set en0 DHCP`
+5. Reset network preferences: delete `/Library/Preferences/SystemConfiguration/` files (sudo, then restart)
+
+### Battery Draining Fast
+
+1. Check Activity Monitor → Energy tab
+2. `pmset -g assertions` — what's preventing sleep?
+3. Check for runaway processes: `top -l 1 -o cpu -n 5`
+4. Disable Bluetooth if not in use
+5. Reduce display brightness
+6. Check battery health: `system_profiler SPPowerDataType | grep Condition`

--- a/skills/macos-maintenance/references/network-diagnostics.md
+++ b/skills/macos-maintenance/references/network-diagnostics.md
@@ -1,0 +1,203 @@
+# Network Diagnostics
+
+Commands and workflows for diagnosing network issues on macOS.
+
+## Quick Connectivity Test
+
+```bash
+# Internet connectivity
+ping -c 3 8.8.8.8
+
+# DNS resolution
+ping -c 3 google.com
+
+# If ping works but DNS doesn't → DNS issue
+# If neither works → connectivity issue
+```
+
+## Network Interface Info
+
+```bash
+# List all interfaces
+networksetup -listallhardwareports
+
+# Current Wi-Fi network
+networksetup -getairportnetwork en0 2>/dev/null
+
+# IP address
+ipconfig getifaddr en0
+
+# Full IP configuration
+ifconfig en0
+
+# Default gateway
+netstat -nr | grep default
+
+# DNS servers in use
+scutil --dns | grep "nameserver" | head -5
+
+# All network services and their order
+networksetup -listnetworkserviceorder
+```
+
+## DNS Diagnostics
+
+```bash
+# Resolve a domain
+dscacheutil -q host -a name google.com
+
+# Detailed DNS lookup
+nslookup google.com
+
+# Trace DNS resolution path
+dig +trace google.com
+
+# Check which DNS server is responding
+dig google.com | grep "SERVER"
+
+# Flush DNS cache
+sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
+
+# Check /etc/hosts for overrides
+cat /etc/hosts | grep -v "^#" | grep -v "^$"
+
+# Check configured DNS servers
+networksetup -getdnsservers Wi-Fi
+```
+
+**Common DNS fixes:**
+- Flush cache (see above)
+- Switch to public DNS: `networksetup -setdnsservers Wi-Fi 1.1.1.1 8.8.8.8`
+- Reset to DHCP DNS: `networksetup -setdnsservers Wi-Fi empty`
+
+## Wi-Fi Diagnostics
+
+```bash
+# Wi-Fi signal strength and channel
+/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I
+
+# Key values:
+#   agrCtlRSSI: signal strength (dBm, higher/closer to 0 = better)
+#     -30 to -50: excellent
+#     -50 to -60: good
+#     -60 to -70: fair
+#     -70 to -80: weak
+#     below -80: very weak / unreliable
+#   agrCtlNoise: background noise (more negative = less noise)
+#   channel: current channel
+#   lastTxRate: current connection speed
+
+# Scan available networks
+/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -s
+
+# Wi-Fi interface details
+system_profiler SPAirPortDataType
+
+# Generate a Wi-Fi diagnostics report (saves to /var/tmp)
+sudo /usr/bin/wdutil diagnose
+```
+
+**Wi-Fi troubleshooting steps:**
+1. Check signal strength (RSSI above -60 is good)
+2. Check for channel congestion (scan nearby networks)
+3. Forget and re-join network
+4. Renew DHCP lease: `sudo ipconfig set en0 DHCP`
+5. Reset Wi-Fi: turn off, wait 10 seconds, turn on
+6. Delete preferences: `sudo rm /Library/Preferences/SystemConfiguration/com.apple.airport.preferences.plist` then restart
+7. Create new network location: `networksetup -createlocation "Fresh" populate`
+
+## Port & Firewall Testing
+
+```bash
+# Check if a port is open locally
+lsof -i :8080
+
+# Check if a remote port is reachable
+nc -z -w 5 google.com 443 && echo "Open" || echo "Closed"
+
+# List all listening ports
+lsof -iTCP -sTCP:LISTEN -P -n
+
+# Check firewall rules
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --listapps
+```
+
+## VPN Status
+
+```bash
+# List VPN configurations
+scutil --nc list
+
+# Check active VPN connections
+ifconfig | grep -A1 "utun"
+
+# Or check for common VPN processes
+ps aux | grep -E "(openvpn|wireguard|tailscaled)" | grep -v grep
+```
+
+## Network Performance
+
+```bash
+# Bandwidth test (requires speedtest-cli)
+# brew install speedtest-cli
+speedtest-cli --simple 2>/dev/null
+
+# Or use networkQuality (built-in macOS Monterey+)
+networkQuality
+
+# Route to a destination
+traceroute google.com
+
+# Packet loss test (30 pings)
+ping -c 30 google.com | tail -3
+# Look at packet loss percentage — any loss above 1% is concerning
+```
+
+## Proxy Settings
+
+```bash
+# Check proxy configuration
+networksetup -getwebproxy Wi-Fi
+networksetup -getsecurewebproxy Wi-Fi
+networksetup -getautoproxyurl Wi-Fi
+
+# System-wide proxy environment
+echo $http_proxy $https_proxy $no_proxy
+
+# Disable all proxies
+networksetup -setwebproxystate Wi-Fi off
+networksetup -setsecurewebproxystate Wi-Fi off
+networksetup -setautoproxystate Wi-Fi off
+```
+
+## Network Reset (Nuclear Option)
+
+If all else fails, reset all network configuration:
+
+```bash
+# Remove all network preferences (requires restart)
+sudo rm -rf /Library/Preferences/SystemConfiguration/com.apple.airport.preferences.plist
+sudo rm -rf /Library/Preferences/SystemConfiguration/com.apple.network.identification.plist
+sudo rm -rf /Library/Preferences/SystemConfiguration/NetworkInterfaces.plist
+sudo rm -rf /Library/Preferences/SystemConfiguration/preferences.plist
+
+# Then restart
+sudo shutdown -r now
+```
+
+This removes all saved Wi-Fi networks, custom DNS, proxy settings, and
+network locations. The Mac will behave like a fresh setup for networking.
+Only do this as a last resort.
+
+## Common Network Issues Quick Reference
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| No internet, Wi-Fi connected | DNS issue | Flush DNS, try 8.8.8.8 |
+| Slow browsing | DNS or congestion | Switch DNS, check bandwidth |
+| Can't connect to Wi-Fi | Auth/password | Forget network, re-join |
+| VPN connected, no internet | Split tunnel config | Check VPN routing |
+| Port not reachable | Firewall blocking | Check `socketfilterfw` rules |
+| Intermittent drops | Weak signal or interference | Check RSSI, change channel |
+| Works on Wi-Fi, not ethernet | Interface priority | Check service order |
+| Captive portal not loading | DNS or proxy | Try `http://captive.apple.com` |

--- a/skills/macos-maintenance/references/security-posture.md
+++ b/skills/macos-maintenance/references/security-posture.md
@@ -1,0 +1,220 @@
+# Security Posture Checks
+
+Verify macOS security features are properly configured. These are the same
+checks Apple Genius Bar technicians run as part of system diagnostics.
+
+## Quick Security Audit
+
+Run all checks at once for a snapshot of security posture:
+
+```bash
+echo "=== SIP ===" && csrutil status
+echo "=== Gatekeeper ===" && spctl --status
+echo "=== FileVault ===" && fdesetup status
+echo "=== Firewall ===" && sudo /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
+echo "=== Remote Login ===" && systemsetup -getremotelogin 2>/dev/null
+echo "=== Auto Updates ===" && defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled 2>/dev/null
+```
+
+## System Integrity Protection (SIP)
+
+```bash
+csrutil status
+# Expected: "System Integrity Protection status: enabled."
+```
+
+SIP prevents modification of protected system files, even by root. It should
+always be enabled unless actively debugging kernel extensions.
+
+**If disabled:**
+- Restart into Recovery Mode (Cmd+R on Intel, hold power on Apple Silicon)
+- Terminal → `csrutil enable`
+- Restart
+
+## Gatekeeper
+
+```bash
+spctl --status
+# Expected: "assessments enabled"
+
+# Check if specific app is allowed
+spctl --assess --verbose /Applications/SomeApp.app
+```
+
+Gatekeeper verifies that apps are signed by identified developers or from
+the App Store. Should always be enabled.
+
+**If disabled:**
+```bash
+sudo spctl --master-enable
+```
+
+## FileVault (Disk Encryption)
+
+```bash
+fdesetup status
+# Expected: "FileVault is On."
+
+# Check encryption progress (if encrypting)
+fdesetup status | grep -i progress
+```
+
+FileVault encrypts the entire startup disk. Critical for laptops that could
+be lost or stolen. On Apple Silicon, hardware encryption is always on, but
+FileVault adds the login-required-to-decrypt layer.
+
+**If disabled:**
+- System Settings → Privacy & Security → FileVault → Turn On
+- Or: `sudo fdesetup enable` (returns recovery key — save it!)
+
+## Firewall
+
+```bash
+# Status
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
+# Expected: "Firewall is enabled."
+
+# Stealth mode (don't respond to pings/port scans)
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode
+
+# List allowed apps
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --listapps
+
+# Block all incoming (except essential services)
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --getblockall
+```
+
+**Recommended settings:**
+- Firewall: enabled
+- Stealth mode: enabled
+- Block all incoming: off (breaks too many things)
+
+**Enable if disabled:**
+```bash
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on
+```
+
+## XProtect & MRT (Malware Protection)
+
+```bash
+# XProtect version and last update
+system_profiler SPInstallHistoryDataType | grep -A3 "XProtect"
+
+# XProtect definitions version
+defaults read /Library/Apple/System/Library/CoreServices/XProtect.bundle/Contents/version.plist 2>/dev/null
+
+# Check XProtect remediator version
+defaults read /Library/Apple/System/Library/CoreServices/XProtect.app/Contents/Info.plist CFBundleShortVersionString 2>/dev/null
+
+# MRT (Malware Removal Tool) version
+defaults read /Library/Apple/System/Library/CoreServices/MRT.app/Contents/Info.plist CFBundleShortVersionString 2>/dev/null
+
+# Last XProtect data update
+ls -la /Library/Apple/System/Library/CoreServices/XProtect.bundle/
+```
+
+XProtect updates silently in the background. If the version is more than
+2 weeks old, something may be blocking background updates.
+
+## Remote Access
+
+```bash
+# Remote Login (SSH)
+systemsetup -getremotelogin 2>/dev/null
+# Should be "Off" unless intentionally used
+
+# Screen Sharing
+sudo launchctl list | grep screensharing
+# Should not be loaded unless intentionally used
+
+# Remote Management (ARD)
+sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -agent -print 2>/dev/null
+```
+
+**Disable if not needed:**
+```bash
+sudo systemsetup -setremotelogin off
+sudo launchctl disable system/com.apple.screensharing
+```
+
+## Automatic Updates
+
+```bash
+# Check all auto-update settings
+defaults read /Library/Preferences/com.apple.SoftwareUpdate 2>/dev/null
+
+# Key settings:
+# AutomaticCheckEnabled = 1 (check for updates)
+# AutomaticDownload = 1 (download in background)
+# AutomaticallyInstallMacOSUpdates = 1 (install macOS updates)
+# CriticalUpdateInstall = 1 (install security updates)
+# ConfigDataInstall = 1 (install XProtect/MRT updates)
+
+# Check via softwareupdate
+softwareupdate --schedule
+```
+
+**Recommended: all auto-update settings should be enabled.**
+Security responses (Rapid Security Response) and XProtect updates are
+critical and should never be delayed.
+
+## Privacy: Location Services, Analytics, Siri
+
+```bash
+# Location Services
+sudo defaults read /var/db/locationd/Library/Preferences/ByHost/com.apple.locationd 2>/dev/null | grep -i "enabled"
+
+# Analytics sharing
+defaults read /Library/Application\ Support/CrashReporter/DiagnosticMessagesHistory.plist 2>/dev/null | grep -i "autosubmit"
+
+# Siri
+defaults read com.apple.assistant.support "Assistant Enabled" 2>/dev/null
+```
+
+These are privacy preferences, not security issues. Inform the user of
+the current state without recommending changes — privacy is personal.
+
+## Login Items & Background Items
+
+```bash
+# List login items (GUI-based, requires osascript)
+osascript -e 'tell application "System Events" to get the name of every login item' 2>/dev/null
+
+# Background items (macOS Ventura+)
+# System Settings → General → Login Items & Extensions
+# No CLI for the new managed background items — direct user to Settings
+
+# Launch Agents (user-level)
+ls ~/Library/LaunchAgents/ 2>/dev/null
+
+# Launch Agents (system-wide)
+ls /Library/LaunchAgents/ 2>/dev/null
+
+# Launch Daemons (system-wide)
+ls /Library/LaunchDaemons/ 2>/dev/null
+```
+
+**Audit guidance:**
+- Apple items (`com.apple.*`) — always fine
+- Known software items (`com.google.*`, `com.microsoft.*`) — typically fine
+- Unknown items — investigate: `launchctl print system/<label>`
+- Items for uninstalled apps — remove the plist file
+
+## Security Scorecard
+
+Present findings as a simple scorecard:
+
+| Check | Expected | Status |
+|-------|----------|--------|
+| SIP | Enabled | |
+| Gatekeeper | Enabled | |
+| FileVault | On | |
+| Firewall | Enabled | |
+| Stealth Mode | Enabled | |
+| Auto Updates | Enabled | |
+| XProtect | Current (<14 days) | |
+| Remote Login | Off | |
+| Screen Sharing | Off | |
+
+Count passing checks. 8-9/9 = excellent, 6-7 = good, <6 = needs attention.

--- a/skills/macos-maintenance/scripts/system-checkup.sh
+++ b/skills/macos-maintenance/scripts/system-checkup.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: bash system-checkup.sh [--json] [--quick] [--security-only]
+
+JSON_OUTPUT=false
+QUICK=false
+SECURITY_ONLY=false
+for arg in "$@"; do
+  case "$arg" in
+    --json) JSON_OUTPUT=true ;;
+    --quick) QUICK=true ;;
+    --security-only) SECURITY_ONLY=true ;;
+  esac
+done
+
+PASS="PASS"
+WARN="WARN"
+FAIL="FAIL"
+INFO="INFO"
+
+declare -a RESULTS=()
+
+add_check() {
+  local category="$1" check="$2" status="$3" detail="$4"
+  RESULTS+=("${category}|${check}|${status}|${detail}")
+}
+
+echo "Running macOS system checkup..." >&2
+
+check_security() {
+  echo "  Checking security posture..." >&2
+
+  local sip_status
+  sip_status=$(csrutil status 2>/dev/null || echo "unknown")
+  if echo "$sip_status" | grep -q "enabled"; then
+    add_check "Security" "System Integrity Protection" "$PASS" "Enabled"
+  else
+    add_check "Security" "System Integrity Protection" "$FAIL" "Disabled — re-enable from Recovery Mode"
+  fi
+
+  local gatekeeper
+  gatekeeper=$(spctl --status 2>/dev/null || echo "unknown")
+  if echo "$gatekeeper" | grep -q "assessments enabled"; then
+    add_check "Security" "Gatekeeper" "$PASS" "Enabled"
+  else
+    add_check "Security" "Gatekeeper" "$FAIL" "Disabled — run: sudo spctl --master-enable"
+  fi
+
+  local filevault
+  filevault=$(fdesetup status 2>/dev/null || echo "unknown")
+  if echo "$filevault" | grep -q "On"; then
+    add_check "Security" "FileVault" "$PASS" "On"
+  elif echo "$filevault" | grep -q "Off"; then
+    add_check "Security" "FileVault" "$WARN" "Off — enable via System Settings > Privacy & Security"
+  else
+    add_check "Security" "FileVault" "$INFO" "Could not determine"
+  fi
+
+  local firewall
+  firewall=$(sudo /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate 2>/dev/null || echo "unknown")
+  if echo "$firewall" | grep -qi "enabled"; then
+    add_check "Security" "Firewall" "$PASS" "Enabled"
+  else
+    add_check "Security" "Firewall" "$WARN" "Disabled — enable via System Settings or socketfilterfw"
+  fi
+
+  local remote_login
+  remote_login=$(systemsetup -getremotelogin 2>/dev/null || echo "unknown")
+  if echo "$remote_login" | grep -qi "off"; then
+    add_check "Security" "Remote Login (SSH)" "$PASS" "Off"
+  elif echo "$remote_login" | grep -qi "on"; then
+    add_check "Security" "Remote Login (SSH)" "$WARN" "On — disable if not needed"
+  fi
+
+  local auto_update
+  auto_update=$(defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled 2>/dev/null || echo "0")
+  if [ "$auto_update" = "1" ]; then
+    add_check "Security" "Automatic Update Check" "$PASS" "Enabled"
+  else
+    add_check "Security" "Automatic Update Check" "$WARN" "Disabled — enable in System Settings > Software Update"
+  fi
+}
+
+check_disk() {
+  echo "  Checking disk health..." >&2
+
+  local smart_status
+  smart_status=$(diskutil info disk0 2>/dev/null | grep "SMART Status" | awk -F: '{print $2}' | xargs || echo "unknown")
+  if [ "$smart_status" = "Verified" ]; then
+    add_check "Disk" "SMART Status" "$PASS" "Verified"
+  elif [ "$smart_status" = "Failing" ]; then
+    add_check "Disk" "SMART Status" "$FAIL" "FAILING — back up immediately, replace drive"
+  else
+    add_check "Disk" "SMART Status" "$INFO" "$smart_status"
+  fi
+
+  local disk_pct
+  disk_pct=$(df -h / 2>/dev/null | tail -1 | awk '{gsub(/%/,""); print $5}')
+  local disk_free
+  disk_free=$(df -h / 2>/dev/null | tail -1 | awk '{print $4}')
+  if [ "$disk_pct" -lt 70 ] 2>/dev/null; then
+    add_check "Disk" "Space Usage" "$PASS" "${disk_pct}% used, ${disk_free} free"
+  elif [ "$disk_pct" -lt 85 ] 2>/dev/null; then
+    add_check "Disk" "Space Usage" "$WARN" "${disk_pct}% used, ${disk_free} free — consider cleanup"
+  else
+    add_check "Disk" "Space Usage" "$FAIL" "${disk_pct}% used, ${disk_free} free — cleanup needed"
+  fi
+}
+
+check_battery() {
+  echo "  Checking battery..." >&2
+
+  local has_battery
+  has_battery=$(system_profiler SPPowerDataType 2>/dev/null | grep "Cycle Count" || echo "")
+  if [ -z "$has_battery" ]; then
+    add_check "Battery" "Battery" "$INFO" "No battery (desktop Mac)"
+    return
+  fi
+
+  local cycle_count
+  cycle_count=$(system_profiler SPPowerDataType 2>/dev/null | grep "Cycle Count" | awk '{print $NF}')
+  if [ "$cycle_count" -lt 500 ] 2>/dev/null; then
+    add_check "Battery" "Cycle Count" "$PASS" "$cycle_count cycles"
+  elif [ "$cycle_count" -lt 800 ] 2>/dev/null; then
+    add_check "Battery" "Cycle Count" "$WARN" "$cycle_count cycles — moderate wear"
+  else
+    add_check "Battery" "Cycle Count" "$FAIL" "$cycle_count cycles — high wear"
+  fi
+
+  local condition
+  condition=$(system_profiler SPPowerDataType 2>/dev/null | grep "Condition" | awk -F: '{print $2}' | xargs)
+  if [ "$condition" = "Normal" ]; then
+    add_check "Battery" "Condition" "$PASS" "Normal"
+  else
+    add_check "Battery" "Condition" "$WARN" "$condition"
+  fi
+}
+
+check_memory() {
+  echo "  Checking memory..." >&2
+
+  local mem_pressure
+  mem_pressure=$(memory_pressure 2>/dev/null | grep "System-wide" | awk '{print $NF}' | tr -d '%')
+  local mem_free=$((100 - ${mem_pressure:-0}))
+
+  if [ "$mem_free" -gt 40 ] 2>/dev/null; then
+    add_check "Memory" "Pressure" "$PASS" "${mem_free}% available"
+  elif [ "$mem_free" -gt 20 ] 2>/dev/null; then
+    add_check "Memory" "Pressure" "$WARN" "${mem_free}% available — moderate pressure"
+  else
+    add_check "Memory" "Pressure" "$FAIL" "${mem_free}% available — high pressure"
+  fi
+
+  local swap_used
+  swap_used=$(sysctl vm.swapusage 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="used") print $(i+2)}' | tr -d 'M.' | head -c4)
+  swap_used=${swap_used:-0}
+  if [ "$swap_used" -lt 1024 ] 2>/dev/null; then
+    add_check "Memory" "Swap" "$PASS" "${swap_used} MB used"
+  elif [ "$swap_used" -lt 4096 ] 2>/dev/null; then
+    add_check "Memory" "Swap" "$WARN" "${swap_used} MB used"
+  else
+    add_check "Memory" "Swap" "$FAIL" "${swap_used} MB used — excessive swapping"
+  fi
+}
+
+check_uptime() {
+  echo "  Checking uptime..." >&2
+
+  local days
+  days=$(uptime 2>/dev/null | awk -F'up ' '{print $2}' | awk -F',' '{print $1}')
+  local day_count
+  day_count=$(echo "$days" | grep -o '[0-9]*' | head -1)
+  day_count=${day_count:-0}
+
+  if [ "$day_count" -lt 7 ] 2>/dev/null; then
+    add_check "System" "Uptime" "$PASS" "$days"
+  elif [ "$day_count" -lt 30 ] 2>/dev/null; then
+    add_check "System" "Uptime" "$WARN" "$days — consider restarting"
+  else
+    add_check "System" "Uptime" "$FAIL" "$days — restart recommended"
+  fi
+}
+
+check_updates() {
+  echo "  Checking for updates..." >&2
+
+  if [ "$QUICK" = false ]; then
+    local updates
+    updates=$(softwareupdate -l 2>&1)
+    if echo "$updates" | grep -q "No new software available"; then
+      add_check "Updates" "macOS Updates" "$PASS" "Up to date"
+    else
+      local count
+      count=$(echo "$updates" | grep -c "^\*" 2>/dev/null || echo "0")
+      add_check "Updates" "macOS Updates" "$WARN" "$count update(s) available"
+    fi
+  fi
+
+  if command -v brew &>/dev/null; then
+    local brew_outdated
+    brew_outdated=$(brew outdated 2>/dev/null | wc -l | xargs)
+    if [ "$brew_outdated" -eq 0 ] 2>/dev/null; then
+      add_check "Updates" "Homebrew" "$PASS" "All packages current"
+    else
+      add_check "Updates" "Homebrew" "$WARN" "$brew_outdated package(s) outdated — run: brew upgrade"
+    fi
+  fi
+}
+
+check_periodic() {
+  echo "  Checking maintenance scripts..." >&2
+
+  for period in daily weekly monthly; do
+    local log="/var/log/${period}.out"
+    if [ -f "$log" ]; then
+      local last_run
+      last_run=$(stat -f "%Sm" -t "%Y-%m-%d" "$log" 2>/dev/null || echo "unknown")
+      local age_days
+      age_days=$(( ($(date +%s) - $(stat -f "%m" "$log" 2>/dev/null || echo "0")) / 86400 ))
+
+      local threshold=3
+      [ "$period" = "weekly" ] && threshold=10
+      [ "$period" = "monthly" ] && threshold=35
+
+      if [ "$age_days" -lt "$threshold" ] 2>/dev/null; then
+        add_check "Maintenance" "Periodic $period" "$PASS" "Last ran: $last_run"
+      else
+        add_check "Maintenance" "Periodic $period" "$WARN" "Last ran: $last_run (${age_days}d ago) — run: sudo periodic $period"
+      fi
+    else
+      add_check "Maintenance" "Periodic $period" "$WARN" "Never ran — run: sudo periodic $period"
+    fi
+  done
+}
+
+check_time_machine() {
+  echo "  Checking Time Machine..." >&2
+
+  local tm_dest
+  tm_dest=$(tmutil destinationinfo 2>/dev/null | grep "Name" || echo "")
+  if [ -z "$tm_dest" ]; then
+    add_check "Backup" "Time Machine" "$WARN" "No backup destination configured"
+    return
+  fi
+
+  local last_backup
+  last_backup=$(tmutil latestbackup 2>/dev/null || echo "")
+  if [ -n "$last_backup" ]; then
+    local backup_date
+    backup_date=$(basename "$last_backup")
+    add_check "Backup" "Time Machine" "$PASS" "Last backup: $backup_date"
+  else
+    add_check "Backup" "Time Machine" "$WARN" "Destination configured but no backup found"
+  fi
+}
+
+check_security
+
+if [ "$SECURITY_ONLY" = false ]; then
+  check_disk
+  check_battery
+  check_memory
+  check_uptime
+  check_updates
+  check_periodic
+  check_time_machine
+fi
+
+echo "  Checkup complete." >&2
+
+if [ "$JSON_OUTPUT" = true ]; then
+  echo "["
+  first=true
+  for result in "${RESULTS[@]}"; do
+    IFS='|' read -r category check status detail <<< "$result"
+    if [ "$first" = true ]; then first=false; else echo ","; fi
+    printf '  {"category": "%s", "check": "%s", "status": "%s", "detail": "%s"}' \
+      "$category" "$check" "$status" "$detail"
+  done
+  echo ""
+  echo "]"
+else
+  pass_count=0
+  warn_count=0
+  fail_count=0
+
+  echo ""
+  echo "macOS System Checkup Report"
+  echo "==========================="
+  echo ""
+
+  current_category=""
+  for result in "${RESULTS[@]}"; do
+    IFS='|' read -r category check status detail <<< "$result"
+    if [ "$category" != "$current_category" ]; then
+      [ -n "$current_category" ] && echo ""
+      echo "--- $category ---"
+      current_category="$category"
+    fi
+
+    local icon="?"
+    case "$status" in
+      "$PASS") icon="[OK]"; pass_count=$((pass_count + 1)) ;;
+      "$WARN") icon="[!!]"; warn_count=$((warn_count + 1)) ;;
+      "$FAIL") icon="[XX]"; fail_count=$((fail_count + 1)) ;;
+      "$INFO") icon="[--]" ;;
+    esac
+
+    printf "  %-6s %-30s %s\n" "$icon" "$check" "$detail"
+  done
+
+  echo ""
+  echo "==========================="
+  total=$((pass_count + warn_count + fail_count))
+  echo "Score: ${pass_count}/${total} checks passed"
+  [ "$warn_count" -gt 0 ] && echo "  ${warn_count} warning(s)"
+  [ "$fail_count" -gt 0 ] && echo "  ${fail_count} issue(s) need attention"
+
+  if [ "$fail_count" -eq 0 ] && [ "$warn_count" -le 2 ]; then
+    echo ""
+    echo "System is in good shape."
+  elif [ "$fail_count" -gt 0 ]; then
+    echo ""
+    echo "Action needed — review items marked [XX] above."
+  fi
+fi

--- a/skills/macos-maintenance/skills.json
+++ b/skills/macos-maintenance/skills.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/macos-maintenance",
+  "version": "1.0.0",
+  "description": "macOS health checks, security audit, and maintenance. Diagnoses disk SMART, battery, memory pressure, security (SIP, Gatekeeper, FileVault, firewall), updates, Time Machine, network, launch daemons. Scored checkup script. Triggers: mac health check, system checkup, is my mac ok, mac maintenance, mac running slow, battery health, SMART status, memory pressure, security audit, firewall status, periodic maintenance, flush DNS, rebuild spotlight, Wi-Fi issues, mac slow, fan loud.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary
- Adds `@tank/macos-maintenance` skill — macOS system health checks, security auditing, and periodic maintenance
- Companion to `@tank/macos-cleanup` (space recovery) — this one focuses on system health, not disk space
- Includes `system-checkup.sh` script that produces a scored health report (PASS/WARN/FAIL per check)
- Covers: disk SMART, battery health, memory pressure, security posture (SIP/Gatekeeper/FileVault/firewall), pending updates, Time Machine, network diagnostics, launch daemon audit, periodic maintenance scripts