### PR TITLE
feat: add intercom-frontend skill

### DIFF
--- a/skills/intercom-frontend/LICENSE
+++ b/skills/intercom-frontend/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Tank Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/intercom-frontend/SKILL.md
+++ b/skills/intercom-frontend/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: "intercom-frontend"
+description: |
+  Intercom frontend integration expert. Covers the JavaScript Messenger SDK
+  (@intercom/messenger-js-sdk), framework-specific patterns (React, Next.js,
+  Angular, Vue/Nuxt), programmatic messenger control, custom launchers,
+  phone/video calling workarounds (no startCall method exists), product tours,
+  surveys, checklists, identity verification (JWT/HMAC), trackEvent automation,
+  and performance optimization (lazy loading, facade pattern).
+  Synthesizes Intercom Developer Documentation, @intercom/messenger-js-sdk
+  API reference, react-use-intercom patterns, and community best practices.
+
+  Trigger phrases: "intercom", "intercom messenger", "intercom widget",
+  "intercom SDK", "@intercom/messenger-js-sdk", "react-use-intercom",
+  "intercom boot", "intercom shutdown", "intercom update", "intercom show",
+  "intercom custom launcher", "intercom product tour", "startTour",
+  "startSurvey", "startChecklist", "intercom identity verification",
+  "intercom trackEvent", "intercom phone call", "intercom video call",
+  "intercom Angular", "intercom Next.js", "intercom Vue",
+  "intercom performance", "intercom lazy load", "showNewMessage",
+  "showSpace", "intercom JWT", "intercom HMAC"
+---
+
+# Intercom Frontend Integration
+
+## Core Philosophy
+
+1. **The Messenger is a guest in your app** -- boot it intentionally, shut it
+   down on logout, and call update() on every route change. Stale sessions
+   cause data leaks and ghost conversations.
+2. **There is no startCall()** -- phone and video calls cannot be initiated
+   from the JS API. Use trackEvent to trigger Workflows that route to phone
+   support. This is the most common misconception.
+3. **Identity verification is non-negotiable** -- without JWT or HMAC,
+   anyone can impersonate users by booting with their email. Generate
+   tokens server-side only.
+4. **Performance is opt-in** -- the widget is ~300KB+ with heartbeat timers.
+   Lazy load with facade pattern or initializeDelay to protect Core Web Vitals.
+5. **Custom attributes go inline** -- pass them at the top level of boot/update,
+   never nested under a custom_attributes key.
+
+## Quick-Start: Common Problems
+
+### "How do I add Intercom to my React/Next.js app?"
+
+1. Install react-use-intercom for React, or @intercom/messenger-js-sdk for others.
+2. Wrap app in IntercomProvider with appId and autoBoot.
+3. For Next.js App Router: wrap provider in a 'use client' component.
+4. Add route change tracking with update() in useEffect.
+   -> See `references/framework-integration.md`
+
+### "How do I open a phone/video call from Intercom?"
+
+1. Accept that no startCall() method exists -- this is a hard API limitation.
+2. Use trackEvent('request-phone-callback', { phone, preferred_time }).
+3. Configure a Workflow in Intercom dashboard with event-based trigger.
+4. For phone-to-Messenger deflection, use Switch API (server-side).
+   -> See `references/calling-and-performance.md`
+
+### "How do I build a custom chat button?"
+
+1. Set hide_default_launcher: true in boot configuration.
+2. Use custom_launcher_selector for automatic binding, or call show() programmatically.
+3. Add unread badge via onUnreadCountChange callback.
+   -> See `references/messenger-ui.md`
+
+### "How do I trigger a product tour or survey?"
+
+1. Get the ID from the Intercom dashboard URL.
+2. Call startTour(id), startSurvey(id), or startChecklist(id).
+3. Tours in a Series cannot be triggered -- duplicate outside the Series.
+4. Surveys have a ~5-7 second delay after calling startSurvey().
+   -> See `references/engagement-features.md`
+
+### "How do I set up identity verification?"
+
+1. Generate JWT server-side using HS256 + INTERCOM_MESSENGER_SECRET_KEY.
+2. Pass as intercom_user_jwt in boot configuration.
+3. Legacy HMAC still works but JWT is recommended.
+   -> See `references/identity-and-data.md`
+
+### "Intercom is slowing down my app"
+
+1. Add initializeDelay to defer loading.
+2. Implement facade pattern: show a static button, load real widget on click.
+3. Use route-based loading to skip public pages.
+4. For Next.js: use next/script with strategy="lazyOnload".
+   -> See `references/calling-and-performance.md`
+
+## Decision Trees
+
+### Package Selection
+
+| Framework | Package | Notes |
+|-----------|---------|-------|
+| React | react-use-intercom | Provider + useIntercom() hook, 408K weekly DLs |
+| React (minimal) | @intercom/messenger-js-sdk | Official SDK, direct API calls |
+| Next.js | react-use-intercom | Add 'use client' wrapper for App Router |
+| Angular | @intercom/messenger-js-sdk | Use NgZone.runOutsideAngular() for all calls |
+| Vue / Nuxt | @intercom/messenger-js-sdk | Plugin + composable pattern |
+| Vanilla JS | @intercom/messenger-js-sdk or script tag | Script tag for simplest setup |
+
+### Method Selection
+
+| Goal | Method | Notes |
+|------|--------|-------|
+| Open messenger | show() | Opens Home or unread messages |
+| Open specific space | showSpace('help') | home, messages, help, news, tasks, tickets |
+| Open composer | showNewMessage('text') | Pre-populated requires Inbox Essential+ |
+| Open article | showArticle(id) | Invalid ID silently opens Home |
+| Start onboarding | startTour(id) | Must be published + "Use everywhere" |
+| Collect feedback | startSurvey(id) | 5-7 second delay is normal |
+| Track progress | startChecklist(id) | Must be published |
+| Log user action | trackEvent(name, meta) | Powers Workflows and segmentation |
+| Request callback | trackEvent + Workflow | No direct call API exists |
+
+### When to Call update()
+
+| Event | Action | Why |
+|-------|--------|-----|
+| Route change | update() with no args | Log page impression, check messages |
+| User data changes | update({ email, name }) | Sync attributes to Intercom |
+| Plan upgrade | update({ plan: 'pro' }) | Update segmentation |
+| Logout | shutdown() | Clear session, prevent data leaks |
+
+## Common Gotchas
+
+| Gotcha | Impact | Fix |
+|--------|--------|-----|
+| update() throttled to 20/30min | Calls silently dropped | Batch updates, call on meaningful events |
+| shutdown() not called on logout | Conversations persist 1 week via cookie | Always call shutdown() in logout flow |
+| Custom attrs nested under custom_attributes | Attributes silently ignored | Pass inline at top level |
+| Angular without NgZone.runOutsideAngular() | Continuous change detection from heartbeats | Wrap all Intercom calls |
+| Next.js App Router without 'use client' | Server component error | Create client wrapper component |
+| Padding settings on mobile | No effect, messenger is full-screen | Use custom launcher for mobile |
+| Tours in a Series | startTour() fails silently | Duplicate tour outside the Series |
+| hide_default_launcher: false | Forces launcher visible even if dashboard hides it | Omit property to respect dashboard setting |
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/js-api-reference.md` | Complete method reference, boot settings, customization options, SPA lifecycle |
+| `references/framework-integration.md` | React, Next.js, Angular, Vue/Nuxt setup, package comparison, route tracking |
+| `references/identity-and-data.md` | JWT/HMAC verification, user/company attributes, custom attributes, visitor flow |
+| `references/events-and-workflows.md` | trackEvent API, metadata types, workflow triggers, webhooks, segmentation, A/B testing |
+| `references/messenger-ui.md` | Custom launcher, positioning, theming, z-index, responsive behavior, notification control |
+| `references/engagement-features.md` | Product tours, surveys, checklists, news, tickets, articles, onboarding patterns |
+| `references/calling-and-performance.md` | Phone/video workarounds, Switch API, lazy loading, facade pattern, testing, TypeScript |

--- a/skills/intercom-frontend/references/calling-and-performance.md
+++ b/skills/intercom-frontend/references/calling-and-performance.md
@@ -1,0 +1,370 @@
+# Calling Workarounds and Performance
+
+Sources: Intercom Developer Documentation, Intercom Phone/Switch API docs, Web Performance best practices
+
+Covers: phone and video calling limitations, Switch API, Fin Voice, trackEvent workarounds, lazy loading, facade pattern, Core Web Vitals impact, testing and mocking.
+
+## Critical: There Is No startCall() Method
+
+The single most common misconception about Intercom's frontend SDK is that a method exists to initiate phone or video calls from JavaScript. It does not. There is no `Intercom('startCall', ...)`, no `startVideoCall()`, no `openPhoneChannel()`. Phone and video are entirely separate systems from the Messenger widget and have no programmatic JavaScript surface for call initiation.
+
+| Feature | Programmatic from JS? | API Available? |
+|---|---|---|
+| Inbound phone (IVR) | No | REST (read-only) |
+| Outbound phone | No — agent-initiated only | REST (read-only) |
+| Phone-to-Messenger deflection | No — server-side REST only | POST /phone_call_redirects |
+| Video (Google Meet) | No — agent-initiated only | None |
+| Fin Voice (AI phone) | No | POST /fin_voice/register (Unstable) |
+
+When a user asks "how do I open a call from Intercom," the answer is: you cannot open a call directly. Route the user toward a call through one of the workaround patterns described in this file.
+
+The table above covers every calling-related feature in Intercom's product as of 2024. If a new calling feature is released, verify whether it has a JavaScript API before assuming it does — Intercom's calling infrastructure is intentionally separate from the Messenger SDK.
+
+## The trackEvent Workaround
+
+The officially confirmed pattern for connecting a frontend action to phone support is to fire a custom event and let an Intercom Workflow handle the routing. Intercom staff have confirmed this as the intended approach for callback requests.
+
+Fire the event from your frontend:
+
+```javascript
+Intercom('trackEvent', 'request-phone-callback', {
+  phone: '+11234567890',
+  preferred_time: 'afternoon',
+  page: 'pricing'
+});
+```
+
+Then in the Intercom dashboard, create a Workflow with an event-based trigger:
+
+1. Trigger: User performs event — `request-phone-callback`
+2. Action: Assign conversation to phone support team
+3. Action: Send automated reply confirming callback request
+4. Optional: Tag the conversation with `callback-requested`
+
+The metadata you pass — phone number, preferred time, originating page — appears in the conversation context for the agent. This gives agents everything they need to make the outbound call without requiring any additional data collection.
+
+For the full trackEvent method signature and event naming conventions, see `references/js-api-reference.md`. For building the Workflow automation side, see `references/events-and-workflows.md`.
+
+Event names should use kebab-case and be descriptive enough that an agent reading the conversation context understands what the user requested. Avoid generic names like `phone-request` — prefer `request-phone-callback` or `schedule-callback-request`.
+
+## Switch API: Phone-to-Messenger Deflection
+
+The Switch API lets you deflect callers from your phone queue to the Intercom Messenger. When a caller is waiting on hold, your IVR or telephony backend calls this endpoint, which sends the caller an SMS with a link to continue the conversation in Messenger.
+
+This is a server-side REST call — your backend makes it, not the browser. The Switch API is designed for telephony systems, not browser JavaScript. Do not attempt to call it from the frontend — it requires your server-side access token and is not a CORS-enabled endpoint.
+
+Endpoint: `POST https://api.intercom.io/phone_call_redirects`
+
+```bash
+curl -X POST https://api.intercom.io/phone_call_redirects \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{ "phone": "+11234567890" }'
+```
+
+Successful response:
+
+```json
+{
+  "type": "phone_call_redirect",
+  "phone": "+11234567890",
+  "url": "https://app.intercom.com/a/apps/YOUR_APP_ID/conversations/..."
+}
+```
+
+The caller receives an SMS: "Continue your support conversation here: [link]". Clicking the link opens the Messenger in their mobile browser with the conversation pre-loaded.
+
+Use this to reduce phone queue volume during peak periods. The typical integration point is your IVR system: after a caller has waited N seconds, trigger the deflection automatically. Your frontend has no role in this flow — it is purely a backend-to-Intercom API call.
+
+The Switch API requires the caller's phone number in E.164 format (e.g., `+11234567890`). If your telephony system provides numbers in a different format, normalize them before calling the endpoint.
+
+## Calling REST API: Read-Only Access
+
+Intercom exposes a read-only REST API for call records. Use this to display call history inside your application — for example, showing a customer's past support calls in an account dashboard.
+
+All calls go through your backend. Never expose your Intercom access token to the browser.
+
+| Endpoint | Description |
+|---|---|
+| GET /calls | List all calls, paginated |
+| GET /calls/{id} | Retrieve a specific call's details |
+| GET /calls/{id}/recording | Retrieve the call recording URL |
+| GET /calls/{id}/transcript | Retrieve the call transcript |
+
+Frontend pattern: your backend exposes a proxy endpoint (e.g., `GET /api/support/calls`) that fetches from Intercom and returns sanitized data to the browser.
+
+```javascript
+app.get('/api/support/calls', async (req, res) => {
+  const response = await fetch('https://api.intercom.io/calls', {
+    headers: {
+      'Authorization': `Bearer ${process.env.INTERCOM_ACCESS_TOKEN}`,
+      'Accept': 'application/json'
+    }
+  });
+  res.json(await response.json());
+});
+```
+
+Call records include duration, outcome, assigned agent, and timestamps. They do not include the ability to initiate new calls.
+
+The proxy pattern is important for security: if you expose your Intercom access token in the browser, any user can read all your call records, contact data, and conversation history. Always proxy through your backend.
+
+## Fin Voice: AI Phone Agent
+
+Fin Voice is Intercom's AI phone agent — it handles inbound calls using the same Fin AI that powers chat. The integration connects your existing telephony provider to Fin Voice.
+
+Registration endpoint: `POST /fin_voice/register`. This endpoint links an external call provider (Twilio, Vonage, etc.) to Fin Voice. The API is marked **Unstable** in Intercom's documentation, meaning the interface may change without notice.
+
+Fin Voice is not a frontend integration. Your frontend has no interaction with Fin Voice at runtime — calls go directly through your phone provider to Fin, bypassing the Messenger entirely. Do not build frontend features that depend on the `/fin_voice/register` endpoint. Use it only for initial setup, and treat it as subject to breaking changes.
+
+## Video Calling Options
+
+Intercom does not provide a native video calling feature with a JavaScript API. The available options are:
+
+- **Google Meet (built-in):** Agents can initiate a Google Meet call from the Intercom inbox. The meeting link is sent to the user in the conversation. There is no way to trigger this from the frontend — the agent must initiate it manually.
+- **24sessions:** Video booking integration. Adds a video call scheduling option to the Messenger. Configured in the Intercom App Store, not through the SDK.
+- **Aircall Now:** Enables voice calls through the Messenger widget. Requires Aircall integration setup.
+- **DIY — send a meeting link:** The most reliable approach. Use `showNewMessage()` to pre-populate a message, or configure a bot flow to send a Calendly or Google Meet link automatically. The user clicks the link and joins the call outside of Intercom.
+
+```javascript
+Intercom('showNewMessage', 'I would like to schedule a video call.');
+```
+
+## Routing Patterns: Connecting Chat Users to Phone or Video
+
+Four patterns cover the majority of use cases for routing Messenger users to phone or video support.
+
+1. **Deflect via Switch API** — Move phone callers to chat, not the reverse. Flow: Caller waits on hold → IVR triggers POST /phone_call_redirects → Caller receives SMS → Opens Messenger link → Conversation continues in chat. Frontend role: none.
+
+2. **Collect phone number, trigger callback** — Chat user wants to speak by phone. Flow: Bot flow collects phone number → fires `trackEvent('request-phone-callback', { phone: '...' })` → Workflow assigns to phone team → Agent calls back. Frontend role: collect the phone number, fire the event.
+
+   ```javascript
+   Intercom('trackEvent', 'request-phone-callback', {
+     phone: userPhoneNumber,
+     preferred_time: selectedTime,
+     issue_type: conversationContext
+   });
+   ```
+
+3. **Send a video call link** — User needs face-to-face support. Flow: Bot asks "Would you prefer a video call?" → User selects yes → Bot sends Calendly or Google Meet link. Configure entirely in the Intercom Workflow builder. No custom JavaScript required.
+
+4. **Pre-populated message shortcut** — "Talk to us by phone" button in your UI. Lowest-effort implementation, works without any Workflow configuration.
+
+   ```javascript
+   document.getElementById('phone-support-btn').addEventListener('click', () => {
+     Intercom('showNewMessage', 'I need to speak with someone by phone. My number is: ');
+   });
+   ```
+
+## Performance Impact of the Intercom Widget
+
+The Intercom Messenger widget is a substantial JavaScript payload. The bundle is approximately 300KB or more when gzipped, depending on which features are enabled. This is comparable to loading a full React application. After initialization, Intercom runs `setInterval` heartbeats to check for new messages. These timers execute on the main thread and contribute to long task counts, which affects Interaction to Next Paint scores on pages where users interact frequently.
+
+| Metric | Impact | Cause |
+|---|---|---|
+| LCP (Largest Contentful Paint) | Delays if loaded synchronously | Script blocks render |
+| FID / INP (Interaction to Next Paint) | Increased input latency | Heartbeat timers on main thread |
+| CLS (Cumulative Layout Shift) | Shift if launcher loads late | Bubble appears after initial layout |
+
+Loading Intercom synchronously in the `<head>` is the worst-case scenario for all three metrics. The launcher bubble appearing after the page has rendered causes a measurable CLS score increase. Measure your CLS before and after adding Intercom using Chrome DevTools or Lighthouse to quantify the impact on your specific pages.
+
+## Lazy Loading Strategies
+
+Defer Intercom loading to reduce its impact on initial page performance. Choose a strategy based on how critical immediate Messenger availability is for your users. For most SaaS applications, the facade pattern or route-based loading provides the best balance between performance and availability.
+
+| Strategy | Implementation | Savings | Tradeoff |
+|---|---|---|---|
+| initializeDelay | IntercomProvider prop | Delays load by N milliseconds | Messenger unavailable during delay |
+| Facade pattern | Show fake button, load on click | Full savings until first click | First-click delay of ~1-2 seconds |
+| Scroll trigger | Load on scroll past fold | Savings for above-fold content | Complexity, may miss fast scrollers |
+| Route-based | Load only on dashboard/support routes | Full savings on public pages | Requires route-aware setup |
+| Dynamic import | import() on user interaction | Full savings until interaction | Async loading gap |
+
+**Facade pattern:** Shows a static button that looks identical to the Intercom launcher. When the user clicks it, the real Intercom loads and opens immediately. The `{ once: true }` option on the event listener ensures the handler fires only once — after Intercom loads, it replaces the facade with the real launcher.
+
+```javascript
+const facadeButton = document.createElement('button');
+facadeButton.id = 'intercom-facade';
+facadeButton.setAttribute('aria-label', 'Open support chat');
+facadeButton.style.cssText = `
+  position: fixed; bottom: 20px; right: 20px;
+  width: 60px; height: 60px; border-radius: 50%;
+  background: #6366f1; border: none; cursor: pointer; z-index: 9999;
+`;
+document.body.appendChild(facadeButton);
+
+facadeButton.addEventListener('click', () => {
+  facadeButton.remove();
+  window.intercomSettings = {
+    app_id: 'YOUR_APP_ID',
+    user_id: currentUser.id,
+    email: currentUser.email
+  };
+  const script = document.createElement('script');
+  script.src = 'https://widget.intercom.io/widget/YOUR_APP_ID';
+  script.onload = () => {
+    Intercom('boot', window.intercomSettings);
+    Intercom('show');
+  };
+  document.head.appendChild(script);
+}, { once: true });
+```
+
+**React facade with @intercom/messenger-js-sdk:**
+
+```jsx
+import { useState } from 'react';
+
+export function IntercomLauncher({ appId, user }) {
+  const [loaded, setLoaded] = useState(false);
+
+  const handleClick = async () => {
+    if (loaded) return;
+    const { Intercom } = await import('@intercom/messenger-js-sdk');
+    Intercom('boot', { app_id: appId, ...user });
+    Intercom('show');
+    setLoaded(true);
+  };
+
+  return (
+    <button onClick={handleClick} className="intercom-facade-launcher" aria-label="Open support chat">
+      {/* Chat icon SVG */}
+    </button>
+  );
+}
+```
+
+## Next.js Script Loading Strategy
+
+Use `next/script` with `strategy="lazyOnload"` to defer Intercom until after the page is fully interactive. The `lazyOnload` strategy loads the script during browser idle time after all other resources have loaded. This is the recommended approach for analytics and chat widgets that are not critical to initial render.
+
+```jsx
+import Script from 'next/script';
+
+export default function RootLayout({ children }) {
+  return (
+    <html><body>
+      {children}
+      <Script
+        id="intercom-init"
+        strategy="lazyOnload"
+        dangerouslySetInnerHTML={{ __html: `
+          window.intercomSettings = { app_id: '${process.env.NEXT_PUBLIC_INTERCOM_APP_ID}' };
+          (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/${process.env.NEXT_PUBLIC_INTERCOM_APP_ID}';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
+        `}}
+      />
+    </body></html>
+  );
+}
+```
+
+For the `@intercom/messenger-js-sdk` package in Next.js, use dynamic import with `ssr: false` to prevent Intercom from running during server-side rendering, where it would throw errors and add unnecessary weight to the server response:
+
+```jsx
+'use client';
+import dynamic from 'next/dynamic';
+
+const IntercomWidget = dynamic(() => import('./IntercomWidget'), { ssr: false });
+
+export function IntercomProvider({ children }) {
+  return <>{children}<IntercomWidget /></>;
+}
+```
+
+## Testing and Mocking
+
+Never let Intercom load in a test environment. The widget makes network requests, runs timers, and modifies the DOM in ways that interfere with test assertions and slow down test suites. A single unguarded Intercom initialization in a test file can add several seconds to your test run and cause flaky failures due to network timeouts.
+
+**Vitest — mock @intercom/messenger-js-sdk:**
+
+```javascript
+vi.mock('@intercom/messenger-js-sdk', () => ({
+  default: vi.fn(),
+  Intercom: vi.fn()
+}));
+```
+
+**Vitest — mock react-use-intercom:**
+
+```javascript
+vi.mock('react-use-intercom', () => ({
+  useIntercom: () => ({
+    boot: vi.fn(), shutdown: vi.fn(), show: vi.fn(), hide: vi.fn(),
+    showNewMessage: vi.fn(), trackEvent: vi.fn(), update: vi.fn(),
+    startTour: vi.fn(), startChecklist: vi.fn()
+  }),
+  IntercomProvider: ({ children }) => children
+}));
+```
+
+Place this mock in your test setup file so it applies globally. Individual tests can then assert on specific calls:
+
+```javascript
+test('fires callback request event on form submit', async () => {
+  const { trackEvent } = useIntercom();
+  // render component, submit form
+  expect(trackEvent).toHaveBeenCalledWith('request-phone-callback', {
+    phone: '+11234567890',
+    preferred_time: 'afternoon'
+  });
+});
+```
+
+**Jest — manual mock:**
+
+```javascript
+// __mocks__/@intercom/messenger-js-sdk.js
+module.exports = { default: jest.fn(), Intercom: jest.fn() };
+```
+
+Jest automatically picks up files in `__mocks__/` directories adjacent to `node_modules`.
+
+**Angular — mock IntercomService in TestBed:**
+
+```typescript
+const mockIntercomService = {
+  boot: jasmine.createSpy('boot'),
+  shutdown: jasmine.createSpy('shutdown'),
+  show: jasmine.createSpy('show'),
+  hide: jasmine.createSpy('hide'),
+  trackEvent: jasmine.createSpy('trackEvent'),
+  showNewMessage: jasmine.createSpy('showNewMessage')
+};
+
+TestBed.configureTestingModule({
+  providers: [{ provide: IntercomService, useValue: mockIntercomService }]
+});
+```
+
+For Vitest in Angular projects, replace `jasmine.createSpy` with `vi.fn()`.
+
+Mock at the module boundary, not at the `window.Intercom` level. Mocking `window.Intercom` directly is fragile because it depends on the global being set before the module initializes. Module-level mocks are resolved at import time and are reliable across all test runners.
+
+## TypeScript Types
+
+The `@intercom/messenger-js-sdk` package includes built-in TypeScript type definitions. No additional `@types/` package is needed when using the SDK. Types are inferred from the SDK's exported functions and cover all standard method calls including `boot`, `update`, `show`, `hide`, `trackEvent`, and `startTour`.
+
+For projects using the legacy `window.Intercom` snippet pattern without the SDK package, install the community type definitions:
+
+```bash
+npm install --save-dev @types/intercom-web
+```
+
+This adds the `Intercom` global type to `window` and provides type checking for all method calls.
+
+When writing custom event metadata types, extend the SDK types rather than using `any`:
+
+```typescript
+interface CallbackRequestMetadata {
+  phone: string;
+  preferred_time: 'morning' | 'afternoon' | 'evening';
+  page: string;
+  issue_type?: string;
+}
+
+function requestCallback(metadata: CallbackRequestMetadata): void {
+  Intercom('trackEvent', 'request-phone-callback', metadata);
+}
+```
+
+This pattern catches type errors at compile time and documents the expected shape of event metadata for other developers.

--- a/skills/intercom-frontend/references/engagement-features.md
+++ b/skills/intercom-frontend/references/engagement-features.md
@@ -1,0 +1,346 @@
+# Engagement Features
+
+Sources: Intercom Developer Documentation, Intercom Product Tours/Surveys/Checklists docs
+Covers: product tours, surveys, checklists, news items, tickets, articles, Help Center, onboarding patterns.
+
+---
+
+## Feature Comparison
+
+| Feature | Method | ID Source | Must Be | Key Gotcha |
+|---------|--------|-----------|---------|------------|
+| Tour | `startTour(id)` | Dashboard URL | Published + "Use everywhere" | Series tours fail silently |
+| Survey | `startSurvey(id)` | "Share" section | Live | 5-7 second delay |
+| Checklist | `startChecklist(id)` | Dashboard URL | Published | None |
+| News | `showNews(id)` | Dashboard URL | Published | None |
+| Ticket | `showTicket(id)` | API/Dashboard | Existing | Opens messenger if closed |
+| Article | `showArticle(id)` | Dashboard URL | Published | Invalid ID opens Home |
+
+---
+
+## Product Tours
+
+### startTour(tourId)
+
+`window.Intercom('startTour', tourId)` triggers a published product tour programmatically. The `tourId` is the numeric ID visible in the Intercom dashboard URL when editing the tour (e.g., `/tours/12345/edit` — the ID is `12345`).
+
+**Prerequisites:**
+- The tour must be published (not draft).
+- The tour must have "Use tour everywhere" enabled in its settings. Tours without this setting only display on the specific URL they were configured for, and calling `startTour()` from any other page silently does nothing.
+
+**Critical gotcha — Series tours:** Tours that belong to an Intercom Series cannot be triggered via `startTour()`. The call returns no error and no visible feedback — it simply fails silently. If a tour is part of a Series, duplicate it as a standalone tour outside the Series, then use the duplicate's ID for programmatic triggering.
+
+```javascript
+function launchWelcomeTour(tourId) {
+  if (!tourId) {
+    console.warn('Intercom: no tourId provided');
+    return;
+  }
+  window.Intercom('startTour', tourId);
+}
+
+// Usage — ID comes from dashboard URL
+launchWelcomeTour(12345);
+```
+
+**When to use:** Feature discovery after a new release, guided setup flows, contextual walkthroughs triggered by a user action (e.g., clicking "Show me how").
+
+**Debugging:** If the tour does not appear, verify in the dashboard that (1) the tour is published, (2) "Use tour everywhere" is checked, and (3) the tour is not inside a Series. There is no JavaScript error thrown on failure.
+
+---
+
+## Surveys
+
+### startSurvey(surveyId)
+
+`window.Intercom('startSurvey', surveyId)` displays a survey to the current user. The `surveyId` is found in the Intercom dashboard under the survey's "Additional ways to share" section — not in the URL.
+
+**Prerequisites:**
+- The survey must be in "Live" status. Draft surveys do not display.
+
+**Critical gotcha — delay:** There is a known delay of approximately 5 to 7 seconds between calling `startSurvey()` and the survey appearing on screen. This is an Intercom platform behavior, not a network issue. Do not call `startSurvey()` multiple times assuming the first call failed — doing so queues duplicate surveys. Inform the user that the survey is loading if the delay would otherwise feel broken.
+
+```javascript
+function requestFeedback(surveyId) {
+  // Show immediate feedback so the user knows something is happening.
+  // The survey itself will appear after ~5-7 seconds.
+  showLoadingIndicator('Loading feedback survey...');
+
+  window.Intercom('startSurvey', surveyId);
+
+  // Hide the indicator after a safe buffer — the survey handles itself from here.
+  setTimeout(() => hideLoadingIndicator(), 8000);
+}
+```
+
+**When to use:** NPS collection after a milestone (e.g., first export, first publish), post-onboarding satisfaction, feature-specific feedback triggered by a button click.
+
+**Targeting note:** `startSurvey()` bypasses Intercom's audience targeting rules. The survey fires for whoever is currently identified, regardless of the survey's configured audience filters. Use this intentionally — it is a feature, not a bug — but ensure the user context is correct before calling.
+
+For trackEvent patterns that complement survey triggers, see `references/events-and-workflows.md`.
+
+---
+
+## Checklists
+
+### startChecklist(checklistId)
+
+`window.Intercom('startChecklist', checklistId)` opens a specific onboarding checklist. The `checklistId` is the numeric ID in the dashboard URL when editing the checklist.
+
+**Prerequisites:**
+- The checklist must be published.
+
+```javascript
+window.Intercom('startChecklist', 67890);
+```
+
+**Show all active checklists:** `window.Intercom('showSpace', 'tasks')` opens the Tasks space in the messenger, which lists all checklists currently active for the user. Use this for a "View your setup checklist" CTA rather than targeting a specific checklist ID.
+
+```javascript
+// Open the tasks space to show all active checklists
+document.getElementById('view-checklist-btn').addEventListener('click', () => {
+  window.Intercom('showSpace', 'tasks');
+});
+```
+
+**When to use:** Activation flows, setup wizards, feature adoption tracking. Checklists are more persistent than tours — users can return to them at any time via the messenger.
+
+---
+
+## News and Announcements
+
+### showNews(newsItemId) and showSpace('news')
+
+`window.Intercom('showNews', newsItemId)` opens a specific news item inside the messenger. The `newsItemId` is the numeric ID in the dashboard URL when viewing the news item.
+
+`window.Intercom('showSpace', 'news')` opens the full news feed without targeting a specific item.
+
+**Creating news items:** News items are created in the Intercom dashboard (Outbound > News) or via the Intercom REST API server-side. There is no client-side API for creating news items — creation always happens server-side or through the dashboard.
+
+```javascript
+// Open a specific announcement — e.g., from a "What's new" button
+document.getElementById('whats-new-btn').addEventListener('click', () => {
+  window.Intercom('showSpace', 'news');
+});
+
+// Deep-link to a specific release note
+function openReleaseNote(newsItemId) {
+  window.Intercom('showNews', newsItemId);
+}
+```
+
+**When to use:**
+- Product launch announcements triggered from a banner or notification dot.
+- Feature update changelogs surfaced from a "What's new" badge.
+- Seasonal or time-sensitive announcements.
+
+News items support rich text, images, and reactions. They persist in the news feed so users can revisit them.
+
+---
+
+## Tickets
+
+### showTicket(ticketId) and showSpace('tickets')
+
+`window.Intercom('showTicket', ticketId)` opens a specific support ticket inside the messenger. If the messenger is closed, it opens automatically. The `ticketId` comes from the Intercom REST API response when a ticket is created, or from the dashboard.
+
+`window.Intercom('showSpace', 'tickets')` opens the Tickets space, listing all tickets associated with the current user.
+
+**Creating tickets:** Tickets are created via the Intercom REST API server-side. Never expose your Intercom API token to the browser — ticket creation must go through your backend. The backend creates the ticket and returns the `ticketId` to the frontend for display.
+
+```javascript
+// After backend creates a ticket and returns the ID
+async function createAndShowTicket(issueDescription) {
+  const response = await fetch('/api/support/tickets', {
+    method: 'POST',
+    body: JSON.stringify({ description: issueDescription }),
+  });
+  const { ticketId } = await response.json();
+
+  // Surface the ticket in the messenger
+  window.Intercom('showTicket', ticketId);
+}
+
+// Show all tickets for the current user
+document.getElementById('my-tickets-btn').addEventListener('click', () => {
+  window.Intercom('showSpace', 'tickets');
+});
+```
+
+**When to use:**
+- Support request tracking — show users their open tickets after submission.
+- Feature request workflows — create a ticket on form submit, then surface it.
+- "Check your request status" CTAs in the app.
+
+---
+
+## Articles and Help Center
+
+### showArticle(articleId) and showSpace('help')
+
+`window.Intercom('showArticle', articleId)` opens a specific Help Center article inside the messenger. The `articleId` is the numeric ID in the dashboard URL when editing the article (e.g., `/articles/12345-article-title` — the ID is `12345`).
+
+`window.Intercom('showSpace', 'help')` opens the Help Center search interface inside the messenger.
+
+**Critical gotcha — invalid IDs:** If `articleId` does not correspond to a published article, Intercom silently opens the Messenger Home instead of showing an error. There is no thrown exception and no console warning. Always verify article IDs against published articles before shipping. Unpublished or deleted articles also trigger this fallback behavior.
+
+```javascript
+// Contextual help — open the relevant article for the current feature
+function showContextualHelp(articleId) {
+  window.Intercom('showArticle', articleId);
+}
+
+// Generic help — open the Help Center search
+document.getElementById('help-btn').addEventListener('click', () => {
+  window.Intercom('showSpace', 'help');
+});
+
+// Open help article from a tooltip or "?" icon using data attributes
+document.querySelectorAll('[data-help-article]').forEach((el) => {
+  el.addEventListener('click', () => {
+    const articleId = parseInt(el.dataset.helpArticle, 10);
+    window.Intercom('showArticle', articleId);
+  });
+});
+```
+
+**When to use:**
+- Contextual help icons ("?") next to complex UI elements.
+- Error states — surface the relevant troubleshooting article.
+- Onboarding — link to setup guides from within the product.
+- Reduce support volume by surfacing self-serve answers at the point of confusion.
+
+For messenger UI customization (custom launcher, hide default launcher), see `references/messenger-ui.md`.
+
+---
+
+## Conversations
+
+### showConversation, showMessages, showNewMessage
+
+`window.Intercom('showConversation', conversationId)` opens a specific conversation. The `conversationId` comes from the Intercom REST API or webhook payloads — it is not available client-side without a prior API call.
+
+`window.Intercom('showMessages')` opens the message list (inbox view) inside the messenger.
+
+`window.Intercom('showNewMessage', prepopulatedText)` opens the new message composer. Pass a string to pre-fill the message body — useful for support CTAs that include context.
+
+```javascript
+// "Continue your conversation" CTA — ID from backend
+function openConversation(conversationId) {
+  window.Intercom('showConversation', conversationId);
+}
+
+// Open the inbox
+document.getElementById('messages-btn').addEventListener('click', () => {
+  window.Intercom('showMessages');
+});
+
+// Pre-filled support message from an error state
+function reportError(errorCode) {
+  const message = `I encountered error ${errorCode} while using the app.`;
+  window.Intercom('showNewMessage', message);
+}
+```
+
+**When to use:**
+- "Continue your conversation" CTAs in transactional emails or in-app notifications.
+- Support follow-up prompts after a failed action.
+- Pre-filled messages from error states to reduce friction in reporting issues.
+
+---
+
+## Onboarding Pattern
+
+Combine engagement features to build a complete onboarding flow. The pattern below sequences a tour, checklist, event tracking, and survey across a user's first session and beyond.
+
+```javascript
+// onboarding.js — called after successful login for new users
+
+const ONBOARDING = {
+  welcomeTourId: 11111,         // Published standalone tour (not in a Series)
+  activationChecklistId: 22222, // Published checklist
+  npsSurveyId: 33333,           // Live survey
+};
+
+function startOnboarding(user) {
+  if (user.isNewUser && !user.hasSeenWelcomeTour) {
+    // Step 1: Launch the welcome tour immediately on first login.
+    // Ensure the tour has "Use tour everywhere" enabled.
+    window.Intercom('startTour', ONBOARDING.welcomeTourId);
+
+    // Step 2: After the tour, surface the activation checklist.
+    // Stagger with a delay — firing both simultaneously overwhelms the user.
+    setTimeout(() => {
+      window.Intercom('startChecklist', ONBOARDING.activationChecklistId);
+    }, 30000); // 30 seconds — enough time for the tour to complete
+  }
+}
+
+// Step 3: Track activation milestones as the user completes checklist items.
+// See references/events-and-workflows.md for trackEvent patterns.
+function onUserCompletedStep(stepName) {
+  window.Intercom('trackEvent', `completed-${stepName}`);
+
+  // Update a custom attribute to gate downstream features
+  window.Intercom('update', {
+    onboarding_step: stepName,
+    [`completed_${stepName}`]: true,
+  });
+}
+
+// Step 4: After the user completes onboarding, request NPS feedback.
+// The ~5-7 second delay is expected — do not retry.
+function requestPostOnboardingFeedback() {
+  window.Intercom('startSurvey', ONBOARDING.npsSurveyId);
+}
+
+// Step 5: Gate a feature behind checklist completion.
+// Check the custom attribute set in step 3.
+function canAccessAdvancedFeature(user) {
+  return user.intercomAttributes?.completed_setup === true;
+}
+```
+
+**Sequencing principles:**
+- Do not fire a tour, checklist, and survey simultaneously. Users dismiss everything when overwhelmed.
+- Use `setTimeout` or event-driven triggers (e.g., fire the checklist after the tour's final step event) to stagger engagement.
+- Store onboarding state in Intercom custom attributes via `update()` so it persists across sessions and devices.
+- Use `showSpace('tasks')` as the entry point for returning users who want to resume their checklist — do not re-call `startChecklist()` on every login.
+
+---
+
+## Targeting and Timing
+
+Use custom attributes and events to control when engagement features appear, rather than firing them unconditionally.
+
+**Pattern — attribute-gated triggers:**
+
+```javascript
+// Set the user's onboarding step on login
+window.Intercom('update', {
+  onboarding_step: user.onboardingStep, // e.g., 'invited', 'activated', 'retained'
+  plan_type: user.plan,
+  days_since_signup: user.daysSinceSignup,
+});
+
+// Trigger a tour only for users on a specific step
+function maybeShowFeatureTour(user, tourId) {
+  if (user.onboardingStep === 'activated' && !user.hasSeenFeatureTour) {
+    window.Intercom('startTour', tourId);
+  }
+}
+
+// Show a contextual article when a user hits an error for the first time
+function onFirstTimeError(errorType, articleId) {
+  window.Intercom('update', { [`encountered_${errorType}`]: true });
+  window.Intercom('showArticle', articleId);
+}
+```
+
+**Avoid:**
+- Calling `startTour()`, `startSurvey()`, or `startChecklist()` on every page load without a guard. These calls are not idempotent — repeated calls re-trigger the feature.
+- Relying solely on Intercom's audience targeting for critical onboarding flows. Combine client-side guards with Intercom's targeting for reliability.
+- Firing engagement features before `Intercom('boot', ...)` completes. Wrap calls in an `onload` callback or defer until the messenger is ready.
+
+For trackEvent patterns and event-driven workflows, see `references/events-and-workflows.md`.
+For messenger UI customization and launcher control, see `references/messenger-ui.md`.

--- a/skills/intercom-frontend/references/events-and-workflows.md
+++ b/skills/intercom-frontend/references/events-and-workflows.md
@@ -1,0 +1,389 @@
+# Events, Workflows, and Automation
+
+Sources: Intercom Developer Documentation, Intercom Workflows documentation
+
+Covers: trackEvent API, event metadata, workflow triggers from frontend, webhooks, segmentation, A/B testing patterns.
+
+For the trackEvent method signature, see `references/js-api-reference.md`. For phone callback patterns using trackEvent, see `references/calling-and-performance.md`.
+
+---
+
+## trackEvent API
+
+Fire custom events to record user actions in Intercom. Events power workflow triggers, segmentation, and behavioral analytics.
+
+```js
+// Basic event — no metadata
+Intercom('trackEvent', 'completed-onboarding');
+
+// Event with metadata
+Intercom('trackEvent', 'upgraded-plan', {
+  from_plan: 'starter',
+  to_plan: 'pro',
+  revenue: { amount: 4900, currency: 'usd' }
+});
+```
+
+### Naming Conventions
+
+Use past-tense verb-noun format. This signals that the action already occurred and reads naturally in Intercom's event log.
+
+Good names:
+- `created-project`
+- `upgraded-plan`
+- `completed-onboarding`
+- `viewed-pricing`
+- `requested-phone-callback`
+- `feature-activated`
+
+Avoid:
+- Present tense: `create-project`, `upgrade-plan`
+- Vague names: `button-click`, `page-view`
+- PII in event names: `user-john@example.com-signed-up`
+- Spaces or special characters — use hyphens
+
+Event names are case-sensitive. Standardize on lowercase-hyphenated across your codebase.
+
+### Advanced Example
+
+```js
+// Track a feature activation with rich context
+Intercom('trackEvent', 'feature-activated', {
+  feature: 'analytics-dashboard',
+  plan: 'enterprise',
+  days_since_signup: 7,
+  is_trial: true,
+  trial_end_date: 1735689600,  // Unix timestamp — key must end in _date
+  docs_url: 'https://docs.example.com/analytics'
+});
+```
+
+---
+
+## Event Metadata Types
+
+Intercom supports seven metadata value types. Keep all metadata flat — nested JSON objects are not supported (except for Rich Link and Monetary, which have defined schemas).
+
+| Type | Example | Notes |
+|------|---------|-------|
+| String | `{ plan: 'enterprise' }` | Most common type; use for labels, names, identifiers |
+| Number | `{ items: 5 }` | Integer or float; use for counts, scores, quantities |
+| Boolean | `{ is_trial: true }` | Use for flags and binary states |
+| Date | `{ trial_end_date: 1735689600 }` | Unix timestamp (seconds); key must end in `_date` |
+| Link | `{ docs_url: 'https://docs.example.com' }` | Plain URL string; renders as clickable link |
+| Rich Link | `{ article: { url: 'https://...', value: 'Getting Started' } }` | Clickable link with display label |
+| Monetary | `{ revenue: { amount: 9900, currency: 'usd' } }` | Amount in cents; currency as ISO 4217 lowercase |
+
+### Metadata Rules
+
+- Flat structure only. Do not nest arbitrary objects.
+- Rich Link and Monetary are the only exceptions — they use a defined two-key schema.
+- Monetary amounts are in the smallest currency unit (cents for USD, pence for GBP).
+- Date keys must end in `_date` for Intercom to render them as dates in the UI.
+- String values over 255 characters are truncated.
+- Maximum 5 metadata keys per event is a practical guideline; Intercom does not enforce a hard limit but excessive keys reduce readability.
+
+```js
+// Correct monetary metadata
+Intercom('trackEvent', 'completed-purchase', {
+  revenue: { amount: 9900, currency: 'usd' },  // $99.00
+  items: 3,
+  invoice_url: { url: 'https://billing.example.com/inv/123', value: 'Invoice #123' }
+});
+
+// Incorrect — nested object not supported
+Intercom('trackEvent', 'completed-purchase', {
+  product: { name: 'Pro Plan', sku: 'PRO-001' }  // Will not work as expected
+});
+```
+
+---
+
+## Workflow Trigger Pattern
+
+Intercom provides no JavaScript method to trigger a Workflow by ID directly. The correct pattern is event-driven: fire a custom event from the frontend, then configure a Workflow in the Intercom dashboard to listen for that event.
+
+### End-to-End Pattern
+
+**Step 1 — Fire the event from your frontend:**
+
+```js
+Intercom('trackEvent', 'requested-phone-callback', {
+  phone: user.phone,
+  preferred_time: 'morning',
+  timezone: 'America/New_York'
+});
+```
+
+**Step 2 — Configure the Workflow in Intercom dashboard:**
+
+1. Navigate to Workflows in the Intercom dashboard.
+2. Create a new Workflow.
+3. Set the trigger to "A user performs an event."
+4. Enter the exact event name: `requested-phone-callback`.
+5. Optionally add conditions on metadata attributes (e.g., `preferred_time is morning`).
+6. Add actions: assign to inbox, send a message, create a ticket, notify a teammate.
+
+**Step 3 — Verify the connection:**
+
+Fire the event in your staging environment. Check the Intercom event log for the contact to confirm the event was received. Confirm the Workflow ran by checking the Workflow activity log.
+
+### Why This Pattern Works
+
+Workflows in Intercom are rule-based automations that respond to triggers. Event-based triggers are the most reliable way to connect frontend user actions to backend automation. The event acts as a signal; the Workflow acts as the responder. This decouples your frontend code from Intercom's automation logic — you can change Workflow behavior without deploying frontend code.
+
+---
+
+## Common Event Patterns
+
+Fire these events at the moments described. Include the suggested metadata to enable segmentation and workflow targeting.
+
+| Event Name | When to Fire | Suggested Metadata |
+|------------|-------------|-------------------|
+| `viewed-pricing` | User visits or scrolls to pricing page | `{ plan_viewed: 'enterprise', source: 'navbar' }` |
+| `started-trial` | Trial period begins | `{ plan: 'pro', trial_days: 14, trial_end_date: unixTimestamp }` |
+| `completed-onboarding` | User finishes onboarding flow | `{ steps_completed: 5, skipped_steps: 1 }` |
+| `requested-phone-callback` | User submits callback request | `{ phone: '...', preferred_time: 'afternoon' }` |
+| `upgraded-plan` | User upgrades subscription | `{ from_plan: 'starter', to_plan: 'pro', revenue: { amount: 4900, currency: 'usd' } }` |
+| `feature-activated` | User uses a feature for the first time | `{ feature: 'analytics', plan: 'pro' }` |
+| `invited-teammate` | User sends a team invitation | `{ invitee_role: 'admin', team_size: 4 }` |
+| `exported-data` | User exports a report or dataset | `{ format: 'csv', rows: 1200 }` |
+| `connected-integration` | User connects a third-party tool | `{ integration: 'salesforce' }` |
+| `cancelled-subscription` | User initiates cancellation | `{ plan: 'pro', reason: 'too-expensive' }` |
+
+---
+
+## Webhooks (Server-Side)
+
+Webhooks deliver real-time HTTP POST notifications from Intercom to your server when specific events occur. They are server-side only — the browser does not receive webhooks directly.
+
+### Supported Webhook Topics
+
+| Topic | Fires When |
+|-------|-----------|
+| `conversation.created` | A new conversation starts |
+| `conversation.closed` | A conversation is closed |
+| `conversation.assigned` | A conversation is assigned to a teammate |
+| `contact.created` | A new contact is created |
+| `contact.signed_up` | A contact converts from visitor to user |
+| `ticket.created` | A new ticket is created |
+| `ticket.state_updated` | A ticket changes state |
+| `call.completed` | A phone call ends |
+
+### Architecture: Webhook to Frontend Update
+
+Webhooks cannot push directly to the browser. Use this pattern to surface real-time updates in your UI:
+
+```
+Intercom Event
+     |
+     v
+Intercom Webhook (HTTP POST)
+     |
+     v
+Your Server (webhook endpoint)
+     |
+     +---> Validate signature
+     |
+     +---> Process payload
+     |
+     v
+WebSocket or SSE connection
+     |
+     v
+Frontend UI update
+```
+
+Text diagram:
+
+```
+[Intercom] --webhook POST--> [Your API Server]
+                                    |
+                              validate + process
+                                    |
+                         [WebSocket / SSE server]
+                                    |
+                         [Browser: update UI state]
+```
+
+### Webhook Signature Validation
+
+Intercom signs webhook payloads with HMAC-SHA1. Validate every incoming webhook before processing.
+
+```js
+// Node.js example
+const crypto = require('crypto');
+
+function validateWebhook(rawBody, signature, secret) {
+  const expected = crypto
+    .createHmac('sha1', secret)
+    .update(rawBody)
+    .digest('hex');
+  return `sha1=${expected}` === signature;
+}
+```
+
+Check the `X-Hub-Signature` header against your webhook secret from the Intercom developer settings.
+
+---
+
+## Segmentation via Custom Attributes
+
+Segments in Intercom are saved filters on contact or company attributes. Set attributes via `Intercom('boot', {...})` or `Intercom('update', {...})`, then build Segments in the dashboard.
+
+### Attribute-to-Segment Flow
+
+1. Set a custom attribute on the user:
+
+```js
+Intercom('update', {
+  plan_tier: 'enterprise',
+  account_age_days: 45,
+  has_completed_onboarding: true
+});
+```
+
+2. In the Intercom dashboard, navigate to Contacts > Segments.
+3. Create a new Segment with filter: `plan_tier is enterprise`.
+4. Use this Segment as an audience for outbound messages or Workflow conditions.
+
+### Segmentation Use Cases
+
+- Target onboarding messages to users where `has_completed_onboarding is false`
+- Trigger upgrade prompts for users where `plan_tier is starter` and `account_age_days > 30`
+- Route conversations to specialized teams based on `plan_tier`
+- Exclude churned users from campaigns using `subscription_status is cancelled`
+
+Segments update in real time as attribute values change. When you call `Intercom('update', { plan_tier: 'pro' })`, the contact moves into or out of Segments immediately.
+
+---
+
+## A/B Testing Pattern
+
+Intercom's A/B testing tools live entirely in the dashboard. The frontend's role is to fire goal events and set audience attributes.
+
+### Frontend Responsibilities
+
+1. Fire conversion goal events when the target action occurs:
+
+```js
+// Goal: user upgrades after seeing a message
+Intercom('trackEvent', 'upgraded-plan', {
+  from_plan: 'starter',
+  to_plan: 'pro',
+  revenue: { amount: 4900, currency: 'usd' }
+});
+```
+
+2. Set attributes that define the test audience:
+
+```js
+Intercom('update', {
+  plan_tier: 'starter',
+  account_age_days: 14,
+  has_seen_upgrade_prompt: false
+});
+```
+
+### Dashboard Responsibilities
+
+- Define the A/B test variants (message copy, timing, channel)
+- Set the audience using Segments built from custom attributes
+- Configure the goal event that measures conversion
+- Monitor results in the A/B test report
+
+### What Not to Do
+
+Do not implement A/B test logic in your frontend code (e.g., randomly assigning users to variants and conditionally calling Intercom). Let Intercom handle variant assignment. Your frontend only needs to fire accurate goal events and maintain up-to-date user attributes.
+
+---
+
+## Outbound Messaging Types
+
+All outbound message creation happens in the Intercom dashboard. The frontend enables targeting by keeping user attributes current and firing events that trigger message rules.
+
+| Message Type | Channel | Best For |
+|-------------|---------|---------|
+| Chat | Messenger | In-app announcements, onboarding nudges |
+| Post | Messenger | Long-form announcements, release notes |
+| Banner | Top/bottom of page | Urgent notices, trial expiry warnings |
+| Tooltip | Specific UI element | Feature discovery, contextual help |
+| Email | Email | Re-engagement, drip sequences |
+| Push | Mobile push | Mobile app re-engagement |
+
+### Event-Triggered Outbound Pattern
+
+```js
+// User activates a feature for the first time
+// This event triggers a Workflow that sends a contextual tip
+Intercom('trackEvent', 'feature-activated', {
+  feature: 'analytics-dashboard'
+});
+```
+
+In the dashboard, configure a Workflow:
+- Trigger: user performs event `feature-activated`
+- Condition: `feature is analytics-dashboard`
+- Action: send a Chat message with analytics tips
+
+This pattern delivers contextual messages at the exact moment of relevance without hardcoding message logic in your frontend.
+
+---
+
+## Best Practices
+
+### When to Fire Events
+
+Fire events at meaningful, discrete user actions — not on every page load or scroll. Each event should represent a decision or achievement that has business significance.
+
+Good moments to fire events:
+- Completing a multi-step flow
+- Activating a feature for the first time
+- Reaching a usage milestone
+- Initiating a high-intent action (requesting a demo, starting a trial)
+
+Avoid:
+- Firing events on every page view (use Intercom's built-in page tracking instead)
+- Firing the same event multiple times for the same action
+- Firing events before the action completes (e.g., before a form submits successfully)
+
+### Event Volume
+
+Keep unique event names under 50. A large number of distinct events makes Workflows harder to manage and event logs harder to read. Consolidate similar actions using metadata:
+
+```js
+// Instead of: 'activated-analytics', 'activated-reporting', 'activated-exports'
+// Use one event with a feature attribute:
+Intercom('trackEvent', 'feature-activated', { feature: 'analytics' });
+Intercom('trackEvent', 'feature-activated', { feature: 'reporting' });
+Intercom('trackEvent', 'feature-activated', { feature: 'exports' });
+```
+
+### Naming Consistency
+
+Establish a naming convention and document it. Inconsistent event names (e.g., `plan-upgraded` vs `upgraded-plan` vs `upgrade_plan`) create duplicate events in Intercom that cannot be merged.
+
+Recommended convention: `past-tense-verb-noun`, lowercase, hyphen-separated.
+
+### Metadata and PII
+
+Include enough metadata to enable segmentation and Workflow conditions. Avoid including personally identifiable information in event names or metadata keys. Phone numbers and email addresses belong in user attributes (set via `boot`/`update`), not in event metadata — unless the event specifically captures that data (e.g., `requested-phone-callback` where the phone number is the point of the event).
+
+### Timing
+
+Fire events after the action succeeds, not before. For async operations, fire the event in the success callback:
+
+```js
+async function upgradePlan(planId) {
+  const result = await api.upgradePlan(planId);
+  if (result.success) {
+    Intercom('trackEvent', 'upgraded-plan', {
+      from_plan: result.previousPlan,
+      to_plan: result.newPlan,
+      revenue: { amount: result.amountCents, currency: 'usd' }
+    });
+  }
+}
+```
+
+Firing events on failure or before confirmation produces inaccurate data in Intercom and can trigger Workflows prematurely.

--- a/skills/intercom-frontend/references/framework-integration.md
+++ b/skills/intercom-frontend/references/framework-integration.md
@@ -1,0 +1,433 @@
+# Framework Integration Patterns
+
+Sources: @intercom/messenger-js-sdk docs, react-use-intercom docs, community packages, framework documentation
+
+Covers: React, Next.js (App Router and Pages Router), Angular, Vue 3, Nuxt 3 — installation, provider patterns, SPA routing, conditional loading.
+
+For complete method signatures, see `references/js-api-reference.md`.
+
+## Package Selection
+
+| Package | Version | Weekly DLs | Framework | Recommendation |
+|---|---|---|---|---|
+| `@intercom/messenger-js-sdk` | 0.0.18 | ~853K | Any | Official SDK — use for Angular, Vue, vanilla JS |
+| `react-use-intercom` | 5.5.0 | ~408K | React | Best React wrapper — Provider + hook pattern |
+| `@supy-io/ngx-intercom` | 14.2.12 | ~7.5K | Angular | Newer Angular wrapper, actively maintained |
+| `ng-intercom` | 8.0.2 | low | Angular | Legacy, unmaintained — avoid |
+
+Use `react-use-intercom` for all React and Next.js projects. Use `@intercom/messenger-js-sdk` directly for Angular and Vue — the official SDK is well-maintained and the community wrappers add little value for those frameworks.
+
+## React with react-use-intercom
+
+```bash
+npm install react-use-intercom
+```
+
+### IntercomProvider Props
+
+Wrap your application root with `IntercomProvider`. All props except `appId` are optional.
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `appId` | `string` | required | Your Intercom workspace app ID |
+| `autoBoot` | `boolean` | `false` | Boot Intercom immediately on mount |
+| `autoBootProps` | `IntercomProps` | — | User/visitor data passed on auto-boot |
+| `shouldInitialize` | `boolean` | `true` | Conditionally prevent initialization |
+| `initializeDelay` | `number` | — | Milliseconds to delay initialization |
+| `apiBase` | `string` | — | Override API base URL (EU data residency) |
+| `onHide` | `() => void` | — | Callback when messenger hides |
+| `onShow` | `() => void` | — | Callback when messenger shows |
+| `onUnreadCountChange` | `(count: number) => void` | — | Callback when unread count changes |
+
+### useIntercom Hook
+
+`useIntercom()` returns an object with the following methods and values:
+
+| Method / Value | Description |
+|---|---|
+| `boot(props?)` | Initialize Intercom with optional user data |
+| `shutdown()` | Shut down Intercom and clear session |
+| `hardShutdown()` | Shut down and remove all Intercom cookies |
+| `update(props?)` | Update user data and check for new messages |
+| `hide()` / `show()` | Hide or show the messenger |
+| `showMessages()` | Open messenger to message list |
+| `showNewMessage(content?)` | Open new message composer |
+| `showArticle(articleId)` | Open a specific Help Center article |
+| `showSpace(spaceName)` | Open a specific Space (home, messages, help, news, tasks, tickets) |
+| `showTicket(ticketId)` | Open a specific ticket |
+| `showConversation(conversationId)` | Open a specific conversation |
+| `startSurvey(surveyId)` | Trigger a specific survey |
+| `startChecklist(checklistId)` | Trigger a specific checklist |
+| `trackEvent(name, metadata?)` | Track a custom event |
+| `getVisitorId()` | Return the current visitor ID |
+| `startTour(tourId)` | Trigger a product tour |
+| `isOpen` | `boolean` — current open state of the messenger |
+| `unreadCount` | `number` — current unread message count |
+
+### Boot Example
+
+```tsx
+// main.tsx — wrap app root; use autoBoot for visitors, or call boot() after auth
+import { IntercomProvider, useIntercom } from 'react-use-intercom';
+
+export default function Root() {
+  return (
+    <IntercomProvider appId="your_app_id" autoBoot onUnreadCountChange={(n) => console.log('Unread:', n)}>
+      <App />
+    </IntercomProvider>
+  );
+}
+
+// After user authenticates, boot with identity verification data
+function useBootIntercom(user: User | null) {
+  const { boot, shutdown } = useIntercom();
+  useEffect(() => {
+    if (user) {
+      boot({ userId: user.id, email: user.email, name: user.name, createdAt: user.createdAt });
+    } else {
+      shutdown(); // clears session on logout
+    }
+  }, [user]);
+}
+
+// Access messenger state anywhere in the tree
+function SupportButton() {
+  const { show, unreadCount } = useIntercom();
+  return <button onClick={show}>Support {unreadCount > 0 && `(${unreadCount})`}</button>;
+}
+```
+## Next.js App Router
+
+### Critical Constraint: Client Boundary
+
+The Intercom messenger runs in the browser. In the App Router, all Intercom code must live in a Client Component. Mark the provider file with `'use client'` at the top — the `react-use-intercom` library does not include this directive itself.
+
+### IntercomClientProvider
+
+```tsx
+// components/IntercomClientProvider.tsx
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import { IntercomProvider, useIntercom } from 'react-use-intercom';
+
+const INTERCOM_APP_ID = process.env.NEXT_PUBLIC_INTERCOM_APP_ID!;
+
+function IntercomRouteTracker() {
+  const pathname = usePathname();
+  const { update } = useIntercom();
+  // Call update() on every route change to track page impressions
+  // and trigger message rules based on the current URL
+  useEffect(() => { update(); }, [pathname]);
+  return null;
+}
+
+export function IntercomClientProvider({
+  children,
+  userId,
+  userEmail,
+  userName,
+}: {
+  children: React.ReactNode;
+  userId?: string;
+  userEmail?: string;
+  userName?: string;
+}) {
+  return (
+    <IntercomProvider
+      appId={INTERCOM_APP_ID}
+      autoBoot
+      autoBootProps={{ userId, email: userEmail, name: userName }}
+      shouldInitialize={!!INTERCOM_APP_ID}
+    >
+      <IntercomRouteTracker />
+      {children}
+    </IntercomProvider>
+  );
+}
+```
+
+### Place in Root Layout
+
+```tsx
+// app/layout.tsx
+import { IntercomClientProvider } from '@/components/IntercomClientProvider';
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const session = await getServerSession(); // fetch session server-side, pass as props
+  return (
+    <html lang="en">
+      <body>
+        <IntercomClientProvider
+          userId={session?.user?.id}
+          userEmail={session?.user?.email}
+          userName={session?.user?.name}
+        >
+          {children}
+        </IntercomClientProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+`router.events` does not exist in App Router — use `usePathname()` inside a Client Component instead.
+
+## Next.js Pages Router
+
+```tsx
+// pages/_app.tsx
+import type { AppProps } from 'next/app';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import { IntercomProvider, useIntercom } from 'react-use-intercom';
+
+const INTERCOM_APP_ID = process.env.NEXT_PUBLIC_INTERCOM_APP_ID!;
+
+function RouteChangeHandler() {
+  const router = useRouter();
+  const { update } = useIntercom();
+  useEffect(() => {
+    const handleRouteChange = () => { update(); };
+    router.events.on('routeChangeComplete', handleRouteChange);
+    return () => { router.events.off('routeChangeComplete', handleRouteChange); };
+  }, [router.events, update]);
+  return null;
+}
+
+export default function App({ Component, pageProps }: AppProps) {
+  const { user } = pageProps;
+  return (
+    <IntercomProvider
+      appId={INTERCOM_APP_ID}
+      autoBoot
+      autoBootProps={{ userId: user?.id, email: user?.email, name: user?.name }}
+    >
+      <RouteChangeHandler />
+      <Component {...pageProps} />
+    </IntercomProvider>
+  );
+}
+```
+
+## Angular
+
+### Critical Constraint: NgZone
+
+Intercom's internal heartbeat timer runs on a `setInterval`. Without `NgZone.runOutsideAngular()`, every tick of that interval triggers Angular's change detection cycle across your entire application. This causes severe performance degradation — wrap every Intercom call in `runOutsideAngular`.
+
+```bash
+npm install @intercom/messenger-js-sdk
+```
+
+### IntercomService
+
+```typescript
+// services/intercom.service.ts
+import { Injectable, NgZone, OnDestroy } from '@angular/core';
+import Intercom from '@intercom/messenger-js-sdk';
+
+export interface IntercomUser {
+  userId?: string; email?: string; name?: string; createdAt?: number;
+  [key: string]: unknown;
+}
+
+@Injectable({ providedIn: 'root' })
+export class IntercomService implements OnDestroy {
+  private readonly appId = 'your_app_id';
+  constructor(private ngZone: NgZone) {}
+
+  boot(user?: IntercomUser): void {
+    this.ngZone.runOutsideAngular(() => {
+      Intercom({ app_id: this.appId, user_id: user?.userId, email: user?.email, name: user?.name, created_at: user?.createdAt });
+    });
+  }
+  update(props?: Partial<IntercomUser>): void {
+    this.ngZone.runOutsideAngular(() => { window.Intercom('update', props ?? {}); });
+  }
+  shutdown(): void { this.ngZone.runOutsideAngular(() => { window.Intercom('shutdown'); }); }
+  show(): void { this.ngZone.runOutsideAngular(() => { window.Intercom('show'); }); }
+  hide(): void { this.ngZone.runOutsideAngular(() => { window.Intercom('hide'); }); }
+  trackEvent(name: string, metadata?: Record<string, unknown>): void {
+    this.ngZone.runOutsideAngular(() => { window.Intercom('trackEvent', name, metadata); });
+  }
+  ngOnDestroy(): void { this.shutdown(); }
+}
+```
+
+### AppComponent with Route Tracking
+
+```typescript
+// app.component.ts
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
+import { filter, Subject, takeUntil } from 'rxjs';
+import { IntercomService } from './services/intercom.service';
+
+@Component({ selector: 'app-root', template: '<router-outlet />' })
+export class AppComponent implements OnInit, OnDestroy {
+  private destroy$ = new Subject<void>();
+  constructor(private intercom: IntercomService, private router: Router) {}
+  ngOnInit(): void {
+    this.intercom.boot(); // pass user data if authenticated
+    this.router.events.pipe(filter((e) => e instanceof NavigationEnd), takeUntil(this.destroy$))
+      .subscribe(() => { this.intercom.update(); });
+  }
+  ngOnDestroy(): void { this.destroy$.next(); this.destroy$.complete(); }
+}
+```
+
+## Vue 3
+
+```bash
+npm install @intercom/messenger-js-sdk
+```
+
+### Plugin and Composable
+
+```typescript
+// plugins/intercom.ts
+import type { App } from 'vue';
+import Intercom from '@intercom/messenger-js-sdk';
+
+export interface IntercomInstance {
+  boot: (props?: Record<string, unknown>) => void;
+  update: (props?: Record<string, unknown>) => void;
+  shutdown: () => void;
+  show: () => void;
+  hide: () => void;
+  trackEvent: (name: string, metadata?: Record<string, unknown>) => void;
+}
+
+const APP_ID = import.meta.env.VITE_INTERCOM_APP_ID;
+
+export const intercomPlugin = {
+  install(app: App) {
+    const intercom: IntercomInstance = {
+      boot: (props = {}) => Intercom({ app_id: APP_ID, ...props }),
+      update: (props = {}) => window.Intercom('update', props),
+      shutdown: () => window.Intercom('shutdown'),
+      show: () => window.Intercom('show'),
+      hide: () => window.Intercom('hide'),
+      trackEvent: (name, metadata) => window.Intercom('trackEvent', name, metadata),
+    };
+    app.provide('intercom', intercom);
+  },
+};
+```
+
+```typescript
+// composables/useIntercom.ts
+import { inject } from 'vue';
+import type { IntercomInstance } from '@/plugins/intercom';
+export function useIntercom(): IntercomInstance {
+  return inject<IntercomInstance>('intercom')!;
+}
+```
+
+### Register Plugin and Track Routes
+
+```typescript
+// main.ts
+import { createApp } from 'vue';
+import { createRouter, createWebHistory } from 'vue-router';
+import App from './App.vue';
+import { intercomPlugin } from './plugins/intercom';
+
+const router = createRouter({ history: createWebHistory(), routes: [...] });
+const app = createApp(App);
+app.use(router);
+app.use(intercomPlugin);
+
+router.afterEach(() => { window.Intercom?.('update'); }); // track route changes
+
+app.mount('#app');
+```
+
+## Nuxt 3
+
+Use a `.client.ts` plugin suffix to run only in the browser, preventing SSR initialization.
+
+```typescript
+// plugins/intercom.client.ts
+import Intercom from '@intercom/messenger-js-sdk';
+
+export default defineNuxtPlugin(() => {
+  const appId = useRuntimeConfig().public.intercomAppId as string;
+  const intercom = {
+    boot: (props: Record<string, unknown> = {}) => Intercom({ app_id: appId, ...props }),
+    update: (props: Record<string, unknown> = {}) => window.Intercom('update', props),
+    shutdown: () => window.Intercom('shutdown'),
+    show: () => window.Intercom('show'),
+    hide: () => window.Intercom('hide'),
+    trackEvent: (name: string, meta?: Record<string, unknown>) => window.Intercom('trackEvent', name, meta),
+  };
+  intercom.boot();
+  useRouter().afterEach(() => { intercom.update(); });
+  return { provide: { intercom } };
+});
+```
+
+Configure `runtimeConfig.public.intercomAppId` in `nuxt.config.ts`. Access via `const { $intercom } = useNuxtApp()`.
+
+## Conditional Loading Patterns
+
+### Auth-Only Loading
+
+Pass `shouldInitialize={!!user}` to prevent the SDK from booting for unauthenticated visitors.
+
+```tsx
+<IntercomProvider appId={APP_ID} autoBoot={!!user} shouldInitialize={!!user}
+  autoBootProps={user ? { userId: user.id, email: user.email } : undefined}>
+  {children}
+</IntercomProvider>
+```
+
+### Layout-Based Loading
+
+Load Intercom only in authenticated layouts, not on marketing pages.
+
+```tsx
+// app/(dashboard)/layout.tsx — Intercom present
+'use client';
+import { IntercomClientProvider } from '@/components/IntercomClientProvider';
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return <IntercomClientProvider>{children}</IntercomClientProvider>;
+}
+// app/(marketing)/layout.tsx — no Intercom
+export default function MarketingLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}
+```
+
+### Dynamic Import on Interaction
+
+Defer the SDK until the user explicitly requests support — eliminates it from the initial bundle.
+
+```tsx
+export function LazySupportButton() {
+  const [loaded, setLoaded] = useState(false);
+  const handleClick = async () => {
+    if (!loaded) {
+      const { default: Intercom } = await import('@intercom/messenger-js-sdk');
+      Intercom({ app_id: 'your_app_id' });
+      setLoaded(true);
+    }
+    window.Intercom('show');
+  };
+  return <button onClick={handleClick}>Contact Support</button>;
+}
+```
+
+## SPA Route Change Pattern
+
+Call `update()` on every route change. Pass no arguments — Intercom reads `window.location` automatically. Without this, Intercom cannot record page impressions or trigger URL-based messages.
+
+| Framework | Route Event | Method |
+|---|---|---|
+| React Router | `useLocation()` in `useEffect` | `update()` via `useIntercom` hook |
+| Next.js App Router | `usePathname()` in `useEffect` | `update()` via `useIntercom` hook |
+| Next.js Pages Router | `router.events.on('routeChangeComplete')` | `update()` via `useIntercom` hook |
+| Angular | `Router.events` filtered to `NavigationEnd` | `IntercomService.update()` |
+| Vue 3 / Nuxt 3 | `router.afterEach()` | `window.Intercom('update')` |

--- a/skills/intercom-frontend/references/identity-and-data.md
+++ b/skills/intercom-frontend/references/identity-and-data.md
@@ -1,0 +1,388 @@
+# Identity Verification and Data Modeling
+
+Sources: Intercom Developer Documentation, Intercom Security Best Practices
+
+Covers: JWT and HMAC identity verification, user attributes, company data, custom attributes, visitor identification.
+
+For boot configuration, see `references/js-api-reference.md`.
+
+---
+
+## Why Identity Verification Matters
+
+Without identity verification, any user can boot the Intercom Messenger with an arbitrary email or user_id and impersonate another user. An attacker who knows a target's email can open a conversation as that person, access their conversation history, and receive support responses intended for them.
+
+Identity verification closes this attack vector by requiring a cryptographic proof — generated server-side with a secret key — that the frontend cannot forge. Intercom validates this proof before associating the session with the claimed identity.
+
+Enable identity verification for all production deployments where users are logged in. Unverified deployments are acceptable only for anonymous visitor flows or internal tools with no sensitive data.
+
+---
+
+## JWT Verification (Recommended)
+
+JWT is the current recommended approach. The server generates a signed token using the `INTERCOM_MESSENGER_SECRET_KEY` (found in Settings → Security). The client passes this token as `intercom_user_jwt` in the `boot()` call.
+
+### Server-Side: Node.js
+
+```javascript
+const jwt = require('jsonwebtoken');
+
+function generateIntercomJWT(userId) {
+  const payload = {
+    sub: userId,
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + (60 * 60), // 1 hour expiry
+  };
+
+  return jwt.sign(payload, process.env.INTERCOM_MESSENGER_SECRET_KEY, {
+    algorithm: 'HS256',
+  });
+}
+
+// In your API endpoint:
+app.get('/api/intercom-token', requireAuth, (req, res) => {
+  const token = generateIntercomJWT(req.user.id);
+  res.json({ token });
+});
+```
+
+The `sub` claim must match the `user_id` passed to `boot()`. The `exp` claim controls token expiry — use short-lived tokens (1 hour or less) and refresh them before expiry.
+
+### Client-Side: Boot with JWT
+
+```javascript
+window.Intercom('boot', {
+  app_id: 'YOUR_APP_ID',
+  user_id: currentUser.id,
+  email: currentUser.email,
+  name: currentUser.name,
+  intercom_user_jwt: tokenFromServer, // fetched from your API
+});
+```
+
+Fetch the JWT from your server after the user authenticates. Do not hardcode or cache the secret key in frontend code.
+
+---
+
+## HMAC Verification (Legacy)
+
+HMAC-SHA256 is the older verification method. It remains supported but JWT is preferred for new implementations. HMAC generates a static hash of the user identifier — it does not expire, which is a security limitation compared to JWT.
+
+Pass the hash as `user_hash` in the `boot()` call.
+
+### Server-Side: Node.js
+
+```javascript
+const crypto = require('crypto');
+
+function generateIntercomHMAC(identifier) {
+  return crypto
+    .createHmac('sha256', process.env.INTERCOM_SECRET_KEY)
+    .update(identifier)
+    .digest('hex');
+}
+
+// For user_id-based verification:
+const hash = generateIntercomHMAC(user.id.toString());
+
+// For email-based verification (when no user_id):
+const hash = generateIntercomHMAC(user.email);
+```
+
+Use `user_id` as the identifier when available. Fall back to `email` only for lead flows where no user_id exists yet.
+
+### Server-Side: Python
+
+```python
+import hmac
+import hashlib
+
+def generate_intercom_hmac(identifier: str) -> str:
+    secret = os.environ['INTERCOM_SECRET_KEY'].encode('utf-8')
+    message = identifier.encode('utf-8')
+    return hmac.new(secret, message, hashlib.sha256).hexdigest()
+```
+
+### Client-Side: Boot with HMAC
+
+```javascript
+window.Intercom('boot', {
+  app_id: 'YOUR_APP_ID',
+  user_id: currentUser.id,
+  email: currentUser.email,
+  user_hash: hashFromServer, // fetched from your API
+});
+```
+
+---
+
+## JWT vs HMAC Comparison
+
+| Aspect | JWT | HMAC |
+|---|---|---|
+| Mechanism | Signed token with claims | Static keyed hash |
+| Recommended | Yes (current standard) | Legacy |
+| Expiration | Built-in via `exp` claim | None — hash never expires |
+| Complexity | Higher — requires JWT library | Lower — single HMAC call |
+| Security | Stronger — tokens expire | Weaker — compromised hash is permanent |
+| Boot parameter | `intercom_user_jwt` | `user_hash` |
+| Identifier | `sub` claim = `user_id` | Hash of `user_id` or `email` |
+
+Migrate from HMAC to JWT for new projects. For existing HMAC implementations, migration is low-risk: generate JWT server-side and swap the boot parameter.
+
+---
+
+## User Attributes Reference
+
+Pass user attributes directly in the `boot()` or `update()` call. All attributes are optional except those required by your identity verification method.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `user_id` | string | Unique identifier in your system. Required for identity verification. |
+| `email` | string | User's email address. |
+| `name` | string | Full display name. |
+| `phone` | string | E.164 format recommended: `+15551234567`. |
+| `created_at` | number | Unix timestamp in **seconds** (not milliseconds) when the user signed up. |
+| `unsubscribed_from_emails` | boolean | Set `true` to suppress marketing emails. |
+| `language_override` | string | BCP 47 language tag, e.g. `'en'`, `'fr'`, `'de'`. Overrides browser locale. |
+| `avatar` | object | `{ type: 'avatar', image_url: 'https://...' }` |
+| `user_hash` | string | HMAC verification hash (legacy). |
+| `intercom_user_jwt` | string | JWT verification token (recommended). |
+
+### Boot Example with Full User Data
+
+```javascript
+window.Intercom('boot', {
+  app_id: 'YOUR_APP_ID',
+  user_id: '12345',
+  email: 'alice@example.com',
+  name: 'Alice Nguyen',
+  phone: '+15551234567',
+  created_at: 1704067200, // Unix seconds
+  unsubscribed_from_emails: false,
+  language_override: 'en',
+  avatar: {
+    type: 'avatar',
+    image_url: 'https://example.com/avatars/alice.png',
+  },
+  intercom_user_jwt: tokenFromServer,
+});
+```
+
+Pass `created_at` as a Unix timestamp in seconds. JavaScript's `Date.now()` returns milliseconds — divide by 1000 and use `Math.floor()`.
+
+---
+
+## Company Data
+
+Associate a user with one or more companies by passing a `company` object or a `companies` array. The `id` field is required; all other fields are optional.
+
+### Single Company
+
+```javascript
+window.Intercom('boot', {
+  app_id: 'YOUR_APP_ID',
+  user_id: '12345',
+  email: 'alice@example.com',
+  company: {
+    id: 'company_abc',
+    name: 'Acme Corp',
+    created_at: 1672531200,
+    plan: 'Enterprise',
+    monthly_spend: 1500,
+    size: 200,
+    website: 'https://acme.example.com',
+    industry: 'Technology',
+  },
+});
+```
+
+### Multiple Companies
+
+```javascript
+window.Intercom('boot', {
+  app_id: 'YOUR_APP_ID',
+  user_id: '12345',
+  companies: [
+    { id: 'company_abc', name: 'Acme Corp' },
+    { id: 'company_xyz', name: 'Beta Inc', plan: 'Starter' },
+  ],
+});
+```
+
+### Company Attribute Reference
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `id` | string | Required. Your internal company identifier. |
+| `name` | string | Display name in Intercom. |
+| `created_at` | number | Unix timestamp in seconds when the company was created. |
+| `plan` | string | Subscription plan name. |
+| `monthly_spend` | number | Monthly revenue from this company in your account currency. |
+| `size` | number | Number of employees. |
+| `website` | string | Company website URL. |
+| `industry` | string | Industry classification. |
+
+Custom attributes on companies follow the same inline pattern as user custom attributes (see below).
+
+---
+
+## Custom Attributes
+
+Custom attributes extend the standard schema with your own data. They go **inline at the top level** of the boot or update object — not nested under a `custom_attributes` key.
+
+### Correct Pattern
+
+```javascript
+window.Intercom('boot', {
+  app_id: 'YOUR_APP_ID',
+  user_id: '12345',
+  email: 'alice@example.com',
+  // Custom attributes inline at top level:
+  subscription_tier: 'pro',
+  trial_ends_at: 1709251200,
+  seats_used: 5,
+  is_admin: true,
+});
+```
+
+### Incorrect Pattern
+
+```javascript
+// WRONG — Intercom does not read nested custom_attributes
+window.Intercom('boot', {
+  app_id: 'YOUR_APP_ID',
+  user_id: '12345',
+  custom_attributes: {       // This key is ignored
+    subscription_tier: 'pro',
+  },
+});
+```
+
+### Supported Types
+
+| Type | Example | Notes |
+|---|---|---|
+| string | `'pro'` | Max 255 characters. |
+| number | `42` | Integer or float. |
+| boolean | `true` | |
+| date | `1709251200` | Unix timestamp in seconds. |
+| monetary | `{ amount: 4999, currency: 'usd' }` | Amount in smallest currency unit (cents). |
+
+Define custom attributes in Settings → Data → Custom Attributes before using them. Attributes sent before definition are silently dropped.
+
+### Custom Attributes on Companies
+
+```javascript
+window.Intercom('boot', {
+  app_id: 'YOUR_APP_ID',
+  user_id: '12345',
+  company: {
+    id: 'company_abc',
+    name: 'Acme Corp',
+    // Custom company attributes inline:
+    contract_value: { amount: 120000, currency: 'usd' },
+    renewal_date: 1735689600,
+    account_manager: 'Bob Smith',
+  },
+});
+```
+
+---
+
+## Visitor vs Lead vs User
+
+Intercom distinguishes three identity states. Understanding the progression prevents duplicate contact records and ensures correct conversation routing.
+
+```
+Anonymous Visitor
+  │  No email, no user_id
+  │  Auto-generated visitor ID (getVisitorId())
+  │
+  ▼ (user submits email in Messenger or via update())
+Lead
+  │  Has email, no user_id
+  │  Stored as a Lead in Intercom
+  │
+  ▼ (user authenticates; boot() called with user_id)
+User
+     Has user_id (and usually email)
+     Full contact record in Intercom
+```
+
+### Retrieving the Visitor ID
+
+```javascript
+const visitorId = window.Intercom('getVisitorId');
+```
+
+Use this to associate pre-authentication activity with the eventual user record. Pass `visitorId` to your server when the user signs up so you can link the anonymous session.
+
+### Converting a Visitor to a Lead
+
+```javascript
+// Visitor provides email (e.g., in a lead capture form)
+window.Intercom('update', {
+  email: 'prospect@example.com',
+});
+```
+
+### Converting a Lead to a User
+
+```javascript
+// After authentication, boot with user_id
+window.Intercom('boot', {
+  app_id: 'YOUR_APP_ID',
+  user_id: authenticatedUser.id,
+  email: authenticatedUser.email,
+  intercom_user_jwt: tokenFromServer,
+});
+```
+
+Calling `boot()` with a `user_id` that matches an existing Lead merges the records.
+
+---
+
+## Data Update Patterns
+
+Use `update()` to change user or company attributes after the initial `boot()` call. This is appropriate for attribute changes that occur during a session — plan upgrades, profile edits, feature flag changes.
+
+```javascript
+window.Intercom('update', {
+  subscription_tier: 'enterprise',
+  seats_used: 12,
+  last_upgraded_at: Math.floor(Date.now() / 1000),
+});
+```
+
+### Throttle Limits
+
+Intercom enforces a limit of 20 `update()` calls per 30-minute window per user. Exceeding this limit causes subsequent calls to be silently dropped.
+
+Update on meaningful state changes — plan upgrades, role changes, significant feature interactions. Do not call `update()` on every keystroke, scroll event, or minor UI interaction.
+
+### Null and Empty Values
+
+| Value passed | Displayed in Intercom |
+|---|---|
+| `''` (empty string) | "Unknown" |
+| `'undefined'` (string) | "Unknown" |
+| `'null'` (string) | "Unknown" |
+| `null` | Clears the attribute |
+| `undefined` | Attribute unchanged |
+
+Pass `null` explicitly to clear an attribute. Avoid passing the string `"null"` or `"undefined"` — these are treated as literal unknown values, not as clearing operations.
+
+---
+
+## Security Checklist
+
+Follow these practices for every production deployment that uses identity verification.
+
+- Generate JWT or HMAC server-side only. The secret key must never appear in frontend JavaScript, environment variables accessible to the browser, or version control.
+- Validate the user's identity on your server before signing the token or hash. Confirm the requesting session belongs to the claimed `user_id` before generating the proof.
+- Use short-lived JWTs. Set `exp` to 1 hour or less. Implement a token refresh endpoint that the frontend calls before expiry.
+- Serve all pages over HTTPS. Identity verification tokens transmitted over HTTP are vulnerable to interception.
+- Rotate the Intercom secret key if it is ever exposed. Generate a new key in Settings → Security and redeploy all server-side signing code.
+- Do not log JWT or HMAC values in application logs. Treat them as credentials.
+- Audit `user_id` values before signing. Ensure users cannot manipulate the identifier passed to your signing endpoint to obtain a token for another user's ID.

--- a/skills/intercom-frontend/references/js-api-reference.md
+++ b/skills/intercom-frontend/references/js-api-reference.md
@@ -1,0 +1,380 @@
+# Intercom JavaScript API Reference
+
+Sources: Intercom Developer Documentation (developers.intercom.com), @intercom/messenger-js-sdk v0.0.18
+
+Covers: complete method reference, boot configuration, messenger customization, callback events.
+
+## Installation
+
+### Script Tag (Legacy)
+
+Add the snippet to your HTML `<head>` or before `</body>`. Replace `YOUR_APP_ID` with your workspace app ID.
+
+```javascript
+<script>
+  window.intercomSettings = { app_id: "YOUR_APP_ID" };
+</script>
+<script>
+  (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){
+    ic('reattach_activator');ic('update',w.intercomSettings);
+  } else {
+    var d=document;var i=function(){i.c(arguments);};
+    i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;
+    var l=function(){var s=d.createElement('script');s.type='text/javascript';
+    s.async=true;s.src='https://widget.intercom.io/widget/YOUR_APP_ID';
+    var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};
+    if(document.readyState==='complete'){l();}
+    else if(w.attachEvent){w.attachEvent('onload',l);}
+    else{w.addEventListener('load',l,false);}
+  }})();
+</script>
+```
+
+### NPM Package
+
+```bash
+npm install @intercom/messenger-js-sdk
+```
+
+```javascript
+import Intercom from '@intercom/messenger-js-sdk';
+Intercom({ app_id: 'YOUR_APP_ID' });
+```
+
+### Legacy vs SDK Comparison
+
+| Aspect | `window.Intercom(method, ...)` | `@intercom/messenger-js-sdk` |
+|--------|-------------------------------|------------------------------|
+| Installation | Script snippet in HTML | `npm install` |
+| TypeScript | No built-in types | Full TypeScript definitions |
+| Tree shaking | Not applicable | Named imports supported |
+| Method calls | `window.Intercom('boot', {...})` | `Intercom({...})` / `boot({...})` |
+| Named imports | Not available | `import { boot, show, hide } from '@intercom/messenger-js-sdk'` |
+| Bundle impact | External script, no bundle cost | Adds ~10KB to bundle |
+
+Both approaches call the same Intercom messenger. The SDK is preferred for modern JavaScript projects.
+
+## Boot Configuration
+
+Call `boot()` once per session after the user's identity is known. Pass all known attributes at boot time.
+
+```javascript
+import { boot } from '@intercom/messenger-js-sdk';
+
+boot({
+  app_id: 'YOUR_APP_ID',
+  email: 'user@example.com',
+  user_id: 'user_123',
+  name: 'Jane Smith',
+  created_at: 1704067200,
+  user_hash: 'HMAC_SHA256_HASH',
+  api_base: 'https://api-iam.intercom.io',
+  hide_default_launcher: false,
+  alignment: 'right',
+  horizontal_padding: 20,
+  vertical_padding: 20,
+});
+```
+
+### Boot Settings Reference
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `app_id` | string | **Required.** Your Intercom workspace app ID. |
+| `email` | string | User's email address. |
+| `user_id` | string | Your internal user ID. Stable identifier across sessions. |
+| `name` | string | User's display name shown in the Intercom inbox. |
+| `created_at` | number | Unix timestamp (seconds) of account creation. Used for segmentation. |
+| `user_hash` | string | HMAC-SHA256 of `user_id` (or `email` if no `user_id`). Enables identity verification. |
+| `intercom_user_jwt` | string | JWT-based identity token. Alternative to `user_hash`. |
+| `api_base` | string | Regional API endpoint. Defaults to US. See regional table below. |
+| `custom_launcher_selector` | string | CSS selector for a custom launcher element (e.g. `'#my-button'`). |
+| `hide_default_launcher` | boolean | Hides the default chat bubble. Use with `custom_launcher_selector`. |
+| `alignment` | string | `'left'` or `'right'`. Default: `'right'`. |
+| `horizontal_padding` | number | Pixels from screen edge. Default: `20`. |
+| `vertical_padding` | number | Pixels from screen bottom. Default: `20`. |
+| `z_index` | number | CSS z-index of the messenger widget. Default: `2147483001`. |
+| `action_color` | string | Hex color for action buttons and links. |
+| `background_color` | string | Hex color for the messenger header and launcher. |
+| `theme_mode` | string | `'light'`, `'dark'`, or `'system'`. |
+| `session_duration` | number | Milliseconds of inactivity before session expires. |
+
+Custom user or company attributes are passed flat in the boot object — not nested under a `custom_attributes` key:
+
+```javascript
+boot({ app_id: 'YOUR_APP_ID', user_id: 'user_123', plan: 'pro', company_size: 50 });
+```
+
+### Regional API Base URLs
+
+| Region | `api_base` value |
+|--------|-----------------|
+| United States (default) | `https://api-iam.intercom.io` |
+| European Union | `https://api-iam.eu.intercom.io` |
+| Australia | `https://api-iam.au.intercom.io` |
+
+Set `api_base` to match the region where your Intercom workspace is hosted. Mismatched regions cause boot failures.
+
+## Lifecycle Methods
+
+### boot(settings)
+
+Initializes the messenger and identifies the user. Call once per page load or session start.
+
+```javascript
+boot({ app_id: 'YOUR_APP_ID', user_id: 'user_123' });
+```
+
+### update(attributes?)
+
+Refreshes the messenger with new user data and checks for new messages. Call on every route change in SPAs. Throttled to **20 calls per 30 minutes** — batch attribute changes rather than calling repeatedly.
+
+```javascript
+update();                                          // Ping for new messages
+update({ email: 'new@example.com' });              // Update attributes
+```
+
+### shutdown()
+
+Clears the current user session and removes the messenger. Call on logout. Without `shutdown()`, Intercom stores the session in a cookie for up to 1 week — a logged-out user returning within that window may see the previous user's conversations.
+
+```javascript
+shutdown();
+```
+
+## Visibility Methods
+
+| Method | Description |
+|--------|-------------|
+| `show()` | Opens the messenger to its default view (home or last open space). |
+| `hide()` | Closes the messenger if open. |
+| `hideNotifications(hide)` | Shows or hides the notification badge. Pass `true` to hide, `false` to show. |
+
+```javascript
+import { show, hide, hideNotifications } from '@intercom/messenger-js-sdk';
+
+show();
+hide();
+hideNotifications(true);
+```
+
+## Navigation Methods
+
+### showSpace(space)
+
+Opens the messenger to a named space. Each space must be enabled in Messenger > Spaces. Calling with a disabled space opens the home screen instead.
+
+```javascript
+showSpace('home');      // Home screen
+showSpace('messages'); // Conversations list
+showSpace('help');     // Help center / articles
+showSpace('news');     // News feed
+showSpace('tasks');    // Tasks / checklists
+showSpace('tickets');  // Tickets view
+```
+
+### showMessages()
+
+Opens the conversations list. Equivalent to `showSpace('messages')`.
+
+```javascript
+showMessages();
+```
+
+### showNewMessage(prepopulatedContent?)
+
+Opens the new message composer. Optionally pre-fills the message body.
+
+```javascript
+showNewMessage();
+showNewMessage('I need help with my billing.');
+```
+
+### showArticle(articleId)
+
+Opens a specific help center article by numeric ID. Find IDs in the Articles section URL: `app.intercom.com/a/apps/YOUR_APP_ID/articles/12345678`.
+
+```javascript
+showArticle(12345678);
+```
+
+### showNews(newsItemId)
+
+Opens a specific news item by numeric ID. Find IDs in the Intercom News section.
+
+```javascript
+showNews(87654321);
+```
+
+### showTicket(ticketId)
+
+Opens a specific ticket by numeric ID.
+
+```javascript
+showTicket(11223344);
+```
+
+### showConversation(conversationId)
+
+Opens a specific conversation by numeric ID.
+
+```javascript
+showConversation(99887766);
+```
+
+## Engagement Methods
+
+### startTour(tourId)
+
+Triggers a product tour by numeric ID. Only standalone, live tours work — tours in a Series cannot be triggered via this method. The user must match the tour's audience rules.
+
+```javascript
+startTour(123456);
+```
+
+### startSurvey(surveyId)
+
+Triggers an in-product survey by numeric ID. Surveys have an inherent delay of approximately **5-7 seconds** before appearing — do not assume failure if the survey does not appear immediately.
+
+```javascript
+startSurvey(654321);
+```
+
+### startChecklist(checklistId)
+
+Opens a specific checklist by numeric ID. The checklist must be published — calling with a draft ID silently fails.
+
+```javascript
+startChecklist(112233);
+```
+
+### trackEvent(eventName, metadata?)
+
+Records a custom event for the current user. Metadata values must be strings, numbers, or booleans — not nested objects or arrays.
+
+```javascript
+trackEvent('signed_up');
+trackEvent('purchased_plan', { plan_name: 'Pro', amount: 99, currency: 'USD' });
+```
+
+## Callback Events
+
+Register callbacks after `boot()` to respond to messenger state changes.
+
+### onHide(callback)
+
+Fires when the messenger is closed.
+
+```javascript
+onHide(() => { console.log('Messenger closed'); });
+```
+
+### onShow(callback)
+
+Fires when the messenger is opened.
+
+```javascript
+onShow(() => { console.log('Messenger opened'); });
+```
+
+### onUnreadCountChange(callback)
+
+Fires when the unread count changes. Also fires **immediately upon registration** with the current count — account for this initial call in your handler.
+
+```javascript
+onUnreadCountChange((count) => {
+  document.getElementById('badge').textContent = count > 0 ? count : '';
+});
+```
+
+### onUserEmailSupplied(callback)
+
+Fires when a visitor (non-identified user) submits their email address in the messenger.
+
+```javascript
+onUserEmailSupplied(() => { console.log('Visitor provided email'); });
+```
+
+## Identity
+
+### getVisitorId()
+
+Returns the anonymous visitor ID assigned before a user is identified. Returns `undefined` if the user is already identified. Use to associate pre-login activity with a user after authentication — pass the visitor ID to your backend and use the Intercom REST API to merge the visitor with the identified user.
+
+```javascript
+const visitorId = getVisitorId();
+```
+
+## Messenger Customization
+
+Appearance settings can be passed at `boot()` or updated via `update()`.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `alignment` | string | `'right'` | `'left'` or `'right'` — side of screen. |
+| `horizontal_padding` | number | `20` | Pixels from screen edge. Desktop only. |
+| `vertical_padding` | number | `20` | Pixels from screen bottom. Desktop only. |
+| `z_index` | number | `2147483001` | CSS z-index. Raise if other elements overlap the messenger. |
+| `action_color` | string | Workspace default | Hex color for buttons and links. |
+| `background_color` | string | Workspace default | Hex color for header and launcher. |
+| `theme_mode` | string | `'system'` | `'light'`, `'dark'`, or `'system'`. |
+| `hide_default_launcher` | boolean | `false` | Hides the default bubble. Requires a custom launcher. |
+| `custom_launcher_selector` | string | — | CSS selector for your custom open button. |
+| `session_duration` | number | — | Inactivity timeout in milliseconds. |
+
+### Custom Launcher Pattern
+
+Intercom attaches a click listener to the element matching `custom_launcher_selector`. The element must exist in the DOM when `boot()` is called.
+
+```javascript
+boot({ app_id: 'YOUR_APP_ID', hide_default_launcher: true, custom_launcher_selector: '#support-button' });
+```
+
+```html
+<button id="support-button">Contact Support</button>
+```
+
+## SPA Considerations
+
+Call `update()` on every route change — the messenger does not detect navigation automatically. This logs the page view, checks for URL-triggered messages, and keeps the session active.
+
+```javascript
+// React Router / History API pattern
+router.on('routeChange', () => { update(); });
+
+// After programmatic navigation
+history.pushState({}, '', '/new-path');
+update();
+```
+
+Call `shutdown()` on logout, then `boot()` again when a new user logs in. Do not call `boot()` twice without an intervening `shutdown()` — the second call is ignored.
+
+```javascript
+async function logout() {
+  await api.logout();
+  shutdown();
+  router.push('/login');
+}
+
+async function login(credentials) {
+  const user = await api.login(credentials);
+  boot({ app_id: 'YOUR_APP_ID', user_id: user.id, email: user.email, user_hash: user.intercomHash });
+}
+```
+
+## Common Gotchas
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `update()` calls silently dropped | Exceeds 20 calls per 30 minutes | Debounce route change handlers; batch attribute updates |
+| Previous user's conversations visible after logout | `shutdown()` not called | Always call `shutdown()` on logout |
+| Custom attributes not appearing in Intercom | Attributes nested under `custom_attributes` key | Pass attributes flat in the boot/update object |
+| `startTour()` does nothing | Tour is part of a Series, or is in draft | Use only standalone, live tours |
+| Survey appears 5-7 seconds late | Intentional delay built into Intercom | Do not retry; wait for the survey to appear |
+| `startChecklist()` does nothing | Checklist is in draft state | Publish the checklist before triggering |
+| `showSpace()` opens home instead of target | Space not enabled in workspace settings | Enable the space in Messenger > Spaces |
+| Messenger overlaps page content | Default z-index too high or too low | Adjust `z_index` in boot settings |
+| Padding settings ignored on mobile | Mobile layout overrides padding | Intercom controls mobile positioning; padding applies desktop only |
+| `onUnreadCountChange` fires immediately | Fires on registration with current count | Handle the initial call; do not treat it as a new message |
+| `boot()` called twice | Second call ignored silently | Call `shutdown()` between sessions |
+| `getVisitorId()` returns undefined | User is already identified | Only call before `boot()` with user identity |

