### PR TITLE
fix: trim security-review description for Tank publishing

### DIFF
--- a/skills/security-review/skills.json
+++ b/skills/security-review/skills.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/security-review",
   "version": "1.0.0",
-  "description": "Comprehensive security review for any codebase, PR, or architecture. Covers OWASP Top 10 (2021) and API Security Top 10 (2023), CWE Top 25, code review methodology (differential and full audit), SAST tools (Semgrep, CodeQL, Bandit, ESLint security), dependency and supply chain scanning (npm audit, Trivy, Snyk, OSV-Scanner, SBOM), secret detection (Gitleaks, TruffleHog), IaC scanning (Checkov, tfsec), threat modeling (STRIDE, PASTA), language-specific vulnerability patterns (JS/TS, Python, Go, Rust, Java), and remediation patterns for every vulnerability class. Synthesizes OWASP Foundation standards, MITRE CWE, NIST NVD, Trail of Bits audit methodology, and OWASP Testing Guide (WSTG v5). Triggers: security review, security audit, OWASP, vulnerability, CVE, CWE, code audit, threat model, STRIDE, PASTA, Semgrep, CodeQL, SAST, DAST, dependency scan, npm audit, Trivy, Snyk, Gitleaks, TruffleHog, secret scanning, supply chain, XSS, SQL injection, SSRF, CSRF, IDOR, Checkov, tfsec, IaC security, security scanning, secure code review, attack surface, SBOM, ASVS, security checklist.",
+  "description": "Security review for any codebase, PR, or architecture. OWASP Top 10, API Security Top 10, CWE Top 25, SAST (Semgrep, CodeQL, Bandit), dependency scanning (Trivy, Snyk), secret detection (Gitleaks, TruffleHog), IaC scanning (Checkov, tfsec), threat modeling (STRIDE, PASTA), language vulnerability patterns, and remediation. Triggers: security review, OWASP, vulnerability, CVE, CWE, Semgrep, CodeQL, Trivy, Gitleaks, threat model, STRIDE, XSS, SQL injection, SSRF, Checkov, security scanning, SBOM.",
   "permissions": {
     "network": {
       "outbound": []


### PR DESCRIPTION
Trims skills.json description to 498 chars (from 1089) to meet Tank 500-char limit.