### PR TITLE
feat(windows-skills): add Windows cleanup and maintenance skills

### DIFF
--- a/skills/windows-cleanup/.tankignore
+++ b/skills/windows-cleanup/.tankignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.ruff_cache/
+.venv/

--- a/skills/windows-cleanup/SKILL.md
+++ b/skills/windows-cleanup/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: "@tank/windows-cleanup"
+description: |
+  Windows 10/11 disk space recovery and system cleanup for developers.
+  Analyzes disk usage, identifies space hogs (temp files, Windows Update
+  cache, WinSxS, browser caches, dev tool artifacts, stale node_modules,
+  Docker WSL2 images, NuGet/Gradle/npm/pip/Cargo caches, hibernation file,
+  Recycle Bin), and safely reclaims storage with risk-aware PowerShell
+  workflows. Includes an analysis script that produces a prioritized report.
+  Companion to @tank/macos-cleanup for Windows users.
+
+  Trigger phrases: "disk cleanup", "free disk space", "clean up windows",
+  "disk full", "running out of space", "clear cache", "clean storage",
+  "ccleaner", "windows cleanup", "temp files", "cleanmgr", "Storage Sense",
+  "WinSxS", "Windows Update cache", "node_modules cleanup",
+  "docker disk space", "WSL disk", "npm cache", "pip cache", "cargo clean",
+  "NuGet cache", "reclaim space", "hiberfil.sys", "Windows.old",
+  "Recycle Bin", "system data large", "purge caches", "clean dev tools"
+---
+
+# Windows Disk Cleanup
+
+Recover disk space on Windows 10/11 by cleaning temp files, caches, dev
+tool artifacts, stale dependencies, and other reclaimable storage.
+Developer-focused — knows where the real space hogs hide on a dev machine.
+
+## Core Philosophy
+
+1. **Analyze before deleting.** Always scan first with the analysis script.
+2. **Risk-aware cleanup.** Categorize by risk (safe/low/moderate/high).
+   Clean safe items freely, confirm everything else.
+3. **Use built-in tools when possible.** `cleanmgr`, `DISM`, `Storage Sense`,
+   `dotnet nuget locals`, `npm cache clean` over raw `Remove-Item`.
+4. **PowerShell everything.** All commands are PowerShell. Indicate which
+   need elevation (Run as Administrator).
+5. **Never touch user data.** Documents, Desktop, Pictures, credentials,
+   SSH keys, registry — hands off.
+
+## Quick-Start
+
+### "My disk is full, help me clean up"
+
+| Step | Action |
+|------|--------|
+| 1 | Run `.\scripts\analyze-disk.ps1` to scan all targets |
+| 2 | Review report — prioritize by size and risk |
+| 3 | Clean safe targets first (caches, temp files, logs) |
+| 4 | Present moderate targets for user confirmation |
+| 5 | Mention high-risk targets only if asked |
+| 6 | Show before/after disk space comparison |
+
+### "Clean everything safe"
+
+```powershell
+Remove-Item "$env:TEMP\*" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item "C:\Windows\Temp\*" -Recurse -Force -ErrorAction SilentlyContinue  # Admin
+Remove-Item "C:\Windows\Prefetch\*" -Force -ErrorAction SilentlyContinue       # Admin
+npm cache clean --force 2>$null
+pip cache purge 2>$null
+dotnet nuget locals all --clear 2>$null
+```
+
+## Cleanup Priority Order
+
+| Priority | Target | Typical Savings | Risk |
+|----------|--------|----------------|------|
+| 1 | Windows.old | 15-30 GB | Moderate |
+| 2 | Docker WSL2 vhdx | 10-100 GB | Moderate |
+| 3 | Hibernation file | 8-64 GB (=RAM) | Low |
+| 4 | Stale node_modules | 5-50 GB | Moderate |
+| 5 | Rust target dirs | 5-50 GB | Moderate |
+| 6 | Windows Update + WinSxS | 2-15 GB | Safe |
+| 7 | NuGet/Gradle/npm caches | 5-25 GB | Safe |
+| 8 | User & system temp | 1-15 GB | Safe |
+| 9 | Browser caches | 1-5 GB | Safe |
+| 10 | Recycle Bin | 0-50 GB | Moderate |
+
+## Decision Trees
+
+### What to Clean Based on Request
+
+| User Says | Action |
+|-----------|--------|
+| "Clean up my PC" | Full scan, report, clean safe, confirm moderate |
+| "Clean caches" | Temp files, browser caches, dev tool caches |
+| "Clean dev tools" | npm/pip/NuGet/cargo/gradle caches only |
+| "What's using space?" | Analysis only, no cleanup |
+| "Clean Docker" | `docker system prune -a` + compact WSL2 vhdx |
+| "Free up X GB" | Prioritized cleanup until target reached |
+
+### WinSxS Cleanup
+
+Never manually delete from WinSxS. Use DISM only:
+```powershell
+DISM /Online /Cleanup-Image /StartComponentCleanup  # Admin
+```
+
+### Docker WSL2 Disk
+
+Docker's WSL2 virtual disk doesn't auto-shrink. After `docker system prune`:
+```powershell
+wsl --shutdown
+Optimize-VHD -Path "$env:LOCALAPPDATA\Docker\wsl\disk\docker_data.vhdx" -Mode Full  # Admin
+```
+
+## Safety Rules
+
+Never touch:
+- User profile folders (Documents, Desktop, Pictures, etc.)
+- `C:\Windows\Installer` (breaks app repair/uninstall)
+- `C:\Windows\WinSxS` directly (use DISM only)
+- `$env:USERPROFILE\.ssh`, `.gnupg`, `.aws`, `.kube` (credentials)
+- `C:\Windows\System32`, `C:\Windows\SysWOW64`
+- Registry hives, `.git` directories, database files
+
+See `references/safety-protocols.md` for full safety rules.
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/cleanup-targets.md` | Exhaustive cleanup targets with paths, PowerShell commands, risk levels, typical sizes |
+| `references/safety-protocols.md` | Golden rules, confirmation flows, never-touch paths, recovery procedures |
+| `references/space-analysis.md` | Disk analysis techniques, finding large files/dirs, stale node_modules, recommended tools |
+
+## Scripts
+
+| Script | Usage |
+|--------|-------|
+| `scripts/analyze-disk.ps1` | Scans all targets, reports sizes and risk. Flags: `-Json`, `-DevOnly`, `-Quick` |

--- a/skills/windows-cleanup/references/cleanup-targets.md
+++ b/skills/windows-cleanup/references/cleanup-targets.md
@@ -1,0 +1,444 @@
+# Windows Cleanup Targets
+
+Exhaustive reference of what can be safely cleaned on Windows 10/11,
+organized by category. All commands are PowerShell unless noted otherwise.
+Run PowerShell as Administrator for items marked (Admin).
+
+## Risk Levels
+
+| Level | Meaning | Action |
+|-------|---------|--------|
+| Safe | Regenerated automatically, no data loss | Clean without asking |
+| Low | Unlikely to cause issues, minor convenience loss | List and confirm |
+| Moderate | May require re-download, re-login, or rebuild | Warn and confirm |
+| High | Potential data loss if user hasn't backed up | Explain risk, require explicit opt-in |
+
+## 1. Temporary Files
+
+### User Temp
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| User temp | `$env:TEMP` (usually `%LOCALAPPDATA%\Temp`) | Safe | 0.5-10 GB |
+| Windows temp | `C:\Windows\Temp` | Safe (Admin) | 0.5-5 GB |
+| Recent items | `$env:APPDATA\Microsoft\Windows\Recent` | Safe | minimal |
+
+```powershell
+# User temp (safe — apps recreate as needed)
+Remove-Item "$env:TEMP\*" -Recurse -Force -ErrorAction SilentlyContinue
+
+# Windows temp (Admin)
+Remove-Item "C:\Windows\Temp\*" -Recurse -Force -ErrorAction SilentlyContinue
+```
+
+### Disk Cleanup (cleanmgr)
+
+The built-in tool handles many categories. Run it programmatically:
+
+```powershell
+# Interactive
+cleanmgr /d C:
+
+# Automated with pre-configured options (Admin)
+# First set flags in registry, then run with /sagerun
+cleanmgr /sageset:1    # Configure which items to clean (GUI)
+cleanmgr /sagerun:1    # Run the saved configuration silently
+```
+
+### Storage Sense
+
+Windows 10/11 built-in automatic cleanup:
+
+```powershell
+# Enable Storage Sense
+$path = "HKCU:\Software\Microsoft\Windows\CurrentVersion\StorageSense\Parameters\StoragePolicy"
+Set-ItemProperty -Path $path -Name "01" -Value 1 -Type DWord
+
+# Run Storage Sense now
+# Settings > System > Storage > Configure Storage Sense > Clean now
+```
+
+## 2. Windows Update & System
+
+### Windows Update Cache
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| Update cache | `C:\Windows\SoftwareDistribution\Download` | Safe (Admin) | 1-15 GB |
+| Delivery Optimization | `C:\Windows\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization` | Safe (Admin) | 0.5-5 GB |
+
+```powershell
+# Stop Windows Update service first (Admin)
+Stop-Service wuauserv -Force
+Stop-Service bits -Force
+Remove-Item "C:\Windows\SoftwareDistribution\Download\*" -Recurse -Force -ErrorAction SilentlyContinue
+Start-Service wuauserv
+Start-Service bits
+```
+
+### WinSxS (Component Store)
+
+The WinSxS folder stores component versions for Windows features and updates.
+It appears huge (10-20 GB) but most content is hard links — actual unique
+data is usually 5-8 GB. Never manually delete from WinSxS.
+
+```powershell
+# Analyze component store size (Admin)
+Dism /Online /Cleanup-Image /AnalyzeComponentStore
+
+# Clean superseded components (Admin, safe)
+Dism /Online /Cleanup-Image /StartComponentCleanup
+
+# Aggressive: also remove old service pack backups (Admin)
+Dism /Online /Cleanup-Image /StartComponentCleanup /ResetBase
+# Warning: /ResetBase prevents uninstalling previous updates
+```
+
+### Windows.old
+
+Left after a major Windows upgrade. Contains the entire previous installation.
+
+```powershell
+# Check if it exists and size
+Get-ChildItem "C:\Windows.old" -ErrorAction SilentlyContinue |
+  Measure-Object -Property Length -Sum
+
+# Remove via Disk Cleanup (safest method, Admin)
+cleanmgr /d C:
+# Select "Previous Windows installation(s)"
+
+# Or via Settings > System > Storage > Temporary files
+```
+
+**Risk: Moderate** — removes ability to roll back to previous Windows version.
+Typical size: 15-30 GB.
+
+### Hibernation File
+
+```powershell
+# Check size
+Get-Item "C:\hiberfil.sys" -Force -ErrorAction SilentlyContinue |
+  Select-Object Length, @{N='SizeGB';E={[math]::Round($_.Length/1GB,1)}}
+
+# Disable hibernation to remove hiberfil.sys (Admin)
+powercfg /hibernate off
+# This deletes hiberfil.sys immediately, freeing RAM-sized space
+
+# Re-enable if needed
+powercfg /hibernate on
+```
+
+**Size: Equal to your RAM** (8-64 GB). Risk: Low — you lose hibernate/Fast
+Startup. Sleep still works.
+
+### Prefetch
+
+```powershell
+# Prefetch files (Admin)
+Remove-Item "C:\Windows\Prefetch\*" -Force -ErrorAction SilentlyContinue
+```
+
+**Risk: Safe** — Windows rebuilds these. Apps may launch slightly slower
+on first run after cleaning.
+
+## 3. Browser Caches
+
+### Google Chrome
+
+| Path | Risk | Typical Size |
+|------|------|-------------|
+| `$env:LOCALAPPDATA\Google\Chrome\User Data\Default\Cache` | Safe | 0.5-3 GB |
+| `$env:LOCALAPPDATA\Google\Chrome\User Data\Default\Code Cache` | Safe | 0.1-0.5 GB |
+
+```powershell
+# Close Chrome first
+Stop-Process -Name "chrome" -Force -ErrorAction SilentlyContinue
+Start-Sleep 2
+Remove-Item "$env:LOCALAPPDATA\Google\Chrome\User Data\Default\Cache\*" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item "$env:LOCALAPPDATA\Google\Chrome\User Data\Default\Code Cache\*" -Recurse -Force -ErrorAction SilentlyContinue
+```
+
+### Microsoft Edge
+
+| Path | Risk | Typical Size |
+|------|------|-------------|
+| `$env:LOCALAPPDATA\Microsoft\Edge\User Data\Default\Cache` | Safe | 0.3-2 GB |
+
+```powershell
+Stop-Process -Name "msedge" -Force -ErrorAction SilentlyContinue
+Start-Sleep 2
+Remove-Item "$env:LOCALAPPDATA\Microsoft\Edge\User Data\Default\Cache\*" -Recurse -Force -ErrorAction SilentlyContinue
+```
+
+### Firefox
+
+| Path | Risk | Typical Size |
+|------|------|-------------|
+| `$env:LOCALAPPDATA\Mozilla\Firefox\Profiles\*\cache2` | Safe | 0.3-2 GB |
+
+```powershell
+Stop-Process -Name "firefox" -Force -ErrorAction SilentlyContinue
+Start-Sleep 2
+Get-ChildItem "$env:LOCALAPPDATA\Mozilla\Firefox\Profiles" -Directory |
+  ForEach-Object { Remove-Item "$($_.FullName)\cache2\*" -Recurse -Force -ErrorAction SilentlyContinue }
+```
+
+## 4. Developer Tool Caches
+
+### Node.js / npm / yarn / pnpm
+
+| Target | Path/Command | Risk | Typical Size |
+|--------|-------------|------|-------------|
+| npm cache | `npm cache clean --force` | Safe | 0.5-5 GB |
+| npm cache dir | `$env:APPDATA\npm-cache` | Safe | 0.5-5 GB |
+| yarn cache | `$env:LOCALAPPDATA\Yarn\Cache` | Safe | 0.5-5 GB |
+| pnpm store | `pnpm store path` | Safe | 1-10 GB |
+| Stale node_modules | scattered in projects | Moderate | 5-50 GB |
+
+```powershell
+# npm cache
+npm cache clean --force 2>$null
+
+# yarn
+yarn cache clean 2>$null
+
+# pnpm
+pnpm store prune 2>$null
+
+# Find stale node_modules (not modified in 30+ days)
+Get-ChildItem -Path "$env:USERPROFILE\dev" -Filter "node_modules" -Directory -Recurse -Depth 4 -ErrorAction SilentlyContinue |
+  Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-30) } |
+  ForEach-Object { "{0,10} {1}" -f ((Get-ChildItem $_.FullName -Recurse -File -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum / 1MB).ToString("N0") + " MB", $_.FullName }
+```
+
+### Python / pip
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| pip cache | `$env:LOCALAPPDATA\pip\Cache` | Safe | 0.5-3 GB |
+
+```powershell
+pip cache purge 2>$null
+# Or manual
+Remove-Item "$env:LOCALAPPDATA\pip\Cache\*" -Recurse -Force -ErrorAction SilentlyContinue
+```
+
+### Rust / Cargo
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| Cargo registry cache | `$env:USERPROFILE\.cargo\registry\cache` | Safe | 1-5 GB |
+| Cargo registry src | `$env:USERPROFILE\.cargo\registry\src` | Safe | 2-10 GB |
+| Cargo git | `$env:USERPROFILE\.cargo\git\checkouts` | Safe | 0.5-5 GB |
+| Rust target dirs | `*\target\` in projects | Moderate | 5-50 GB |
+
+```powershell
+# Clean cargo caches
+Remove-Item "$env:USERPROFILE\.cargo\registry\cache\*" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item "$env:USERPROFILE\.cargo\registry\src\*" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item "$env:USERPROFILE\.cargo\git\checkouts\*" -Recurse -Force -ErrorAction SilentlyContinue
+```
+
+### Go
+
+```powershell
+go clean -cache 2>$null
+go clean -modcache 2>$null
+```
+
+### .NET / NuGet
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| NuGet cache | `$env:USERPROFILE\.nuget\packages` | Safe | 2-15 GB |
+| NuGet HTTP cache | `$env:LOCALAPPDATA\NuGet\v3-cache` | Safe | 0.1-1 GB |
+
+```powershell
+# NuGet cache cleanup
+dotnet nuget locals all --clear 2>$null
+
+# Or manual
+Remove-Item "$env:LOCALAPPDATA\NuGet\v3-cache\*" -Recurse -Force -ErrorAction SilentlyContinue
+```
+
+### Visual Studio
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| Component cache | `$env:LOCALAPPDATA\Microsoft\VisualStudio\Packages` | Moderate | 2-10 GB |
+| MEF cache | `$env:LOCALAPPDATA\Microsoft\VisualStudio\<ver>\ComponentModelCache` | Safe | 0.1-0.5 GB |
+| Web cache | `$env:LOCALAPPDATA\Microsoft\VisualStudio\<ver>\WebCache` | Safe | 0.1-1 GB |
+
+### JetBrains IDEs
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| Caches | `$env:LOCALAPPDATA\JetBrains\<Product>\caches` | Safe | 1-5 GB |
+| Logs | `$env:LOCALAPPDATA\JetBrains\<Product>\log` | Safe | 0.1-0.5 GB |
+
+```powershell
+# Clean all JetBrains caches
+Get-ChildItem "$env:LOCALAPPDATA\JetBrains" -Directory -ErrorAction SilentlyContinue |
+  ForEach-Object {
+    $caches = Join-Path $_.FullName "caches"
+    if (Test-Path $caches) { Remove-Item "$caches\*" -Recurse -Force -ErrorAction SilentlyContinue }
+  }
+```
+
+### VS Code
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| Cache | `$env:APPDATA\Code\Cache` | Safe | 0.2-1 GB |
+| CachedData | `$env:APPDATA\Code\CachedData` | Safe | 0.5-2 GB |
+| CachedExtensions | `$env:APPDATA\Code\CachedExtensions` | Safe | 0.1-0.5 GB |
+| Logs | `$env:APPDATA\Code\logs` | Safe | 0.05-0.2 GB |
+
+### Gradle / Android Studio
+
+| Target | Path | Risk | Typical Size |
+|--------|------|------|-------------|
+| Gradle cache | `$env:USERPROFILE\.gradle\caches` | Safe | 2-10 GB |
+| Gradle wrapper | `$env:USERPROFILE\.gradle\wrapper\dists` | Safe | 1-3 GB |
+| AVD images | `$env:USERPROFILE\.android\avd` | Moderate | 5-30 GB |
+
+```powershell
+Remove-Item "$env:USERPROFILE\.gradle\caches\*" -Recurse -Force -ErrorAction SilentlyContinue
+```
+
+## 5. Docker Desktop (WSL2 Backend)
+
+| Target | Description | Risk | Typical Size |
+|--------|------------|------|-------------|
+| Docker data | `ext4.vhdx` inside WSL2 | Moderate | 10-100 GB |
+
+```powershell
+# Check Docker disk usage
+docker system df
+
+# Prune stopped containers + dangling images
+docker system prune -f
+
+# Prune ALL unused images
+docker system prune -a -f
+
+# Nuclear: include volumes (DATA LOSS for databases!)
+docker system prune -a --volumes -f
+
+# The WSL2 ext4.vhdx doesn't auto-shrink after pruning.
+# To reclaim host disk space (Admin):
+wsl --shutdown
+# Then compact the disk:
+# Find the vhdx: usually at
+# $env:LOCALAPPDATA\Docker\wsl\disk\docker_data.vhdx
+# or $env:LOCALAPPDATA\Packages\...\ext4.vhdx
+Optimize-VHD -Path "$env:LOCALAPPDATA\Docker\wsl\disk\docker_data.vhdx" -Mode Full
+# If Optimize-VHD unavailable, use diskpart:
+# select vdisk file="<path>"
+# compact vdisk
+```
+
+## 6. WSL2 Disk Reclaim
+
+WSL2 distributions use virtual disks that grow but don't auto-shrink.
+
+```powershell
+# List WSL distributions and their disk usage
+wsl --list --verbose
+
+# Shut down WSL
+wsl --shutdown
+
+# Find the VHDX file
+Get-ChildItem "$env:LOCALAPPDATA\Packages\*WSL*" -Recurse -Filter "ext4.vhdx" -ErrorAction SilentlyContinue
+Get-ChildItem "$env:LOCALAPPDATA\Packages\*Ubuntu*" -Recurse -Filter "ext4.vhdx" -ErrorAction SilentlyContinue
+
+# Compact using diskpart (Admin)
+# diskpart
+# select vdisk file="<path_to_ext4.vhdx>"
+# compact vdisk
+# exit
+
+# Or Optimize-VHD if Hyper-V tools installed (Admin)
+Optimize-VHD -Path "<path>" -Mode Full
+```
+
+## 7. Package Manager Caches
+
+### winget
+
+```powershell
+# winget doesn't have a cache clean command, but cache is at:
+Remove-Item "$env:LOCALAPPDATA\Packages\Microsoft.DesktopAppInstaller_*\LocalState\DiagOutputDir\*" -Recurse -Force -ErrorAction SilentlyContinue
+```
+
+### Chocolatey
+
+```powershell
+# Chocolatey cache
+Remove-Item "$env:LOCALAPPDATA\Temp\chocolatey\*" -Recurse -Force -ErrorAction SilentlyContinue
+# Or
+choco cache remove 2>$null
+```
+
+### Scoop
+
+```powershell
+# Clean old versions of installed apps
+scoop cleanup * 2>$null
+# Clear download cache
+scoop cache rm * 2>$null
+```
+
+## 8. Recycle Bin
+
+```powershell
+# Empty Recycle Bin
+Clear-RecycleBin -Force -ErrorAction SilentlyContinue
+
+# Check Recycle Bin size first
+(New-Object -ComObject Shell.Application).Namespace(0xA).Items() |
+  Measure-Object -Property Size -Sum |
+  ForEach-Object { "{0:N2} GB" -f ($_.Sum / 1GB) }
+```
+
+## 9. Event Logs
+
+```powershell
+# Clear all event logs (Admin)
+Get-WinEvent -ListLog * -ErrorAction SilentlyContinue |
+  Where-Object { $_.RecordCount -gt 0 } |
+  ForEach-Object { [System.Diagnostics.Eventing.Reader.EventLogSession]::GlobalSession.ClearLog($_.LogName) }
+
+# Or clear specific logs (Admin)
+wevtutil cl System
+wevtutil cl Application
+wevtutil cl Security
+```
+
+**Risk: Low** — logs are for troubleshooting. Clear only if not actively
+debugging an issue.
+
+## 10. Thumbnail Cache
+
+```powershell
+# Close Explorer first
+Stop-Process -Name "explorer" -Force -ErrorAction SilentlyContinue
+Start-Sleep 2
+Remove-Item "$env:LOCALAPPDATA\Microsoft\Windows\Explorer\thumbcache_*.db" -Force -ErrorAction SilentlyContinue
+Start-Process explorer
+```
+
+## Priority Order for Maximum Impact
+
+1. **Windows.old** — 15-30 GB (if present after upgrade)
+2. **Docker (WSL2 vhdx)** — 10-100 GB
+3. **Stale node_modules** — 5-50 GB
+4. **Rust target dirs** — 5-50 GB
+5. **Hibernation file** — 8-64 GB (equals RAM)
+6. **Windows Update cache + WinSxS cleanup** — 2-15 GB
+7. **NuGet/Gradle/npm caches** — 5-25 GB combined
+8. **User temp** — 0.5-10 GB
+9. **Browser caches** — 1-5 GB
+10. **Recycle Bin** — 0-50 GB
+11. **Event logs** — 0.1-1 GB

--- a/skills/windows-cleanup/references/safety-protocols.md
+++ b/skills/windows-cleanup/references/safety-protocols.md
@@ -1,0 +1,122 @@
+# Windows Safety Protocols
+
+Rules and workflows for safely cleaning a Windows 10/11 system.
+
+## Golden Rules
+
+1. **Analyze before deleting.** Always scan first. Show what will be cleaned
+   and how much space will be freed before touching anything.
+2. **Dry-run by default.** Show what WOULD be deleted with sizes. Only
+   proceed after user confirmation.
+3. **Never touch these without explicit user consent:**
+   - User profile folders: Documents, Desktop, Pictures, Music, Videos
+   - `C:\Windows\Installer` — MSI repair data (breaks uninstall/repair)
+   - `$env:USERPROFILE\.ssh`, `.gnupg`, `.aws`, `.kube` — credentials
+   - Registry hives directly
+   - `C:\Windows\System32` or `C:\Windows\SysWOW64`
+   - Any database files (.mdf, .ldf, .sqlite) in app directories
+   - Git repositories (.git directories)
+   - WSL2 root filesystems
+4. **Use built-in tools when available.** `cleanmgr`, `DISM`, `Storage Sense`,
+   `dotnet nuget locals`, `npm cache clean` know their own cleanup semantics.
+5. **Admin operations need elevation.** Clearly indicate which commands
+   require "Run as Administrator."
+
+## Confirmation Flow
+
+### Safe Operations
+
+```
+Cache cleanup will free ~3.8 GB:
+  User temp files                    1.2 GB  (auto-regenerated)
+  Browser caches                     1.4 GB  (re-downloaded on visit)
+  npm cache                          1.2 GB  (re-downloaded on install)
+
+Proceed? [Y/n]
+```
+
+### Moderate Operations
+
+```
+The following require re-download or rebuild:
+  3 stale node_modules dirs          4.1 GB  (run npm install to restore)
+    C:\dev\old-project\node_modules  (last modified 89 days ago)
+    C:\dev\archived\node_modules     (last modified 142 days ago)
+  Hibernation file (hiberfil.sys)    16.0 GB (lose hibernate, keep sleep)
+
+Clean these? [y/N]
+```
+
+### High-Risk Operations
+
+```
+WARNING: The following operations may cause DATA LOSS:
+
+  Docker volumes                     5.2 GB
+    postgres_data                    3.1 GB
+    redis_data                       2.1 GB
+
+These cannot be recovered after deletion.
+Type 'DELETE' to confirm, or press Enter to skip:
+```
+
+## Paths to NEVER Touch
+
+| Path | Reason |
+|------|--------|
+| `C:\Windows\Installer` | MSI repair/uninstall metadata |
+| `C:\Windows\System32` | Core OS binaries |
+| `C:\Windows\WinSxS` (directly) | Use DISM only, never manual deletion |
+| `$env:USERPROFILE\.ssh` | SSH keys |
+| `$env:USERPROFILE\.gnupg` | GPG keys |
+| `$env:USERPROFILE\.aws`, `.kube`, `.azure` | Cloud credentials |
+| `C:\ProgramData` (broadly) | App data, databases |
+| User profile folders | Documents, Desktop, Pictures, etc. |
+| `.git` directories | Version control history |
+| Registry hives | System configuration |
+| EFI System Partition | Boot configuration |
+
+## Pre-Cleanup Checklist
+
+1. **Check available space**: `Get-PSDrive C | Select Used,Free`
+2. **Close applications** whose caches you're cleaning
+3. **Check running Docker containers**: `docker ps`
+4. **Note if Windows Update is running**: check Task Manager
+5. **Ensure no builds in progress** (Visual Studio, Gradle, Cargo)
+
+## Recovery Procedures
+
+| Problem | Recovery |
+|---------|----------|
+| App won't launch after cache clean | Restart app — rebuilds cache |
+| npm packages missing | `cd <project>; npm install` |
+| NuGet restore failed | `dotnet restore` in project |
+| Docker images gone | `docker pull <image>` |
+| Windows Update broken after cache clean | `sfc /scannow` then retry update |
+| Hibernate not working | `powercfg /hibernate on` (Admin) |
+| Thumbnails not showing | They regenerate automatically |
+| Gradle build fails | `gradle build` re-downloads |
+
+## Space Verification
+
+```powershell
+# Check free space
+Get-PSDrive C | Select-Object @{N='FreeGB';E={[math]::Round($_.Free/1GB,1)}},
+  @{N='UsedGB';E={[math]::Round($_.Used/1GB,1)}},
+  @{N='TotalGB';E={[math]::Round(($_.Used+$_.Free)/1GB,1)}}
+
+# Percentage used
+$drive = Get-PSDrive C
+$pct = [math]::Round(($drive.Used / ($drive.Used + $drive.Free)) * 100, 1)
+Write-Host "$pct% used"
+```
+
+## Agent Behavior Rules
+
+1. **Always show summary first** — total reclaimable by category and risk
+2. **Ask permission per risk level** — don't batch safe and high-risk
+3. **Indicate Admin requirements** — mark which commands need elevation
+4. **Report before/after** — show disk space comparison after cleanup
+5. **Don't touch what wasn't asked** — "clean caches" doesn't mean "prune Docker volumes"
+6. **Prefer built-in tools** — `cleanmgr`, `DISM`, `dotnet nuget locals` over raw `Remove-Item`
+7. **PowerShell over CMD** — use PowerShell for all operations

--- a/skills/windows-cleanup/references/space-analysis.md
+++ b/skills/windows-cleanup/references/space-analysis.md
@@ -1,0 +1,133 @@
+# Space Analysis Techniques (Windows)
+
+How to find where disk space is consumed on Windows, identify biggest
+offenders, and present actionable recommendations. All commands are
+PowerShell.
+
+## Quick Disk Overview
+
+```powershell
+# Drive summary
+Get-PSDrive -PSProvider FileSystem | Select-Object Name,
+  @{N='UsedGB';E={[math]::Round($_.Used/1GB,1)}},
+  @{N='FreeGB';E={[math]::Round($_.Free/1GB,1)}},
+  @{N='TotalGB';E={[math]::Round(($_.Used+$_.Free)/1GB,1)}},
+  @{N='PctUsed';E={[math]::Round($_.Used/($_.Used+$_.Free)*100,1)}}
+
+# Just C: drive
+$c = Get-PSDrive C
+"{0:N1} GB free of {1:N1} GB ({2:N1}% used)" -f ($c.Free/1GB), (($c.Used+$c.Free)/1GB), ($c.Used/($c.Used+$c.Free)*100)
+```
+
+## The Scan, Report, Clean Workflow
+
+### Step 1: Scan
+
+Run the analysis script to discover all cleanup targets:
+
+```powershell
+# The analyze-disk.ps1 script automates this
+.\scripts\analyze-disk.ps1
+
+# Manual equivalent — scan key locations
+"User Temp: " + "{0:N2} GB" -f ((Get-ChildItem $env:TEMP -Recurse -Force -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum / 1GB)
+"Windows Temp: " + "{0:N2} GB" -f ((Get-ChildItem "C:\Windows\Temp" -Recurse -Force -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum / 1GB)
+```
+
+### Step 2: Report
+
+Present as categorized summary — same format as macOS cleanup skill.
+
+### Step 3: Clean
+
+Execute in risk-level order: safe first, then moderate with confirmation,
+high-risk only if specifically asked.
+
+## Finding Large Files
+
+```powershell
+# Files larger than 500 MB in user profile
+Get-ChildItem $env:USERPROFILE -Recurse -File -Force -ErrorAction SilentlyContinue |
+  Where-Object { $_.Length -gt 500MB } |
+  Sort-Object Length -Descending |
+  Select-Object @{N='SizeGB';E={[math]::Round($_.Length/1GB,2)}}, FullName |
+  Format-Table -AutoSize
+
+# Files larger than 1 GB anywhere on C:
+Get-ChildItem C:\ -Recurse -File -Force -ErrorAction SilentlyContinue |
+  Where-Object { $_.Length -gt 1GB } |
+  Sort-Object Length -Descending |
+  Select-Object @{N='SizeGB';E={[math]::Round($_.Length/1GB,2)}}, FullName |
+  Format-Table -AutoSize
+```
+
+## Finding Large Directories
+
+```powershell
+# Top-level user profile directories by size
+Get-ChildItem $env:USERPROFILE -Directory -Force -ErrorAction SilentlyContinue |
+  ForEach-Object {
+    $size = (Get-ChildItem $_.FullName -Recurse -File -Force -ErrorAction SilentlyContinue |
+      Measure-Object -Property Length -Sum).Sum
+    [PSCustomObject]@{ SizeGB = [math]::Round($size/1GB,2); Path = $_.FullName }
+  } | Sort-Object SizeGB -Descending | Format-Table -AutoSize
+```
+
+## Finding Stale node_modules
+
+```powershell
+# Find node_modules not modified in 30+ days
+$devDirs = @("$env:USERPROFILE\dev", "$env:USERPROFILE\projects",
+             "$env:USERPROFILE\code", "$env:USERPROFILE\source\repos")
+
+foreach ($dir in $devDirs) {
+  if (Test-Path $dir) {
+    Get-ChildItem $dir -Filter "node_modules" -Directory -Recurse -Depth 4 -ErrorAction SilentlyContinue |
+      Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-30) } |
+      ForEach-Object {
+        $size = (Get-ChildItem $_.FullName -Recurse -File -Force -ErrorAction SilentlyContinue |
+          Measure-Object -Property Length -Sum).Sum
+        [PSCustomObject]@{
+          SizeMB = [math]::Round($size/1MB,0)
+          LastModified = $_.LastWriteTime.ToString("yyyy-MM-dd")
+          Path = (Split-Path $_.FullName -Parent)
+        }
+      } | Sort-Object SizeMB -Descending
+  }
+}
+```
+
+## Docker Space Analysis
+
+```powershell
+# Docker's own report
+docker system df -v
+
+# WSL2 virtual disk size (the real space consumer)
+Get-ChildItem "$env:LOCALAPPDATA\Docker\wsl" -Recurse -Filter "*.vhdx" -ErrorAction SilentlyContinue |
+  Select-Object @{N='SizeGB';E={[math]::Round($_.Length/1GB,2)}}, FullName
+```
+
+## Recommended CLI Tools
+
+| Tool | Install | Description |
+|------|---------|-------------|
+| WizTree | `winget install AntibodySoftware.WizTree` | Fastest disk analyzer (reads MFT directly) |
+| TreeSize Free | `winget install JAMSoftware.TreeSize.Free` | Visual tree view, context menu integration |
+| WinDirStat | `winget install WinDirStat.WinDirStat` | Classic treemap visualization |
+| SpaceSniffer | manual | Portable, real-time treemap |
+
+The agent should use PowerShell commands directly rather than depending on
+these tools being installed. Suggest them for interactive exploration.
+
+## Windows Storage Settings
+
+Windows has a built-in storage breakdown:
+
+```
+Settings > System > Storage
+```
+
+This shows: Apps & features, Temporary files, Other, System & reserved.
+"Temporary files" includes many cleanable items and lets users delete
+from the GUI.

--- a/skills/windows-cleanup/scripts/analyze-disk.ps1
+++ b/skills/windows-cleanup/scripts/analyze-disk.ps1
@@ -1,0 +1,244 @@
+<#
+.SYNOPSIS
+  Windows Disk Cleanup Analyzer
+.DESCRIPTION
+  Scans known cleanup targets and reports sizes with risk levels.
+.PARAMETER Json
+  Output as JSON instead of table
+.PARAMETER DevOnly
+  Only scan developer tool caches
+.PARAMETER Quick
+  Skip slow scans (stale node_modules, large file search)
+.EXAMPLE
+  .\analyze-disk.ps1
+  .\analyze-disk.ps1 -Json
+  .\analyze-disk.ps1 -DevOnly -Quick
+#>
+param(
+  [switch]$Json,
+  [switch]$DevOnly,
+  [switch]$Quick
+)
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+function Get-DirSizeBytes([string]$Path) {
+  if (Test-Path $Path) {
+    (Get-ChildItem $Path -Recurse -File -Force -ErrorAction SilentlyContinue |
+      Measure-Object -Property Length -Sum).Sum
+  } else { 0 }
+}
+
+function Format-Size([long]$Bytes) {
+  if ($Bytes -ge 1GB) { "{0:N1} GB" -f ($Bytes / 1GB) }
+  elseif ($Bytes -ge 1MB) { "{0:N0} MB" -f ($Bytes / 1MB) }
+  elseif ($Bytes -ge 1KB) { "{0:N0} KB" -f ($Bytes / 1KB) }
+  else { "$Bytes B" }
+}
+
+$results = [System.Collections.ArrayList]::new()
+
+function Add-Result([string]$Category, [long]$SizeBytes, [string]$Risk, [string]$Path) {
+  if ($SizeBytes -gt 0) {
+    [void]$results.Add([PSCustomObject]@{
+      Category  = $Category
+      SizeBytes = $SizeBytes
+      SizeHuman = Format-Size $SizeBytes
+      Risk      = $Risk
+      Path      = $Path
+    })
+  }
+}
+
+$drive = Get-PSDrive C
+$totalGB = [math]::Round(($drive.Used + $drive.Free) / 1GB, 1)
+$freeGB  = [math]::Round($drive.Free / 1GB, 1)
+$usedPct = [math]::Round($drive.Used / ($drive.Used + $drive.Free) * 100, 1)
+
+Write-Host "Scanning Windows disk for cleanup targets..." -ForegroundColor Cyan
+
+if (-not $DevOnly) {
+  Write-Host "  Scanning temp files..."
+  Add-Result "User Temp" (Get-DirSizeBytes $env:TEMP) "safe" $env:TEMP
+  Add-Result "Windows Temp" (Get-DirSizeBytes "C:\Windows\Temp") "safe" "C:\Windows\Temp"
+
+  Write-Host "  Scanning Windows Update cache..."
+  Add-Result "Windows Update Cache" (Get-DirSizeBytes "C:\Windows\SoftwareDistribution\Download") "safe" "C:\Windows\SoftwareDistribution\Download"
+
+  $doPath = "C:\Windows\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization"
+  Add-Result "Delivery Optimization" (Get-DirSizeBytes $doPath) "safe" $doPath
+
+  Write-Host "  Scanning Recycle Bin..."
+  try {
+    $rbSize = (New-Object -ComObject Shell.Application).Namespace(0xA).Items() |
+      Measure-Object -Property Size -Sum
+    Add-Result "Recycle Bin" $rbSize.Sum "moderate" '$Recycle.Bin'
+  } catch {}
+
+  Write-Host "  Scanning Windows.old..."
+  if (Test-Path "C:\Windows.old") {
+    Add-Result "Windows.old" (Get-DirSizeBytes "C:\Windows.old") "moderate" "C:\Windows.old"
+  }
+
+  $hibFile = Get-Item "C:\hiberfil.sys" -Force -ErrorAction SilentlyContinue
+  if ($hibFile) {
+    Add-Result "Hibernation File" $hibFile.Length "low" "C:\hiberfil.sys"
+  }
+
+  Add-Result "Prefetch" (Get-DirSizeBytes "C:\Windows\Prefetch") "safe" "C:\Windows\Prefetch"
+
+  $thumbs = Get-ChildItem "$env:LOCALAPPDATA\Microsoft\Windows\Explorer\thumbcache_*.db" -Force -ErrorAction SilentlyContinue |
+    Measure-Object -Property Length -Sum
+  Add-Result "Thumbnail Cache" $thumbs.Sum "safe" "$env:LOCALAPPDATA\...\Explorer\thumbcache_*"
+}
+
+Write-Host "  Scanning browser caches..."
+Add-Result "Chrome Cache" (Get-DirSizeBytes "$env:LOCALAPPDATA\Google\Chrome\User Data\Default\Cache") "safe" "Chrome\Cache"
+Add-Result "Edge Cache" (Get-DirSizeBytes "$env:LOCALAPPDATA\Microsoft\Edge\User Data\Default\Cache") "safe" "Edge\Cache"
+
+$ffProfiles = Get-ChildItem "$env:LOCALAPPDATA\Mozilla\Firefox\Profiles" -Directory -ErrorAction SilentlyContinue
+$ffTotal = 0
+foreach ($p in $ffProfiles) { $ffTotal += Get-DirSizeBytes "$($p.FullName)\cache2" }
+Add-Result "Firefox Cache" $ffTotal "safe" "Firefox\Profiles\*\cache2"
+
+Write-Host "  Scanning dev tool caches..."
+Add-Result "npm Cache" (Get-DirSizeBytes "$env:APPDATA\npm-cache") "safe" "$env:APPDATA\npm-cache"
+Add-Result "Yarn Cache" (Get-DirSizeBytes "$env:LOCALAPPDATA\Yarn\Cache") "safe" "Yarn\Cache"
+
+if (Get-Command pnpm -ErrorAction SilentlyContinue) {
+  $pnpmStore = pnpm store path 2>$null
+  if ($pnpmStore -and (Test-Path $pnpmStore)) {
+    Add-Result "pnpm Store" (Get-DirSizeBytes $pnpmStore) "safe" $pnpmStore
+  }
+}
+
+Add-Result "pip Cache" (Get-DirSizeBytes "$env:LOCALAPPDATA\pip\Cache") "safe" "pip\Cache"
+
+$cargoTotal = 0
+foreach ($sub in @("$env:USERPROFILE\.cargo\registry\cache","$env:USERPROFILE\.cargo\registry\src","$env:USERPROFILE\.cargo\git\checkouts")) {
+  $cargoTotal += Get-DirSizeBytes $sub
+}
+Add-Result "Cargo Cache" $cargoTotal "safe" "~\.cargo\registry + git"
+
+if (Get-Command go -ErrorAction SilentlyContinue) {
+  Add-Result "Go Module Cache" (Get-DirSizeBytes "$env:USERPROFILE\go\pkg\mod") "safe" "~\go\pkg\mod"
+  $goBuild = "$env:LOCALAPPDATA\go-build"
+  Add-Result "Go Build Cache" (Get-DirSizeBytes $goBuild) "safe" $goBuild
+}
+
+Add-Result "NuGet Cache" (Get-DirSizeBytes "$env:USERPROFILE\.nuget\packages") "safe" "~\.nuget\packages"
+Add-Result "Gradle Cache" (Get-DirSizeBytes "$env:USERPROFILE\.gradle\caches") "safe" "~\.gradle\caches"
+Add-Result "Gradle Wrapper" (Get-DirSizeBytes "$env:USERPROFILE\.gradle\wrapper\dists") "safe" "~\.gradle\wrapper\dists"
+
+$jbTotal = 0
+Get-ChildItem "$env:LOCALAPPDATA\JetBrains" -Directory -ErrorAction SilentlyContinue |
+  ForEach-Object { $jbTotal += Get-DirSizeBytes (Join-Path $_.FullName "caches") }
+Add-Result "JetBrains Caches" $jbTotal "safe" "JetBrains\*\caches"
+
+$vscTotal = 0
+foreach ($sub in @("$env:APPDATA\Code\Cache","$env:APPDATA\Code\CachedData","$env:APPDATA\Code\CachedExtensions","$env:APPDATA\Code\logs")) {
+  $vscTotal += Get-DirSizeBytes $sub
+}
+Add-Result "VS Code Caches" $vscTotal "safe" "Code\Cache*"
+
+Write-Host "  Scanning Docker..."
+$dockerVhdx = Get-ChildItem "$env:LOCALAPPDATA\Docker\wsl" -Recurse -Filter "*.vhdx" -ErrorAction SilentlyContinue |
+  Measure-Object -Property Length -Sum
+Add-Result "Docker Desktop VM" $dockerVhdx.Sum "moderate" "Docker\wsl\*.vhdx"
+
+$wslVhdx = Get-ChildItem "$env:LOCALAPPDATA\Packages" -Recurse -Filter "ext4.vhdx" -ErrorAction SilentlyContinue |
+  Where-Object { $_.FullName -notmatch 'Docker' } |
+  Measure-Object -Property Length -Sum
+Add-Result "WSL2 Virtual Disks" $wslVhdx.Sum "moderate" "Packages\*\ext4.vhdx"
+
+if (Get-Command scoop -ErrorAction SilentlyContinue) {
+  $scoopCache = "$env:USERPROFILE\scoop\cache"
+  Add-Result "Scoop Cache" (Get-DirSizeBytes $scoopCache) "safe" $scoopCache
+}
+
+Add-Result "Composer Cache" (Get-DirSizeBytes "$env:USERPROFILE\.composer\cache") "safe" "~\.composer\cache"
+
+if (-not $Quick) {
+  Write-Host "  Scanning for stale node_modules (this may take a moment)..."
+  $nmTotal = 0; $nmCount = 0
+  $devDirs = @("$env:USERPROFILE\dev","$env:USERPROFILE\projects","$env:USERPROFILE\code",
+               "$env:USERPROFILE\source\repos","$env:USERPROFILE\repos")
+  foreach ($dir in $devDirs) {
+    if (Test-Path $dir) {
+      Get-ChildItem $dir -Filter "node_modules" -Directory -Recurse -Depth 4 -ErrorAction SilentlyContinue |
+        Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-30) } |
+        ForEach-Object {
+          $s = Get-DirSizeBytes $_.FullName
+          $nmTotal += $s; $nmCount++
+        }
+    }
+  }
+  if ($nmTotal -gt 0) {
+    Add-Result "Stale node_modules ($nmCount dirs, >30d)" $nmTotal "moderate" "various dev\**\node_modules"
+  }
+
+  Write-Host "  Scanning for stale Rust target/ dirs..."
+  $rtTotal = 0; $rtCount = 0
+  foreach ($dir in $devDirs) {
+    if (Test-Path $dir) {
+      Get-ChildItem $dir -Filter "target" -Directory -Recurse -Depth 4 -ErrorAction SilentlyContinue |
+        Where-Object {
+          $_.LastWriteTime -lt (Get-Date).AddDays(-30) -and
+          (Test-Path (Join-Path (Split-Path $_.FullName -Parent) "Cargo.toml"))
+        } |
+        ForEach-Object {
+          $s = Get-DirSizeBytes $_.FullName
+          $rtTotal += $s; $rtCount++
+        }
+    }
+  }
+  if ($rtTotal -gt 0) {
+    Add-Result "Stale Rust target/ ($rtCount dirs, >30d)" $rtTotal "moderate" "various dev\**\target"
+  }
+}
+
+Write-Host "  Scan complete." -ForegroundColor Green
+
+$sorted = $results | Sort-Object SizeBytes -Descending
+
+if ($Json) {
+  @{
+    disk = @{ total = "${totalGB} GB"; free = "${freeGB} GB"; used_pct = "${usedPct}%" }
+    targets = $sorted | ForEach-Object {
+      @{ category = $_.Category; size_bytes = $_.SizeBytes; size_human = $_.SizeHuman; risk = $_.Risk; path = $_.Path }
+    }
+  } | ConvertTo-Json -Depth 3
+} else {
+  Write-Host ""
+  Write-Host "Windows Disk Cleanup Report" -ForegroundColor Yellow
+  Write-Host "==========================" -ForegroundColor Yellow
+  Write-Host ""
+  Write-Host "Disk: ${totalGB} GB total, ${freeGB} GB free (${usedPct}% used)"
+  Write-Host ""
+
+  $safeTotal = 0; $modTotal = 0; $highTotal = 0; $lowTotal = 0; $grandTotal = 0
+
+  "{0,-45} {1,10}   {2,-10}" -f "Category", "Size", "Risk"
+  "{0,-45} {1,10}   {2,-10}" -f ("-" * 45), ("-" * 10), ("-" * 10)
+
+  foreach ($r in $sorted) {
+    if ($r.SizeBytes -lt 10MB) { continue }
+    "{0,-45} {1,10}   {2,-10}" -f $r.Category, $r.SizeHuman, $r.Risk
+    $grandTotal += $r.SizeBytes
+    switch ($r.Risk) {
+      "safe"     { $safeTotal += $r.SizeBytes }
+      "low"      { $lowTotal += $r.SizeBytes }
+      "moderate" { $modTotal += $r.SizeBytes }
+      "high"     { $highTotal += $r.SizeBytes }
+    }
+  }
+
+  Write-Host ""
+  "{0,-45} {1,10}" -f ("-" * 45), ("-" * 10)
+  "{0,-45} {1,10}" -f "Total reclaimable", (Format-Size $grandTotal)
+  Write-Host ""
+  "  {0,-43} {1,10}" -f "Safe to clean now", (Format-Size $safeTotal)
+  "  {0,-43} {1,10}" -f "Low risk (confirm)", (Format-Size $lowTotal)
+  "  {0,-43} {1,10}" -f "Moderate risk (review first)", (Format-Size $modTotal)
+  "  {0,-43} {1,10}" -f "High risk (explicit opt-in only)", (Format-Size $highTotal)
+}

--- a/skills/windows-cleanup/skills.json
+++ b/skills/windows-cleanup/skills.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/windows-cleanup",
+  "version": "1.0.0",
+  "description": "Windows 10/11 disk space recovery and cleanup for developers. Scans and cleans temp files, Windows Update cache, WinSxS, browser caches, stale node_modules, Docker WSL2, NuGet/npm/pip/Cargo caches, hibernation file, Recycle Bin. Risk-aware PowerShell workflows. Triggers: disk cleanup, free disk space, clean up windows, disk full, running out of space, clear cache, ccleaner, windows cleanup, temp files, cleanmgr, WinSxS, node_modules cleanup, docker disk, npm cache, pip cache, NuGet cache, reclaim space, hiberfil.sys, Windows.old.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}

--- a/skills/windows-maintenance/.tankignore
+++ b/skills/windows-maintenance/.tankignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.ruff_cache/
+.venv/

--- a/skills/windows-maintenance/SKILL.md
+++ b/skills/windows-maintenance/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: "@tank/windows-maintenance"
+description: |
+  Windows 10/11 system health checks, security auditing, and periodic
+  maintenance. Diagnoses disk SMART status, system file integrity (sfc/DISM),
+  Windows Defender and firewall status, BitLocker encryption, UAC, Secure
+  Boot, TPM, battery health, memory pressure, pending updates, event log
+  errors, driver health, and startup program audit. Includes a PowerShell
+  checkup script that produces a scored health report. Companion to
+  @tank/windows-cleanup (space recovery).
+
+  Trigger phrases: "windows health check", "system checkup", "is my pc ok",
+  "windows maintenance", "pc running slow", "sfc scannow", "DISM repair",
+  "check Defender", "check BitLocker", "check firewall", "battery health",
+  "SMART status", "disk health", "memory usage", "security audit",
+  "chkdsk", "windows diagnostics", "windows slow", "BSOD", "blue screen",
+  "startup programs", "event log errors", "driver issues", "windows update",
+  "system file check", "windows tune up", "Secure Boot", "TPM status"
+---
+
+# Windows Maintenance
+
+System health checks, security auditing, and periodic maintenance for
+Windows 10/11. Keeps your PC healthy, secure, and performant — the
+diagnostic counterpart to `@tank/windows-cleanup`.
+
+## Core Philosophy
+
+1. **Diagnose before fixing.** Run the checkup script first.
+2. **Scored health reports.** Every check is PASS/WARN/FAIL.
+3. **Security by default.** Defender, firewall, BitLocker, UAC, Secure Boot
+   should all be enabled. Flag anything that's off.
+4. **PowerShell first.** All commands are PowerShell. Mark Admin requirements.
+5. **Know when to restart.** Many issues resolve with a restart.
+
+## Quick-Start
+
+### "Is my PC OK?" / "Run a health check"
+
+```powershell
+.\scripts\system-checkup.ps1
+```
+
+Flags: `-Json`, `-Quick`, `-SecurityOnly`
+
+### "My PC is running slow"
+
+| Step | Check | Command |
+|------|-------|---------|
+| 1 | Memory | `Get-Process \| Sort WorkingSet64 -Desc \| Select -First 10` |
+| 2 | CPU | `Get-Counter '\Processor(_Total)\% Processor Time'` |
+| 3 | Disk space | `Get-PSDrive C` (needs >10% free) |
+| 4 | Uptime | `(Get-Date) - (gcim Win32_OperatingSystem).LastBootUpTime` |
+| 5 | Startup items | `Get-CimInstance Win32_StartupCommand` |
+| 6 | System files | `sfc /scannow` (Admin) |
+| 7 | Restart | Fixes most transient issues |
+
+### "Run security audit"
+
+```powershell
+.\scripts\system-checkup.ps1 -SecurityOnly
+```
+
+### "Fix corrupted system files"
+
+```powershell
+DISM /Online /Cleanup-Image /RestoreHealth  # Admin, 10-30 min
+sfc /scannow                                # Admin, 5-15 min
+```
+
+## Decision Trees
+
+### What to Check Based on Symptom
+
+| Symptom | First Check | Then |
+|---------|-------------|------|
+| PC is slow | Memory + CPU | Disk space, uptime, startup items |
+| BSOD/crash | Event logs, sfc/DISM | Drivers, disk health |
+| Battery drains fast | Battery report | Startup programs |
+| Updates failing | DISM repair | Clear update cache |
+| App won't install | Disk space, UAC | sfc /scannow |
+| Network issues | DNS, connectivity | Wi-Fi report |
+
+### Security Issue Priority
+
+| Issue | Severity | Fix |
+|-------|----------|-----|
+| Defender disabled | Critical | Enable in Windows Security |
+| UAC disabled | Critical | Registry or Group Policy |
+| BitLocker off | High | `Enable-BitLocker` (Admin) |
+| Firewall off | High | `Set-NetFirewallProfile -Enabled True` |
+| Secure Boot off | Medium | BIOS/UEFI settings |
+| Auto-updates off | Medium | Settings > Windows Update |
+| Remote Desktop on | Low | Disable if not needed |
+
+### Maintenance Frequency
+
+| Task | Frequency |
+|------|-----------|
+| Windows Update check | Weekly |
+| Defender signature check | Weekly |
+| Full health check | Quarterly |
+| sfc /scannow + DISM | Quarterly |
+| Driver audit | Quarterly |
+| Startup programs review | Quarterly |
+| Battery report (laptops) | Monthly |
+| Event log review | Monthly |
+| Component store cleanup | Quarterly |
+| Drive optimization check | Monthly |
+
+## Common Fix Commands
+
+```powershell
+# System file repair (Admin)
+DISM /Online /Cleanup-Image /RestoreHealth
+sfc /scannow
+
+# Flush DNS
+Clear-DnsClientCache
+
+# Network reset (Admin)
+netsh int ip reset
+netsh winsock reset
+
+# Force Windows Update check
+(New-Object -ComObject Microsoft.Update.Session).CreateUpdateSearcher().Search("IsInstalled=0")
+
+# Enable firewall (Admin)
+Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled True
+
+# Generate battery report (Admin)
+powercfg /batteryreport /output "$env:USERPROFILE\Desktop\battery-report.html"
+```
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/health-checks.md` | Disk SMART, chkdsk, battery report, memory/page file, CPU, sfc/DISM, event logs, driver health, uptime, backup status |
+| `references/security-posture.md` | Defender, firewall, BitLocker, UAC, Secure Boot, TPM, auto-updates, remote access, security scorecard |
+| `references/maintenance-tasks.md` | sfc/DISM repair, Windows Update maintenance, drive optimization, startup audit, services audit, DNS flush, network reset, troubleshooting guides |
+| `references/network-diagnostics.md` | Connectivity tests, DNS diagnostics, Wi-Fi report, port/firewall testing, VPN status, network reset |
+
+## Scripts
+
+| Script | Usage |
+|--------|-------|
+| `scripts/system-checkup.ps1` | Full health report with scored results. Flags: `-Json`, `-Quick`, `-SecurityOnly` |

--- a/skills/windows-maintenance/references/health-checks.md
+++ b/skills/windows-maintenance/references/health-checks.md
@@ -1,0 +1,244 @@
+# Windows System Health Checks
+
+Hardware and OS-level diagnostics for Windows 10/11. All commands are
+PowerShell. Items marked (Admin) require an elevated prompt.
+
+## Disk Health
+
+### S.M.A.R.T. Status
+
+```powershell
+# Quick SMART check (Admin)
+Get-PhysicalDisk | Select-Object FriendlyName, MediaType, HealthStatus, OperationalStatus, Size
+
+# Detailed reliability counters (Admin)
+Get-PhysicalDisk | Get-StorageReliabilityCounter |
+  Select-Object DeviceId, Temperature, Wear, ReadErrorsTotal, WriteErrorsTotal, PowerOnHours
+```
+
+**Health thresholds:**
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| HealthStatus | Healthy | Warning | Unhealthy |
+| Wear (SSD) | <50% | 50-80% | >80% |
+| Temperature | <45°C | 45-55°C | >55°C |
+| ReadErrorsTotal | 0 | 1-10 | >10 |
+
+### chkdsk (Filesystem Integrity)
+
+```powershell
+# Check filesystem (read-only, no fix, Admin)
+chkdsk C: /scan
+
+# Full check + fix (requires reboot for boot volume, Admin)
+chkdsk C: /f /r
+
+# Schedule check on next boot (Admin)
+chkdsk C: /f
+# Answer Y to schedule
+```
+
+### Drive Optimization
+
+```powershell
+# Check optimization status (Admin)
+Get-Volume | Where-Object DriveLetter -eq 'C' |
+  Optimize-Volume -Analyze -Verbose
+
+# Optimize (TRIM for SSD, defrag for HDD, Admin)
+Optimize-Volume -DriveLetter C -Verbose
+
+# Check if SSD TRIM is enabled
+fsutil behavior query DisableDeleteNotify
+# 0 = TRIM enabled (good), 1 = TRIM disabled
+```
+
+SSD: Never defragment. Windows automatically sends TRIM commands.
+HDD: Defragmentation helps if fragmentation >10%.
+
+### Disk Space
+
+```powershell
+Get-PSDrive C | Select-Object @{N='UsedGB';E={[math]::Round($_.Used/1GB,1)}},
+  @{N='FreeGB';E={[math]::Round($_.Free/1GB,1)}},
+  @{N='PctUsed';E={[math]::Round($_.Used/($_.Used+$_.Free)*100,1)}}
+```
+
+**Thresholds:** <70% healthy, 70-85% monitor, 85-95% cleanup needed, >95% critical.
+
+## System File Integrity
+
+```powershell
+# System File Checker — scans and repairs protected system files (Admin)
+sfc /scannow
+# Takes 5-15 minutes. Reports: no violations, repaired, or could not repair
+
+# If sfc finds unrepairable files, run DISM first (Admin)
+DISM /Online /Cleanup-Image /RestoreHealth
+# Then re-run sfc /scannow
+
+# Check DISM component store health (Admin)
+DISM /Online /Cleanup-Image /CheckHealth    # Quick check
+DISM /Online /Cleanup-Image /ScanHealth     # Thorough scan
+```
+
+**When to run:**
+- After a crash or BSOD
+- When Windows features stop working
+- After malware removal
+- Before/after major updates
+
+## Battery Health (Laptops)
+
+```powershell
+# Generate battery report (saves to current directory, Admin)
+powercfg /batteryreport /output "$env:USERPROFILE\Desktop\battery-report.html"
+
+# Quick battery info
+Get-CimInstance -ClassName Win32_Battery |
+  Select-Object Name, EstimatedChargeRemaining, BatteryStatus, DesignCapacity, FullChargeCapacity
+```
+
+The HTML battery report includes: design capacity vs full charge capacity,
+cycle count, recent usage history, and capacity over time.
+
+**Health thresholds:**
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| Full/Design capacity | >80% | 60-80% | <60% |
+| Cycle count | <500 | 500-800 | >1000 |
+
+## Memory Health
+
+```powershell
+# Memory usage overview
+Get-CimInstance Win32_OperatingSystem |
+  Select-Object @{N='TotalGB';E={[math]::Round($_.TotalVisibleMemorySize/1MB,1)}},
+    @{N='FreeGB';E={[math]::Round($_.FreePhysicalMemory/1MB,1)}},
+    @{N='PctUsed';E={[math]::Round((1 - $_.FreePhysicalMemory/$_.TotalVisibleMemorySize)*100,1)}}
+
+# Top memory consumers
+Get-Process | Sort-Object WorkingSet64 -Descending | Select-Object -First 10 Name,
+  @{N='MemMB';E={[math]::Round($_.WorkingSet64/1MB,0)}}, Id
+
+# Page file usage
+Get-CimInstance Win32_PageFileUsage |
+  Select-Object Name, @{N='AllocatedMB';E={$_.AllocatedBaseSize}},
+    @{N='CurrentUsageMB';E={$_.CurrentUsage}},
+    @{N='PeakUsageMB';E={$_.PeakUsage}}
+
+# Run Windows Memory Diagnostic (requires reboot)
+mdsched.exe
+```
+
+**Thresholds:**
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| Memory used | <70% | 70-85% | >85% |
+| Page file usage | <50% of allocated | 50-80% | >80% |
+
+## CPU & Performance
+
+```powershell
+# Current CPU usage
+Get-Counter '\Processor(_Total)\% Processor Time' -SampleInterval 2 -MaxSamples 3 |
+  ForEach-Object { $_.CounterSamples.CookedValue }
+
+# Top CPU consumers
+Get-Process | Sort-Object CPU -Descending | Select-Object -First 10 Name,
+  @{N='CPU_Sec';E={[math]::Round($_.CPU,1)}}, Id
+
+# System uptime
+(Get-Date) - (Get-CimInstance Win32_OperatingSystem).LastBootUpTime |
+  Select-Object Days, Hours, Minutes
+
+# Boot time analysis (Admin)
+# Check last boot time
+Get-CimInstance Win32_OperatingSystem | Select-Object LastBootUpTime
+```
+
+## Windows Update Status
+
+```powershell
+# Pending updates (may require PSWindowsUpdate module)
+# Install-Module PSWindowsUpdate -Force
+Get-WindowsUpdate 2>$null
+
+# Built-in: check update history
+Get-HotFix | Sort-Object InstalledOn -Descending | Select-Object -First 10
+
+# Check for updates via COM (no module needed)
+$UpdateSession = New-Object -ComObject Microsoft.Update.Session
+$UpdateSearcher = $UpdateSession.CreateUpdateSearcher()
+$SearchResult = $UpdateSearcher.Search("IsInstalled=0")
+$SearchResult.Updates | Select-Object Title, IsDownloaded
+
+# Last Windows Update
+Get-HotFix | Sort-Object InstalledOn -Descending | Select-Object -First 1
+```
+
+## System Uptime
+
+```powershell
+$uptime = (Get-Date) - (Get-CimInstance Win32_OperatingSystem).LastBootUpTime
+"{0} days, {1} hours, {2} minutes" -f $uptime.Days, $uptime.Hours, $uptime.Minutes
+```
+
+Restart recommended if uptime >30 days.
+
+## Event Log Health (Critical Errors)
+
+```powershell
+# Recent critical/error events in System log (last 24 hours)
+Get-WinEvent -FilterHashtable @{
+  LogName='System'
+  Level=1,2  # 1=Critical, 2=Error
+  StartTime=(Get-Date).AddHours(-24)
+} -MaxEvents 20 -ErrorAction SilentlyContinue |
+  Select-Object TimeCreated, LevelDisplayName, ProviderName, Message |
+  Format-List
+
+# BSOD / bugcheck events
+Get-WinEvent -FilterHashtable @{
+  LogName='System'
+  ProviderName='Microsoft-Windows-WER-SystemErrorReporting'
+} -MaxEvents 5 -ErrorAction SilentlyContinue
+
+# Reliability history summary (launches GUI)
+# perfmon /rel
+```
+
+## Driver Health
+
+```powershell
+# Problem devices
+Get-PnpDevice | Where-Object Status -ne 'OK' |
+  Select-Object Status, Class, FriendlyName, InstanceId
+
+# All non-Microsoft drivers
+Get-CimInstance Win32_PnPSignedDriver |
+  Where-Object { $_.DriverProviderName -ne 'Microsoft' -and $_.DriverProviderName } |
+  Select-Object DeviceName, DriverProviderName, DriverVersion, DriverDate |
+  Sort-Object DriverDate -Descending
+
+# Check for unsigned drivers (Admin)
+sigverif  # launches GUI
+```
+
+## Backup Status
+
+```powershell
+# System Restore points
+Get-ComputerRestorePoint | Select-Object -First 5 SequenceNumber, Description, CreationTime
+
+# File History status
+Get-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\FileHistory" -ErrorAction SilentlyContinue
+
+# Check if System Restore is enabled
+Get-CimInstance -ClassName Win32_ShadowCopy -ErrorAction SilentlyContinue |
+  Select-Object InstallDate, VolumeName
+vssadmin list shadows 2>$null
+```

--- a/skills/windows-maintenance/references/maintenance-tasks.md
+++ b/skills/windows-maintenance/references/maintenance-tasks.md
@@ -1,0 +1,216 @@
+# Windows Maintenance Tasks
+
+Periodic maintenance for Windows 10/11. All commands PowerShell.
+(Admin) = requires elevated prompt.
+
+## System File Repair
+
+The most important maintenance operation on Windows.
+
+```powershell
+# Step 1: DISM — repair the component store (Admin)
+DISM /Online /Cleanup-Image /RestoreHealth
+# Takes 10-30 minutes. Downloads repair files from Windows Update.
+
+# Step 2: SFC — repair system files using the (now repaired) store (Admin)
+sfc /scannow
+# Takes 5-15 minutes.
+```
+
+**When to run:**
+- After BSOD or system crashes
+- When Windows features break
+- After malware removal
+- Quarterly as preventive maintenance
+
+## Windows Update Maintenance
+
+```powershell
+# Check for updates
+$UpdateSession = New-Object -ComObject Microsoft.Update.Session
+$Searcher = $UpdateSession.CreateUpdateSearcher()
+$Results = $Searcher.Search("IsInstalled=0")
+$Results.Updates | Select-Object Title, IsDownloaded, IsMandatory
+
+# Force install all pending updates (Admin)
+# Using PSWindowsUpdate module:
+Install-Module PSWindowsUpdate -Force -Scope CurrentUser
+Install-WindowsUpdate -AcceptAll -AutoReboot 2>$null
+
+# Component store cleanup (Admin)
+DISM /Online /Cleanup-Image /StartComponentCleanup
+
+# Clear update cache and retry (for stuck updates, Admin)
+Stop-Service wuauserv -Force
+Remove-Item "C:\Windows\SoftwareDistribution\Download\*" -Recurse -Force
+Start-Service wuauserv
+```
+
+## Drive Optimization
+
+```powershell
+# Check current fragmentation/optimization status (Admin)
+Optimize-Volume -DriveLetter C -Analyze -Verbose
+
+# Optimize (SSD: TRIM, HDD: defrag, Admin)
+Optimize-Volume -DriveLetter C -Verbose
+
+# Schedule (Windows does this automatically, but verify)
+Get-ScheduledTask -TaskName "ScheduledDefrag" | Select-Object State, LastRunTime
+```
+
+Windows automatically optimizes drives weekly. Only manual intervention
+needed if the scheduled task is disabled or if fragmentation is >10% on HDD.
+
+## Startup Programs Audit
+
+```powershell
+# List startup programs
+Get-CimInstance Win32_StartupCommand | Select-Object Name, Command, Location, User
+
+# Registry-based startup items
+Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run" -ErrorAction SilentlyContinue
+Get-ItemProperty "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run" -ErrorAction SilentlyContinue
+
+# Startup folder items
+Get-ChildItem "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup" -ErrorAction SilentlyContinue
+Get-ChildItem "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Startup" -ErrorAction SilentlyContinue
+
+# Scheduled tasks that run at logon
+Get-ScheduledTask | Where-Object {
+  $_.Triggers | Where-Object { $_ -is [Microsoft.PowerShell.ScheduledJob.ScheduledJobTrigger] -or $_.CimClass.CimClassName -eq 'MSFT_TaskLogonTrigger' }
+} | Select-Object TaskName, State -ErrorAction SilentlyContinue
+```
+
+**Audit guidance:**
+- Microsoft items — typically fine
+- Known software (Google, Adobe, Spotify) — disable if not needed at startup
+- Unknown items — investigate before disabling
+
+## Windows Services Audit
+
+```powershell
+# Non-Microsoft services currently running
+Get-CimInstance Win32_Service |
+  Where-Object { $_.PathName -and $_.PathName -notmatch 'Windows|Microsoft|svchost' } |
+  Select-Object Name, DisplayName, State, StartMode, PathName |
+  Sort-Object State
+
+# Services set to auto-start that aren't Microsoft
+Get-Service | Where-Object { $_.StartType -eq 'Automatic' -and $_.Status -eq 'Running' } |
+  Select-Object Name, DisplayName, Status
+```
+
+## Scheduled Tasks Audit
+
+```powershell
+# Non-Microsoft scheduled tasks
+Get-ScheduledTask |
+  Where-Object { $_.Author -notmatch 'Microsoft' -and $_.State -ne 'Disabled' } |
+  Select-Object TaskName, State, Author,
+    @{N='LastRun';E={$_.LastRunTime}},
+    @{N='NextRun';E={$_.NextRunTime}} |
+  Sort-Object LastRun -Descending
+```
+
+## DNS Cache
+
+```powershell
+# Flush DNS cache
+Clear-DnsClientCache
+
+# Verify
+Resolve-DnsName google.com
+```
+
+**When to flush:** After changing DNS, VPN issues, sites not loading.
+
+## Network Reset
+
+```powershell
+# Reset TCP/IP stack (Admin)
+netsh int ip reset
+
+# Reset Winsock (Admin)
+netsh winsock reset
+
+# Flush DNS
+ipconfig /flushdns
+
+# Release and renew IP
+ipconfig /release
+ipconfig /renew
+```
+
+Requires restart after reset commands.
+
+## Recommended Maintenance Schedule
+
+### Weekly
+- Check for Windows updates
+- Check Defender signature age
+- Review Task Manager startup tab
+
+### Monthly
+- Run `sfc /scannow` (Admin)
+- Check disk space
+- Review Event Viewer for critical errors
+- Run `Optimize-Volume` if HDD
+
+### Quarterly
+- Full security audit (scorecard)
+- DISM + SFC repair cycle
+- Component store cleanup
+- Check battery report (laptops)
+- Audit startup programs and services
+- Review scheduled tasks
+- Check driver health
+- Generate reliability report
+
+### Annually
+- Full system backup before OS upgrade
+- Review installed applications
+- Check BitLocker recovery key access
+- Update driver software
+
+## Troubleshooting Common Issues
+
+### PC Running Slow
+
+1. Check RAM: `Get-Process | Sort-Object WorkingSet64 -Desc | Select -First 5`
+2. Check CPU: `Get-Counter '\Processor(_Total)\% Processor Time'`
+3. Check disk: `Get-PSDrive C` (needs >10% free)
+4. Check startup programs (disable unnecessary ones)
+5. Check uptime (restart if >30 days)
+6. Run `sfc /scannow`
+
+### BSOD Analysis
+
+```powershell
+# Recent BSOD events
+Get-WinEvent -FilterHashtable @{
+  LogName='System'
+  ProviderName='Microsoft-Windows-WER-SystemErrorReporting'
+} -MaxEvents 5 -ErrorAction SilentlyContinue |
+  Select-Object TimeCreated, Message
+
+# Minidump files
+Get-ChildItem "C:\Windows\Minidump" -ErrorAction SilentlyContinue |
+  Select-Object Name, CreationTime, Length
+```
+
+### Windows Update Stuck
+
+```powershell
+# 1. Stop update services (Admin)
+Stop-Service wuauserv, bits, cryptSvc, msiserver -Force
+
+# 2. Rename update folders (Admin)
+Rename-Item "C:\Windows\SoftwareDistribution" "SoftwareDistribution.old" -Force
+Rename-Item "C:\Windows\System32\catroot2" "catroot2.old" -Force
+
+# 3. Restart services (Admin)
+Start-Service wuauserv, bits, cryptSvc, msiserver
+
+# 4. Re-check for updates
+```

--- a/skills/windows-maintenance/references/network-diagnostics.md
+++ b/skills/windows-maintenance/references/network-diagnostics.md
@@ -1,0 +1,168 @@
+# Windows Network Diagnostics
+
+Commands and workflows for diagnosing network issues on Windows 10/11.
+All PowerShell.
+
+## Quick Connectivity Test
+
+```powershell
+# Internet connectivity
+Test-NetConnection -ComputerName 8.8.8.8
+
+# DNS resolution
+Test-NetConnection -ComputerName google.com
+
+# If ping works but DNS doesn't — DNS issue
+# If neither works — connectivity issue
+```
+
+## Network Interface Info
+
+```powershell
+# All adapters with status
+Get-NetAdapter | Select-Object Name, Status, LinkSpeed, MacAddress
+
+# IP configuration
+Get-NetIPAddress -AddressFamily IPv4 |
+  Where-Object { $_.InterfaceAlias -notmatch 'Loopback' } |
+  Select-Object InterfaceAlias, IPAddress, PrefixLength
+
+# Default gateway
+Get-NetRoute -DestinationPrefix '0.0.0.0/0' | Select-Object NextHop, InterfaceAlias
+
+# DNS servers
+Get-DnsClientServerAddress -AddressFamily IPv4 |
+  Where-Object { $_.ServerAddresses } |
+  Select-Object InterfaceAlias, ServerAddresses
+```
+
+## DNS Diagnostics
+
+```powershell
+# Resolve a domain
+Resolve-DnsName google.com
+
+# Specific DNS server
+Resolve-DnsName google.com -Server 8.8.8.8
+
+# Flush DNS cache
+Clear-DnsClientCache
+
+# View DNS cache
+Get-DnsClientCache | Select-Object -First 20 Entry, RecordName, Data
+
+# Check hosts file
+Get-Content "$env:SystemRoot\System32\drivers\etc\hosts" |
+  Where-Object { $_ -and $_ -notmatch '^\s*#' }
+
+# Set DNS servers (Admin)
+Set-DnsClientServerAddress -InterfaceAlias "Wi-Fi" -ServerAddresses @("1.1.1.1","8.8.8.8")
+
+# Reset to DHCP DNS
+Set-DnsClientServerAddress -InterfaceAlias "Wi-Fi" -ResetServerAddresses
+```
+
+## Wi-Fi Diagnostics
+
+```powershell
+# Current Wi-Fi connection
+netsh wlan show interfaces
+
+# Key values:
+#   Signal: percentage (>70% good, <50% weak)
+#   Channel: current channel
+#   Receive/Transmit rate: connection speed
+
+# Available networks
+netsh wlan show networks mode=bssid
+
+# Generate Wi-Fi report (Admin, saves HTML)
+netsh wlan show wlanreport
+# Report at: C:\ProgramData\Microsoft\Windows\WlanReport\wlan-report-latest.html
+
+# Wi-Fi driver info
+netsh wlan show drivers
+```
+
+**Signal strength thresholds:**
+- >70% — excellent
+- 50-70% — good
+- 30-50% — fair (may drop)
+- <30% — poor
+
+## Port & Firewall Testing
+
+```powershell
+# Check if a remote port is reachable
+Test-NetConnection -ComputerName google.com -Port 443
+
+# List all listening ports
+Get-NetTCPConnection -State Listen | Select-Object LocalPort, OwningProcess,
+  @{N='Process';E={(Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue).Name}} |
+  Sort-Object LocalPort
+
+# Check if a specific port is in use
+Get-NetTCPConnection -LocalPort 8080 -ErrorAction SilentlyContinue
+
+# Firewall rules for a program
+Get-NetFirewallRule | Where-Object { $_.DisplayName -match 'Chrome' } |
+  Select-Object DisplayName, Direction, Action, Enabled
+```
+
+## Network Performance
+
+```powershell
+# Latency test
+Test-NetConnection -ComputerName google.com -TraceRoute |
+  Select-Object ComputerName, RemotePort, PingSucceeded,
+    @{N='LatencyMS';E={$_.PingReplyDetails.RoundtripTime}}
+
+# Continuous ping (Ctrl+C to stop)
+Test-Connection google.com -Count 30 |
+  Select-Object ResponseTime, StatusCode
+
+# Packet loss check
+$results = Test-Connection google.com -Count 30
+$lost = ($results | Where-Object { $_.StatusCode -ne 0 }).Count
+"Packet loss: {0}%" -f [math]::Round($lost/30*100,1)
+```
+
+## VPN Status
+
+```powershell
+# Built-in VPN connections
+Get-VpnConnection | Select-Object Name, ServerAddress, ConnectionStatus
+
+# Active VPN interfaces
+Get-NetAdapter | Where-Object { $_.InterfaceDescription -match 'VPN|TAP|TUN|WireGuard' } |
+  Select-Object Name, Status, InterfaceDescription
+```
+
+## Network Reset (Nuclear Option)
+
+```powershell
+# Full network reset (Admin, requires restart)
+netsh int ip reset
+netsh winsock reset
+ipconfig /flushdns
+ipconfig /release
+ipconfig /renew
+
+# Or via Settings:
+# Settings > Network & Internet > Advanced network settings > Network reset
+```
+
+Removes all network adapters and reinstalls them. All Wi-Fi passwords,
+VPN configs, and custom settings are lost.
+
+## Common Network Issues
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| No internet, connected | DNS issue | Flush DNS, try 8.8.8.8 |
+| Slow browsing | DNS or congestion | Switch DNS servers |
+| Can't connect to Wi-Fi | Driver or password | Forget + re-join |
+| VPN breaks internet | Routing table | Check VPN split tunnel |
+| Port not reachable | Firewall | Check `Get-NetFirewallRule` |
+| Intermittent drops | Weak signal | Check signal %, move closer |
+| "No internet" icon | NCSI probe failing | `netsh int ip reset` |

--- a/skills/windows-maintenance/references/security-posture.md
+++ b/skills/windows-maintenance/references/security-posture.md
@@ -1,0 +1,190 @@
+# Windows Security Posture Checks
+
+Verify Windows 10/11 security features are properly configured. All commands
+PowerShell. (Admin) = requires elevated prompt.
+
+## Quick Security Audit
+
+```powershell
+Write-Host "=== Windows Defender ===" -ForegroundColor Cyan
+Get-MpComputerStatus | Select-Object AMRunningMode, AntivirusEnabled, RealTimeProtectionEnabled, AntivirusSignatureAge
+
+Write-Host "`n=== Firewall ===" -ForegroundColor Cyan
+Get-NetFirewallProfile | Select-Object Name, Enabled
+
+Write-Host "`n=== BitLocker ===" -ForegroundColor Cyan
+Get-BitLockerVolume -MountPoint C: -ErrorAction SilentlyContinue | Select-Object MountPoint, ProtectionStatus, EncryptionPercentage
+
+Write-Host "`n=== UAC ===" -ForegroundColor Cyan
+$uac = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"
+"UAC Enabled: $($uac.EnableLUA -eq 1)"
+
+Write-Host "`n=== Secure Boot ===" -ForegroundColor Cyan
+Confirm-SecureBootUEFI 2>$null
+
+Write-Host "`n=== TPM ===" -ForegroundColor Cyan
+Get-Tpm | Select-Object TpmPresent, TpmReady, TpmEnabled
+```
+
+## Windows Defender
+
+```powershell
+# Full status (Admin)
+Get-MpComputerStatus | Select-Object *
+
+# Key checks
+Get-MpComputerStatus | Select-Object `
+  AntivirusEnabled,
+  RealTimeProtectionEnabled,
+  IoavProtectionEnabled,
+  AntispywareEnabled,
+  BehaviorMonitorEnabled,
+  AntivirusSignatureAge,
+  AntivirusSignatureLastUpdated,
+  QuickScanAge
+
+# Check if definitions are current
+$status = Get-MpComputerStatus
+if ($status.AntivirusSignatureAge -gt 3) {
+  Write-Warning "Defender signatures are $($status.AntivirusSignatureAge) days old. Update recommended."
+  # Update-MpSignature  # (Admin)
+}
+
+# Run quick scan (Admin)
+Start-MpScan -ScanType QuickScan
+
+# Check threat history
+Get-MpThreatDetection | Select-Object -First 5 ThreatName, DomainUser, ProcessName, InitialDetectionTime
+```
+
+**Health checks:**
+- AntivirusEnabled: should be True
+- RealTimeProtectionEnabled: should be True
+- AntivirusSignatureAge: should be <3 days
+- QuickScanAge: should be <7 days
+
+## Windows Firewall
+
+```powershell
+# Profile status
+Get-NetFirewallProfile | Select-Object Name, Enabled, DefaultInboundAction, DefaultOutboundAction
+
+# All three profiles should be enabled (Domain, Private, Public)
+
+# Enable all profiles (Admin)
+Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled True
+
+# List recent blocked connections (Admin)
+Get-WinEvent -FilterHashtable @{
+  LogName='Security'
+  Id=5157  # Connection blocked
+} -MaxEvents 10 -ErrorAction SilentlyContinue |
+  Select-Object TimeCreated, Message
+```
+
+## BitLocker (Disk Encryption)
+
+```powershell
+# Check encryption status (Admin)
+Get-BitLockerVolume | Select-Object MountPoint, VolumeStatus, ProtectionStatus,
+  EncryptionPercentage, EncryptionMethod, KeyProtector
+
+# Check if recovery key is backed up
+(Get-BitLockerVolume -MountPoint C:).KeyProtector | Select-Object KeyProtectorType, KeyProtectorId
+```
+
+**Expected state:**
+- ProtectionStatus: On
+- VolumeStatus: FullyEncrypted
+- EncryptionMethod: XtsAes256 (preferred) or XtsAes128
+
+**If disabled:**
+```powershell
+# Enable BitLocker (Admin, requires TPM)
+Enable-BitLocker -MountPoint "C:" -EncryptionMethod XtsAes256 -RecoveryPasswordProtector
+# Save the recovery key!
+```
+
+## UAC (User Account Control)
+
+```powershell
+$uac = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"
+[PSCustomObject]@{
+  UACEnabled = $uac.EnableLUA -eq 1
+  ConsentPromptBehaviorAdmin = switch($uac.ConsentPromptBehaviorAdmin) {
+    0 { "Elevate without prompting (NOT RECOMMENDED)" }
+    1 { "Prompt for credentials on secure desktop" }
+    2 { "Prompt for consent on secure desktop" }
+    3 { "Prompt for credentials" }
+    4 { "Prompt for consent" }
+    5 { "Prompt for consent for non-Windows binaries (default)" }
+  }
+}
+```
+
+UAC should always be enabled. Level 5 is the Windows default.
+
+## Secure Boot & TPM
+
+```powershell
+# Secure Boot
+try { $sb = Confirm-SecureBootUEFI; "Secure Boot: $sb" }
+catch { "Secure Boot: Not supported or unavailable" }
+
+# TPM status (Admin)
+Get-Tpm | Select-Object TpmPresent, TpmReady, TpmEnabled, TpmActivated, ManufacturerVersion
+
+# TPM version (need 2.0 for Windows 11)
+Get-CimInstance -Namespace "root\cimv2\Security\MicrosoftTpm" -ClassName Win32_Tpm -ErrorAction SilentlyContinue |
+  Select-Object SpecVersion
+```
+
+## Windows Update Settings
+
+```powershell
+# Check if auto-updates are enabled
+$au = (New-Object -ComObject Microsoft.Update.AutoUpdate).Results
+"Last search: $($au.LastSearchSuccessDate)"
+"Last install: $($au.LastInstallationSuccessDate)"
+
+# Active hours
+Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings" -ErrorAction SilentlyContinue |
+  Select-Object ActiveHoursStart, ActiveHoursEnd
+
+# Pause status
+Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings" -ErrorAction SilentlyContinue |
+  Select-Object PauseUpdatesExpiryTime
+```
+
+## Remote Access
+
+```powershell
+# Remote Desktop
+$rdp = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server"
+"Remote Desktop: $(if($rdp.fDenyTSConnections -eq 0){'Enabled (WARN)'}else{'Disabled (Good)'})"
+
+# SSH Server
+Get-Service sshd -ErrorAction SilentlyContinue | Select-Object Status, StartType
+
+# WinRM (remote management)
+Get-Service WinRM | Select-Object Status, StartType
+```
+
+**Recommendation:** Remote Desktop, SSH, and WinRM should be disabled unless
+intentionally used.
+
+## Security Scorecard
+
+| Check | Expected | Status |
+|-------|----------|--------|
+| Windows Defender | Enabled + Real-time | |
+| Defender signatures | <3 days old | |
+| Firewall (all profiles) | Enabled | |
+| BitLocker | On (FullyEncrypted) | |
+| UAC | Enabled (level 5) | |
+| Secure Boot | Enabled | |
+| TPM | Present + Ready | |
+| Auto Updates | Enabled | |
+| Remote Desktop | Disabled | |
+
+Score 8-9/9 = excellent, 6-7 = good, <6 = needs attention.

--- a/skills/windows-maintenance/scripts/system-checkup.ps1
+++ b/skills/windows-maintenance/scripts/system-checkup.ps1
@@ -1,0 +1,319 @@
+<#
+.SYNOPSIS
+  Windows System Health Checkup
+.DESCRIPTION
+  Runs security, disk, memory, updates, and maintenance checks. Produces a scored report.
+.PARAMETER Json
+  Output as JSON
+.PARAMETER Quick
+  Skip slow checks (Windows Update scan)
+.PARAMETER SecurityOnly
+  Only run security posture checks
+.EXAMPLE
+  .\system-checkup.ps1
+  .\system-checkup.ps1 -SecurityOnly
+  .\system-checkup.ps1 -Json -Quick
+#>
+param(
+  [switch]$Json,
+  [switch]$Quick,
+  [switch]$SecurityOnly
+)
+
+$ErrorActionPreference = 'SilentlyContinue'
+$results = [System.Collections.ArrayList]::new()
+
+function Add-Check([string]$Category, [string]$Check, [string]$Status, [string]$Detail) {
+  [void]$results.Add([PSCustomObject]@{
+    Category = $Category; Check = $Check; Status = $Status; Detail = $Detail
+  })
+}
+
+Write-Host "Running Windows system checkup..." -ForegroundColor Cyan
+
+function Test-Security {
+  Write-Host "  Checking security posture..."
+
+  try {
+    $defender = Get-MpComputerStatus
+    if ($defender.AntivirusEnabled -and $defender.RealTimeProtectionEnabled) {
+      Add-Check "Security" "Windows Defender" "PASS" "Enabled, real-time protection on"
+    } else {
+      Add-Check "Security" "Windows Defender" "FAIL" "Disabled or real-time protection off"
+    }
+    if ($defender.AntivirusSignatureAge -le 3) {
+      Add-Check "Security" "Defender Signatures" "PASS" "$($defender.AntivirusSignatureAge) day(s) old"
+    } else {
+      Add-Check "Security" "Defender Signatures" "WARN" "$($defender.AntivirusSignatureAge) day(s) old — update recommended"
+    }
+  } catch {
+    Add-Check "Security" "Windows Defender" "INFO" "Could not query (may need Admin)"
+  }
+
+  $profiles = Get-NetFirewallProfile
+  $allEnabled = ($profiles | Where-Object { -not $_.Enabled }).Count -eq 0
+  if ($allEnabled) {
+    Add-Check "Security" "Firewall" "PASS" "All profiles enabled"
+  } else {
+    $disabled = ($profiles | Where-Object { -not $_.Enabled }).Name -join ", "
+    Add-Check "Security" "Firewall" "WARN" "Disabled profiles: $disabled"
+  }
+
+  try {
+    $bl = Get-BitLockerVolume -MountPoint C:
+    if ($bl.ProtectionStatus -eq 'On') {
+      Add-Check "Security" "BitLocker" "PASS" "On ($($bl.EncryptionMethod))"
+    } else {
+      Add-Check "Security" "BitLocker" "WARN" "Off — enable for disk encryption"
+    }
+  } catch {
+    Add-Check "Security" "BitLocker" "INFO" "Could not query (may need Admin)"
+  }
+
+  $uac = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"
+  if ($uac.EnableLUA -eq 1) {
+    Add-Check "Security" "UAC" "PASS" "Enabled"
+  } else {
+    Add-Check "Security" "UAC" "FAIL" "Disabled — re-enable immediately"
+  }
+
+  try {
+    $sb = Confirm-SecureBootUEFI
+    if ($sb) { Add-Check "Security" "Secure Boot" "PASS" "Enabled" }
+    else { Add-Check "Security" "Secure Boot" "WARN" "Disabled" }
+  } catch {
+    Add-Check "Security" "Secure Boot" "INFO" "Not available (legacy BIOS or unsupported)"
+  }
+
+  try {
+    $tpm = Get-Tpm
+    if ($tpm.TpmPresent -and $tpm.TpmReady) {
+      Add-Check "Security" "TPM" "PASS" "Present and ready"
+    } elseif ($tpm.TpmPresent) {
+      Add-Check "Security" "TPM" "WARN" "Present but not ready"
+    } else {
+      Add-Check "Security" "TPM" "WARN" "Not detected"
+    }
+  } catch {
+    Add-Check "Security" "TPM" "INFO" "Could not query"
+  }
+
+  $rdp = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server"
+  if ($rdp.fDenyTSConnections -eq 1) {
+    Add-Check "Security" "Remote Desktop" "PASS" "Disabled"
+  } else {
+    Add-Check "Security" "Remote Desktop" "WARN" "Enabled — disable if not needed"
+  }
+
+  $au = try { (New-Object -ComObject Microsoft.Update.AutoUpdate).Results } catch { $null }
+  if ($au) {
+    $lastSearch = $au.LastSearchSuccessDate
+    $daysSince = ((Get-Date) - $lastSearch).Days
+    if ($daysSince -le 7) {
+      Add-Check "Security" "Auto Updates" "PASS" "Last check: $($lastSearch.ToString('yyyy-MM-dd'))"
+    } else {
+      Add-Check "Security" "Auto Updates" "WARN" "Last check $daysSince days ago"
+    }
+  }
+}
+
+function Test-Disk {
+  Write-Host "  Checking disk health..."
+
+  try {
+    $disk = Get-PhysicalDisk | Select-Object -First 1
+    if ($disk.HealthStatus -eq 'Healthy') {
+      Add-Check "Disk" "Physical Disk" "PASS" "$($disk.FriendlyName) — Healthy"
+    } else {
+      Add-Check "Disk" "Physical Disk" "FAIL" "$($disk.FriendlyName) — $($disk.HealthStatus)"
+    }
+  } catch {
+    Add-Check "Disk" "Physical Disk" "INFO" "Could not query SMART (may need Admin)"
+  }
+
+  $c = Get-PSDrive C
+  $pct = [math]::Round($c.Used / ($c.Used + $c.Free) * 100, 1)
+  $freeGB = [math]::Round($c.Free / 1GB, 1)
+  if ($pct -lt 70) {
+    Add-Check "Disk" "Space Usage" "PASS" "${pct}% used, ${freeGB} GB free"
+  } elseif ($pct -lt 85) {
+    Add-Check "Disk" "Space Usage" "WARN" "${pct}% used, ${freeGB} GB free — consider cleanup"
+  } else {
+    Add-Check "Disk" "Space Usage" "FAIL" "${pct}% used, ${freeGB} GB free — cleanup needed"
+  }
+}
+
+function Test-Memory {
+  Write-Host "  Checking memory..."
+
+  $os = Get-CimInstance Win32_OperatingSystem
+  $totalGB = [math]::Round($os.TotalVisibleMemorySize / 1MB, 1)
+  $freeGB = [math]::Round($os.FreePhysicalMemory / 1MB, 1)
+  $pct = [math]::Round((1 - $os.FreePhysicalMemory / $os.TotalVisibleMemorySize) * 100, 1)
+
+  if ($pct -lt 70) {
+    Add-Check "Memory" "Usage" "PASS" "${pct}% used (${freeGB} GB free of ${totalGB} GB)"
+  } elseif ($pct -lt 85) {
+    Add-Check "Memory" "Usage" "WARN" "${pct}% used — moderate pressure"
+  } else {
+    Add-Check "Memory" "Usage" "FAIL" "${pct}% used — high pressure"
+  }
+
+  $pf = Get-CimInstance Win32_PageFileUsage
+  if ($pf) {
+    $pfPct = if ($pf.AllocatedBaseSize -gt 0) { [math]::Round($pf.CurrentUsage / $pf.AllocatedBaseSize * 100, 0) } else { 0 }
+    if ($pfPct -lt 50) {
+      Add-Check "Memory" "Page File" "PASS" "${pfPct}% used ($($pf.CurrentUsage) MB of $($pf.AllocatedBaseSize) MB)"
+    } else {
+      Add-Check "Memory" "Page File" "WARN" "${pfPct}% used — consider more RAM"
+    }
+  }
+}
+
+function Test-Uptime {
+  Write-Host "  Checking uptime..."
+  $boot = (Get-CimInstance Win32_OperatingSystem).LastBootUpTime
+  $uptime = (Get-Date) - $boot
+  $uptimeStr = "{0}d {1}h {2}m" -f $uptime.Days, $uptime.Hours, $uptime.Minutes
+
+  if ($uptime.Days -lt 7) {
+    Add-Check "System" "Uptime" "PASS" $uptimeStr
+  } elseif ($uptime.Days -lt 30) {
+    Add-Check "System" "Uptime" "WARN" "$uptimeStr — consider restarting"
+  } else {
+    Add-Check "System" "Uptime" "FAIL" "$uptimeStr — restart recommended"
+  }
+}
+
+function Test-Updates {
+  if ($Quick) { return }
+  Write-Host "  Checking for updates (this may take a moment)..."
+
+  try {
+    $session = New-Object -ComObject Microsoft.Update.Session
+    $searcher = $session.CreateUpdateSearcher()
+    $result = $searcher.Search("IsInstalled=0")
+    $count = $result.Updates.Count
+    if ($count -eq 0) {
+      Add-Check "Updates" "Windows Update" "PASS" "Up to date"
+    } else {
+      Add-Check "Updates" "Windows Update" "WARN" "$count update(s) available"
+    }
+  } catch {
+    Add-Check "Updates" "Windows Update" "INFO" "Could not check"
+  }
+}
+
+function Test-EventLogErrors {
+  Write-Host "  Checking event logs..."
+
+  $critErrors = Get-WinEvent -FilterHashtable @{
+    LogName='System'; Level=1,2; StartTime=(Get-Date).AddHours(-24)
+  } -MaxEvents 50 -ErrorAction SilentlyContinue
+
+  $count = ($critErrors | Measure-Object).Count
+  if ($count -eq 0) {
+    Add-Check "System" "Event Log (24h)" "PASS" "No critical/error events"
+  } elseif ($count -lt 10) {
+    Add-Check "System" "Event Log (24h)" "WARN" "$count error(s) in last 24h"
+  } else {
+    Add-Check "System" "Event Log (24h)" "FAIL" "$count error(s) in last 24h — review Event Viewer"
+  }
+}
+
+function Test-Drivers {
+  Write-Host "  Checking drivers..."
+
+  $problemDevices = Get-PnpDevice | Where-Object Status -ne 'OK'
+  $count = ($problemDevices | Measure-Object).Count
+  if ($count -eq 0) {
+    Add-Check "Drivers" "Device Status" "PASS" "All devices OK"
+  } else {
+    Add-Check "Drivers" "Device Status" "WARN" "$count device(s) with issues"
+  }
+}
+
+function Test-Battery {
+  Write-Host "  Checking battery..."
+  $batt = Get-CimInstance Win32_Battery
+  if (-not $batt) {
+    Add-Check "Battery" "Battery" "INFO" "No battery (desktop PC)"
+    return
+  }
+
+  $charge = $batt.EstimatedChargeRemaining
+  Add-Check "Battery" "Charge" "INFO" "${charge}%"
+
+  if ($batt.DesignCapacity -and $batt.FullChargeCapacity -and $batt.DesignCapacity -gt 0) {
+    $healthPct = [math]::Round($batt.FullChargeCapacity / $batt.DesignCapacity * 100, 0)
+    if ($healthPct -gt 80) {
+      Add-Check "Battery" "Health" "PASS" "${healthPct}% of design capacity"
+    } elseif ($healthPct -gt 60) {
+      Add-Check "Battery" "Health" "WARN" "${healthPct}% of design capacity"
+    } else {
+      Add-Check "Battery" "Health" "FAIL" "${healthPct}% of design capacity — consider replacement"
+    }
+  }
+}
+
+Test-Security
+
+if (-not $SecurityOnly) {
+  Test-Disk
+  Test-Memory
+  Test-Uptime
+  Test-Battery
+  Test-Updates
+  Test-EventLogErrors
+  Test-Drivers
+}
+
+Write-Host "  Checkup complete." -ForegroundColor Green
+
+if ($Json) {
+  $results | ConvertTo-Json -Depth 3
+} else {
+  $passCount = ($results | Where-Object Status -eq 'PASS').Count
+  $warnCount = ($results | Where-Object Status -eq 'WARN').Count
+  $failCount = ($results | Where-Object Status -eq 'FAIL').Count
+  $total = $passCount + $warnCount + $failCount
+
+  Write-Host ""
+  Write-Host "Windows System Checkup Report" -ForegroundColor Yellow
+  Write-Host "=============================" -ForegroundColor Yellow
+  Write-Host ""
+
+  $currentCat = ""
+  foreach ($r in $results) {
+    if ($r.Category -ne $currentCat) {
+      if ($currentCat) { Write-Host "" }
+      Write-Host "--- $($r.Category) ---" -ForegroundColor Cyan
+      $currentCat = $r.Category
+    }
+    $icon = switch ($r.Status) {
+      "PASS" { "[OK]" }
+      "WARN" { "[!!]" }
+      "FAIL" { "[XX]" }
+      "INFO" { "[--]" }
+    }
+    $color = switch ($r.Status) {
+      "PASS" { "Green" }
+      "WARN" { "Yellow" }
+      "FAIL" { "Red" }
+      "INFO" { "Gray" }
+    }
+    Write-Host ("  {0,-6} {1,-30} {2}" -f $icon, $r.Check, $r.Detail) -ForegroundColor $color
+  }
+
+  Write-Host ""
+  Write-Host "=============================" -ForegroundColor Yellow
+  Write-Host "Score: ${passCount}/${total} checks passed"
+  if ($warnCount -gt 0) { Write-Host "  ${warnCount} warning(s)" -ForegroundColor Yellow }
+  if ($failCount -gt 0) { Write-Host "  ${failCount} issue(s) need attention" -ForegroundColor Red }
+
+  if ($failCount -eq 0 -and $warnCount -le 2) {
+    Write-Host "`nSystem is in good shape." -ForegroundColor Green
+  } elseif ($failCount -gt 0) {
+    Write-Host "`nAction needed - review items marked [XX] above." -ForegroundColor Red
+  }
+}

--- a/skills/windows-maintenance/skills.json
+++ b/skills/windows-maintenance/skills.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/windows-maintenance",
+  "version": "1.0.0",
+  "description": "Windows 10/11 health checks, security audit, and maintenance. Diagnoses disk SMART, sfc/DISM integrity, Defender, firewall, BitLocker, UAC, Secure Boot, TPM, battery, memory, updates, event log errors, driver health. Scored checkup script. Triggers: windows health check, system checkup, is my pc ok, windows maintenance, pc running slow, sfc scannow, DISM repair, check Defender, BitLocker, firewall status, BSOD, blue screen, startup programs, event log errors, driver issues, windows update, system check.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

- Add **@tank/windows-cleanup** skill: Windows 10/11 disk space recovery via PowerShell (temp files, Windows Update, WinSxS, browser caches, dev tools, Docker/WSL2, package managers, Recycle Bin)
- Add **@tank/windows-maintenance** skill: Windows 10/11 health checks, security audit, and diagnostics (SMART, sfc/DISM, Defender, BitLocker, TPM, network, event logs, drivers)

## Details

Both skills follow the same structure as the published macOS counterparts:
- `SKILL.md` with YAML frontmatter, philosophy, quick-start, and decision trees
- `references/` with deep knowledge docs (250-450 lines each)
- `scripts/` with PowerShell scripts supporting `-Json`, `-Quick`, and domain-specific flags
- `skills.json` manifest with proper permissions
- `.tankignore` for build artifacts

Windows-specific adaptations:
- PowerShell instead of Bash
- Windows-native tools: `cleanmgr`, `sfc`, `DISM`, `chkdsk`, `Get-PhysicalDisk`, `Get-MpComputerStatus`
- Windows paths and registries
- Admin elevation handling via `#Requires -RunAsAdministrator`