--- a/skills/intercom-frontend/references/messenger-ui.md
+++ b/skills/intercom-frontend/references/messenger-ui.md
@@ -1,0 +1,387 @@
+# Messenger UI Customization
+
+Sources: Intercom Developer Documentation, Intercom Messenger Customization Guide
+
+Covers: custom launcher patterns, hiding default launcher, positioning, theming, z-index management, responsive behavior, notification control.
+
+For complete boot settings, see `references/js-api-reference.md`. For framework-specific provider patterns, see `references/framework-integration.md`.
+
+## Custom Launcher Patterns
+
+Three approaches exist for replacing or augmenting the default launcher bubble. Choose based on how much control you need over click behavior and badge display.
+
+### A. CSS Selector Approach
+
+Pass a CSS selector string to `custom_launcher_selector` during boot. Intercom attaches its own click handler to the matched element automatically. Combine with `hide_default_launcher: true` to suppress the default bubble.
+
+```javascript
+Intercom('boot', {
+  app_id: 'YOUR_APP_ID',
+  custom_launcher_selector: '#open-chat',
+  hide_default_launcher: true,
+});
+```
+
+```html
+<button id="open-chat">Chat with us</button>
+```
+
+Intercom re-queries the selector after each `update()` call, so elements rendered after boot are picked up as long as they match the selector at the time of the next update. Use a stable, unique selector — class selectors work but are more fragile if class names change.
+
+### B. Programmatic Approach
+
+Hide the default launcher and call `Intercom('show')` directly from your button's event handler. This gives full control: you can conditionally open the messenger, log analytics events, or delay the open until some condition is met.
+
+```javascript
+Intercom('boot', { app_id: 'YOUR_APP_ID', hide_default_launcher: true });
+
+document.getElementById('open-chat').addEventListener('click', () => {
+  Intercom('show');
+});
+```
+
+Use this approach when you need to run logic before opening (e.g., check authentication state, fire an analytics event, or open to a specific space rather than the default home).
+
+### C. Hybrid Approach with Unread Badge
+
+Use `custom_launcher_selector` for automatic click handling and `onUnreadCountChange` to drive a badge counter on the same element.
+
+```javascript
+Intercom('boot', {
+  app_id: 'YOUR_APP_ID',
+  custom_launcher_selector: '#chat-launcher',
+  hide_default_launcher: true,
+});
+
+Intercom('onUnreadCountChange', (count) => {
+  const badge = document.getElementById('chat-badge');
+  badge.textContent = count > 99 ? '99+' : String(count);
+  badge.style.display = count > 0 ? 'flex' : 'none';
+});
+```
+
+```html
+<button id="chat-launcher" style="position: relative;">
+  Chat
+  <span id="chat-badge" style="
+    display: none; position: absolute; top: -6px; right: -6px;
+    background: #e74c3c; color: white; border-radius: 50%;
+    width: 18px; height: 18px; font-size: 11px;
+    align-items: center; justify-content: center;
+  "></span>
+</button>
+```
+
+`onUnreadCountChange` fires immediately on registration with the current unread count, then fires again on every subsequent change. Initialize badge state in the callback rather than assuming zero at boot.
+
+## Hiding the Default Launcher
+
+Set `hide_default_launcher: true` in the boot call to suppress the default bubble. Toggle after boot with `update()`:
+
+```javascript
+Intercom('update', { hide_default_launcher: true });  // hide
+Intercom('update', { hide_default_launcher: false }); // show
+```
+
+Setting `hide_default_launcher: false` explicitly forces the launcher visible, overriding any visibility settings configured in the Intercom dashboard. If you want the dashboard to control launcher visibility, omit the property entirely rather than setting it to `false`. Only set it explicitly when your code owns the visibility decision.
+
+## Positioning
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `alignment` | `'left'` or `'right'` | `'right'` | Which side of the viewport the launcher anchors to |
+| `horizontal_padding` | number (px) | 20 | Distance from the aligned edge; minimum 20 |
+| `vertical_padding` | number (px) | 20 | Distance from the bottom of the viewport; minimum 20 |
+
+```javascript
+Intercom('boot', {
+  app_id: 'YOUR_APP_ID',
+  alignment: 'left',
+  horizontal_padding: 32,
+  vertical_padding: 80,
+});
+```
+
+Update positioning dynamically — for example, to move the launcher above a cookie banner that appears after boot:
+
+```javascript
+function showCookieBanner() {
+  renderCookieBanner();
+  Intercom('update', { vertical_padding: 120 });
+}
+
+function dismissCookieBanner() {
+  removeCookieBanner();
+  Intercom('update', { vertical_padding: 20 });
+}
+```
+
+`horizontal_padding` and `vertical_padding` have no effect on mobile viewports. On mobile, the messenger opens full-screen and the launcher renders at a fixed position. Do not rely on padding values for mobile layout — use a custom launcher instead (see Responsive Behavior section).
+
+## Z-Index Management
+
+Set `z_index` in boot or via `update()` to control stacking order:
+
+```javascript
+Intercom('boot', { app_id: 'YOUR_APP_ID', z_index: 9999 });
+```
+
+The default z-index is approximately `2147483000` — near the maximum integer value for CSS z-index.
+
+If your application has modals or overlays that must appear above the messenger, set `z_index` to a value below your overlay's z-index:
+
+```javascript
+// Your modal uses z-index: 10000 — set messenger below it
+Intercom('update', { z_index: 9000 });
+// When modal closes, restore
+Intercom('update', { z_index: 2147483000 });
+```
+
+If a third-party library raises its own elements to a very high z-index and covers the messenger, set `z_index` explicitly above the offending element. Avoid using `2147483647` (the CSS maximum) unless necessary — it can cause rendering issues in some browsers.
+
+## Theming and Colors
+
+| Property | Values | Description |
+|---|---|---|
+| `action_color` | CSS hex or rgb string | Color for buttons, links, and CTAs inside the messenger |
+| `background_color` | CSS hex or rgb string | Color for the team profile header area |
+| `theme_mode` | `'light'`, `'dark'`, `'system'` | Light/dark mode; `'system'` follows OS preference |
+
+Set at boot:
+
+```javascript
+Intercom('boot', {
+  app_id: 'YOUR_APP_ID',
+  action_color: '#6366f1',
+  background_color: '#1e1b4b',
+  theme_mode: 'system',
+});
+```
+
+All three properties can be changed dynamically with `update()`. Use this to synchronize the messenger with your application's own theme toggle:
+
+```javascript
+function applyTheme(theme) {
+  document.documentElement.setAttribute('data-theme', theme);
+  Intercom('update', {
+    theme_mode: theme === 'dark' ? 'dark' : 'light',
+    action_color: theme === 'dark' ? '#818cf8' : '#6366f1',
+    background_color: theme === 'dark' ? '#1e1b4b' : '#eef2ff',
+  });
+}
+```
+
+`theme_mode: 'system'` reads `prefers-color-scheme` from the OS. If your app manages its own theme state independently of the OS preference, use `'light'` or `'dark'` explicitly and drive it from your app's theme state rather than relying on `'system'`.
+
+## Responsive Behavior
+
+On mobile viewports (typically below 768px), the Intercom messenger opens full-screen. The launcher bubble still appears, but `horizontal_padding` and `vertical_padding` are ignored.
+
+Recommended pattern: detect the mobile viewport, hide the default launcher, and render a custom launcher positioned to fit your mobile layout.
+
+```javascript
+function setupIntercomForViewport() {
+  const isMobile = window.matchMedia('(max-width: 767px)').matches;
+  Intercom('update', { hide_default_launcher: isMobile });
+}
+
+setupIntercomForViewport();
+window.matchMedia('(max-width: 767px)').addEventListener('change', setupIntercomForViewport);
+```
+
+On mobile, pair this with a custom launcher element that fits your mobile navigation — for example, a bottom navigation bar item:
+
+```html
+<nav class="bottom-nav">
+  <button class="nav-item" id="mobile-chat-launcher">
+    Support
+    <span id="mobile-chat-badge" style="display: none;"></span>
+  </button>
+</nav>
+```
+
+```javascript
+Intercom('boot', {
+  app_id: 'YOUR_APP_ID',
+  custom_launcher_selector: '#mobile-chat-launcher',
+  hide_default_launcher: true,
+});
+```
+
+To restore the default launcher on desktop, you must explicitly set `hide_default_launcher: false` — omitting the property does not reset it.
+
+## Notification Control
+
+`hideNotifications` suppresses in-app notification badges and message popups without closing the messenger or affecting unread counts:
+
+```javascript
+Intercom('hideNotifications', true);  // suppress notifications
+Intercom('hideNotifications', false); // restore notifications
+```
+
+Use this when the user enters a focused mode where notification popups would be disruptive:
+
+```javascript
+// Video call or screen share
+function enterFocusMode() {
+  Intercom('hideNotifications', true);
+}
+
+function exitFocusMode() {
+  Intercom('hideNotifications', false);
+}
+
+// Presentation / fullscreen mode
+document.addEventListener('fullscreenchange', () => {
+  Intercom('hideNotifications', !!document.fullscreenElement);
+});
+```
+
+`hideNotifications` does not affect the unread count returned by `onUnreadCountChange` — messages still accumulate, they just do not surface as popups. When notifications are re-enabled, any accumulated messages become visible.
+
+## Showing Specific Spaces
+
+`showSpace` opens the messenger to a specific section:
+
+```javascript
+Intercom('showSpace', 'home');      // default home screen
+Intercom('showSpace', 'messages');  // conversation list
+Intercom('showSpace', 'help');      // help center / articles
+Intercom('showSpace', 'news');      // news feed
+Intercom('showSpace', 'tasks');     // task center
+Intercom('showSpace', 'tickets');   // tickets list
+```
+
+Each space must be enabled in your Intercom workspace settings. Calling `showSpace` with a disabled space falls back to the home screen.
+
+Use `showSpace` to create contextual entry points throughout your application:
+
+```javascript
+// Footer help link
+document.getElementById('help-link').addEventListener('click', (e) => {
+  e.preventDefault();
+  Intercom('showSpace', 'help');
+});
+
+// Navigation messages link
+document.getElementById('nav-messages').addEventListener('click', (e) => {
+  e.preventDefault();
+  Intercom('showSpace', 'messages');
+});
+
+// Sidebar task center
+document.getElementById('task-center-btn').addEventListener('click', () => {
+  Intercom('showSpace', 'tasks');
+});
+```
+
+## Pre-populated Messages
+
+`showNewMessage` opens the new message composer with pre-filled text:
+
+```javascript
+Intercom('showNewMessage');                              // empty composer
+Intercom('showNewMessage', 'I need help with billing'); // pre-filled
+```
+
+Requires Inbox Essential or Pro plan. Use for contextual help buttons where the user's intent is already known:
+
+```javascript
+// Bug report button on a specific feature
+document.getElementById('report-bug').addEventListener('click', () => {
+  const page = window.location.pathname;
+  const feature = document.querySelector('[data-feature]')?.dataset.feature;
+  Intercom('showNewMessage', `Bug report — Page: ${page}, Feature: ${feature}\n\n`);
+});
+
+// Billing help button
+document.getElementById('billing-help').addEventListener('click', () => {
+  Intercom('showNewMessage', 'I have a question about my billing.');
+});
+```
+
+The pre-filled text is editable by the user before sending. Include a trailing newline or space to position the cursor after the pre-filled content.
+
+## Conditional Visibility by Page
+
+In single-page applications, show or hide the messenger launcher based on the current route. Update visibility on every route change rather than only at boot.
+
+**React Router pattern**:
+
+```javascript
+const MESSENGER_HIDDEN_ROUTES = ['/onboarding', '/checkout', '/presentation'];
+
+function useIntercomVisibility() {
+  const location = useLocation();
+  useEffect(() => {
+    const hidden = MESSENGER_HIDDEN_ROUTES.some((route) =>
+      location.pathname.startsWith(route)
+    );
+    Intercom('update', { hide_default_launcher: hidden });
+  }, [location.pathname]);
+}
+```
+
+**Vanilla SPA pattern** (history API):
+
+```javascript
+const HIDDEN_PATHS = ['/onboarding', '/checkout'];
+
+function updateIntercomVisibility() {
+  const hidden = HIDDEN_PATHS.some((path) =>
+    window.location.pathname.startsWith(path)
+  );
+  Intercom('update', { hide_default_launcher: hidden });
+}
+
+const originalPushState = history.pushState.bind(history);
+history.pushState = (...args) => { originalPushState(...args); updateIntercomVisibility(); };
+window.addEventListener('popstate', updateIntercomVisibility);
+updateIntercomVisibility();
+```
+
+Prefer `update()` for route-based visibility changes over conditionally rendering the `IntercomProvider` — the latter triggers a full shutdown and re-boot on each route change, resetting conversation state and firing additional API calls.
+
+## Unread Count Badge
+
+`onUnreadCountChange` registers a callback that fires with the current unread message count immediately on registration, then on every subsequent change:
+
+```javascript
+// Update browser tab title
+Intercom('onUnreadCountChange', (count) => {
+  document.title = count > 0 ? `(${count}) My App` : 'My App';
+});
+
+// Update navigation badge
+Intercom('onUnreadCountChange', (count) => {
+  const badge = document.getElementById('nav-support-badge');
+  if (!badge) return;
+  badge.textContent = count > 9 ? '9+' : String(count);
+  badge.setAttribute('aria-label', `${count} unread support messages`);
+  badge.style.display = count > 0 ? 'inline-flex' : 'none';
+});
+```
+
+Register `onUnreadCountChange` after boot. In React, register it inside a `useEffect` that runs after the Intercom boot effect.
+
+## Summary: Property Reference
+
+| Property | Set via | Effect |
+|---|---|---|
+| `custom_launcher_selector` | boot, update | CSS selector for custom launcher element |
+| `hide_default_launcher` | boot, update | Show/hide default bubble; omit for dashboard control |
+| `alignment` | boot, update | `'left'` or `'right'` |
+| `horizontal_padding` | boot, update | px from aligned edge (desktop only) |
+| `vertical_padding` | boot, update | px from bottom (desktop only) |
+| `z_index` | boot, update | Stacking order of messenger iframe |
+| `action_color` | boot, update | Button and link color inside messenger |
+| `background_color` | boot, update | Team profile header color |
+| `theme_mode` | boot, update | `'light'`, `'dark'`, or `'system'` |
+
+| Method | Purpose |
+|---|---|
+| `Intercom('show')` | Open messenger to default view |
+| `Intercom('showSpace', space)` | Open messenger to specific space |
+| `Intercom('showNewMessage', text)` | Open new message composer |
+| `Intercom('hideNotifications', bool)` | Suppress/restore notification popups |
+| `Intercom('onUnreadCountChange', fn)` | Register unread count callback |

