### PR TITLE
feat: add git-worktrees skill for worktree lifecycle management

### DIFF
--- a/skills/git-worktrees/SKILL.md
+++ b/skills/git-worktrees/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: "@tank/git-worktrees"
+description: |
+  Git worktree lifecycle management — create, work, resolve, clean up. Covers
+  all git worktree subcommands (add, list, remove, prune, lock, unlock, move,
+  repair), common workflows (hotfix while on feature, PR review, parallel
+  development, AI agent isolation), directory layout conventions, bare repo
+  patterns, and proactive cleanup to prevent worktree sprawl. Synthesizes
+  official Git documentation (v2.53+), production worktree patterns, and
+  multi-agent development workflows.
+
+  Trigger phrases: "git worktree", "worktree", "worktrees", "git worktree add",
+  "git worktree remove", "git worktree list", "git worktree prune",
+  "parallel branches", "work on two branches", "hotfix while on feature",
+  "review PR without switching", "multiple working directories",
+  "branch already checked out", "clean up worktrees", "remove worktree",
+  "bare repo worktrees", "worktree cleanup", "too many worktrees",
+  "context switch without stash", "isolated working directory"
+---
+
+# Git Worktrees
+
+Manage the full worktree lifecycle: create → work → resolve → clean up.
+
+## Core Philosophy
+
+1. **Worktrees are temporary.** Create for a task, remove when done. Lingering
+   worktrees waste disk and create confusion.
+2. **One branch, one worktree.** Git enforces this — a branch can only be
+   checked out in one worktree at a time.
+3. **Always clean up.** After merging or closing a PR, ask the user to remove
+   the worktree and delete the branch. Never leave stale worktrees behind.
+4. **Fetch before creating.** Run `git fetch origin` before `git worktree add`
+   to ensure you have current remote state.
+5. **Dependencies are per-worktree.** Each worktree needs its own `npm install`,
+   `pip install`, etc. — build artifacts are not shared.
+
+## Lifecycle
+
+```
+1. CREATE  →  git worktree add (new directory, new or existing branch)
+     ↓
+2. WORK    →  normal git workflow inside the worktree
+     ↓
+3. RESOLVE →  push, open PR, merge
+     ↓
+4. CLEANUP →  git worktree remove + git branch -d + git worktree prune
+```
+
+After step 3, prompt the user:
+
+> The worktree task is complete. Want me to clean up?
+> - Remove worktree: `git worktree remove <path>`
+> - Delete branch: `git branch -d <branch>`
+> - Prune stale refs: `git worktree prune`
+
+See `references/cleanup-and-lifecycle.md` for the full cleanup protocol.
+
+## Quick-Start
+
+### "I need to fix a bug without losing my current work"
+
+```bash
+git fetch origin
+git worktree add -b hotfix/issue-123 ../myproject-hotfix main
+cd ../myproject-hotfix
+# ... fix, commit, push, open PR ...
+```
+
+After merge → clean up. See `references/workflows.md`.
+
+### "I want to review a PR without switching branches"
+
+```bash
+git fetch origin
+git worktree add ../myproject-review origin/feature/their-branch
+cd ../myproject-review
+# ... review, run tests ...
+```
+
+After review → clean up. See `references/workflows.md`.
+
+### "Branch already checked out" error
+
+A branch can only live in one worktree. Either remove the existing worktree
+or create a new branch:
+
+```bash
+git worktree remove /path/to/existing-worktree
+# or
+git worktree add -b new-branch-name ../path main
+```
+
+See `references/pitfalls-and-troubleshooting.md`.
+
+### "I have too many old worktrees"
+
+```bash
+git worktree list              # audit what exists
+git worktree remove ../stale   # remove each stale one
+git worktree prune             # clean up broken references
+```
+
+See `references/cleanup-and-lifecycle.md`.
+
+## Decision Trees
+
+### When to use a worktree vs alternatives
+
+| Scenario | Use | Why |
+|----------|-----|-----|
+| Quick hotfix while on a feature | Worktree | No stash/context loss |
+| Review a PR | Worktree | Isolated test environment |
+| Parallel development on 2+ features | Worktree | True parallel work |
+| Quick one-file fix on same branch | `git stash` | Faster for trivial changes |
+| Full project isolation (CI, different configs) | `git clone` | Separate git history |
+| Experiment you might throw away | Worktree (detached) | Easy cleanup |
+
+### Directory layout
+
+| Team size | Pattern | Setup |
+|-----------|---------|-------|
+| Solo / small | Sibling directories | `../myproject-hotfix` next to `../myproject` |
+| Power users / teams | Bare repo + subdirectories | All worktrees under one parent |
+
+See `references/advanced-patterns.md` for bare repo setup.
+
+### Cleanup timing
+
+| Event | Action |
+|-------|--------|
+| PR merged | Remove worktree + delete branch + prune |
+| PR closed without merge | Remove worktree + delete branch + prune |
+| Review complete | Remove worktree (branch belongs to author) |
+| Experiment abandoned | Remove worktree + force-delete branch |
+| End of sprint | Audit `git worktree list`, remove all stale |
+
+## Command Quick Reference
+
+```bash
+# Create
+git worktree add ../path branch              # existing branch
+git worktree add -b new-branch ../path main  # new branch from base
+git worktree add --detach ../path v1.0.0     # detached HEAD at tag/commit
+
+# Inspect
+git worktree list                            # list all worktrees
+git worktree list -v                         # verbose (shows locks)
+
+# Remove
+git worktree remove ../path                  # safe remove
+git worktree remove -f ../path               # force (discards changes)
+
+# Maintain
+git worktree prune                           # clean stale metadata
+git worktree lock ../path                    # prevent accidental prune
+git worktree unlock ../path                  # allow prune again
+git worktree move ../old ../new              # relocate worktree
+git worktree repair                          # fix broken links
+```
+
+Full command reference in `references/worktree-commands.md`.
+
+## Cleanup Behavior
+
+After completing any worktree-based task, follow this protocol:
+
+1. Confirm the work is merged or no longer needed.
+2. Offer to run cleanup commands for the user.
+3. List remaining worktrees so the user can audit.
+
+This prevents worktree sprawl — the #1 problem with worktree adoption.
+
+See `references/cleanup-and-lifecycle.md` for automation and aliases.
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/worktree-commands.md` | Complete command reference for all subcommands with options, examples, and edge cases |
+| `references/workflows.md` | Step-by-step workflows: hotfix, PR review, parallel development, bisect, AI agent isolation |
+| `references/cleanup-and-lifecycle.md` | Cleanup protocol, proactive reminders, pruning, aliases, automation, sprint-end audit |
+| `references/pitfalls-and-troubleshooting.md` | Common errors, branch conflicts, submodule issues, stash confusion, IDE integration |
+| `references/advanced-patterns.md` | Bare repo setup, CI/CD patterns, directory conventions, naming, editor integration |

--- a/skills/git-worktrees/references/advanced-patterns.md
+++ b/skills/git-worktrees/references/advanced-patterns.md
@@ -1,0 +1,386 @@
+# Advanced Patterns
+
+Sources: Official Git documentation, ChristopherA's workspace patterns,
+production CI/CD worktree deployments, community bare repo conventions
+
+Covers: Bare repo setup, CI/CD patterns, directory layout conventions,
+naming strategies, comparison with alternatives, and editor configuration.
+
+## Bare Repo + Worktrees Pattern
+
+The cleanest approach for developers who use worktrees as their primary
+workflow. Instead of a regular clone with a main worktree, use a bare repo
+as the central store and create named worktrees for each branch.
+
+### Why Bare Repos?
+
+| Aspect | Regular clone | Bare + worktrees |
+|--------|--------------|-----------------|
+| Accidental checkout in root | Disrupts work | Impossible (no working files) |
+| Directory organization | Siblings scatter | All under one parent |
+| `git status` in root | Shows main branch files | Nothing (bare has no working tree) |
+| `git fetch` scope | Updates local refs | Updates all worktrees' refs |
+
+### Setup from Scratch
+
+```bash
+# 1. Create container directory
+mkdir myproject && cd myproject
+
+# 2. Clone as bare repo into hidden directory
+git clone --bare https://github.com/user/repo.git .bare
+
+# 3. Create a .git file that points to the bare repo
+echo "gitdir: ./.bare" > .git
+
+# 4. Configure remote fetch (critical for bare repos)
+git config remote.origin.fetch "+refs/heads/*:refs/heads/*"
+git fetch origin
+
+# 5. Create worktrees for each branch you need
+git worktree add main main
+git worktree add develop develop
+```
+
+Result:
+
+```
+myproject/
+├── .bare/              ← bare git repo (object store, refs)
+├── .git                ← file: "gitdir: ./.bare"
+├── main/               ← main branch worktree
+├── develop/            ← develop branch worktree
+└── feature-auth/       ← feature branch worktree (created later)
+```
+
+### Setup from Existing Clone
+
+```bash
+# 1. From existing clone, create bare copy
+cd ~/projects
+git clone --bare myproject myproject-new/.bare
+cd myproject-new
+
+# 2. Set up .git file
+echo "gitdir: ./.bare" > .git
+
+# 3. Configure fetch and create worktrees
+git config remote.origin.fetch "+refs/heads/*:refs/heads/*"
+git fetch origin
+git worktree add main main
+```
+
+### Working with Bare Repos
+
+```bash
+cd myproject
+
+# Create a new feature worktree
+git worktree add feature-login -b feature/login main
+
+# List all worktrees
+git worktree list
+
+# Remove a completed feature
+git worktree remove feature-login
+git branch -d feature/login
+```
+
+### Shell Function for Bare Repo Clone
+
+```bash
+wt-clone() {
+  local url="$1"
+  local name="${2:-$(basename "$url" .git)}"
+  mkdir "$name" && cd "$name"
+  git clone --bare "$url" .bare
+  echo "gitdir: ./.bare" > .git
+  git config remote.origin.fetch "+refs/heads/*:refs/heads/*"
+  git fetch origin
+  git worktree add main main
+  cd main
+  echo "Bare repo + main worktree ready in $name/"
+}
+```
+
+## Directory Layout Conventions
+
+### Pattern 1: Sibling Directories
+
+Simple, works for occasional worktree use:
+
+```
+~/projects/
+├── myproject/               ← main worktree
+├── myproject-hotfix/        ← hotfix worktree
+├── myproject-review-pr-42/  ← PR review
+└── myproject-experiment/    ← experiment
+```
+
+**Naming convention**: `{repo}-{purpose-or-branch}` with slashes converted
+to hyphens.
+
+### Pattern 2: Bare Repo Parent
+
+Recommended for regular worktree use:
+
+```
+~/projects/myproject/
+├── .bare/
+├── .git
+├── main/
+├── develop/
+├── feature-auth/
+└── hotfix-payment/
+```
+
+**Naming convention**: Short directory names matching the branch's last
+segment. The parent directory provides the repo context.
+
+### Pattern 3: Workspace Organization
+
+For developers managing many repositories:
+
+```
+~/workspace/
+├── github.com/
+│   ├── myorg/
+│   │   ├── frontend/
+│   │   │   ├── .bare/
+│   │   │   ├── main/
+│   │   │   └── feature-nav/
+│   │   └── backend/
+│   │       ├── .bare/
+│   │       ├── main/
+│   │       └── hotfix-api/
+│   └── personal/
+│       └── dotfiles/
+│           ├── .bare/
+│           └── main/
+```
+
+### Naming Best Practices
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Worktree directory | Kebab-case, no slashes | `feature-user-auth` |
+| Branch name | Standard git convention | `feature/user-auth` |
+| Sibling pattern | `{repo}-{branch-slug}` | `myapp-hotfix-login` |
+| Bare repo pattern | Branch last segment | `hotfix-login` |
+| Ticket reference | Include ticket ID | `myapp-JIRA-456` |
+| AI agent worktree | `agent-{task}` | `agent-auth-refactor` |
+
+## CI/CD Patterns
+
+### Parallel Test Runs
+
+Run tests on multiple branches simultaneously:
+
+```bash
+# In CI script
+git fetch origin
+git worktree add /tmp/test-main main
+git worktree add /tmp/test-feature "$BRANCH_NAME"
+
+# Run tests in parallel
+(cd /tmp/test-main && npm ci && npm test) &
+(cd /tmp/test-feature && npm ci && npm test) &
+wait
+
+# Cleanup
+git worktree remove /tmp/test-main
+git worktree remove /tmp/test-feature
+git worktree prune
+```
+
+### GitHub Actions Integration
+
+```yaml
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history needed for worktrees
+
+      - name: Create comparison worktree
+        run: |
+          git worktree add /tmp/baseline main
+
+      - name: Run tests on both branches
+        run: |
+          npm ci && npm test &
+          (cd /tmp/baseline && npm ci && npm test) &
+          wait
+
+      - name: Cleanup
+        if: always()
+        run: |
+          git worktree remove /tmp/baseline || true
+          git worktree prune
+```
+
+### Server Deployment Pattern
+
+Keep multiple environments as persistent worktrees:
+
+```bash
+# Initial setup on server
+cd /srv/repos
+git clone --bare https://github.com/org/app.git app.git
+cd app.git
+
+# Create environment worktrees
+git worktree add /var/www/production main
+git worktree add /var/www/staging staging
+git worktree add /var/www/preview preview
+
+# Lock production
+git worktree lock --reason "Production deployment" /var/www/production
+
+# Deploy script
+deploy() {
+  local env="$1"
+  cd "/var/www/$env"
+  git pull origin "$env"
+  npm ci --production
+  npm run build
+  pm2 restart "$env"
+}
+```
+
+## Worktrees vs Alternatives
+
+### vs git stash
+
+| Factor | `git stash` | `git worktree` |
+|--------|------------|----------------|
+| Speed | Instant | Seconds (+ dependency install) |
+| Parallel work | No — sequential | Yes — true parallel |
+| Risk | Medium — stash can be dropped | Low — full working copy |
+| Context loss | High — mental context switch | None — separate directory |
+| Disk usage | Minimal | Working copy per worktree |
+| Best for | Quick 1-file fixes | Multi-file, multi-hour work |
+
+### vs git clone
+
+| Factor | `git clone` | `git worktree` |
+|--------|------------|----------------|
+| Disk usage | Full repo copy | Shared object store |
+| Sync | Manual `git pull` each | `git fetch` syncs all |
+| History | Independent copy | Shared history |
+| Setup time | Slow (full download) | Fast (local refs) |
+| Best for | Full isolation (CI, configs) | Same-repo parallel work |
+
+### vs git branch + checkout
+
+| Factor | `checkout` | `worktree` |
+|--------|-----------|------------|
+| Working directory | Shared (one at a time) | Separate (parallel) |
+| Build cache | Lost on switch | Preserved per worktree |
+| Editor state | Disrupted | Preserved per window |
+| Mental context | Lost on switch | Preserved per terminal |
+| Best for | Linear, sequential work | Parallel, interleaved work |
+
+## Git Configuration for Worktrees
+
+### Worktree-Specific Config
+
+Git 2.20+ supports per-worktree configuration:
+
+```bash
+# Set config only for the current worktree
+git config --worktree core.sparseCheckout true
+git config --worktree receive.denyCurrentBranch ignore
+```
+
+Per-worktree config is stored in `.git/worktrees/<name>/config.worktree`.
+
+### Recommended Global Config
+
+```ini
+# ~/.gitconfig
+[alias]
+  wt = worktree
+  wtl = worktree list
+  wta = worktree add
+  wtr = worktree remove
+  wtp = worktree prune
+  wt-clean = "!git worktree prune && git worktree list"
+
+[worktree]
+  # Enable per-worktree config (Git 2.20+)
+  guessRemote = true
+```
+
+The `worktree.guessRemote` option makes `git worktree add` automatically
+set up tracking for remote branches without explicit `origin/` prefix.
+
+## Sparse Checkout with Worktrees
+
+For large monorepos, combine sparse checkout with worktrees to reduce
+disk usage and checkout time:
+
+```bash
+# Create worktree without populating files
+git worktree add --no-checkout ../myproject-feature feature/auth
+
+# Configure sparse checkout in the new worktree
+cd ../myproject-feature
+git sparse-checkout init --cone
+git sparse-checkout set packages/auth packages/shared
+
+# Only the specified directories are checked out
+git checkout  # populates the sparse set
+```
+
+This is useful for monorepos where each worktree only needs a subset
+of the codebase.
+
+## Multi-Agent Development Pattern
+
+When multiple AI agents work on the same repository simultaneously, each
+agent needs isolation to prevent file conflicts. Worktrees provide this
+without the overhead of separate clones.
+
+### Architecture
+
+```
+myproject/
+├── .bare/                        ← shared object store
+├── .git
+├── main/                         ← human development
+├── agent-auth/                   ← Agent 1: auth feature
+├── agent-tests/                  ← Agent 2: test coverage
+└── agent-perf/                   ← Agent 3: performance optimization
+```
+
+### Merge Strategy
+
+Merge agents' work sequentially to catch conflicts early:
+
+```bash
+cd main
+git merge agent/auth-feature       # merge first agent's work
+# resolve any conflicts
+git worktree remove ../agent-auth
+git branch -d agent/auth-feature
+
+git merge agent/test-suite         # merge second
+git worktree remove ../agent-tests
+git branch -d agent/test-suite
+
+git merge agent/perf-optimization  # merge third
+git worktree remove ../agent-perf
+git branch -d agent/perf-optimization
+
+git worktree prune
+```
+
+### Coordination Rules
+
+- Each agent works on a distinct directory/module to minimize conflicts
+- Agents should fetch and rebase periodically to stay current
+- Merge in dependency order (shared code first, dependent code second)
+- Always clean up worktrees after merging each agent's work

--- a/skills/git-worktrees/references/cleanup-and-lifecycle.md
+++ b/skills/git-worktrees/references/cleanup-and-lifecycle.md
@@ -1,0 +1,313 @@
+# Cleanup and Lifecycle
+
+Sources: Official Git documentation, production worktree management patterns,
+community best practices for worktree hygiene
+
+Covers: The full worktree lifecycle, cleanup protocol, proactive reminder
+behavior, pruning strategies, automation aliases, and sprint-end audits.
+
+## The Worktree Lifecycle
+
+Every worktree follows this lifecycle. Deviating from it — especially
+skipping cleanup — leads to worktree sprawl.
+
+```
+CREATE  →  SETUP  →  WORK  →  RESOLVE  →  CLEANUP
+  │          │         │         │           │
+  │          │         │         │           ├─ remove worktree
+  │          │         │         │           ├─ delete branch
+  │          │         │         │           └─ prune metadata
+  │          │         │         │
+  │          │         │         ├─ push branch
+  │          │         │         ├─ open PR
+  │          │         │         └─ merge (or close)
+  │          │         │
+  │          │         └─ normal git add/commit cycle
+  │          │
+  │          ├─ install dependencies
+  │          ├─ init submodules (if needed)
+  │          └─ open in editor
+  │
+  ├─ git fetch origin
+  └─ git worktree add ...
+```
+
+## Cleanup Protocol
+
+This is the standard cleanup sequence. Run after every resolved worktree task.
+
+### Step 1: Confirm Resolution
+
+Before cleaning up, verify the work is done:
+
+```bash
+# Check if branch was merged
+git log --oneline main..feature/branch-name
+# Empty output = fully merged
+
+# Check if PR is merged (GitHub)
+gh pr status
+# or
+gh pr view <number> --json state -q '.state'
+```
+
+### Step 2: Remove the Worktree
+
+```bash
+# Safe removal (fails if uncommitted changes exist)
+git worktree remove ../myproject-feature
+
+# If uncommitted changes exist and you're sure you want to discard
+git worktree remove --force ../myproject-feature
+```
+
+### Step 3: Delete the Branch
+
+Only delete branches you own and that have been merged:
+
+```bash
+# Safe delete (fails if not merged)
+git branch -d feature/branch-name
+
+# Force delete (for unmerged experiments)
+git branch -D experiment/approach-a
+```
+
+Do NOT delete branches you don't own (e.g., a teammate's PR branch).
+
+### Step 4: Prune Stale Metadata
+
+```bash
+git worktree prune
+```
+
+This is a safety net — it cleans up metadata for worktrees whose directories
+were removed outside of git (e.g., `rm -rf`). Always run after removal.
+
+### Step 5: Verify Clean State
+
+```bash
+git worktree list
+```
+
+Should show only actively-used worktrees. If stale entries remain, repeat
+steps 2-4.
+
+## Proactive Cleanup Behavior
+
+The agent should prompt for cleanup after completing any worktree-based task.
+This is the key behavior that prevents worktree sprawl.
+
+### When to Prompt
+
+| Event | Prompt cleanup? |
+|-------|----------------|
+| Hotfix merged | Yes — remove worktree + delete branch |
+| PR review completed | Yes — remove worktree (keep branch) |
+| Experiment decided | Yes — remove loser worktree + delete branch |
+| Feature branch merged | Yes — remove worktree + delete branch |
+| Bisect completed | Yes — remove worktree |
+| Tests finished running | Yes — remove worktree |
+| User says "done" or "finished" | Yes — offer cleanup |
+
+### Prompt Template
+
+After the task is resolved:
+
+```
+The worktree work is complete. To keep your workspace clean:
+
+1. Remove worktree: git worktree remove <path>
+2. Delete branch: git branch -d <branch>
+3. Prune stale refs: git worktree prune
+
+Want me to run these cleanup commands?
+```
+
+Adapt the template based on context — omit "delete branch" if the branch
+belongs to someone else (e.g., PR review).
+
+### When NOT to Prompt
+
+- Deployment worktrees (persistent, locked)
+- Worktrees the user explicitly said to keep
+- Active work still in progress
+
+## Handling Stale Worktrees
+
+When a user has accumulated stale worktrees, help them audit and clean.
+
+### Audit Command
+
+```bash
+git worktree list -v
+```
+
+For each worktree shown, check:
+
+| Check | How | Action if stale |
+|-------|-----|-----------------|
+| Directory still exists? | `ls <path>` | `git worktree prune` |
+| Branch merged? | `git log --oneline main..<branch>` | Remove + delete branch |
+| PR closed? | `gh pr list --head <branch>` | Remove + delete branch |
+| Last commit date? | `git log -1 --format=%cr <branch>` | If >2 weeks, flag as stale |
+| Any uncommitted changes? | `git -C <path> status --short` | Warn user before removing |
+
+### Bulk Cleanup Script
+
+For users with many stale worktrees:
+
+```bash
+# List all worktrees except the main one
+git worktree list --porcelain | grep "^worktree " | tail -n +2 | sed 's/^worktree //'
+
+# For each, check if it should be removed:
+for wt in $(git worktree list --porcelain | grep "^worktree " | tail -n +2 | sed 's/^worktree //'); do
+  branch=$(git -C "$wt" branch --show-current 2>/dev/null)
+  echo "$wt → $branch"
+done
+```
+
+Present findings to the user before running any removal commands.
+
+## Automation: Git Aliases
+
+Recommend these aliases for users who work with worktrees regularly:
+
+```ini
+# ~/.gitconfig
+[alias]
+  # Short aliases
+  wt = worktree
+  wtl = worktree list
+  wta = worktree add
+  wtr = worktree remove
+  wtp = worktree prune
+
+  # Combined operations
+  wt-clean = "!git worktree prune && git worktree list"
+```
+
+## Automation: Shell Functions
+
+For power users, suggest these shell functions:
+
+```bash
+# Create worktree with repo-name prefix
+wt-new() {
+  local branch="$1"
+  local base="${2:-main}"
+  local repo
+  repo=$(basename "$(git rev-parse --show-toplevel)")
+  local dir="../${repo}-${branch//\//-}"
+  git fetch origin
+  git worktree add -b "$branch" "$dir" "$base"
+  echo "Created worktree at $dir on branch $branch"
+  echo "Run: cd $dir"
+}
+
+# Remove worktree and optionally delete branch
+wt-done() {
+  local path="${1:-.}"
+  local abs_path
+  abs_path=$(cd "$path" 2>/dev/null && pwd)
+  local branch
+  branch=$(git -C "$path" branch --show-current 2>/dev/null)
+
+  # Go to main repo first
+  local main_wt
+  main_wt=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')
+  cd "$main_wt" || return 1
+
+  git worktree remove "$abs_path"
+  if [ -n "$branch" ]; then
+    echo "Delete branch '$branch'? (y/n)"
+    read -r answer
+    if [ "$answer" = "y" ]; then
+      git branch -d "$branch" 2>/dev/null || git branch -D "$branch"
+    fi
+  fi
+  git worktree prune
+  git worktree list
+}
+
+# Show status of all worktrees
+wt-status() {
+  echo "=== Worktrees ==="
+  git worktree list
+  echo ""
+  for dir in $(git worktree list --porcelain | grep "^worktree " | tail -n +2 | sed 's/^worktree //'); do
+    echo "--- $dir ---"
+    git -C "$dir" status --short 2>/dev/null || echo "  (directory missing)"
+    echo ""
+  done
+}
+```
+
+## Sprint-End Audit
+
+At the end of a sprint or work cycle, run a full audit:
+
+```bash
+# 1. List all worktrees
+git worktree list -v
+
+# 2. For each non-main worktree, check:
+#    - Is the branch merged?
+#    - Is the PR closed?
+#    - When was the last commit?
+
+# 3. Remove all stale worktrees
+git worktree remove ../path-1
+git worktree remove ../path-2
+# ...
+
+# 4. Delete merged branches
+git branch -d branch-1
+git branch -d branch-2
+
+# 5. Final prune
+git worktree prune
+
+# 6. Verify clean state
+git worktree list
+# Should only show the main worktree (and any active work)
+```
+
+## Disk Space Considerations
+
+Each worktree consumes disk for:
+
+| Item | Shared? | Size impact |
+|------|---------|-------------|
+| Git objects (commits, blobs) | Yes | Zero additional |
+| Working files (source code) | No | ~= repo size |
+| `node_modules` | No | Can be 200MB+ per worktree |
+| Build artifacts (`dist/`, `.next/`) | No | Varies |
+| Submodule checkouts | No | Can be large |
+
+### Reducing Disk Impact
+
+```bash
+# Use pnpm instead of npm (global package store)
+pnpm install  # shares packages across worktrees
+
+# Use sparse checkout for large repos
+git -C ../new-worktree sparse-checkout set src/ tests/
+
+# Skip checkout for metadata-only operations
+git worktree add --no-checkout ../temp-worktree branch
+```
+
+## Lifecycle Decision Tree
+
+| Situation | Correct action |
+|-----------|---------------|
+| Work is merged, PR closed | Remove worktree + delete branch + prune |
+| Work is merged, branch shared | Remove worktree + prune (keep branch) |
+| PR rejected, work abandoned | Remove worktree + force-delete branch + prune |
+| Work paused, will resume later | Keep worktree (optionally lock it) |
+| Worktree directory manually deleted | Run `git worktree prune` |
+| Deployment worktree | Lock it, never remove |
+| Can't remove — uncommitted changes | Commit, stash, or force-remove |
+| Can't remove — worktree is locked | Unlock first, then remove |

--- a/skills/git-worktrees/references/pitfalls-and-troubleshooting.md
+++ b/skills/git-worktrees/references/pitfalls-and-troubleshooting.md
@@ -1,0 +1,360 @@
+# Pitfalls and Troubleshooting
+
+Sources: Official Git documentation, Stack Overflow common issues,
+community worktree adoption reports
+
+Covers: Common errors, branch conflicts, submodule issues, stash confusion,
+dependency management, IDE integration, and recovery procedures.
+
+## Error: Branch Already Checked Out
+
+The most common worktree error. Git enforces one-branch-per-worktree.
+
+```
+fatal: 'feature/auth' is already checked out at '/path/to/existing-worktree'
+```
+
+### Solutions
+
+| Approach | When to use | Command |
+|----------|-------------|---------|
+| Remove existing worktree | Work on that branch is done | `git worktree remove /path/to/existing-worktree` |
+| Use a different branch | Need a fresh start | `git worktree add -b feature/auth-v2 ../path main` |
+| Check out in place | Want to switch to that worktree | `cd /path/to/existing-worktree` |
+| Force (dangerous) | Understand the risks | `git worktree add -f ../path feature/auth` |
+
+Forcing is dangerous — two worktrees on the same branch means changes in one
+are invisible to the other until committed, leading to confusing merge conflicts.
+
+## Error: Cannot Delete Branch Checked Out in Worktree
+
+```
+error: Cannot delete branch 'feature/auth' checked out at '/path/to/worktree'
+```
+
+### Solution
+
+Remove the worktree first, then delete the branch:
+
+```bash
+git worktree remove /path/to/worktree
+git branch -d feature/auth
+```
+
+## Error: Path Already Exists
+
+```
+fatal: '/path/to/dir' already exists
+```
+
+### Solutions
+
+```bash
+# If the directory is from a previously removed worktree
+rm -rf /path/to/dir
+git worktree prune
+git worktree add /path/to/dir branch
+
+# If you want to reuse the path
+git worktree add -f /path/to/dir branch
+```
+
+## Pitfall: Manually Deleting Worktree Directories
+
+Deleting a worktree directory with `rm -rf` leaves stale metadata in
+`.git/worktrees/`. Git still thinks the worktree exists.
+
+```bash
+# WRONG
+rm -rf ../myproject-hotfix
+git worktree list  # still shows the deleted path
+
+# FIX
+git worktree prune
+
+# RIGHT (always use git's command)
+git worktree remove ../myproject-hotfix
+```
+
+## Pitfall: Submodule Initialization
+
+New worktrees do NOT automatically initialize submodules. Submodule
+directories will be empty.
+
+```bash
+# After creating a worktree
+git worktree add ../myproject-feature feature/new-ui
+cd ../myproject-feature
+
+# Submodule directories are EMPTY at this point
+git submodule update --init --recursive  # REQUIRED
+
+# For repos with many submodules, init only what you need
+git submodule update --init frontend backend
+```
+
+Each worktree maintains its own submodule state. Updating a submodule in
+one worktree does not affect others.
+
+## Pitfall: Stash Confusion
+
+Stashes are shared across all worktrees because they live in the common
+`.git` directory. A stash created in worktree A is visible in worktree B.
+
+```bash
+# In worktree A
+cd ../myproject-feature-a
+git stash push -m "WIP on feature A"
+
+# In worktree B — this stash is visible
+cd ../myproject-feature-b
+git stash list
+# stash@{0}: On feature-a: WIP on feature A
+```
+
+### Prevention
+
+Always use descriptive stash messages that include the worktree context:
+
+```bash
+git stash push -m "worktree:feature-a — WIP auth validation"
+```
+
+### Recovery
+
+If you apply the wrong stash, undo with:
+
+```bash
+git stash show -p stash@{0}  # preview before applying
+git checkout -- .             # discard all working tree changes
+```
+
+## Pitfall: Dependency and Build Artifact Isolation
+
+Each worktree has its own working files. Dependencies and build artifacts
+are NOT shared.
+
+| Language/Tool | Action needed per worktree |
+|--------------|--------------------------|
+| Node.js (npm/yarn) | `npm install` or `yarn install` |
+| Node.js (pnpm) | `pnpm install` (shares global store — less disk) |
+| Python (pip) | `pip install -r requirements.txt` |
+| Python (poetry) | `poetry install` |
+| Go | `go mod download` |
+| Rust | `cargo build` (redownloads dependencies) |
+| Java (Maven) | `mvn install` |
+| Ruby (Bundler) | `bundle install` |
+
+### Disk Space Impact
+
+With npm, each worktree gets its own `node_modules`. For a project with
+200MB of dependencies and 5 worktrees, that's 1GB just for `node_modules`.
+
+**Mitigation**:
+
+```bash
+# Use pnpm — shares packages via global content-addressable store
+pnpm install  # each worktree's node_modules uses symlinks, ~10MB per worktree
+
+# Use Yarn PnP — no node_modules at all
+yarn install  # uses .pnp.cjs for resolution
+```
+
+## Pitfall: Locked Worktrees Blocking Operations
+
+Locked worktrees cannot be removed or pruned. If you forget about a lock,
+cleanup commands silently skip the locked worktree.
+
+```bash
+# Check for locks
+git worktree list -v
+# /path/to/worktree  abc1234 [feature/old]  locked reason: Sprint work
+
+# Unlock before removing
+git worktree unlock ../myproject-feature
+git worktree remove ../myproject-feature
+```
+
+## Pitfall: Hooks Running in All Worktrees
+
+Hooks live in `.git/hooks/` which is shared. A pre-commit hook runs in
+every worktree. This is usually desired, but can cause issues:
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| Hook fails in new worktree | Hook references absolute paths | Use `$(git rev-parse --show-toplevel)` |
+| Hook references wrong `.git` | Uses `$GIT_DIR` directly | Use `$(git rev-parse --git-common-dir)` for shared resources |
+| Hook installs dependencies | Runs `npm install` in pre-commit | Add `node_modules` check before install |
+| Husky hooks missing | Husky needs `.husky/` in worktree root | Run `npx husky install` in new worktree |
+
+### Portable Hook Pattern
+
+```bash
+#!/bin/sh
+# Use relative paths in hooks
+REPO_ROOT=$(git rev-parse --show-toplevel)
+COMMON_DIR=$(git rev-parse --git-common-dir)
+
+# For worktree-specific paths (e.g., check staged files)
+cd "$REPO_ROOT"
+
+# For shared resources (e.g., config files in .git/)
+cat "$COMMON_DIR/config"
+```
+
+## Pitfall: Moving Repos Without Repair
+
+If the main repository or a worktree directory is moved with `mv` instead
+of `git worktree move`, the internal links break.
+
+```bash
+# Moved main repo
+mv ~/projects/myproject ~/code/myproject
+
+# Worktrees now have broken links
+cd ~/code/myproject
+git worktree list  # shows old paths
+
+# Fix
+git worktree repair
+```
+
+```bash
+# Moved a worktree directory
+mv ~/projects/myproject-feature ~/elsewhere/myproject-feature
+
+# Fix from main repo
+cd ~/code/myproject
+git worktree repair ~/elsewhere/myproject-feature
+```
+
+## Pitfall: Bare Repo Remote Tracking
+
+Bare repos created with `git clone --bare` don't set up remote tracking
+correctly by default.
+
+```bash
+# After cloning bare
+git clone --bare https://github.com/user/repo.git .bare
+
+# New worktrees won't track remote branches
+git worktree add ../feature feature-branch
+cd ../feature
+git pull  # error: no tracking information
+
+# Fix: configure fetch refspec
+git config remote.origin.fetch "+refs/heads/*:refs/heads/*"
+git fetch origin
+
+# Set upstream for existing worktree branch
+git branch -u origin/feature-branch
+```
+
+Always configure the fetch refspec immediately after creating a bare clone.
+
+## IDE and Editor Integration
+
+### VS Code
+
+VS Code works well with worktrees — open each as a separate window:
+
+```bash
+code ../myproject-feature
+```
+
+**Known issues**:
+- Extensions may conflict if both windows use the same global state
+- File watchers can strain CPU with many worktrees open
+- Git extension shows only the current worktree's branch
+
+**Recommendation**: One VS Code window per worktree. Close windows for
+removed worktrees.
+
+### JetBrains IDEs
+
+Native worktree support via **Git > Manage Worktrees** menu.
+
+**Known issues**:
+- IDE indexes each worktree separately (CPU/RAM cost)
+- Project settings are per-directory, not per-worktree
+- Opening multiple worktrees of the same project requires multiple IDE
+  instances
+
+### Neovim
+
+The `git-worktree.nvim` plugin by ThePrimeagen adds telescope integration:
+
+```lua
+-- Quick switch between worktrees
+require("telescope").extensions.git_worktree.git_worktrees()
+
+-- Create new worktree from telescope
+require("telescope").extensions.git_worktree.create_git_worktree()
+```
+
+### Terminal Multiplexers (tmux, zellij)
+
+Pair each worktree with its own tmux session or pane:
+
+```bash
+# Create worktree + tmux session
+wt-tmux() {
+  local branch="$1"
+  local base="${2:-main}"
+  local repo=$(basename "$(git rev-parse --show-toplevel)")
+  local dir="../${repo}-${branch//\//-}"
+  local session="${repo}-${branch//\//-}"
+
+  git worktree add -b "$branch" "$dir" "$base"
+  tmux new-session -d -s "$session" -c "$dir"
+  tmux switch-client -t "$session"
+}
+```
+
+## Recovery Procedures
+
+### Recovering Work from a Force-Removed Worktree
+
+If you force-removed a worktree with uncommitted changes:
+
+```bash
+# The branch still exists with its last commit
+git log --oneline feature/branch-name
+
+# Uncommitted changes are GONE (force-remove discarded them)
+# If you had staged changes, they might be in git's reflog
+git fsck --lost-found
+# Check .git/lost-found/other/ for recovered blobs
+```
+
+### Recovering from Corrupted Worktree State
+
+If `git worktree list` shows incorrect information:
+
+```bash
+# Nuclear option: prune everything and re-verify
+git worktree prune
+git worktree list
+
+# If still broken, manually clean .git/worktrees/
+ls .git/worktrees/
+# Remove directories for worktrees that no longer exist
+rm -rf .git/worktrees/stale-worktree-name
+```
+
+### Fixing "Not a git repository" in Worktree
+
+If a worktree's `.git` file is corrupted:
+
+```bash
+# Check the .git file contents
+cat ../myproject-feature/.git
+# Should contain: gitdir: /path/to/main/.git/worktrees/feature-name
+
+# If missing or wrong, recreate it
+echo "gitdir: /path/to/main/.git/worktrees/feature-name" > ../myproject-feature/.git
+
+# Then repair from main repo
+cd /path/to/main
+git worktree repair
+```

--- a/skills/git-worktrees/references/workflows.md
+++ b/skills/git-worktrees/references/workflows.md
@@ -1,0 +1,270 @@
+# Workflows
+
+Sources: Official Git documentation, production worktree patterns, multi-agent
+development workflows (2025-2026)
+
+Covers: Step-by-step workflows for hotfix, PR review, parallel development,
+bisect, long-running tests, and AI agent isolation.
+
+## Workflow 1: Hotfix While Working on a Feature
+
+The most common worktree use case. You're deep in feature work, a production
+bug is reported, and you need to fix it without losing context.
+
+```bash
+# 1. From your main repo (you're on feature/new-dashboard)
+git fetch origin
+
+# 2. Create hotfix worktree from main
+git worktree add -b hotfix/payment-timeout ../myproject-hotfix main
+
+# 3. Switch terminal to the hotfix
+cd ../myproject-hotfix
+
+# 4. Install dependencies (not shared between worktrees)
+npm install  # or pip install, go mod download, etc.
+
+# 5. Fix the bug
+# ... edit files ...
+git add -A
+git commit -m "fix: resolve payment processing timeout"
+
+# 6. Push and open PR
+git push -u origin hotfix/payment-timeout
+# Open PR, get review, merge
+
+# 7. CLEANUP (after merge)
+cd ../myproject  # back to main repo
+git worktree remove ../myproject-hotfix
+git branch -d hotfix/payment-timeout
+git worktree prune
+```
+
+Your feature branch is exactly as you left it. No stashing, no lost context.
+
+## Workflow 2: PR Review Without Context Switching
+
+Review a teammate's PR in an isolated environment without disrupting your work.
+
+```bash
+# 1. Fetch latest remote state
+git fetch origin
+
+# 2. Create review worktree from the PR branch
+git worktree add ../myproject-review origin/feature/user-auth
+
+# 3. Open in editor and review
+cd ../myproject-review
+code .  # or your preferred editor
+
+# 4. Install dependencies and run tests
+npm install
+npm test
+
+# 5. Leave review comments on the PR
+
+# 6. CLEANUP (after review is complete)
+cd ../myproject
+git worktree remove ../myproject-review
+git worktree prune
+```
+
+The branch belongs to the PR author, so don't delete it — only remove the
+worktree.
+
+## Workflow 3: Parallel Feature Development
+
+Work on two features simultaneously, running tests on one while coding on
+the other.
+
+```bash
+# 1. Create worktrees for both features
+git worktree add -b feature/auth ../myproject-auth main
+git worktree add -b feature/payments ../myproject-payments main
+
+# 2. Work on auth in one terminal
+cd ../myproject-auth
+npm install
+# ... develop ...
+
+# 3. Work on payments in another terminal
+cd ../myproject-payments
+npm install
+# ... develop ...
+
+# 4. CLEANUP (as each feature completes)
+cd ../myproject
+git worktree remove ../myproject-auth
+git branch -d feature/auth  # after merge
+git worktree remove ../myproject-payments
+git branch -d feature/payments  # after merge
+git worktree prune
+```
+
+## Workflow 4: A/B Experiment Comparison
+
+Try two different approaches to the same problem, benchmark, pick a winner.
+
+```bash
+# 1. Create both experiment worktrees
+git worktree add -b experiment/approach-a ../myproject-approach-a main
+git worktree add -b experiment/approach-b ../myproject-approach-b main
+
+# 2. Implement approach A
+cd ../myproject-approach-a
+# ... implement ...
+
+# 3. Implement approach B
+cd ../myproject-approach-b
+# ... implement ...
+
+# 4. Compare, benchmark, decide
+
+# 5. CLEANUP — remove loser, keep winner
+cd ../myproject
+git worktree remove ../myproject-approach-a
+git branch -D experiment/approach-a  # force delete, never merged
+
+# Continue with approach-b or merge it
+git merge experiment/approach-b
+git worktree remove ../myproject-approach-b
+git branch -d experiment/approach-b
+git worktree prune
+```
+
+## Workflow 5: Bisect in Isolation
+
+Run `git bisect` without disturbing your current working tree.
+
+```bash
+# 1. Create detached worktree for bisecting
+git worktree add --detach ../myproject-bisect HEAD
+
+# 2. Run bisect
+cd ../myproject-bisect
+git bisect start
+git bisect bad HEAD
+git bisect good v2.0.0
+# ... git bisect marks commits good/bad ...
+# ... until the culprit commit is found ...
+git bisect reset
+
+# 3. CLEANUP
+cd ../myproject
+git worktree remove ../myproject-bisect
+git worktree prune
+```
+
+## Workflow 6: Long-Running Tests on Another Branch
+
+Run a full test suite on main while continuing to develop.
+
+```bash
+# 1. Create test worktree
+git worktree add ../myproject-tests main
+
+# 2. Run tests in background terminal
+cd ../myproject-tests
+npm install
+npm test -- --watchAll  # long-running test suite
+
+# 3. Continue development in your main worktree
+cd ../myproject
+# ... code, commit, etc ...
+
+# 4. CLEANUP (when tests are done)
+cd ../myproject
+git worktree remove ../myproject-tests
+git worktree prune
+```
+
+## Workflow 7: AI Agent Isolation
+
+Give each AI coding agent its own isolated worktree to prevent file
+conflicts when agents work in parallel.
+
+```bash
+# 1. Create worktrees for each agent task
+git worktree add -b agent/auth-feature ../myproject-agent-auth main
+git worktree add -b agent/test-suite ../myproject-agent-tests main
+git worktree add -b agent/api-refactor ../myproject-agent-api main
+
+# 2. Point each agent at its worktree directory
+# Claude Code, Cursor, or other AI tools operate in each directory
+
+# 3. Merge results one at a time
+cd ../myproject
+git merge agent/auth-feature
+git worktree remove ../myproject-agent-auth
+git branch -d agent/auth-feature
+
+git merge agent/test-suite
+git worktree remove ../myproject-agent-tests
+git branch -d agent/test-suite
+
+git merge agent/api-refactor
+git worktree remove ../myproject-agent-api
+git branch -d agent/api-refactor
+
+# 4. Final cleanup
+git worktree prune
+```
+
+## Workflow 8: Staging + Production Deployment
+
+Keep multiple environments checked out simultaneously on a server.
+
+```bash
+# 1. Set up deployment worktrees
+git worktree add /var/www/staging staging
+git worktree add /var/www/production main
+
+# Lock production to prevent accidental removal
+git worktree lock --reason "Production deployment" /var/www/production
+
+# 2. Deploy to staging
+cd /var/www/staging
+git pull origin staging
+npm run build && pm2 restart staging
+
+# 3. Deploy to production
+cd /var/www/production
+git pull origin main
+npm run build && pm2 restart production
+```
+
+These worktrees are persistent — do NOT clean them up.
+
+## Workflow Comparison Table
+
+| Workflow | Worktree type | Branch type | Cleanup timing |
+|----------|--------------|-------------|----------------|
+| Hotfix | Linked, new branch | `hotfix/*` | After PR merge |
+| PR review | Linked, remote tracking | Remote branch | After review |
+| Parallel features | Linked, new branches | `feature/*` | After each merge |
+| A/B experiment | Linked, new branches | `experiment/*` | After decision |
+| Bisect | Detached HEAD | None | After bisect reset |
+| Long-running tests | Linked, existing branch | `main` or target | After tests done |
+| AI agents | Linked, new branches | `agent/*` | After each merge |
+| Deployment | Linked, existing branches | `main`, `staging` | Never (persistent) |
+
+## Post-Workflow Cleanup Checklist
+
+After any workflow completes:
+
+1. **Remove the worktree**: `git worktree remove ../path`
+2. **Delete the branch** (if you own it and it's merged): `git branch -d branch-name`
+3. **Prune stale metadata**: `git worktree prune`
+4. **Verify**: `git worktree list` — only active worktrees should remain
+
+If the branch wasn't merged and you want to force-delete:
+
+```bash
+git branch -D branch-name  # uppercase -D forces deletion
+```
+
+If the worktree has uncommitted changes and you want to force-remove:
+
+```bash
+git worktree remove --force ../path
+```

--- a/skills/git-worktrees/references/worktree-commands.md
+++ b/skills/git-worktrees/references/worktree-commands.md
@@ -1,0 +1,307 @@
+# Worktree Commands
+
+Sources: Official git-scm.com documentation (v2.53.0, 2026), git man pages
+
+Covers: All git worktree subcommands — add, list, remove, prune, lock,
+unlock, move, repair — with full option sets, examples, and edge cases.
+
+## How Worktrees Work Internally
+
+Each linked worktree contains a `.git` FILE (not directory) pointing back
+to the main repository:
+
+```
+main-repo/
+└── .git/
+    ├── objects/           ← shared across all worktrees
+    ├── refs/              ← shared
+    ├── config             ← shared
+    └── worktrees/         ← per-worktree metadata
+        └── feature-auth/
+            ├── HEAD       ← this worktree's checked-out commit
+            ├── index      ← this worktree's staging area
+            └── gitdir     ← path back to the worktree directory
+
+feature-auth-dir/
+├── src/
+└── .git                   ← FILE containing: "gitdir: ../main-repo/.git/worktrees/feature-auth"
+```
+
+Key internals:
+
+| Variable | Points to | Use in hooks/scripts |
+|----------|-----------|---------------------|
+| `$GIT_DIR` | Worktree-specific `.git` path | Per-worktree state |
+| `$GIT_COMMON_DIR` | Shared `.git` directory | Shared resources |
+
+```bash
+git rev-parse --git-dir          # worktree-specific path
+git rev-parse --git-common-dir   # shared .git directory
+git rev-parse --show-toplevel    # current worktree root
+```
+
+## git worktree add
+
+Creates a new linked working tree at `<path>` with `<branch>` checked out.
+
+### Synopsis
+
+```
+git worktree add [-f] [--detach] [--checkout] [--lock [--reason <string>]]
+                 [--orphan] [(-b | -B) <new-branch>] <path> [<commit-ish>]
+```
+
+### Common Usage
+
+```bash
+# Check out an existing branch
+git worktree add ../myproject-hotfix hotfix/login-fix
+
+# Create a NEW branch from a base and check it out
+git worktree add -b hotfix/payment-bug ../myproject-hotfix main
+
+# Create new branch from current HEAD
+git worktree add -b experiment/new-parser ../parser-experiment
+
+# Detached HEAD at a tag or commit (no branch)
+git worktree add --detach ../release-review v2.4.1
+git worktree add --detach ../bisect-test abc1234
+
+# Track a remote branch (auto-creates local tracking branch)
+git fetch origin
+git worktree add ../review-pr origin/feature/new-dashboard
+
+# Create and immediately lock (prevents accidental pruning)
+git worktree add --lock --reason "Sprint work" ../feature-dir feature-branch
+```
+
+### Options
+
+| Option | Effect |
+|--------|--------|
+| `-b <branch>` | Create new branch at `<commit-ish>` (default: HEAD) |
+| `-B <branch>` | Create or reset branch (like `checkout -B`) |
+| `--detach` | Detached HEAD — no branch, just a commit |
+| `--checkout` / `--no-checkout` | Whether to populate working files (default: checkout) |
+| `--lock [--reason <str>]` | Lock on creation to prevent pruning |
+| `--orphan` | Create orphan branch with no history (Git 2.36+) |
+| `-f` / `--force` | Override safety checks (branch already checked out, path exists) |
+| `--track` / `--no-track` | Whether new branch tracks remote upstream |
+| `-q` / `--quiet` | Suppress feedback |
+
+### Behavior Notes
+
+- If `<commit-ish>` is omitted, defaults to HEAD.
+- If `<branch>` matches a remote tracking branch (e.g., `origin/feature`),
+  git automatically creates a local branch that tracks it.
+- Creating a worktree does NOT `cd` into it — you must change directory manually.
+- If the project uses submodules, run `git submodule update --init --recursive`
+  inside the new worktree after creation.
+
+## git worktree list
+
+Shows all worktrees associated with the repository.
+
+### Synopsis
+
+```
+git worktree list [-v | --porcelain [-z]]
+```
+
+### Usage
+
+```bash
+# Human-readable
+git worktree list
+# /home/dev/myproject           a1b2c3d [main]
+# /home/dev/myproject-hotfix    e4f5g6h [hotfix/login-fix]
+# /home/dev/myproject-review    i7j8k9l (detached HEAD)
+
+# Verbose — shows lock status and prunable state
+git worktree list -v
+
+# Machine-readable (for scripting)
+git worktree list --porcelain
+
+# NUL-terminated (for paths with spaces)
+git worktree list --porcelain -z
+```
+
+### Porcelain Output Format
+
+```
+worktree /home/dev/myproject
+HEAD a1b2c3d4e5f6789012345678abcdef1234567890
+branch refs/heads/main
+
+worktree /home/dev/myproject-hotfix
+HEAD e4f5g6h7i8j9012345678901234567890abcdef
+branch refs/heads/hotfix/login-fix
+locked reason: Sprint work
+```
+
+## git worktree remove
+
+Removes a linked worktree directory and its metadata.
+
+### Synopsis
+
+```
+git worktree remove [-f] <worktree>
+```
+
+### Usage
+
+```bash
+# Safe removal (fails if uncommitted changes or untracked files exist)
+git worktree remove ../myproject-hotfix
+
+# Force removal (ignores uncommitted changes)
+git worktree remove --force ../myproject-hotfix
+```
+
+### Behavior Notes
+
+- Does NOT delete the branch. The branch remains in the repository.
+- Cannot remove the main worktree (the original checkout).
+- Cannot remove a locked worktree — unlock first.
+- Deletes the worktree directory from disk and cleans metadata from
+  `.git/worktrees/`.
+
+## git worktree prune
+
+Cleans up stale worktree metadata left behind when directories are manually
+deleted (e.g., `rm -rf`).
+
+### Synopsis
+
+```
+git worktree prune [-n] [-v] [--expire <expire>]
+```
+
+### Usage
+
+```bash
+# Prune all stale references
+git worktree prune
+
+# Dry run — show what would be pruned without doing it
+git worktree prune -n
+git worktree prune --dry-run
+
+# Verbose output
+git worktree prune -v
+
+# Prune worktrees older than a specific time
+git worktree prune --expire 2.weeks.ago
+```
+
+### When to Use
+
+- After manually deleting a worktree directory with `rm -rf`
+- As part of regular maintenance
+- The command is safe — it only removes metadata for worktrees whose
+  directories no longer exist. It never deletes branches or commits.
+
+## git worktree lock / unlock
+
+Prevents a worktree from being pruned. Useful for worktrees on removable
+media, network drives, or long-running work.
+
+### Synopsis
+
+```
+git worktree lock [--reason <string>] <worktree>
+git worktree unlock <worktree>
+```
+
+### Usage
+
+```bash
+# Lock with a reason
+git worktree lock --reason "Active sprint, do not prune" ../myproject-feature
+
+# Lock without reason
+git worktree lock ../myproject-feature
+
+# Check lock status
+git worktree list -v
+# Shows "locked" or "locked reason: ..." next to locked worktrees
+
+# Unlock
+git worktree unlock ../myproject-feature
+```
+
+### Behavior Notes
+
+- Locked worktrees are never removed by `git worktree prune`.
+- `git worktree remove` also refuses to remove locked worktrees.
+- Unlock before removing: `git worktree unlock ../path && git worktree remove ../path`
+
+## git worktree move
+
+Relocates a linked worktree to a new filesystem path.
+
+### Synopsis
+
+```
+git worktree move <worktree> <new-path>
+```
+
+### Usage
+
+```bash
+git worktree move ../old-location ../new-location
+```
+
+### Constraints
+
+- Cannot move the main worktree.
+- Cannot move a locked worktree (unlock first).
+- Prefer `move` over manual `mv` + `repair` — it updates all internal
+  references atomically.
+
+## git worktree repair
+
+Fixes broken links between the main repository and worktrees after manual
+filesystem moves.
+
+### Synopsis
+
+```
+git worktree repair [<path>...]
+```
+
+### Usage
+
+```bash
+# Repair all worktree links (run from main repo)
+git worktree repair
+
+# Repair specific paths
+git worktree repair /new/path/to/worktree1 /new/path/to/worktree2
+```
+
+### When to Use
+
+- After moving the main repository directory manually
+- After moving a worktree directory with `mv` instead of `git worktree move`
+- After symlink changes affecting `.git` paths
+
+## Shared vs Per-Worktree State
+
+Understanding what is shared prevents subtle bugs.
+
+| Resource | Shared? | Notes |
+|----------|---------|-------|
+| Object database (commits, blobs) | Yes | All history is shared |
+| Branch refs | Yes | Creating/deleting branches visible everywhere |
+| Tags | Yes | All worktrees see all tags |
+| Stash | Yes | Stash from worktree A visible in worktree B |
+| Hooks | Yes | Pre-commit runs in all worktrees |
+| `.git/config` | Yes | Config changes affect all worktrees |
+| HEAD | No | Each worktree has its own checked-out branch |
+| Index (staging area) | No | Each worktree stages independently |
+| Working files | No | Each worktree has its own file state |
+| Submodule checkouts | No | Must `git submodule update` per worktree |
+| `node_modules`, build cache | No | Must install dependencies per worktree |

--- a/skills/git-worktrees/skills.json
+++ b/skills/git-worktrees/skills.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/git-worktrees",
+  "version": "1.0.0",
+  "description": "Git worktree lifecycle management — create, work, resolve, clean up. Covers all git worktree subcommands (add, list, remove, prune, lock, unlock, move, repair), common workflows (hotfix, PR review, parallel development, AI agent isolation), directory conventions, bare repo patterns, and proactive cleanup to prevent worktree sprawl. Triggers: git worktree, worktree, worktrees, parallel branches, work on two branches, hotfix while on feature, review PR without switching, multiple working directories, branch already checked out, clean up worktrees, bare repo worktrees, context switch without stash.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

- Adds `@tank/git-worktrees` skill covering the full git worktree lifecycle: create → work → resolve → clean up
- Includes 5 reference files (1636 lines) covering commands, workflows, cleanup protocol, pitfalls, and advanced patterns
- Key behavior: agent proactively prompts for cleanup after worktree tasks complete, preventing worktree sprawl

## Files

| File | Lines | Purpose |
|------|-------|---------|
| `SKILL.md` | 184 | Entry point — lifecycle, quick-start, decision trees, cleanup behavior |
| `skills.json` | 18 | Read-only permissions |
| `references/worktree-commands.md` | 307 | All 8 subcommands with full options |
| `references/workflows.md` | 270 | 8 workflows — hotfix, PR review, parallel dev, AI agents |
| `references/cleanup-and-lifecycle.md` | 313 | Cleanup protocol, proactive reminders, aliases |
| `references/pitfalls-and-troubleshooting.md` | 360 | Common errors, submodules, stash, IDE integration |
| `references/advanced-patterns.md` | 386 | Bare repos, CI/CD, sparse checkout, multi-agent |