### PR TITLE
fix(frontend-craft): trim description to ≤500 chars for Tank validation

### DIFF
--- a/skills/frontend-craft/skills.json
+++ b/skills/frontend-craft/skills.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/frontend-craft",
   "version": "1.2.0",
-  "description": "Frontend craft for polished, distinctive apps. Micro-interactions, perceived performance, premium components, visual polish, state choreography, design foundations (typography, OKLCH color, spatial design), responsive design, interaction patterns, UX writing, AI slop detection, shadcn registry search (11K+ components, 50+ registries). Triggers: animation, skeleton, optimistic update, framer motion, command palette, data table, toast, sonner, cmdk, shadcn, aceternity, 21st.dev, react bits, UI polish, premium feel, parallax, text effect, hero section, typography, font pairing, OKLCH, color system, tinted neutrals, dark mode, responsive, mobile first, container query, focus visible, interaction design, UX writing, error message, button label, AI slop, design looks generic.",
+  "description": "Frontend craft for polished, distinctive apps. Micro-interactions, perceived performance, premium components, visual polish, design foundations (typography, OKLCH color, spatial design), responsive, interaction patterns, UX writing, AI slop detection, shadcn registry search (11K+ components). Triggers: animation, skeleton, framer motion, shadcn, aceternity, UI polish, premium feel, typography, OKLCH, dark mode, responsive, interaction design, UX writing, AI slop, design looks generic.",
   "permissions": {
     "network": {
       "outbound": [


### PR DESCRIPTION
Trim skills.json description from 780→489 chars to pass Tank's 500-char limit. Required for publishing v1.2.0.