### PR TITLE
fix(windows-skills): trim descriptions to ≤500 chars

### DIFF
--- a/skills/windows-cleanup/skills.json
+++ b/skills/windows-cleanup/skills.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/windows-cleanup",
   "version": "1.0.0",
-  "description": "Windows 10/11 disk space recovery and cleanup for developers. Scans and cleans temp files, Windows Update cache, WinSxS, browser caches, stale node_modules, Docker WSL2, NuGet/npm/pip/Cargo caches, hibernation file, Recycle Bin. Risk-aware PowerShell workflows. Triggers: disk cleanup, free disk space, clean up windows, disk full, running out of space, clear cache, ccleaner, windows cleanup, temp files, cleanmgr, WinSxS, node_modules cleanup, docker disk, npm cache, pip cache, NuGet cache, reclaim space, hiberfil.sys, Windows.old.",
+  "description": "Windows 10/11 disk space recovery for developers. Cleans temp files, Windows Update cache, WinSxS, browser caches, stale node_modules, Docker WSL2, NuGet/npm/pip/Cargo caches, hibernation file, Recycle Bin. Risk-aware PowerShell workflows. Triggers: disk cleanup, free disk space, clean up windows, disk full, clear cache, ccleaner, windows cleanup, temp files, cleanmgr, WinSxS, node_modules cleanup, docker disk, npm cache, pip cache, NuGet cache, reclaim space, hiberfil.sys.",
   "permissions": {
     "network": {
       "outbound": []

--- a/skills/windows-maintenance/skills.json
+++ b/skills/windows-maintenance/skills.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/windows-maintenance",
   "version": "1.0.0",
-  "description": "Windows 10/11 health checks, security audit, and maintenance. Diagnoses disk SMART, sfc/DISM integrity, Defender, firewall, BitLocker, UAC, Secure Boot, TPM, battery, memory, updates, event log errors, driver health. Scored checkup script. Triggers: windows health check, system checkup, is my pc ok, windows maintenance, pc running slow, sfc scannow, DISM repair, check Defender, BitLocker, firewall status, BSOD, blue screen, startup programs, event log errors, driver issues, windows update, system check.",
+  "description": "Windows 10/11 health checks, security audit, and maintenance. Diagnoses disk SMART, sfc/DISM integrity, Defender, firewall, BitLocker, UAC, Secure Boot, TPM, battery, memory, updates, event log errors, driver health. Scored checkup script. Triggers: windows health check, system checkup, is my pc ok, windows maintenance, pc running slow, sfc scannow, DISM repair, check Defender, BitLocker, firewall status, BSOD, blue screen, startup programs, event log errors, windows update.",
   "permissions": {
     "network": {
       "outbound": []


### PR DESCRIPTION
## Summary

- Trim `skills.json` description for both `@tank/windows-cleanup` and `@tank/windows-maintenance` to stay within Tank's 500-character validation limit
- `windows-cleanup`: 535 → 478 chars (removed redundant trigger phrases)
- `windows-maintenance`: 508 → 479 chars (removed redundant trigger phrases)