### PR TITLE
feat(unix-media-compressor): add cross-platform file compression skill

### DIFF
--- a/skills/unix-media-compressor/SKILL.md
+++ b/skills/unix-media-compressor/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: unix-media-compressor
+description: |
+  Compress and optimize any file on macOS and Linux. Covers the full
+  compression stack: images (JPEG via mozjpeg/jpegoptim, PNG via
+  pngquant+oxipng, WebP via cwebp, AVIF via avifenc, GIF via gifsicle),
+  video (H.264/H.265/AV1 with ffmpeg CRF encoding, resolution scaling,
+  hardware acceleration), audio (MP3/AAC/Opus/FLAC codec selection and
+  quality tiers), PDFs (Ghostscript quality presets, qpdf optimization),
+  and archives (zip, tar.gz, tar.xz, tar.zst, 7z, brotli with format
+  selection guidance and parallel compression). Auto-detects installed
+  tools, guides installation of missing ones, supports batch processing
+  with before/after size reporting. Synthesizes ffmpeg official docs,
+  Ghostscript docs, Google WebP/AVIF docs, Xiph.org Opus docs, and
+  production compression guides.
+
+  Trigger phrases: "compress", "shrink", "optimize", "reduce file size",
+  "make smaller", "image compression", "video compression", "audio
+  compression", "compress PDF", "optimize PDF", "zip", "archive",
+  "tar", "gzip", "7z", "zstd", "brotli", "convert to WebP",
+  "convert to AVIF", "ffmpeg compress", "reduce video size",
+  "optimize images", "optimize PNG", "optimize JPEG", "batch compress",
+  "pngquant", "oxipng", "jpegoptim", "mozjpeg", "cwebp", "avifenc",
+  "gifsicle", "ghostscript", "compress video for web", "smaller file",
+  "file too large", "reduce size", "lossy compression", "lossless
+  compression", "CRF", "quality preset", "compress folder",
+  "make video smaller", "make image smaller", "shrink PDF"
+---
+
+# Unix Media Compressor
+
+Compress any file to its smallest practical size on macOS and Linux.
+
+## Core Philosophy
+
+1. **Right tool for the job** — Each file type has a best-in-class compressor.
+   JPEG and PNG need different tools. Video and audio need different codecs.
+   Match the tool to the content.
+2. **Quality tiers, not magic numbers** — Three tiers for every domain: "web"
+   (aggressive, smallest), "balanced" (good quality, reasonable size), and
+   "quality" (visually/audibly lossless). Pick a tier, get the right settings.
+3. **Detect before compressing** — Run `scripts/check-tools.sh` first. Know
+   what tools are available. Install missing ones. Do not guess.
+4. **Preserve originals by default** — Output to a new file unless the user
+   explicitly asks to overwrite. Compression is lossy and irreversible for
+   most formats.
+5. **Show the results** — Always report before/after file sizes and percentage
+   reduction. Compression without measurement is guessing.
+
+## Quick-Start
+
+### What are you compressing?
+
+| File Type | Best Tool | Start Here |
+|-----------|-----------|------------|
+| JPEG photos | mozjpeg or jpegoptim | `references/image-compression.md` |
+| PNG graphics | pngquant + oxipng | `references/image-compression.md` |
+| Convert to WebP | cwebp | `references/image-compression.md` |
+| Convert to AVIF | avifenc | `references/image-compression.md` |
+| GIF animation | gifsicle | `references/image-compression.md` |
+| Video (any format) | ffmpeg (libx264/libx265/libsvtav1) | `references/video-compression.md` |
+| Audio (any format) | ffmpeg (libopus/aac/libmp3lame) | `references/audio-compression.md` |
+| PDF documents | Ghostscript (gs) | `references/pdf-compression.md` |
+| Folder / multiple files | zip, tar.zst, 7z | `references/archive-formats.md` |
+| Missing tools? | check-tools.sh | `references/tool-setup.md` |
+
+### Quality Tier Quick Reference
+
+| Tier | Images | Video (H.264) | Audio (Opus) | PDF |
+|------|--------|---------------|--------------|-----|
+| Web | cwebp -q 75 | CRF 28, fast | 64-96k | /screen (72 DPI) |
+| Balanced | cwebp -q 85 | CRF 22, slow | 128k | /ebook (150 DPI) |
+| Quality | cwebp -q 92 | CRF 18, veryslow | 192k | /printer (300 DPI) |
+
+## Common Workflows
+
+### Compress all images in a folder
+
+```bash
+# Check tools first
+bash scripts/check-tools.sh
+
+# JPEG: optimize in-place
+jpegoptim --max=85 --strip-all *.jpg
+
+# PNG: lossy + lossless pipeline
+pngquant --quality 65-80 --force --ext .png *.png
+oxipng -o 3 -i 0 --strip safe *.png
+
+# Convert all to WebP
+for f in *.jpg *.png; do cwebp -q 85 "$f" -o "${f%.*}.webp"; done
+```
+
+### Compress a video for web
+
+```bash
+ffmpeg -i input.mov -c:v libx264 -crf 23 -preset medium \
+  -pix_fmt yuv420p -c:a aac -b:a 128k \
+  -movflags +faststart output.mp4
+```
+
+### Compress a PDF
+
+```bash
+gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/ebook \
+   -dNOPAUSE -dQUIET -dBATCH -sOutputFile=output.pdf input.pdf
+```
+
+### Archive a folder (best speed/ratio)
+
+```bash
+tar -cf - ./folder/ | zstd -3 -T0 -o folder.tar.zst
+```
+
+## Decision Trees
+
+### Which video codec?
+
+| Priority | Codec | Encoder | When |
+|----------|-------|---------|------|
+| Max compatibility | H.264 | libx264 | Web, mobile, legacy devices |
+| Better compression | H.265 | libx265 | 4K, storage savings, modern devices |
+| Best compression | AV1 | libsvtav1 | Modern web, encode time acceptable |
+
+### Which archive format?
+
+| Priority | Format | When |
+|----------|--------|------|
+| Cross-platform | zip | Sharing with Windows/Mac users |
+| Best speed+ratio | tar.zst | Backups, pipelines, general use |
+| Maximum ratio | 7z | Archival, maximum compression needed |
+| Web assets | brotli | Pre-compressing JS/CSS for HTTP |
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| "command not found" | Tool not installed | Run `bash scripts/check-tools.sh --install` |
+| Output larger than input | Already optimized or wrong settings | Try different quality tier or tool |
+| Video has no audio | Missing -c:a flag | Add `-c:a aac -b:a 128k` |
+| H.265 won't play on iPhone | Missing tag | Add `-tag:v hvc1` |
+| PNG barely shrinks | Already optimized or few colors | Try pngquant (lossy) before oxipng |
+| ffmpeg "width not divisible by 2" | Odd resolution | Use `scale=WIDTH:-2` |
+| Ghostscript font errors | Missing fonts | Add `-dSubsetFonts=true` |
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/image-compression.md` | JPEG (mozjpeg, jpegoptim), PNG (pngquant+oxipng), WebP (cwebp), AVIF (avifenc), GIF (gifsicle), format selection, quality presets, batch processing |
+| `references/video-compression.md` | H.264/H.265/AV1 codecs, CRF quality tiers, resolution scaling, two-pass encoding, hardware acceleration, audio handling, batch video |
+| `references/audio-compression.md` | MP3/AAC/Opus/FLAC codecs, quality tiers, codec selection guide, extract audio from video, batch audio |
+| `references/pdf-compression.md` | Ghostscript quality presets (/screen through /prepress), advanced optimization flags, qpdf, batch PDF compression |
+| `references/archive-formats.md` | zip, tar.gz, tar.xz, tar.zst, 7z, brotli, format comparison, parallel compression (pigz, pbzip2), format selection guide |
+| `references/tool-setup.md` | Tool detection, macOS/Linux installation, batch processing patterns, before/after reporting, preserving originals |
+
+## Scripts
+
+| Script | Usage |
+|--------|-------|
+| `scripts/check-tools.sh` | Detect installed tools, suggest missing. Flags: `--json` (JSON output), `--install` (auto-install missing via brew/apt) |

--- a/skills/unix-media-compressor/references/archive-formats.md
+++ b/skills/unix-media-compressor/references/archive-formats.md
@@ -1,0 +1,410 @@
+# Archive Formats and File Compression
+
+Sources: zstd official docs, 7-Zip documentation, GNU tar manual, Google Brotli docs
+
+---
+
+## Format Comparison Table
+
+| Format | Ext | Ratio | Compress Speed | Decompress Speed | Parallel | Best Use Case |
+|--------|-----|-------|----------------|------------------|----------|---------------|
+| zip | .zip | Fair | Fast | Fast | No (native) | Cross-platform sharing, Windows users |
+| tar+gzip | .tar.gz | Good | Medium | Fast | pigz | General Unix archives, wide compatibility |
+| tar+bzip2 | .tar.bz2 | Better | Slow | Slow | pbzip2 | Legacy systems, slightly better ratio than gz |
+| tar+xz | .tar.xz | Excellent | Very Slow | Medium | pixz / -T0 | Distribution packages, max ratio with time |
+| tar+zstd | .tar.zst | Excellent | Very Fast | Very Fast | Built-in -T0 | **Recommended default** — best speed/ratio balance |
+| 7z | .7z | Best | Slow | Medium | Partial | Maximum compression, encrypted archives |
+| brotli | .br | Excellent | Medium | Very Fast | No | Web assets only — HTTP pre-compression |
+
+Ratio scale: Fair < Good < Better < Excellent < Best (all relative to uncompressed size)
+
+---
+
+## Format Selection Guide
+
+```
+Need Windows users to open without extra tools?
+  → zip
+
+Compressing for web delivery (JS, CSS, HTML, fonts)?
+  → brotli -q 9 (pre-compress, serve via nginx/CDN)
+
+Need maximum compression ratio, time not a concern?
+  → 7z -mx=9
+
+Need password-protected archive?
+  → 7z -p
+
+Archiving for distribution / package manager?
+  → tar.zst (Arch Linux, Fedora use this natively)
+
+Everything else (backups, transfers, general use)?
+  → tar.zst with zstd -3 -T0  ← recommended default
+```
+
+---
+
+## zip
+
+Standard format. No external tools needed on Windows, macOS, or Linux.
+
+**Create:**
+```bash
+# Basic archive
+zip archive.zip file1 file2
+
+# Recursive directory
+zip -r archive.zip directory/
+
+# Max compression
+zip -9 -r archive.zip directory/
+
+# No compression (store only, fast for already-compressed files)
+zip -0 -r archive.zip directory/
+
+# Exclude patterns
+zip -r archive.zip directory/ -x "*.DS_Store" -x "__pycache__/*" -x "*.pyc"
+
+# Exclude a subdirectory
+zip -r archive.zip directory/ -x "directory/node_modules/*"
+```
+
+**Extract:**
+```bash
+unzip archive.zip
+unzip archive.zip -d /target/directory/
+unzip -l archive.zip          # list contents without extracting
+```
+
+**Compression levels:** 0 (store) through 9 (max). Default is 6. Level 9 rarely worth the time cost.
+
+---
+
+## tar + gzip
+
+The classic Unix archive format. Widely supported everywhere.
+
+**Create:**
+```bash
+tar -czf archive.tar.gz directory/
+tar -czf archive.tar.gz file1 file2 file3
+
+# Verbose (shows files as they're added)
+tar -czvf archive.tar.gz directory/
+
+# Exclude patterns
+tar -czf archive.tar.gz directory/ --exclude="*.pyc" --exclude=".git"
+tar -czf archive.tar.gz directory/ --exclude-vcs
+```
+
+**Extract:**
+```bash
+tar -xzf archive.tar.gz
+tar -xzf archive.tar.gz -C /target/directory/
+tar -xzvf archive.tar.gz    # verbose
+```
+
+**Parallel with pigz** (drop-in gzip replacement, uses all cores):
+```bash
+tar -cf - directory/ | pigz -9 > archive.tar.gz
+tar -cf - directory/ | pigz -p 8 > archive.tar.gz   # explicit 8 threads
+
+# Extract with pigz
+pigz -dc archive.tar.gz | tar -xf -
+```
+
+pigz is a drop-in replacement — same flags as gzip. Install: `brew install pigz` / `apt install pigz`.
+
+---
+
+## tar + bzip2
+
+Better compression ratio than gzip, but significantly slower. Largely superseded by xz and zstd.
+
+**Create:**
+```bash
+tar -cjf archive.tar.bz2 directory/
+tar -cjvf archive.tar.bz2 directory/   # verbose
+tar -cjf archive.tar.bz2 directory/ --exclude="*.log"
+```
+
+**Extract:**
+```bash
+tar -xjf archive.tar.bz2
+tar -xjf archive.tar.bz2 -C /target/directory/
+```
+
+**Parallel with pbzip2:**
+```bash
+tar -cf - directory/ | pbzip2 -9 > archive.tar.bz2
+tar -cf - directory/ | pbzip2 -p8 > archive.tar.bz2   # 8 threads
+
+# Extract
+pbzip2 -dc archive.tar.bz2 | tar -xf -
+```
+
+Use bzip2 only when the recipient specifically requires it. For new archives, prefer zstd.
+
+---
+
+## tar + xz
+
+Excellent compression ratio. Slow to compress, moderate to decompress. Used by many Linux distributions for package distribution.
+
+**Create:**
+```bash
+tar -cJf archive.tar.xz directory/
+tar -cJvf archive.tar.xz directory/   # verbose
+
+# Multi-threaded via xz directly
+tar -cf - directory/ | xz -T0 -9 > archive.tar.xz
+# -T0 = use all available CPU threads
+# -9 = max compression (levels 0-9)
+```
+
+**Extract:**
+```bash
+tar -xJf archive.tar.xz
+tar -xJf archive.tar.xz -C /target/directory/
+
+# Multi-threaded extract
+xz -T0 -dc archive.tar.xz | tar -xf -
+```
+
+**Parallel with pixz:**
+```bash
+tar -Ipixz -cf archive.tar.xz directory/
+tar -Ipixz -xf archive.tar.xz
+```
+
+xz -T0 is built into modern xz (5.2+). pixz adds better parallelism for older versions.
+
+---
+
+## tar + zstd (Recommended)
+
+Best overall choice for most use cases. Compresses faster than gzip at better ratios. Decompresses extremely fast. Parallel support is built in — no wrapper tool needed.
+
+**Why zstd is recommended:**
+- Compression speed rivals gzip at level 3, with better ratios
+- Decompression is 3-5x faster than gzip, 10x faster than xz
+- `-T0` parallel flag is native, no external tool required
+- Adopted by Arch Linux (pacman), Fedora (rpm), and Facebook's infrastructure
+- Levels 1-22 give fine-grained control from ultra-fast to ultra-compressed
+
+**Create:**
+```bash
+# Recommended default: level 3, all threads
+tar -cf - directory/ | zstd -3 -T0 > archive.tar.zst
+
+# Using tar's built-in zstd support (GNU tar 1.31+)
+tar --zstd -cf archive.tar.zst directory/
+
+# Higher compression
+tar -cf - directory/ | zstd -9 -T0 > archive.tar.zst
+
+# Max compression (slow, use for archival)
+tar -cf - directory/ | zstd -19 -T0 > archive.tar.zst
+
+# Verbose
+tar -cf - directory/ | zstd -3 -T0 -v > archive.tar.zst
+```
+
+**Extract:**
+```bash
+zstd -dc archive.tar.zst | tar -xf -
+
+# GNU tar built-in
+tar --zstd -xf archive.tar.zst
+tar --zstd -xf archive.tar.zst -C /target/directory/
+```
+
+**Compression levels:**
+- Level 1: Fastest, ~gzip ratio
+- Level 3: Default — good balance (use this)
+- Level 9: Better ratio, still fast
+- Level 19: Near-max ratio, slow
+- Level 22: Ultra (requires `--ultra` flag): `zstd --ultra -22 -T0`
+
+---
+
+## 7z
+
+Highest compression ratio of any common format. Supports encryption, split volumes, and self-extracting archives. No native Unix streaming — works on complete files.
+
+**Create:**
+```bash
+# Standard archive
+7z a archive.7z directory/
+
+# Maximum compression
+7z a -mx=9 archive.7z directory/
+
+# Compression levels: -mx=0 (store) through -mx=9 (ultra)
+7z a -mx=5 archive.7z directory/   # balanced
+
+# Exclude files
+7z a -mx=9 archive.7z directory/ -xr!"*.pyc" -xr!".git"
+
+# Password encryption (AES-256)
+7z a -mx=9 -p"yourpassword" archive.7z directory/
+# Encrypt file headers too (hides filenames)
+7z a -mx=9 -p"yourpassword" -mhe=on archive.7z directory/
+
+# Split into volumes (e.g., 100MB each)
+7z a -mx=9 -v100m archive.7z directory/
+# Creates: archive.7z.001, archive.7z.002, ...
+```
+
+**Extract:**
+```bash
+7z x archive.7z
+7z x archive.7z -o/target/directory/
+
+# Test archive integrity
+7z t archive.7z
+
+# Extract with password
+7z x -p"yourpassword" archive.7z
+```
+
+**When to use 7z:** Maximum compression for archival storage, encrypted archives, or when recipients are on Windows (7-Zip is free and widely installed). Not suitable for streaming or piping.
+
+---
+
+## brotli
+
+Designed for HTTP pre-compression of web assets. Decompresses faster than gzip at better ratios. Browsers decompress brotli natively when served over HTTPS with `Content-Encoding: br`.
+
+brotli is not a general-purpose archive format — use it only for web asset pre-compression.
+
+**Single file:**
+```bash
+brotli -q 9 file.js           # creates file.js.br
+brotli -q 11 file.css         # max compression (slow)
+brotli -d file.js.br          # decompress
+```
+
+**Batch compress web assets:**
+```bash
+# Compress all JS and CSS files in a directory
+find dist/ -type f \( -name "*.js" -o -name "*.css" \) -exec brotli -q 9 {} \;
+
+# Compress HTML, JS, CSS, SVG, fonts
+find dist/ -type f \( -name "*.html" -o -name "*.js" -o -name "*.css" \
+  -o -name "*.svg" -o -name "*.woff2" \) -exec brotli -q 9 {} \;
+
+# Keep original files (brotli -k keeps originals)
+find dist/ -type f -name "*.js" -exec brotli -k -q 9 {} \;
+```
+
+**Quality levels:**
+- `-q 1`: Fastest, minimal compression
+- `-q 9`: Recommended for production (good ratio, reasonable speed)
+- `-q 11`: Maximum compression, very slow — use for static assets that rarely change
+
+**nginx configuration for pre-compressed brotli:**
+```nginx
+brotli_static on;   # serves .br files if they exist
+```
+
+---
+
+## Parallel Compression Tools
+
+| Tool | Replaces | Install (macOS) | Install (Linux) | Notes |
+|------|----------|-----------------|-----------------|-------|
+| pigz | gzip | `brew install pigz` | `apt install pigz` | Drop-in replacement, same flags |
+| pbzip2 | bzip2 | `brew install pbzip2` | `apt install pbzip2` | Drop-in replacement |
+| pixz | xz | `brew install pixz` | `apt install pixz` | Parallel + indexed xz |
+| zstd | — | `brew install zstd` | `apt install zstd` | Parallel built-in with -T0 |
+
+**When to use parallel tools:**
+- Files larger than ~500MB benefit significantly from parallelism
+- On machines with 4+ cores, pigz/pbzip2 can be 3-8x faster than single-threaded
+- zstd -T0 is always worth using — no downside, automatic thread count
+
+**Check available threads:**
+```bash
+nproc          # Linux
+sysctl -n hw.logicalcpu   # macOS
+```
+
+---
+
+## Single File Compression
+
+For compressing individual files (not creating archives), use these tools directly without tar.
+
+**zstd (recommended):**
+```bash
+zstd -3 -T0 largefile.sql          # creates largefile.sql.zst
+zstd -d largefile.sql.zst          # decompress
+zstd -3 -T0 -k largefile.sql       # keep original with -k
+```
+
+**gzip:**
+```bash
+gzip -9 file.log                   # creates file.log.gz, removes original
+gzip -9 -k file.log                # keep original
+gzip -d file.log.gz                # decompress
+```
+
+**xz:**
+```bash
+xz -9 -T0 database.dump            # creates database.dump.xz
+xz -d database.dump.xz             # decompress
+xz -T0 -k -9 database.dump        # keep original
+```
+
+Single-file compression is useful for log files, database dumps, and large text files before transfer.
+
+---
+
+## Compression Level Guidance
+
+| Tool | Fast | Balanced | Max | Notes |
+|------|------|----------|-----|-------|
+| zip | `-1` | `-6` (default) | `-9` | Level 9 rarely worth it |
+| gzip / pigz | `-1` | `-6` (default) | `-9` | Same scale |
+| bzip2 / pbzip2 | `-1` | `-6` (default) | `-9` | All levels are slow |
+| xz | `-0` | `-6` (default) | `-9` | -9 is very slow; -6 is good |
+| zstd | `-1` | `-3` (recommended) | `--ultra -22` | Sweet spot is 3; 19 for archival |
+| 7z | `-mx=1` | `-mx=5` | `-mx=9` | -mx=9 for archival only |
+| brotli | `-q 1` | `-q 9` | `-q 11` | -q 11 for static assets |
+
+**Rules of thumb:**
+- Default levels are calibrated for general use — only override when you have a specific reason
+- "Fast" levels are useful when compressing many small files or when CPU is the bottleneck
+- "Max" levels are for archival storage where you compress once and decompress rarely
+- zstd -3 beats gzip -9 in both speed and ratio — it is the correct default for new work
+
+---
+
+## Quick Reference: Common Tasks
+
+```bash
+# Backup a directory (recommended)
+tar -cf - mydir/ | zstd -3 -T0 > mydir-backup.tar.zst
+
+# Share with Windows users
+zip -9 -r archive.zip mydir/
+
+# Maximum compression for archival
+7z a -mx=9 archive.7z mydir/
+
+# Pre-compress web assets
+find dist/ -type f \( -name "*.js" -o -name "*.css" \) -exec brotli -k -q 9 {} \;
+
+# Fast parallel gzip
+tar -cf - mydir/ | pigz -9 > archive.tar.gz
+
+# Compress a single large file
+zstd -3 -T0 -k database.dump
+```
+
+---
+
+For tool installation and availability checks, see `tool-setup.md`.
+
+For compressing individual media files before archiving, see `image-compression.md`, `video-compression.md`, or `audio-compression.md`.

--- a/skills/unix-media-compressor/references/audio-compression.md
+++ b/skills/unix-media-compressor/references/audio-compression.md
@@ -1,0 +1,353 @@
+# Audio Compression
+
+Sources: FFmpeg official docs, Xiph.org Opus Recommended Settings, EBU R128 standard
+
+---
+
+## Codec Decision Guide
+
+| Codec | Container | Best For | Avoid When |
+|-------|-----------|----------|------------|
+| Opus (libopus) | OGG, WebM, MKV | Voice, podcast, music streaming, web delivery | Need MP4 container, legacy device support |
+| AAC (libfdk_aac / aac) | MP4, M4A, MOV | Apple ecosystem, MP4 video audio, broad compatibility | Lowest bitrate voice (Opus wins there) |
+| MP3 (libmp3lame) | MP3 | Legacy players, maximum compatibility, old hardware | Any new project where Opus or AAC is viable |
+| FLAC | FLAC, MKV | Archival, lossless backup, source for re-encoding | Distribution, streaming, storage-constrained |
+
+**Key facts:**
+- Opus beats AAC and MP3 at equal bitrates — Xiph.org listening tests show Opus at 96k matches AAC at 128k
+- AAC is required for MP4 container; browsers and Apple devices expect it
+- `libfdk_aac` outperforms the built-in `aac` encoder at bitrates below 128k; use it when available
+- MP3 is legacy — only choose it when the target device or platform cannot handle Opus or AAC
+- FLAC is lossless; compression level affects encode speed, not audio quality
+
+---
+
+## Quality Tier Reference
+
+| Tier | Opus | AAC (libfdk_aac) | AAC (native) | MP3 (VBR) | MP3 (CBR) | FLAC |
+|------|------|-----------------|--------------|-----------|-----------|------|
+| Web / small | 64k | 96k | 128k | -q:a 4 (~165k) | 128k | — |
+| Balanced | 96–128k | 128k | 192k | -q:a 2 (~190k) | 192k | -compression_level 5 |
+| Quality | 160k | 192k | 256k | -q:a 0 (~245k) | 256k | -compression_level 8 |
+| Archival / transparent | 192k | 256k | 320k | -q:a 0 (~245k) | 320k | -compression_level 8 |
+
+MP3 VBR scale: 0 = best (~245 kbps), 9 = worst (~45 kbps). `-q:a 2` (~190 kbps) is the standard recommendation for transparent-enough quality.
+
+---
+
+## Opus Recipes
+
+Opus is the best general-purpose lossy codec for new work. Use OGG for standalone audio files, WebM for web video.
+
+**Voice and podcast (24–64k):**
+
+```bash
+# Minimum viable voice — phone quality
+ffmpeg -i input.wav -c:a libopus -b:a 24k -application voip output.ogg
+
+# Podcast mono — clear speech, small file
+ffmpeg -i input.wav -c:a libopus -b:a 32k -application voip -ac 1 output.ogg
+
+# Podcast stereo — good quality
+ffmpeg -i input.wav -c:a libopus -b:a 64k -application voip output.ogg
+```
+
+`-application voip` tunes the encoder for speech: optimizes for intelligibility over music fidelity.
+
+**Music streaming (96–128k):**
+
+```bash
+# Standard music streaming — OGG container
+ffmpeg -i input.flac -c:a libopus -b:a 96k output.ogg
+
+# Higher quality music — OGG container
+ffmpeg -i input.flac -c:a libopus -b:a 128k output.ogg
+
+# WebM container (for web video or HTML5 audio)
+ffmpeg -i input.flac -c:a libopus -b:a 128k output.webm
+```
+
+**Transparent (192k):**
+
+```bash
+# Perceptually transparent — indistinguishable from lossless in most tests
+ffmpeg -i input.flac -c:a libopus -b:a 192k output.ogg
+
+# WebM transparent
+ffmpeg -i input.flac -c:a libopus -b:a 192k output.webm
+```
+
+---
+
+## AAC Recipes
+
+AAC is the standard for MP4 containers. Use `libfdk_aac` when available; fall back to the built-in `aac` encoder otherwise.
+
+**Check if libfdk_aac is available:**
+
+```bash
+ffmpeg -encoders 2>/dev/null | grep fdk
+```
+
+**Standard MP4 audio (libfdk_aac):**
+
+```bash
+# Balanced — good for most MP4 video audio
+ffmpeg -i input.wav -c:a libfdk_aac -b:a 128k output.m4a
+
+# High quality
+ffmpeg -i input.wav -c:a libfdk_aac -b:a 192k output.m4a
+
+# VBR mode — 1 (lowest) to 5 (highest); VBR 4 ≈ 128k average
+ffmpeg -i input.wav -c:a libfdk_aac -vbr 4 output.m4a
+ffmpeg -i input.wav -c:a libfdk_aac -vbr 5 output.m4a
+```
+
+**Standard MP4 audio (native aac fallback):**
+
+```bash
+# Native aac needs higher bitrate to match libfdk_aac quality
+ffmpeg -i input.wav -c:a aac -b:a 192k output.m4a
+
+# High quality native
+ffmpeg -i input.wav -c:a aac -b:a 256k output.m4a
+```
+
+**HE-AAC for low-bitrate speech (libfdk_aac only):**
+
+```bash
+# HE-AAC v2 — 32–64k speech, uses spectral band replication + parametric stereo
+ffmpeg -i input.wav -c:a libfdk_aac -profile:a aac_he_v2 -b:a 48k output.m4a
+```
+
+Use HE-AAC v2 only for speech at very low bitrates. For music, standard AAC at 128k+ sounds better.
+
+---
+
+## MP3 Recipes
+
+Use MP3 only for legacy compatibility. For any new project, prefer Opus or AAC.
+
+**VBR (recommended for MP3):**
+
+```bash
+# Transparent — highest VBR quality (~245 kbps average)
+ffmpeg -i input.wav -c:a libmp3lame -q:a 0 output.mp3
+
+# Recommended — good quality, smaller than -q:a 0 (~190 kbps average)
+ffmpeg -i input.wav -c:a libmp3lame -q:a 2 output.mp3
+
+# Smaller file — acceptable quality (~165 kbps average)
+ffmpeg -i input.wav -c:a libmp3lame -q:a 4 output.mp3
+```
+
+**CBR (when exact bitrate is required):**
+
+```bash
+# Maximum CBR — legacy players, guaranteed bitrate
+ffmpeg -i input.wav -c:a libmp3lame -b:a 320k output.mp3
+
+# Standard CBR
+ffmpeg -i input.wav -c:a libmp3lame -b:a 192k output.mp3
+
+# Minimum acceptable CBR
+ffmpeg -i input.wav -c:a libmp3lame -b:a 128k output.mp3
+```
+
+VBR `-q:a 2` is the standard recommendation: better quality than 192k CBR at similar or smaller file size.
+
+---
+
+## FLAC Recipes
+
+FLAC is lossless — compression level only affects encode speed and file size, never audio quality. Higher levels produce smaller files but take longer to encode.
+
+```bash
+# Default compression — fast encode, reasonable size
+ffmpeg -i input.wav -c:a flac output.flac
+
+# Maximum compression — slowest encode, smallest lossless file
+ffmpeg -i input.wav -c:a flac -compression_level 8 output.flac
+
+# Fast compression — quick encode for large batches
+ffmpeg -i input.wav -c:a flac -compression_level 0 output.flac
+```
+
+**When to use FLAC:**
+- Archiving original recordings before lossy distribution encodes
+- Source files for re-encoding to other formats later
+- Situations where lossless is contractually or technically required
+- Intermediate files in a processing pipeline
+
+**When not to use FLAC:**
+- Web delivery (use Opus or AAC)
+- Streaming (use Opus or AAC)
+- Storage-constrained environments (FLAC is 50–60% of uncompressed WAV, not dramatically smaller)
+
+---
+
+## Extract Audio from Video
+
+**Stream copy — fastest, no quality loss, preserves original codec:**
+
+```bash
+# Copy audio stream as-is (output format must match codec)
+ffmpeg -i input.mp4 -vn -c:a copy output.aac
+
+# Copy from MKV (may contain various codecs — check first)
+ffmpeg -i input.mkv -vn -c:a copy output.mka
+
+# Check what audio codec is in the file before copying
+ffmpeg -i input.mp4 2>&1 | grep Audio
+```
+
+`-vn` disables video output. `-c:a copy` copies the audio stream without re-encoding. The output container must be compatible with the source codec.
+
+**Re-encode during extraction:**
+
+```bash
+# Extract and convert to Opus
+ffmpeg -i input.mp4 -vn -c:a libopus -b:a 128k output.ogg
+
+# Extract and convert to MP3
+ffmpeg -i input.mp4 -vn -c:a libmp3lame -q:a 2 output.mp3
+
+# Extract to lossless WAV (for editing or archiving)
+ffmpeg -i input.mp4 -vn -c:a pcm_s16le output.wav
+
+# Extract specific audio stream (when file has multiple)
+ffmpeg -i input.mkv -map 0:a:1 -vn -c:a copy output.ac3
+```
+
+Use stream copy when the source codec matches the target. Re-encode when changing format or when the source audio needs quality improvement.
+
+---
+
+## Re-encode Video Audio (Keep Video)
+
+Replace or transcode the audio track while preserving the video stream exactly.
+
+**Keep video, replace audio codec:**
+
+```bash
+# Keep video, re-encode audio to AAC (standard for MP4)
+ffmpeg -i input.mkv -c:v copy -c:a aac -b:a 192k output.mp4
+
+# Keep video, re-encode audio to libfdk_aac
+ffmpeg -i input.mkv -c:v copy -c:a libfdk_aac -b:a 128k output.mp4
+
+# Keep video, re-encode audio to Opus (for MKV or WebM)
+ffmpeg -i input.mkv -c:v copy -c:a libopus -b:a 128k output.mkv
+```
+
+`-c:v copy` copies the video stream without re-encoding — fast and lossless for the video. Only the audio is processed.
+
+**Replace audio with external file:**
+
+```bash
+# Swap audio track entirely
+ffmpeg -i video.mp4 -i new_audio.wav -map 0:v -map 1:a -c:v copy -c:a aac -b:a 192k output.mp4
+```
+
+`-map 0:v` takes video from the first input, `-map 1:a` takes audio from the second input.
+
+---
+
+## Sample Rate and Channels
+
+**Sample rate (`-ar`):**
+
+```bash
+# Downsample to 44.1 kHz (CD quality — sufficient for most audio)
+ffmpeg -i input.wav -ar 44100 output.wav
+
+# Downsample to 22.05 kHz (voice, reduces file size further)
+ffmpeg -i input.wav -ar 22050 output.wav
+
+# Upsample to 48 kHz (video standard — required for some video containers)
+ffmpeg -i input.wav -ar 48000 output.wav
+```
+
+Downsampling reduces file size and is appropriate when the source has no meaningful content above the new Nyquist frequency. Voice content above 8 kHz is minimal; 22 kHz sample rate is sufficient for voice-only files.
+
+**Channels (`-ac`):**
+
+```bash
+# Stereo to mono — halves file size, appropriate for voice
+ffmpeg -i stereo.wav -ac 1 mono.wav
+
+# Mono to stereo (duplicates channel — does not add stereo information)
+ffmpeg -i mono.wav -ac 2 stereo.wav
+
+# 5.1 surround to stereo downmix
+ffmpeg -i surround.ac3 -ac 2 stereo.wav
+```
+
+Use mono (`-ac 1`) for voice recordings, podcasts, and phone audio. Stereo is only meaningful when the source has actual stereo content.
+
+**Combined sample rate and channel reduction for voice:**
+
+```bash
+# Podcast-optimized: mono, 22 kHz, Opus voice mode
+ffmpeg -i input.wav -ac 1 -ar 22050 -c:a libopus -b:a 32k -application voip output.ogg
+```
+
+---
+
+## Batch Audio Compression
+
+**Convert a folder of WAV files to Opus:**
+
+```bash
+for f in *.wav; do
+  ffmpeg -i "$f" -c:a libopus -b:a 128k "${f%.wav}.ogg"
+done
+```
+
+**Convert a folder of FLAC files to AAC (MP4):**
+
+```bash
+for f in *.flac; do
+  ffmpeg -i "$f" -c:a libfdk_aac -b:a 128k "${f%.flac}.m4a"
+done
+```
+
+**Convert a folder of MP3 files to Opus (re-encode):**
+
+```bash
+for f in *.mp3; do
+  ffmpeg -i "$f" -c:a libopus -b:a 96k "${f%.mp3}.ogg"
+done
+```
+
+**Recursive batch — all WAV files in subdirectories:**
+
+```bash
+find . -name "*.wav" -exec sh -c '
+  out="${1%.wav}.ogg"
+  ffmpeg -i "$1" -c:a libopus -b:a 128k "$out"
+' _ {} \;
+```
+
+**Parallel batch with GNU parallel (faster on multi-core):**
+
+```bash
+ls *.flac | parallel ffmpeg -i {} -c:a libopus -b:a 128k {.}.ogg
+```
+
+**Batch with output directory:**
+
+```bash
+mkdir -p compressed
+for f in *.wav; do
+  ffmpeg -i "$f" -c:a libopus -b:a 128k "compressed/${f%.wav}.ogg"
+done
+```
+
+---
+
+## Cross-Reference
+
+For combined video and audio compression in a single pass, see `video-compression.md`. That file covers CRF-based video encoding with simultaneous audio transcoding, container selection, and `-movflags +faststart` for web delivery.
+
+Audio normalization (EBU R128 loudnorm, two-pass measurement) and audio editing operations (mixing, fading, silence removal, EQ) are outside the scope of this file — those are covered in the ffmpeg-mastery skill's `audio-processing.md`.

--- a/skills/unix-media-compressor/references/image-compression.md
+++ b/skills/unix-media-compressor/references/image-compression.md
@@ -1,0 +1,386 @@
+# Image Compression
+
+Sources: ffmpeg docs, Google WebP docs, libavif docs, mozjpeg project, Addy Osmani (Essential Image Optimization)
+
+## Format Selection Guide
+
+Choose the output format based on content type and target environment, not habit.
+
+| Format | Best For | Lossy | Lossless | Alpha | Browser Support |
+|--------|----------|-------|----------|-------|-----------------|
+| JPEG | Photos, gradients, complex scenes | Yes | No | No | Universal |
+| PNG | Screenshots, logos, text, sharp edges | No | Yes | Yes | Universal |
+| WebP | Web delivery of photos or graphics | Yes | Yes | Yes | 97%+ (all modern) |
+| AVIF | Web delivery, highest compression | Yes | Yes | Yes | 93%+ (Chrome, Firefox, Safari 16+) |
+| GIF | Simple animations, legacy icons | No | Yes | Partial | Universal |
+
+**Decision rule:** Serve WebP for web photos and graphics where AVIF is not yet required. Use AVIF when maximum compression matters and Safari 16+ is acceptable. Keep PNG for assets requiring lossless fidelity. JPEG remains the safe fallback for email and legacy systems.
+
+---
+
+## JPEG Optimization
+
+### mozjpeg — cjpeg (re-encode from source)
+
+`cjpeg` re-encodes from a raw or lossless source. Always re-encode from the original, never from an already-compressed JPEG.
+
+```bash
+# Web preset (quality 75-80)
+cjpeg -quality 78 -optimize -progressive -outfile output.jpg input.png
+
+# Balanced preset (quality 85)
+cjpeg -quality 85 -optimize -progressive -outfile output.jpg input.png
+
+# Quality preset (quality 92)
+cjpeg -quality 92 -optimize -progressive -outfile output.jpg input.png
+
+```
+
+Key flags: `-optimize` enables Huffman table optimization. `-progressive` creates progressive JPEG (loads blurry-to-sharp, perceived as faster). Both add a small encode cost but reduce file size. Metadata stripping is not a cjpeg flag — strip at source using ImageMagick (`convert -strip`) or handle with jpegtran post-encode.
+
+### mozjpeg — jpegtran (lossless re-optimization)
+
+`jpegtran` optimizes an existing JPEG without re-encoding. Use when you cannot re-encode from source.
+
+```bash
+# Lossless optimization + progressive conversion
+jpegtran -copy none -optimize -progressive -outfile output.jpg input.jpg
+
+# Strip all metadata, keep progressive
+jpegtran -copy none -optimize -progressive -perfect -outfile output.jpg input.jpg
+```
+
+`-copy none` strips all EXIF/IPTC/XMP metadata. `-perfect` aborts if lossless transform is not possible (safe guard).
+
+### jpegoptim — batch-friendly optimizer
+
+```bash
+# Lossy: set maximum quality (web preset)
+jpegoptim --max=80 --strip-all --all-progressive image.jpg
+
+# Lossy: balanced preset
+jpegoptim --max=85 --strip-all --all-progressive image.jpg
+
+# Target file size (useful for upload limits)
+jpegoptim --size=200k --strip-all image.jpg
+
+# Batch: optimize all JPEGs in directory, output to separate dir
+jpegoptim --max=85 --strip-all --all-progressive --dest=./optimized/ *.jpg
+```
+
+`--strip-all` removes EXIF, IPTC, and ICC profiles. `--all-progressive` converts to progressive encoding. `--dest` writes output to a different directory, preserving originals.
+
+**Gotcha:** jpegoptim modifies files in-place by default. Always use `--dest` or work on copies.
+
+---
+
+## PNG Optimization
+
+### Recommended pipeline: pngquant + oxipng
+
+Run pngquant first (lossy palette reduction), then oxipng (lossless re-compression). This two-stage pipeline consistently achieves 60-80% size reduction on typical PNGs.
+
+```bash
+# Stage 1: pngquant — lossy palette quantization
+pngquant --quality 65-80 --speed 1 --force --ext .png input.png
+
+# Stage 2: oxipng — lossless re-compression
+oxipng -o 3 -i 0 --strip safe input.png
+```
+
+**Full pipeline in one command:**
+
+```bash
+pngquant --quality 65-80 --speed 1 --force --ext .png input.png && \
+  oxipng -o 3 -i 0 --strip safe input.png
+```
+
+### pngquant flags
+
+```bash
+# Web preset (aggressive reduction)
+pngquant --quality 60-75 --speed 1 --force --ext .png input.png
+
+# Balanced preset
+pngquant --quality 65-80 --speed 1 --force --ext .png input.png
+
+# Quality preset (minimal loss)
+pngquant --quality 80-90 --speed 1 --force --ext .png input.png
+
+# Output to new file (preserve original)
+pngquant --quality 65-80 --speed 1 --output output.png input.png
+```
+
+`--speed 1` is the slowest/best compression (1-11 scale). `--force` overwrites existing output. `--ext .png` overwrites the input file in-place (use `--output` to avoid this).
+
+**Gotcha:** pngquant converts 24-bit PNG to 8-bit palette (256 colors max). This is lossy. Do not use on images requiring full color fidelity — use oxipng alone instead.
+
+### oxipng flags
+
+```bash
+# Standard optimization (recommended)
+oxipng -o 3 -i 0 --strip safe input.png
+
+# Maximum compression (slow)
+oxipng -o 6 --zopfli -i 0 --strip safe input.png
+
+# Recursive directory optimization
+oxipng -o 3 -i 0 --strip safe -r ./images/
+
+# Preserve original, write to new file
+oxipng -o 3 -i 0 --strip safe --out output.png input.png
+```
+
+`-o 3` is the optimization level (0-6). `-i 0` removes interlacing (interlaced PNGs are larger and slower to decode in browsers). `--strip safe` removes non-essential metadata while preserving color profiles. `--zopfli` uses the Zopfli deflate algorithm for maximum compression at significant speed cost.
+
+### optipng — simpler alternative
+
+```bash
+# Standard optimization
+optipng -o5 -strip all input.png
+
+# Batch
+find . -name "*.png" | xargs optipng -o5 -strip all
+```
+
+`-o5` is the optimization level (0-7). `-strip all` removes all metadata. optipng is slower than oxipng at equivalent quality and does not support Zopfli. Use oxipng unless optipng is the only available tool.
+
+---
+
+## WebP Conversion
+
+### cwebp — lossy conversion
+
+```bash
+# Web preset (quality 75-80)
+cwebp -q 78 -mt -strip input.jpg -o output.webp
+
+# Balanced preset (quality 85)
+cwebp -q 85 -mt -strip input.jpg -o output.webp
+
+# Quality preset (quality 92)
+cwebp -q 92 -mt -strip input.jpg -o output.webp
+```
+
+`-mt` enables multithreaded encoding. `-strip` removes all metadata (EXIF, XMP, ICC). `-q` sets quality (0-100, higher = better quality and larger file).
+
+### cwebp — lossless conversion
+
+```bash
+# Lossless (for PNG sources with transparency)
+cwebp -lossless -z 9 -mt -strip input.png -o output.webp
+
+# Near-lossless (visually lossless, smaller than lossless)
+cwebp -near_lossless 60 -mt -strip input.png -o output.webp
+```
+
+`-lossless` produces a lossless WebP. `-z 9` sets the compression level (0-9, 9 = smallest file, slowest). `-near_lossless 60` applies preprocessing to reduce file size while remaining visually indistinguishable (0 = no preprocessing, 100 = maximum preprocessing).
+
+### cwebp — resize during conversion
+
+```bash
+# Resize to max width 1200px, maintain aspect ratio
+cwebp -q 85 -resize 1200 0 -mt -strip input.jpg -o output.webp
+```
+
+`-resize width height` — set either dimension to 0 to maintain aspect ratio.
+
+### ffmpeg WebP fallback
+
+```bash
+# ffmpeg WebP (when cwebp is unavailable)
+ffmpeg -i input.jpg -quality 85 output.webp
+
+# Lossless via ffmpeg
+ffmpeg -i input.png -lossless 1 output.webp
+```
+
+**Gotcha:** ffmpeg's WebP encoder is less efficient than cwebp. Prefer cwebp when available.
+
+---
+
+## AVIF Conversion
+
+### avifenc — primary tool
+
+```bash
+# Web preset (quality 60, speed 6)
+avifenc --quality 60 --speed 6 --jobs 8 input.jpg output.avif
+
+# Balanced preset (quality 50, speed 6)
+avifenc --quality 50 --speed 6 --jobs 8 input.jpg output.avif
+
+# Quality preset (quality 35, speed 4)
+avifenc --quality 35 --speed 4 --jobs 8 input.jpg output.avif
+
+# Lossless
+avifenc --lossless --jobs 8 input.png output.avif
+```
+
+`--quality` ranges 0-100 (lower = smaller file, more loss — inverse of JPEG). `--speed` ranges 0-10 (0 = slowest/best, 10 = fastest/worst). `--jobs 8` enables parallel encoding threads.
+
+**Gotcha:** avifenc quality scale is inverted relative to JPEG/WebP. Quality 50 in AVIF is roughly equivalent to JPEG quality 85 in visual output.
+
+### avifenc — chroma subsampling
+
+```bash
+# 4:2:0 (default, smaller, good for photos)
+avifenc --quality 50 --speed 6 --yuv 420 --jobs 8 input.jpg output.avif
+
+# 4:4:4 (larger, better for text/graphics)
+avifenc --quality 50 --speed 6 --yuv 444 --jobs 8 input.png output.avif
+```
+
+Use `--yuv 444` for images with sharp text or fine color detail. Use `--yuv 420` for photographs.
+
+### ffmpeg libaom-av1 fallback
+
+```bash
+# AVIF via ffmpeg (when avifenc is unavailable)
+ffmpeg -i input.jpg -c:v libaom-av1 -crf 30 -still-picture 1 output.avif
+
+# Higher quality
+ffmpeg -i input.jpg -c:v libaom-av1 -crf 20 -still-picture 1 output.avif
+```
+
+`-still-picture 1` disables temporal prediction, which is required for single-frame AVIF. `-crf` ranges 0-63 (lower = better quality).
+
+**Gotcha:** libaom-av1 is significantly slower than avifenc. Use avifenc for batch work.
+
+---
+
+## GIF Optimization
+
+### gifsicle — lossless optimization
+
+```bash
+# Lossless re-optimization
+gifsicle -O3 --batch input.gif
+
+# Output to new file
+gifsicle -O3 input.gif -o output.gif
+```
+
+`-O3` is the highest optimization level (1-3). `--batch` modifies files in-place.
+
+### gifsicle — lossy optimization
+
+```bash
+# Lossy (web preset, significant size reduction)
+gifsicle -O3 --lossy=80 input.gif -o output.gif
+
+# Lossy with color reduction
+gifsicle -O3 --lossy=80 --colors 64 input.gif -o output.gif
+
+# Aggressive lossy (smallest file)
+gifsicle -O3 --lossy=120 --colors 32 input.gif -o output.gif
+```
+
+`--lossy=N` sets the lossy compression level (20-200, higher = more loss and smaller file). `--colors N` reduces the color palette (2-256). Reducing colors from 256 to 64 typically cuts file size 30-50% with minimal visible impact on simple animations.
+
+### gifsicle — resize
+
+```bash
+# Resize to max width 480px
+gifsicle -O3 --lossy=80 --resize-width 480 input.gif -o output.gif
+```
+
+**Gotcha:** `--batch` modifies in-place. Always use `-o output.gif` when preserving originals.
+
+---
+
+## Quality Tier Presets
+
+| Format | Web | Balanced | Quality |
+|--------|-----|----------|---------|
+| JPEG (cjpeg) | `-quality 78 -optimize -progressive` | `-quality 85 -optimize -progressive` | `-quality 92 -optimize -progressive` |
+| JPEG (jpegoptim) | `--max=80 --strip-all --all-progressive` | `--max=85 --strip-all --all-progressive` | `--max=92 --strip-all --all-progressive` |
+| PNG (pngquant) | `--quality 60-75 --speed 1` | `--quality 65-80 --speed 1` | `--quality 80-90 --speed 1` |
+| PNG (oxipng) | `-o 3 -i 0 --strip safe` | `-o 3 -i 0 --strip safe` | `-o 6 --zopfli -i 0 --strip safe` |
+| WebP (cwebp) | `-q 78 -mt -strip` | `-q 85 -mt -strip` | `-q 92 -mt -strip` |
+| AVIF (avifenc) | `--quality 60 --speed 6` | `--quality 50 --speed 6` | `--quality 35 --speed 4` |
+| GIF (gifsicle) | `-O3 --lossy=80 --colors 64` | `-O3 --lossy=60 --colors 128` | `-O3 --lossy=30` |
+
+**Note on AVIF quality:** Lower numbers mean higher quality (inverse of JPEG/WebP). Quality 35 is visually near-lossless for most content.
+
+---
+
+## Batch Processing
+
+### JPEG batch
+
+```bash
+# jpegoptim: all JPEGs in directory, preserve originals
+mkdir -p optimized
+jpegoptim --max=85 --strip-all --all-progressive --dest=./optimized/ *.jpg *.jpeg
+
+# cjpeg: re-encode from lossless source
+for f in *.png; do
+  cjpeg -quality 85 -optimize -progressive -outfile "optimized/${f%.*}.jpg" "$f"
+done
+```
+
+### PNG batch pipeline (pngquant + oxipng)
+
+```bash
+mkdir -p optimized
+for f in *.png; do
+  [ -f "$f" ] || continue
+  cp "$f" "optimized/$f"
+  pngquant --quality 65-80 --speed 1 --force --ext .png "optimized/$f"
+  oxipng -o 3 -i 0 --strip safe "optimized/$f"
+done
+```
+
+### WebP and AVIF batch with find + xargs
+
+```bash
+# WebP: all JPEGs and PNGs recursively, 4 parallel jobs
+find . -type f \( -name "*.jpg" -o -name "*.jpeg" -o -name "*.png" \) | \
+  xargs -P4 -I{} sh -c 'cwebp -q 85 -mt -strip "{}" -o "${1%.*}.webp"' _ {}
+
+# AVIF: all JPEGs recursively
+find . -type f \( -name "*.jpg" -o -name "*.jpeg" \) | \
+  xargs -P4 -I{} sh -c 'avifenc --quality 50 --speed 6 --jobs 4 "{}" "${1%.*}.avif"' _ {}
+```
+
+### Mixed format batch (route by extension)
+
+```bash
+mkdir -p optimized
+for f in images/*; do
+  ext="${f##*.}"
+  base="optimized/$(basename "$f")"
+  case "${ext,,}" in
+    jpg|jpeg) jpegoptim --max=85 --strip-all --all-progressive --dest=./optimized/ "$f" ;;
+    png)
+      cp "$f" "$base"
+      pngquant --quality 65-80 --speed 1 --force --ext .png "$base"
+      oxipng -o 3 -i 0 --strip safe "$base" ;;
+    gif)  gifsicle -O3 --lossy=80 "$f" -o "$base" ;;
+    webp) cwebp -q 85 -mt -strip "$f" -o "$base" ;;
+  esac
+done
+```
+
+### Before/after size reporting
+
+```bash
+# Report savings for a single file
+before=$(stat -f%z "$input" 2>/dev/null || stat -c%s "$input")
+# ... run compression command ...
+after=$(stat -f%z "$output" 2>/dev/null || stat -c%s "$output")
+echo "${input}: ${before} -> ${after} bytes ($(( (before - after) * 100 / before ))% saved)"
+```
+
+---
+
+## Cross-Reference
+
+For video compression (H.264, H.265, AV1, VP9), see `video-compression.md`.
+
+For audio compression (MP3, AAC, Opus, FLAC), see `audio-compression.md`.
+
+For PDF compression (Ghostscript, qpdf), see `pdf-compression.md`.
+
+For tool installation and availability checks, see `tool-setup.md`.

--- a/skills/unix-media-compressor/references/pdf-compression.md
+++ b/skills/unix-media-compressor/references/pdf-compression.md
@@ -1,0 +1,356 @@
+# PDF Compression
+
+Sources: Ghostscript official docs, Transloadit Ghostscript CLI guide, qpdf documentation
+
+Ghostscript re-renders the PDF through its interpreter and recompresses all content. It can
+dramatically reduce file size by downsampling images, subsetting fonts, and removing redundant
+data, but it cannot make already-optimized or text-only PDFs smaller.
+
+---
+
+## Quality Preset Overview
+
+| Preset | DPI | Use Case | Typical Size Reduction |
+|---|---|---|---|
+| `/screen` | 72 | Screen viewing only, email attachments | 70-90% |
+| `/ebook` | 150 | General sharing, tablets, web download | 50-75% |
+| `/printer` | 300 | Desktop printing, office documents | 20-40% |
+| `/prepress` | 300 + ICC | Commercial printing, color-critical work | 10-25% |
+
+Percentages apply to image-heavy PDFs. Text-only PDFs may see little or no reduction.
+
+**Default recommendation: `/ebook`** — 150 DPI balances quality and size for everyday use.
+Use `/screen` only when file size is the absolute priority and print quality is irrelevant.
+
+---
+
+## Ghostscript Core Command
+
+```bash
+gs \
+  -sDEVICE=pdfwrite \
+  -dCompatibilityLevel=1.4 \
+  -dPDFSETTINGS=/ebook \
+  -dNOPAUSE \
+  -dQUIET \
+  -dBATCH \
+  -sOutputFile=output.pdf \
+  input.pdf
+```
+
+Flag breakdown:
+
+| Flag | Purpose |
+|---|---|
+| `-sDEVICE=pdfwrite` | Output device: write a PDF file |
+| `-dCompatibilityLevel=1.4` | PDF version; 1.4 is widely compatible, 2.0 enables better compression |
+| `-dPDFSETTINGS=/ebook` | Quality preset controlling DPI and compression aggressiveness |
+| `-dNOPAUSE` | Do not pause between pages (required for batch/scripted use) |
+| `-dQUIET` | Suppress informational output to stderr |
+| `-dBATCH` | Exit after processing; do not wait for more input |
+| `-sOutputFile=output.pdf` | Destination file path |
+
+Flag order matters: `-sOutputFile` and `-sDEVICE` must appear before the input file.
+
+---
+
+## Quality Preset Recipes
+
+### /screen — Maximum compression, screen only
+
+```bash
+gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 \
+   -dPDFSETTINGS=/screen \
+   -dNOPAUSE -dQUIET -dBATCH \
+   -sOutputFile=output-screen.pdf input.pdf
+```
+
+72 DPI. Text stays sharp; photos blur when zoomed. Not suitable for printing.
+
+### /ebook — Recommended default
+
+```bash
+gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 \
+   -dPDFSETTINGS=/ebook \
+   -dNOPAUSE -dQUIET -dBATCH \
+   -sOutputFile=output-ebook.pdf input.pdf
+```
+
+150 DPI. Good for sharing, tablets, and casual printing. The right choice for most situations.
+
+### /printer — Print quality
+
+```bash
+gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 \
+   -dPDFSETTINGS=/printer \
+   -dNOPAUSE -dQUIET -dBATCH \
+   -sOutputFile=output-printer.pdf input.pdf
+```
+
+300 DPI. Smaller reduction than `/ebook` but preserves detail for printed output.
+
+### /prepress — Commercial print
+
+```bash
+gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 \
+   -dPDFSETTINGS=/prepress \
+   -dNOPAUSE -dQUIET -dBATCH \
+   -sOutputFile=output-prepress.pdf input.pdf
+```
+
+300 DPI with ICC color profile preservation. Least compression of all presets. Use only for
+professional print workflows where color accuracy is critical.
+
+---
+
+## Advanced Optimization Flags
+
+Add any of these to a preset command for additional size reduction.
+
+### Duplicate image detection
+
+```bash
+-dDetectDuplicateImages=true
+```
+
+Detects identical images embedded multiple times and replaces duplicates with references to a
+single copy. Effective for template-based PDFs where the same logo appears on every page.
+
+### Font compression and subsetting
+
+```bash
+-dCompressFonts=true \
+-dSubsetFonts=true
+```
+
+`-dCompressFonts=true` compresses embedded font data. `-dSubsetFonts=true` removes unused
+glyphs from embedded fonts — if a PDF embeds a full font family but only uses 40 characters,
+subsetting discards the other 200+ glyphs. This can save several megabytes in documents that
+embed large CJK or decorative fonts.
+
+### Remove unused resources
+
+```bash
+-dRemoveUnusedResources=true
+```
+
+Strips resources (fonts, images, color profiles) that are defined in the PDF but never
+referenced by any page content. Common in PDFs exported from design tools.
+
+### Custom DPI control
+
+Override the DPI set by the preset for more precise control:
+
+```bash
+-dColorImageResolution=150 \
+-dGrayImageResolution=150 \
+-dMonoImageResolution=300
+```
+
+Monochrome (black and white bitmap) images tolerate higher DPI without significant size cost,
+so 300 DPI preserves sharpness for scanned text and line art. To use custom DPI without a
+preset, omit `-dPDFSETTINGS` and set all three resolution flags manually.
+
+---
+
+## Maximum Compression Recipe
+
+Smallest possible output. Use when the PDF contains images, repeated graphics, or embedded fonts.
+
+```bash
+gs -sDEVICE=pdfwrite \
+   -dCompatibilityLevel=1.4 \
+   -dPDFSETTINGS=/screen \
+   -dNOPAUSE -dQUIET -dBATCH \
+   -dDetectDuplicateImages=true \
+   -dCompressFonts=true \
+   -dSubsetFonts=true \
+   -dRemoveUnusedResources=true \
+   -dColorImageResolution=72 \
+   -dGrayImageResolution=72 \
+   -dMonoImageResolution=150 \
+   -sOutputFile=output-max.pdf \
+   input.pdf
+```
+
+For slightly better quality at still-aggressive compression, swap `/screen` for `/ebook` and
+set color/gray resolution to 120.
+
+---
+
+## qpdf — Web Optimization and Stream Compression
+
+qpdf is a structural PDF transformer, not a re-renderer. It does not downsample images or
+re-encode content — it reorganizes PDF structure and applies lossless stream compression.
+
+### Linearization (fast web view)
+
+```bash
+qpdf --linearize input.pdf output-web.pdf
+```
+
+Reorganizes the PDF so the first page displays before the full file downloads. Does not reduce
+file size significantly, but improves perceived load time for PDFs served over HTTP. Apply as
+a post-processing step after Ghostscript compression.
+
+### Stream compression
+
+```bash
+qpdf --compress-streams=y input.pdf output.pdf
+```
+
+Applies zlib compression to uncompressed streams. Effective on PDFs assembled by older tools
+that skip compression.
+
+### Object stream generation
+
+```bash
+qpdf --object-streams=generate input.pdf output.pdf
+```
+
+Packs multiple PDF objects into compressed object streams (PDF 1.5+ output). Combine with
+linearization:
+
+```bash
+qpdf --linearize --compress-streams=y --object-streams=generate \
+     input.pdf output-optimized.pdf
+```
+
+### Combined Ghostscript + qpdf pipeline
+
+```bash
+gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/ebook \
+   -dNOPAUSE -dQUIET -dBATCH \
+   -dDetectDuplicateImages=true -dCompressFonts=true -dSubsetFonts=true \
+   -sOutputFile=tmp-compressed.pdf input.pdf
+qpdf --linearize --compress-streams=y tmp-compressed.pdf output-final.pdf
+rm tmp-compressed.pdf
+```
+
+---
+
+## Batch PDF Compression
+
+### Loop over all PDFs in a folder
+
+```bash
+for f in *.pdf; do
+  gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/ebook \
+     -dNOPAUSE -dQUIET -dBATCH \
+     -dDetectDuplicateImages=true -dCompressFonts=true -dSubsetFonts=true \
+     -sOutputFile="${f%.pdf}-compressed.pdf" "$f"
+done
+```
+
+Writes `document-compressed.pdf` alongside each `document.pdf`. `${f%.pdf}` strips the
+extension before appending the suffix.
+
+### Shell function for reuse
+
+```bash
+compress_pdf() {
+  local input="$1"
+  local output="${2:-${input%.pdf}-compressed.pdf}"
+  local preset="${3:-/ebook}"
+  gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS="$preset" \
+     -dNOPAUSE -dQUIET -dBATCH \
+     -dDetectDuplicateImages=true -dCompressFonts=true -dSubsetFonts=true \
+     -sOutputFile="$output" "$input"
+  echo "Compressed: $input -> $output"
+}
+# compress_pdf report.pdf
+# compress_pdf report.pdf report-small.pdf /screen
+```
+
+Add to `~/.bashrc` or `~/.zshrc` for persistent availability.
+
+---
+
+## Quality Tier Mapping
+
+Map user-facing language to Ghostscript presets:
+
+| User Request | Ghostscript Preset | Notes |
+|---|---|---|
+| "web", "email", "small", "maximum" | `/screen` | 72 DPI, aggressive |
+| "balanced", "default", "normal" | `/ebook` | 150 DPI, recommended |
+| "quality", "print", "high" | `/printer` | 300 DPI, moderate reduction |
+| "professional", "commercial", "prepress" | `/prepress` | 300 DPI + color profiles |
+
+---
+
+## Real-World Results
+
+Typical outcomes. Results vary significantly based on original content.
+
+| Document Type | Original Size | /screen | /ebook | /printer |
+|---|---|---|---|---|
+| Image-heavy report (photos) | 25 MB | 2.5 MB | 5 MB | 12 MB |
+| Scanned document (300 DPI scan) | 8 MB | 0.9 MB | 1.8 MB | 4 MB |
+| Mixed (charts + text) | 5 MB | 0.8 MB | 1.5 MB | 3 MB |
+| Text-only (no images) | 1.2 MB | 1.0 MB | 1.1 MB | 1.15 MB |
+| Already-optimized PDF | 800 KB | 850 KB | 820 KB | 810 KB |
+
+The last two rows show the key limitation: Ghostscript cannot compress what is already compact.
+Already-optimized PDFs may grow slightly due to re-encoding overhead.
+
+---
+
+## Troubleshooting
+
+### Output is larger than input
+
+Ghostscript re-encodes everything, including already-compressed content. Common causes:
+- Text-only PDFs (no images to downsample)
+- PDFs already processed by Ghostscript
+- PDFs with very few pages
+
+If the input is under 500 KB, compression is unlikely to help. Compare sizes before replacing:
+
+```bash
+ls -lh input.pdf output.pdf
+```
+
+If output is larger, discard it and keep the original.
+
+### Font rendering issues after compression
+
+Symptoms: garbled characters, missing glyphs, substituted fonts.
+
+`-dSubsetFonts=true` occasionally causes issues with non-standard font embeddings. Disable it
+as a first diagnostic step:
+
+```bash
+gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/ebook \
+   -dNOPAUSE -dQUIET -dBATCH \
+   -dSubsetFonts=false \
+   -sOutputFile=output.pdf input.pdf
+```
+
+### Color space problems
+
+`/prepress` preserves ICC profiles; other presets may convert or discard them. If color
+accuracy matters, use `/prepress` or add `-dUseCIEColor=false`.
+
+### Errors on encrypted PDFs
+
+Ghostscript cannot process password-protected PDFs. Decrypt first with qpdf:
+
+```bash
+qpdf --decrypt --password="owner-password" input.pdf decrypted.pdf
+# Then compress the decrypted file
+gs -sDEVICE=pdfwrite -dPDFSETTINGS=/ebook -dNOPAUSE -dQUIET -dBATCH \
+   -sOutputFile=output.pdf decrypted.pdf
+rm decrypted.pdf
+```
+
+### Slow processing on large PDFs
+
+Ghostscript processes PDFs page by page. A 500-page document with high-resolution images can
+take several minutes — expected behavior. No parallel processing option exists.
+
+---
+
+For tool installation and availability checks, see `tool-setup.md`.
+
+For image compression (JPEG, PNG, WebP, AVIF), see `image-compression.md`.

--- a/skills/unix-media-compressor/references/tool-setup.md
+++ b/skills/unix-media-compressor/references/tool-setup.md
@@ -1,0 +1,328 @@
+# Tool Setup and Operations
+
+Sources: Homebrew docs, Debian/Ubuntu package repositories, tool official documentation
+
+---
+
+## Tool Inventory
+
+| Tool | Compresses | Check Command | Status |
+|------|-----------|---------------|--------|
+| ffmpeg | video, audio, images (WebP, AVIF, PNG, JPEG) | `ffmpeg -version` | Required |
+| gs (ghostscript) | PDF | `gs --version` | Required |
+| cwebp | PNG/JPEG → WebP | `cwebp -version` | Recommended |
+| avifenc | PNG/JPEG → AVIF | `avifenc --version` | Recommended |
+| pngquant | PNG (lossy palette reduction) | `pngquant --version` | Recommended |
+| oxipng | PNG (lossless re-encoding) | `oxipng --version` | Recommended |
+| jpegoptim | JPEG (lossy or lossless strip) | `jpegoptim --version` | Recommended |
+| zstd | archives (tar.zst) | `zstd --version` | Recommended |
+| gifsicle | GIF | `gifsicle --version` | Optional |
+| optipng | PNG (lossless, slower than oxipng) | `optipng --version` | Optional |
+| pigz | gzip archives (parallel) | `pigz --version` | Optional |
+| pbzip2 | bzip2 archives (parallel) | `pbzip2 --version` | Optional |
+| brotli | web assets (.br) | `brotli --version` | Optional |
+| 7z | archives (highest ratio) | `7z i` | Optional |
+| qpdf | PDF (linearize, stream compress) | `qpdf --version` | Optional |
+
+---
+
+## Detection
+
+Check whether a tool is available before invoking it:
+
+```bash
+command -v ffmpeg &>/dev/null && echo "found" || echo "missing"
+```
+
+Check all required tools and collect missing ones:
+
+```bash
+check_tools() {
+    local missing=()
+    for tool in ffmpeg gs; do
+        command -v "$tool" &>/dev/null || missing+=("$tool")
+    done
+    [[ ${#missing[@]} -gt 0 ]] && { echo "Missing: ${missing[*]}" >&2; return 1; }
+}
+```
+
+Report which optional tools are available:
+
+```bash
+for tool in cwebp avifenc pngquant oxipng jpegoptim zstd gifsicle optipng pigz pbzip2 brotli 7z qpdf; do
+    command -v "$tool" &>/dev/null && echo "[x] $tool" || echo "[ ] $tool"
+done
+```
+
+Version check patterns for non-standard flags:
+
+```bash
+ffmpeg -version 2>&1 | head -1     # ffmpeg version 6.x ...
+gs --version                        # 10.x.x
+7z i 2>&1 | grep "7-Zip"           # 7-Zip 23.x ...
+```
+
+---
+
+## macOS Installation (Homebrew)
+
+Install individually as needed:
+
+```bash
+brew install ffmpeg          # Required
+brew install ghostscript     # Required
+brew install webp            # cwebp + dwebp
+brew install libavif         # avifenc + avifdec
+brew install pngquant
+brew install oxipng
+brew install jpegoptim
+brew install zstd
+brew install gifsicle
+brew install optipng
+brew install pigz
+brew install pbzip2
+brew install brotli
+brew install p7zip           # provides 7z
+brew install qpdf
+```
+
+Install everything at once:
+
+```bash
+brew install ffmpeg ghostscript webp libavif pngquant oxipng jpegoptim zstd gifsicle optipng pigz pbzip2 brotli p7zip qpdf
+```
+
+If tools are not found after install, confirm Homebrew is on your PATH:
+
+```bash
+eval "$(/opt/homebrew/bin/brew shellenv)"   # Apple Silicon
+```
+
+---
+
+## Linux Installation (Debian/Ubuntu)
+
+Install individually:
+
+```bash
+sudo apt install ffmpeg ghostscript webp libavif-bin pngquant jpegoptim optipng gifsicle zstd pigz pbzip2 brotli p7zip-full qpdf
+```
+
+Install everything available via apt at once:
+
+```bash
+sudo apt install ffmpeg ghostscript webp libavif-bin pngquant jpegoptim optipng gifsicle zstd pigz pbzip2 brotli p7zip-full qpdf
+```
+
+oxipng is not in standard apt repositories. Install via Cargo:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+cargo install oxipng
+```
+
+---
+
+## Minimal vs Full Install
+
+**Minimal** — two tools cover the most common tasks:
+
+- `ffmpeg` — video, audio, and image format conversion (WebP, AVIF, JPEG)
+- `gs` — PDF compression
+
+**Recommended additions** — each fills a gap ffmpeg alone cannot match:
+
+- `pngquant` + `oxipng` — PNG pipeline; pngquant reduces palette (lossy), oxipng re-encodes losslessly. Together they outperform ffmpeg for PNG.
+- `jpegoptim` — strips JPEG metadata and applies targeted quality reduction without full re-encode.
+- `cwebp` / `avifenc` — finer control over WebP/AVIF encoding than ffmpeg's output.
+- `zstd` — fast archive compression with excellent ratio; preferred over gzip for new archives.
+
+**Optional** — situational:
+
+- `gifsicle` — the only reliable tool for GIF optimization.
+- `pigz` / `pbzip2` — parallel gzip/bzip2; useful for large archives on multi-core machines.
+- `brotli` — web asset pre-compression for servers that serve `.br` files.
+- `7z` — highest compression ratio; slow, useful for archival storage.
+- `qpdf` — PDF linearization; complements ghostscript for web-optimized PDFs.
+
+---
+
+## Before/After Size Comparison
+
+`stat` syntax differs between macOS and Linux; use a fallback:
+
+```bash
+original_size=$(stat -f%z "$input" 2>/dev/null || stat -c%s "$input")
+# ... compress ...
+new_size=$(stat -f%z "$output" 2>/dev/null || stat -c%s "$output")
+reduction=$(( (original_size - new_size) * 100 / original_size ))
+echo "  ${original_size} → ${new_size} bytes (${reduction}% reduction)"
+```
+
+Accumulate totals across a batch:
+
+```bash
+total_original=0; total_new=0
+
+# After each file:
+total_original=$(( total_original + orig ))
+total_new=$(( total_new + new ))
+
+# Summary:
+total_reduction=$(( (total_original - total_new) * 100 / total_original ))
+echo "Total: $(numfmt --to=iec $total_original) → $(numfmt --to=iec $total_new) (${total_reduction}% reduction)"
+```
+
+---
+
+## Batch Processing Patterns
+
+**find + xargs** — parallel processing with `-P`:
+
+```bash
+find . -name "*.jpg" -print0 | xargs -0 -P4 -I{} jpegoptim --max=85 {}
+find . -name "*.png" -print0 | xargs -0 -P4 -I{} pngquant --quality 65-80 --force --ext .png {}
+```
+
+**bash for loop** — control over input/output paths:
+
+```bash
+for f in *.mp4; do
+    ffmpeg -i "$f" -crf 28 -preset slow "${f%.mp4}-compressed.mp4"
+done
+```
+
+**GNU parallel** — best throughput, built-in progress:
+
+```bash
+find . -name "*.png" | parallel --progress pngquant --quality 65-80 --force --ext .png {}
+find . -name "*.mp4" | parallel -j2 ffmpeg -i {} -crf 28 {.}-compressed.mp4
+```
+
+**Recursive with preserved directory structure**:
+
+```bash
+input_dir="./originals"; output_dir="./compressed"
+find "$input_dir" -name "*.jpg" | while read -r file; do
+    relative="${file#$input_dir/}"
+    out="$output_dir/$relative"
+    mkdir -p "$(dirname "$out")"
+    jpegoptim --max=85 --dest="$(dirname "$out")" "$file"
+done
+```
+
+---
+
+## Progress and Reporting
+
+Counter during batch:
+
+```bash
+files=( $(find . -name "*.png") )
+total=${#files[@]}; count=0
+for f in "${files[@]}"; do
+    count=$(( count + 1 ))
+    printf "[%d/%d] %s\n" "$count" "$total" "$f"
+    pngquant --quality 65-80 --force --ext .png "$f"
+done
+```
+
+Summary after completion:
+
+```bash
+echo "Processed: $count files"
+echo "Skipped:   $skipped files"
+echo "Total saved: $(numfmt --to=iec $(( total_original - total_new )))"
+echo "Reduction:   ${total_reduction}%"
+```
+
+---
+
+## Safety: Preserving Originals
+
+**Output to a new file** (safest — original untouched):
+
+```bash
+ffmpeg -i input.mp4 -crf 28 output.mp4
+cwebp -q 80 input.png -o output.webp
+```
+
+**Output to a separate directory**:
+
+```bash
+jpegoptim --max=85 --dest=./compressed/ input.jpg
+```
+
+**In-place with backup and size check** (restore if compression made it larger):
+
+```bash
+cp "$f" "${f}.bak"
+pngquant --quality 65-80 --force --ext .png "$f"
+new=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f")
+orig=$(stat -f%z "${f}.bak" 2>/dev/null || stat -c%s "${f}.bak")
+[[ $new -lt $orig ]] && rm "${f}.bak" || mv "${f}.bak" "$f"
+```
+
+**Skip if output already exists** (idempotent batch runs):
+
+```bash
+[[ -f "$out" ]] && continue
+```
+
+---
+
+## Common Issues
+
+**Tool not found after installation**
+
+```bash
+eval "$(/opt/homebrew/bin/brew shellenv)"   # Homebrew (Apple Silicon)
+source "$HOME/.cargo/env"                   # Cargo (oxipng)
+which ffmpeg                                # verify
+```
+
+**brew or apt ships an outdated ffmpeg** (missing AV1, AVIF codecs)
+
+```bash
+ffmpeg -version 2>&1 | head -1
+ffmpeg -codecs 2>/dev/null | grep -E "hevc|av1|vp9"
+# macOS: brew upgrade ffmpeg
+# Ubuntu: sudo add-apt-repository ppa:savoury1/ffmpeg4 && sudo apt update && sudo apt install ffmpeg
+```
+
+**ghostscript produces a larger file than the input**
+
+Already-optimized PDFs or vector-heavy PDFs can grow. Check before keeping:
+
+```bash
+[[ $new_size -lt $original_size ]] || cp "$input" "$output"
+```
+
+**pngquant refuses to overwrite**
+
+Always pass `--force` in batch scripts:
+
+```bash
+pngquant --quality 65-80 --force --ext .png "$f"
+```
+
+**oxipng not found on Linux**
+
+Install via Cargo (see Linux Installation section), or fall back to optipng:
+
+```bash
+command -v oxipng &>/dev/null \
+    && oxipng -o 3 -i 0 --strip safe "$f" \
+    || optipng -o5 -strip all "$f"
+```
+
+**Permission denied on output directory**
+
+```bash
+mkdir -p "$output_dir" && chmod 755 "$output_dir"
+```
+
+---
+
+For domain-specific compression commands, see `image-compression.md`, `video-compression.md`, `audio-compression.md`, `pdf-compression.md`, and `archive-formats.md`.

--- a/skills/unix-media-compressor/references/video-compression.md
+++ b/skills/unix-media-compressor/references/video-compression.md
@@ -1,0 +1,448 @@
+# Video Compression
+
+Sources: FFmpeg official docs (2025-2026), Ozer (Video Encoding by the Numbers), ffmpeg.party AV1 guide
+
+---
+
+## Codec Selection
+
+Pick a codec based on where the file lands, not personal preference. Compatibility beats compression when in doubt.
+
+| Codec | Encoder | Compression vs H.264 | Compatibility | Best For |
+|-------|---------|----------------------|---------------|----------|
+| H.264/AVC | libx264 | Baseline | Universal | Web delivery, streaming, broad device support |
+| H.265/HEVC | libx265 | ~50% smaller | Broad (not all browsers) | 4K, bandwidth-constrained delivery, Apple ecosystem |
+| AV1 | libsvtav1 | ~30% smaller than H.265 | Modern browsers, growing | Web-first content, YouTube, long-term storage |
+
+**Decision rule:** H.264 when you need it to play everywhere. H.265 when you need smaller files and control the playback environment. AV1 when encode time is acceptable and the target is a modern browser or streaming platform.
+
+---
+
+## CRF Reference
+
+CRF (Constant Rate Factor) encodes to a target quality level rather than a target bitrate. Lower values produce higher quality and larger files. This is the right default for compression work — use two-pass only when a specific file size or bitrate is required.
+
+| Quality Tier | libx264 CRF | libx265 CRF | libsvtav1 CRF | Notes |
+|--------------|-------------|-------------|---------------|-------|
+| Web (small file) | 28–32 | 32–36 | 38–45 | Acceptable quality, smallest size |
+| Balanced | 23–27 | 28–31 | 30–37 | Default range, good quality/size tradeoff |
+| Quality | 18–22 | 22–27 | 22–29 | High quality, larger files |
+| Visually lossless | 17–18 | 20–22 | 18–22 | Near-transparent, archival use |
+
+Defaults: x264 CRF 23, x265 CRF 28, SVT-AV1 CRF 30. Start here and adjust based on output size.
+
+---
+
+## H.264 Recipes
+
+H.264 is the safe default. `-pix_fmt yuv420p` is required for compatibility — some sources default to yuv444p or yuv422p which many decoders reject. `-movflags +faststart` moves the MP4 index to the front of the file so browsers can begin playback before the full download completes.
+
+### Web (small file, broad compatibility)
+
+```bash
+ffmpeg -i input.mp4 \
+  -c:v libx264 -crf 28 -preset fast \
+  -pix_fmt yuv420p \
+  -c:a aac -b:a 128k \
+  -movflags +faststart \
+  output.mp4
+```
+
+### Balanced (default, most content)
+
+```bash
+ffmpeg -i input.mp4 \
+  -c:v libx264 -crf 23 -preset medium \
+  -pix_fmt yuv420p \
+  -c:a aac -b:a 128k \
+  -movflags +faststart \
+  output.mp4
+```
+
+### Quality (high fidelity, larger file)
+
+```bash
+ffmpeg -i input.mp4 \
+  -c:v libx264 -crf 18 -preset slow \
+  -pix_fmt yuv420p \
+  -c:a aac -b:a 192k \
+  -movflags +faststart \
+  output.mp4
+```
+
+### Visually lossless (archival, source preservation)
+
+```bash
+ffmpeg -i input.mp4 \
+  -c:v libx264 -crf 17 -preset veryslow \
+  -pix_fmt yuv420p \
+  -c:a aac -b:a 256k \
+  -movflags +faststart \
+  output.mp4
+```
+
+---
+
+## H.265 Recipes
+
+H.265 produces files roughly 50% smaller than H.264 at equivalent quality. `-tag:v hvc1` is required for Apple devices — without it, QuickTime and iOS refuse to play the file even though the codec is supported.
+
+### Web (small file)
+
+```bash
+ffmpeg -i input.mp4 \
+  -c:v libx265 -crf 32 -preset fast \
+  -pix_fmt yuv420p \
+  -tag:v hvc1 \
+  -c:a aac -b:a 128k \
+  -movflags +faststart \
+  output.mp4
+```
+
+### Balanced (default)
+
+```bash
+ffmpeg -i input.mp4 \
+  -c:v libx265 -crf 28 -preset medium \
+  -pix_fmt yuv420p \
+  -tag:v hvc1 \
+  -c:a aac -b:a 128k \
+  -movflags +faststart \
+  output.mp4
+```
+
+### Quality
+
+```bash
+ffmpeg -i input.mp4 \
+  -c:v libx265 -crf 22 -preset slow \
+  -pix_fmt yuv420p \
+  -tag:v hvc1 \
+  -c:a aac -b:a 192k \
+  -movflags +faststart \
+  output.mp4
+```
+
+### Visually lossless (10-bit, archival)
+
+```bash
+ffmpeg -i input.mp4 \
+  -c:v libx265 -crf 20 -preset veryslow \
+  -pix_fmt yuv420p10le \
+  -tag:v hvc1 \
+  -c:a aac -b:a 256k \
+  -movflags +faststart \
+  output.mp4
+```
+
+Use `yuv420p10le` for 10-bit output — better for HDR sources and archival. Use `yuv420p` for standard 8-bit delivery.
+
+---
+
+## AV1 Recipes
+
+SVT-AV1 (`libsvtav1`) is the practical AV1 encoder — significantly faster than `libaom-av1` with comparable quality. The `-svtav1-params` string controls scene detection, keyframe interval, and quality tuning.
+
+**Key params:** `keyint=10s` = keyframe every 10s; `tune=0` = visual quality; `enable-overlays=1` = better scene boundaries; `scd=1` = scene change detection; `scm=0` = off for natural video (set 1 for screencasts).
+
+### Web (small file)
+
+```bash
+ffmpeg -i input.mp4 \
+  -c:v libsvtav1 -crf 40 -preset 8 \
+  -svtav1-params keyint=10s:tune=0:enable-overlays=1:scd=1:scm=0 \
+  -pix_fmt yuv420p \
+  -c:a libopus -b:a 96k \
+  output.mp4
+```
+
+### Balanced (default)
+
+```bash
+ffmpeg -i input.mp4 \
+  -c:v libsvtav1 -crf 30 -preset 6 \
+  -svtav1-params keyint=10s:tune=0:enable-overlays=1:scd=1:scm=0 \
+  -pix_fmt yuv420p \
+  -c:a libopus -b:a 128k \
+  output.mp4
+```
+
+### Quality
+
+```bash
+ffmpeg -i input.mp4 \
+  -c:v libsvtav1 -crf 22 -preset 4 \
+  -svtav1-params keyint=10s:tune=0:enable-overlays=1:scd=1:scm=0 \
+  -pix_fmt yuv420p \
+  -c:a libopus -b:a 192k \
+  output.mp4
+```
+
+### Visually lossless (slow, archival)
+
+```bash
+ffmpeg -i input.mp4 \
+  -c:v libsvtav1 -crf 18 -preset 2 \
+  -svtav1-params keyint=10s:tune=0:enable-overlays=1:scd=1:scm=0 \
+  -pix_fmt yuv420p10le \
+  -c:a libopus -b:a 256k \
+  output.mp4
+```
+
+AV1 in MP4 has broad support in modern browsers. Use `.webm` with `-c:a libopus` for WebM delivery.
+
+---
+
+## Preset Reference
+
+Presets trade encode time for compression efficiency. A slower preset produces a smaller file at the same CRF value — it does not change visual quality, only how efficiently the encoder finds redundancy.
+
+### x264 / x265 Presets
+
+| Preset | Relative Speed | File Size vs medium | Typical Use |
+|--------|---------------|---------------------|-------------|
+| ultrafast | ~10× faster | ~30% larger | Testing, live encoding |
+| superfast | ~7× faster | ~25% larger | Near-live |
+| veryfast | ~4× faster | ~15% larger | Fast batch jobs |
+| faster | ~2× faster | ~8% larger | General batch |
+| fast | ~1.5× faster | ~4% larger | General batch |
+| medium | 1× (baseline) | Baseline | Default |
+| slow | ~2× slower | ~5% smaller | High-quality delivery |
+| slower | ~4× slower | ~8% smaller | Archival, distribution |
+| veryslow | ~8× slower | ~12% smaller | Maximum compression |
+
+For most compression work, `medium` or `fast` is the right choice. `slow` is worth it for final delivery. `veryslow` rarely justifies the encode time.
+
+### SVT-AV1 Presets (0–13)
+
+| Preset | Speed | Quality | Use |
+|--------|-------|---------|-----|
+| 0–1 | Very slow | Best | Research, archival |
+| 2–3 | Slow | High | High-quality delivery |
+| 4–5 | Moderate | Good | Quality batch |
+| 6–7 | Balanced | Good | Default range |
+| 8–9 | Fast | Acceptable | Fast batch |
+| 10–11 | Very fast | Lower | Quick previews |
+| 12–13 | Fastest | Lowest | Real-time only |
+
+Preset 6 is the practical default. Preset 4 for quality-focused work. Preset 8–9 for fast batch jobs.
+
+---
+
+## Resolution Scaling
+
+Scale video during compression to reduce file size further. The `-vf scale` filter handles this. Use `-2` for the auto-calculated dimension to ensure it stays divisible by 2 (required by most codecs).
+
+```bash
+# Scale to 1080p width, auto height
+ffmpeg -i input.mp4 -vf scale=1920:-2 -c:v libx264 -crf 23 -preset medium output.mp4
+
+# Scale to 720p width, auto height
+ffmpeg -i input.mp4 -vf scale=1280:-2 -c:v libx264 -crf 23 -preset medium output.mp4
+
+# Scale to 480p width, auto height
+ffmpeg -i input.mp4 -vf scale=854:-2 -c:v libx264 -crf 23 -preset medium output.mp4
+
+# Scale by height (e.g., 1080p height)
+ffmpeg -i input.mp4 -vf scale=-2:1080 -c:v libx264 -crf 23 -preset medium output.mp4
+```
+
+### Downscale-Only Pattern
+
+Avoid upscaling — it increases file size without improving quality. Use `min()` expressions to skip scaling when the source is already smaller than the target:
+
+```bash
+# Downscale to 1080p only if source is larger; pass through if already smaller
+ffmpeg -i input.mp4 \
+  -vf "scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease,scale=trunc(iw/2)*2:trunc(ih/2)*2" \
+  -c:v libx264 -crf 23 -preset medium \
+  -pix_fmt yuv420p -movflags +faststart \
+  output.mp4
+```
+
+The `trunc(iw/2)*2` expression ensures width and height are always even numbers, which libx264 requires.
+
+---
+
+## Two-Pass Encoding
+
+Use two-pass when you need to hit a specific file size or bitrate target — for example, a 50 MB upload limit or a streaming platform's ingest spec. CRF is simpler and usually better for general compression; two-pass is for constrained delivery.
+
+Pass 1 analyzes the video and writes statistics. Pass 2 uses those statistics to distribute bits optimally.
+
+### x264 Two-Pass
+
+```bash
+ffmpeg -i input.mp4 -c:v libx264 -b:v 2000k -pass 1 -an -f null /dev/null
+ffmpeg -i input.mp4 -c:v libx264 -b:v 2000k -pass 2 \
+  -pix_fmt yuv420p -c:a aac -b:a 128k -movflags +faststart output.mp4
+```
+
+### x265 Two-Pass
+
+x265 uses `-x265-params` for pass control rather than the standard `-pass` flag:
+
+```bash
+ffmpeg -i input.mp4 -c:v libx265 -b:v 1500k -x265-params pass=1 -an -f null /dev/null
+ffmpeg -i input.mp4 -c:v libx265 -b:v 1500k -x265-params pass=2 \
+  -pix_fmt yuv420p -tag:v hvc1 -c:a aac -b:a 128k -movflags +faststart output.mp4
+```
+
+Clean up stats after encoding: `rm -f ffmpeg2pass-0.log ffmpeg2pass-0.log.mbtree x265_2pass.log x265_2pass.log.cutree`
+
+---
+
+## Hardware Acceleration
+
+Hardware encoders are faster than software but produce slightly larger files at equivalent quality. Use when encode speed matters more than maximum compression.
+
+### VideoToolbox (macOS)
+
+Apple Silicon and Intel Macs both support VideoToolbox. Quality uses `-q:v` (0–100, higher = better) rather than CRF.
+
+```bash
+# H.264 via VideoToolbox
+ffmpeg -i input.mp4 \
+  -c:v h264_videotoolbox -q:v 65 \
+  -pix_fmt yuv420p \
+  -c:a aac -b:a 128k -movflags +faststart \
+  output.mp4
+
+# H.265 via VideoToolbox
+ffmpeg -i input.mp4 \
+  -c:v hevc_videotoolbox -q:v 65 \
+  -tag:v hvc1 \
+  -c:a aac -b:a 128k -movflags +faststart \
+  output.mp4
+```
+
+### NVENC (NVIDIA)
+
+NVENC uses `-cq` for quality control (similar to CRF, lower = better quality).
+
+```bash
+# H.264 via NVENC
+ffmpeg -i input.mp4 \
+  -c:v h264_nvenc -cq 23 -preset p4 \
+  -pix_fmt yuv420p \
+  -c:a aac -b:a 128k -movflags +faststart \
+  output.mp4
+
+# H.265 via NVENC
+ffmpeg -i input.mp4 \
+  -c:v hevc_nvenc -cq 28 -preset p4 \
+  -tag:v hvc1 \
+  -c:a aac -b:a 128k -movflags +faststart \
+  output.mp4
+```
+
+NVENC presets: `p1` (fastest) through `p7` (slowest/best). `p4` is a reasonable default.
+
+### VAAPI (Linux/Intel/AMD)
+
+VAAPI requires specifying the render device. Quality uses `-qp` (lower = better).
+
+```bash
+# H.264 via VAAPI
+ffmpeg -vaapi_device /dev/dri/renderD128 \
+  -i input.mp4 \
+  -vf 'format=nv12,hwupload' \
+  -c:v h264_vaapi -qp 23 \
+  -c:a aac -b:a 128k -movflags +faststart \
+  output.mp4
+```
+
+Check available render devices with `ls /dev/dri/`. Use `renderD128` as the default; increment if multiple GPUs are present.
+
+---
+
+## Audio Handling
+
+### Passthrough (no re-encode)
+
+Copy audio without re-encoding when the source is already AAC/MP3 at acceptable quality. Faster and avoids generation loss.
+
+```bash
+ffmpeg -i input.mp4 -c:v libx264 -crf 23 -preset medium \
+  -pix_fmt yuv420p -c:a copy -movflags +faststart output.mp4
+```
+
+### Re-encode Audio
+
+Re-encode when the source codec is incompatible with the output container, or when reducing audio bitrate is part of the size goal.
+
+```bash
+-c:a aac -b:a 128k          # standard web (MP4)
+-c:a aac -b:a 192k          # high quality (MP4)
+-c:a libopus -b:a 128k      # WebM / AV1 (preferred)
+-c:a aac -b:a 192k -ac 2    # stereo downmix from surround
+```
+
+**Pairing rules:** MP4 + H.264/H.265 → AAC. WebM + AV1 → Opus. Opus is more efficient than AAC at equivalent bitrates, especially below 128k.
+
+For audio-only compression (MP3, AAC, Opus, FLAC), see `audio-compression.md`.
+
+---
+
+## Batch Video Compression
+
+### Sequential bash loop
+
+```bash
+for f in *.mp4; do
+  ffmpeg -i "$f" \
+    -c:v libx264 -crf 23 -preset medium \
+    -pix_fmt yuv420p \
+    -c:a aac -b:a 128k \
+    -movflags +faststart \
+    "compressed_${f}"
+done
+```
+
+### Parallel processing with GNU parallel
+
+Process multiple files simultaneously. Limit jobs to avoid saturating CPU — a good default is half the available cores.
+
+```bash
+# Install: brew install parallel (macOS) / apt install parallel (Linux)
+
+ls *.mp4 | parallel -j4 \
+  ffmpeg -i {} \
+    -c:v libx264 -crf 23 -preset medium \
+    -pix_fmt yuv420p \
+    -c:a aac -b:a 128k \
+    -movflags +faststart \
+    compressed_{.}.mp4
+```
+
+`{.}` strips the extension from the input filename. `-j4` runs 4 jobs in parallel.
+
+### Recursive batch (subdirectories)
+
+```bash
+find . -name "*.mp4" -type f | while read -r f; do
+  dir=$(dirname "$f")
+  base=$(basename "$f" .mp4)
+  ffmpeg -i "$f" -c:v libx264 -crf 23 -preset medium \
+    -pix_fmt yuv420p -c:a aac -b:a 128k -movflags +faststart \
+    "${dir}/compressed_${base}.mp4"
+done
+```
+
+---
+
+## Quick Reference: Common Scenarios
+
+| Goal | Codec | CRF | Preset | Extra Flags |
+|------|-------|-----|--------|-------------|
+| Shrink MP4 for web | libx264 | 28 | fast | `-pix_fmt yuv420p -movflags +faststart` |
+| Best quality/size ratio | libx265 | 28 | medium | `-pix_fmt yuv420p -tag:v hvc1 -movflags +faststart` |
+| Maximum compression, modern browser | libsvtav1 | 35 | 6 | `-svtav1-params keyint=10s:tune=0:enable-overlays=1:scd=1:scm=0` |
+| Fast encode (testing) | libx264 | 23 | ultrafast | `-pix_fmt yuv420p` |
+| Apple device delivery | libx265 | 28 | medium | `-tag:v hvc1 -pix_fmt yuv420p` |
+| Archival (lossless-ish) | libx264 | 17 | veryslow | `-pix_fmt yuv420p` |
+| 4K downscale to 1080p | libx265 | 26 | slow | `-vf scale=1920:-2 -tag:v hvc1` |
+
+---
+
+For audio-only compression (MP3, AAC, Opus, FLAC files), see `audio-compression.md`.

--- a/skills/unix-media-compressor/scripts/check-tools.sh
+++ b/skills/unix-media-compressor/scripts/check-tools.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# check-tools.sh — Detect installed compression tools and suggest missing ones.
+# Usage: bash scripts/check-tools.sh [--json] [--install]
+
+set -euo pipefail
+
+JSON_MODE=false
+INSTALL_MODE=false
+for arg in "$@"; do
+  case "$arg" in
+    --json) JSON_MODE=true ;;
+    --install) INSTALL_MODE=true ;;
+  esac
+done
+
+detect_os() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "macos"
+  elif [[ -f /etc/debian_version ]]; then
+    echo "debian"
+  elif [[ -f /etc/redhat-release ]]; then
+    echo "redhat"
+  else
+    echo "unknown"
+  fi
+}
+
+OS=$(detect_os)
+
+# Tool definitions: name|check_command|brew_package|apt_package|category
+TOOLS=(
+  "ffmpeg|ffmpeg -version|ffmpeg|ffmpeg|required"
+  "ghostscript|gs --version|ghostscript|ghostscript|required"
+  "cwebp|cwebp -version|webp|webp|recommended"
+  "avifenc|avifenc --version|libavif|libavif-bin|recommended"
+  "pngquant|pngquant --version|pngquant|pngquant|recommended"
+  "oxipng|oxipng --version|oxipng|cargo:oxipng|recommended"
+  "jpegoptim|jpegoptim --version|jpegoptim|jpegoptim|recommended"
+  "zstd|zstd --version|zstd|zstd|recommended"
+  "gifsicle|gifsicle --version|gifsicle|gifsicle|optional"
+  "optipng|optipng --version|optipng|optipng|optional"
+  "pigz|pigz --version|pigz|pigz|optional"
+  "pbzip2|pbzip2 --version|pbzip2|pbzip2|optional"
+  "brotli|brotli --version|brotli|brotli|optional"
+  "7z|7z i|p7zip|p7zip-full|optional"
+  "qpdf|qpdf --version|qpdf|qpdf|optional"
+)
+
+installed=0
+missing=0
+missing_required=0
+missing_tools=()
+json_entries=()
+
+for entry in "${TOOLS[@]}"; do
+  IFS='|' read -r name check_cmd brew_pkg apt_pkg category <<< "$entry"
+
+  if command -v "$name" &>/dev/null; then
+    version=$($check_cmd 2>&1 | head -1 | sed 's/^[^0-9]*//' | cut -d' ' -f1 | head -c 40)
+    ((installed++))
+    if $JSON_MODE; then
+      json_entries+=("{\"name\":\"$name\",\"installed\":true,\"version\":\"$version\",\"category\":\"$category\"}")
+    else
+      printf "  %-12s %-12s %s\n" "$name" "$category" "$version"
+    fi
+  else
+    ((missing++))
+    if [[ "$category" == "required" ]]; then
+      ((missing_required++))
+    fi
+    missing_tools+=("$name|$brew_pkg|$apt_pkg|$category")
+    if $JSON_MODE; then
+      json_entries+=("{\"name\":\"$name\",\"installed\":false,\"category\":\"$category\"}")
+    else
+      printf "  %-12s %-12s %s\n" "$name" "$category" "(not installed)"
+    fi
+  fi
+done
+
+if $JSON_MODE; then
+  echo "{"
+  echo "  \"os\": \"$OS\","
+  echo "  \"installed\": $installed,"
+  echo "  \"missing\": $missing,"
+  echo "  \"missing_required\": $missing_required,"
+  printf '  "tools": [%s]\n' "$(IFS=,; echo "${json_entries[*]}")"
+  echo "}"
+  exit 0
+fi
+
+echo ""
+echo "Summary: $installed installed, $missing missing ($missing_required required)"
+
+if [[ ${#missing_tools[@]} -gt 0 ]]; then
+  echo ""
+  echo "Install missing tools:"
+
+  if [[ "$OS" == "macos" ]]; then
+    brew_pkgs=()
+    for entry in "${missing_tools[@]}"; do
+      IFS='|' read -r name brew_pkg apt_pkg category <<< "$entry"
+      [[ -n "$brew_pkg" ]] && brew_pkgs+=("$brew_pkg")
+    done
+    if [[ ${#brew_pkgs[@]} -gt 0 ]]; then
+      echo "  brew install ${brew_pkgs[*]}"
+    fi
+  elif [[ "$OS" == "debian" ]]; then
+    apt_pkgs=()
+    cargo_pkgs=()
+    for entry in "${missing_tools[@]}"; do
+      IFS='|' read -r name brew_pkg apt_pkg category <<< "$entry"
+      if [[ "$apt_pkg" == cargo:* ]]; then
+        cargo_pkgs+=("${apt_pkg#cargo:}")
+      elif [[ -n "$apt_pkg" ]]; then
+        apt_pkgs+=("$apt_pkg")
+      fi
+    done
+    if [[ ${#apt_pkgs[@]} -gt 0 ]]; then
+      echo "  sudo apt install ${apt_pkgs[*]}"
+    fi
+    if [[ ${#cargo_pkgs[@]} -gt 0 ]]; then
+      echo "  cargo install ${cargo_pkgs[*]}"
+    fi
+  fi
+
+  if $INSTALL_MODE; then
+    echo ""
+    echo "Installing..."
+    if [[ "$OS" == "macos" ]] && [[ ${#brew_pkgs[@]} -gt 0 ]]; then
+      brew install "${brew_pkgs[@]}"
+    elif [[ "$OS" == "debian" ]] && [[ ${#apt_pkgs[@]} -gt 0 ]]; then
+      sudo apt install -y "${apt_pkgs[@]}"
+    fi
+  fi
+fi
+
+if [[ $missing_required -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/skills/unix-media-compressor/skills.json
+++ b/skills/unix-media-compressor/skills.json
@@ -1,0 +1,17 @@
+{
+  "name": "@tank/unix-media-compressor",
+  "version": "1.0.0",
+  "description": "Compress any file on macOS/Linux. Images (JPEG, PNG, WebP, AVIF, GIF), video (H.264/H.265/AV1), audio (MP3/AAC/Opus/FLAC), PDFs (Ghostscript), archives (zip, tar.gz, 7z, zstd, brotli). Auto-detects tools, guides installation, batch operations. Triggers: compress, shrink, optimize, reduce file size, image compression, video compression, compress PDF, archive, convert to WebP, ffmpeg compress, optimize images, batch compress, pngquant, oxipng, cwebp, avifenc, ghostscript, zstd, brotli.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  }
+}


### PR DESCRIPTION
## Summary

- New `@tank/unix-media-compressor` skill for compressing any file type on macOS/Linux
- Covers images (JPEG/PNG/WebP/AVIF/GIF), video (H.264/H.265/AV1), audio (MP3/AAC/Opus/FLAC), PDFs (Ghostscript), and archives (zip/tar.gz/7z/zstd/brotli)
- Includes `scripts/check-tools.sh` for auto-detecting installed tools and guiding installation of missing ones

## Files

- `SKILL.md` (161 lines) — decision trees, quality tiers, quick-start workflows, troubleshooting
- `skills.json` — `@tank/unix-media-compressor` v1.0.0, subprocess: true
- `scripts/check-tools.sh` — detects 15 tools, supports `--json` and `--install` flags
- 6 reference files (2,281 lines total):
  - `image-compression.md` (386 lines) — JPEG, PNG, WebP, AVIF, GIF
  - `video-compression.md` (448 lines) — H.264/H.265/AV1 CRF encoding, HW accel
  - `audio-compression.md` (353 lines) — MP3/AAC/Opus/FLAC codecs
  - `pdf-compression.md` (356 lines) — Ghostscript presets, qpdf
  - `archive-formats.md` (410 lines) — zip, tar.gz/xz/zst, 7z, brotli
  - `tool-setup.md` (328 lines) — installation, batch patterns, size reporting