--- a/skills/intercom-frontend/skills.json
+++ b/skills/intercom-frontend/skills.json
@@ -1,0 +1,18 @@
+{
+  "name": "intercom-frontend",
+  "version": "1.0.0",
+  "description": "Intercom frontend integration expert. Covers the JavaScript Messenger SDK (@intercom/messenger-js-sdk), framework-specific patterns (React, Next.js, Angular, Vue/Nuxt), programmatic messenger control, custom launchers, phone/video calling workarounds, product tours, surveys, checklists, identity verification (JWT/HMAC), trackEvent automation, and performance optimization. Triggers: intercom, intercom messenger, intercom widget, intercom SDK, @intercom/messenger-js-sdk, react-use-intercom, intercom boot, intercom custom launcher, startTour, startSurvey, intercom identity verification, intercom trackEvent, intercom phone call, intercom Angular, intercom Next.js, intercom Vue, intercom performance, showNewMessage, showSpace, intercom JWT.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

- Adds `intercom-frontend` skill — expert Intercom Messenger SDK integration for frontend developers
- Covers the complete JS API surface, framework-specific patterns (React, Next.js, Angular, Vue), identity verification, custom events/workflows, messenger UI customization, engagement features (tours, surveys, checklists), calling workarounds, and performance optimization
- 7 reference files (all within 250–450 line limits), SKILL.md (149 lines), skills.json, and MIT LICENSE

## Key findings baked into the skill

- **No `startCall()` API exists** — skill documents workarounds via `trackEvent` + Workflows
- **`update()` throttled to 20 calls/30 min** — skill provides debounce patterns for SPAs
- **Angular zone.js conflict** — skill includes `NgZone.runOutsideAngular()` pattern
- **Next.js App Router** — skill covers `'use client'` boundary requirements
- **JWT identity verification** — skill recommends JWT over legacy HMAC

## File structure

```
skills/intercom-frontend/
├── SKILL.md
├── skills.json
├── LICENSE
└── references/
    ├── js-api-reference.md        (380 lines)
    ├── framework-integration.md   (433 lines)
    ├── identity-and-data.md       (388 lines)
    ├── events-and-workflows.md    (389 lines)
    ├── messenger-ui.md            (387 lines)
    ├── engagement-features.md     (346 lines)
    └── calling-and-performance.md (368 lines)
```