### PR TITLE
fix(brand-craft): trim description to ≤500 chars for Tank validation

### DIFF
--- a/skills/brand-craft/skills.json
+++ b/skills/brand-craft/skills.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/brand-craft",
   "version": "1.0.0",
-  "description": "Create complete brand identities — logo, colors, typography, guidelines — in minutes. Discovery interviews, archetype selection, color psychology, font pairing, AI logo generation (QuiverAI Arrow, Recraft V4), brand guideline output (JSON, CSS tokens, HTML). Triggers: brand identity, create a brand, brand design, logo design, color palette, brand colors, brand guidelines, brand style guide, font pairing, brand archetype, visual identity, brand kit, rebrand, color scheme, brand book, logo concept.",
+  "description": "Create complete brand identities — logo, colors, typography, guidelines — in minutes. Archetype selection, color psychology, font pairing, AI logo generation (QuiverAI Arrow, Recraft V4), brand guideline output (JSON, CSS tokens, HTML). Triggers: brand identity, create a brand, logo design, color palette, brand guidelines, brand style guide, font pairing, brand archetype, visual identity, brand kit, rebrand, color scheme, logo concept.",
   "permissions": {
     "network": {
       "outbound": []


### PR DESCRIPTION
Tank packer requires description ≤500 chars. Trimmed from 530 to 448 chars.