### PR TITLE
Add philosophical-reasoning and jewish-wisdom skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,187 @@
+# Tank Skills — Contributing Standard
+
+This repository contains reusable AI agent skills published under the
+`@tank` namespace. Every skill follows the conventions below.
+
+## Directory Structure
+
+```
+skills/{kebab-name}/
+├── SKILL.md              # Required — frontmatter + body (<200 lines)
+├── skills.json           # Required — metadata + permissions
+├── references/           # Optional — context-loaded deep docs (250-450 lines each)
+├── scripts/              # Optional — executable code
+└── assets/               # Optional — templates, images (not loaded into context)
+```
+
+## Naming
+
+- Directory: `skills/{kebab-name}/` — lowercase, digits, hyphens only
+- Package name: `@tank/{kebab-name}` — used in both `SKILL.md` and `skills.json`
+- Max 64 characters for the `{kebab-name}` portion
+
+## SKILL.md
+
+### Frontmatter (YAML)
+
+```yaml
+---
+name: "@tank/{kebab-name}"
+description: |
+  What the skill does — 2-4 lines covering scope and capabilities.
+  Source attribution — books, frameworks, specifications synthesized.
+
+  Trigger phrases: "phrase 1", "phrase 2", ... (10-15 phrases minimum)
+---
+```
+
+- `name`: Must match `@tank/{directory-name}` exactly
+- `description`: The PRIMARY triggering mechanism. Body loads AFTER
+  triggering, so everything needed to decide "should this skill activate?"
+  must be in the description. Include:
+  - What the skill covers (scope)
+  - Source attribution (books, specs, docs)
+  - 10-15 trigger phrases covering how users phrase requests
+
+### Body Structure
+
+```markdown
+# {Title}
+
+## Core Philosophy
+{3-5 numbered principles, bold key phrase + explanation}
+
+## Quick-Start: Common Problems
+### "{Problem 1}"
+1. Step...
+-> See `references/{file}.md`
+
+## Decision Trees
+| Signal | Recommendation |
+|--------|---------------|
+
+## Reference Index
+| File | Contents |
+|------|----------|
+| `references/{file}.md` | One-line description |
+```
+
+### Body Rules
+
+- Under 200 lines (strict)
+- Imperative form: "Run the script" not "You should run"
+- Problem-solution framing: common tasks users bring
+- Decision trees as tables, not prose
+- Reference index table as the LAST section
+- Every reference file listed in the index
+- No "When to Use This Skill" sections (that belongs in `description`)
+
+## skills.json
+
+```json
+{
+  "name": "@tank/{kebab-name}",
+  "version": "1.0.0",
+  "description": "Concise description matching SKILL.md description scope. Include key triggers.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": ["**/*"],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}
+```
+
+- `version`: Semver. Start at `1.0.0` for new skills.
+- `description`: Shorter than SKILL.md description. One paragraph.
+- `permissions`: Minimal by default. Only add when actually needed:
+  - Network: specific hostnames for API calls
+  - Filesystem write: specific paths
+  - Subprocess: only when running scripts
+
+## Reference Files
+
+### Format
+
+```markdown
+# {Title}
+
+Sources: Author1 (Book1), Author2 (Book2), {year} research
+
+Covers: brief scope sentence.
+
+## {Major Section}
+{Content: tables, frameworks, procedures}
+
+### {Subsection}
+{More specific content}
+```
+
+### Rules
+
+| Rule | Requirement |
+|------|-------------|
+| First line | `# Title` (H1) |
+| Third line | `Sources: {attribution}` |
+| Length | 250-450 lines target |
+| Frontmatter | None (only SKILL.md has YAML) |
+| Emoji | None |
+| Tone | Professional, imperative |
+| Tables | Use for frameworks, comparisons, decision trees |
+| Code blocks | Include language annotation |
+| Overlap | Each file covers a distinct subtopic — no duplication |
+| Cross-refs | Link to other reference files when related |
+
+## Quality Checklist
+
+### SKILL.md
+- [ ] `name` field starts with `@tank/`
+- [ ] `description` includes 10-15 trigger phrases
+- [ ] `description` includes scope, capabilities, sources
+- [ ] Body under 200 lines
+- [ ] Core Philosophy section (3-5 principles)
+- [ ] Quick-Start or problem-solution section
+- [ ] Decision trees as tables
+- [ ] Reference Index table at end
+
+### skills.json
+- [ ] `name` matches SKILL.md `name` exactly
+- [ ] `version` is valid semver
+- [ ] `description` is concise (1 paragraph)
+- [ ] `permissions` uses minimal defaults
+- [ ] `repository` points to `https://github.com/tankpkg/skills`
+
+### Reference Files
+- [ ] Each starts with `# Title` then `Sources:` line
+- [ ] No YAML frontmatter
+- [ ] No emoji
+- [ ] No content overlap between files
+- [ ] Professional tone, imperative form
+- [ ] Tables for frameworks and comparisons
+
+## Publishing
+
+### Workflow
+
+1. Create a feature branch for the new or updated skill
+2. Commit all skill files to the branch
+3. Open a PR and merge to `main`
+4. Only after the merge is complete, publish from `main`:
+
+```bash
+tank publish --org tank
+```
+
+Never publish from a feature branch — the source must exist on `main` first.
+
+### Rules
+
+- Every skill in this repo belongs to the `@tank` namespace
+- Always publish under the `tank` organization — never a personal account or other org
+- Verify the `name` field in `skills.json` starts with `@tank/` before publishing
+- Use `tank publish --dry-run` first to catch issues

--- a/skills/jewish-wisdom/SKILL.md
+++ b/skills/jewish-wisdom/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: "@tank/jewish-wisdom"
+description: |
+  Deep engagement with Jewish thought — Torah interpretation, Talmudic reasoning,
+  Jewish philosophy, Kabbalah, Mussar ethics, and Halakha. Teaches and debates using
+  authentic Jewish methodologies: PaRDeS four-level interpretation, 13 rules of
+  Rabbi Ishmael, Talmudic dialectics (shakla v'tarya), machloket (constructive
+  dispute), Maimonidean rationalism, kabbalistic frameworks (Sefirot, Four Worlds),
+  and Mussar character development. Multi-denominational: presents Orthodox,
+  Conservative, Reform, and academic perspectives fairly.
+
+  Synthesizes Maimonides (Guide of the Perplexed, Mishneh Torah), Steinsaltz
+  (Essential Talmud), Luzzatto (Mesillat Yesharim), Heschel (God in Search of Man),
+  Scholem (Major Trends), Kugel (How to Read the Bible), Halevi (Kuzari),
+  Tanya, Sarna (JPS Commentary), Pirkei Avot.
+
+  Trigger phrases: "Torah", "Talmud", "Judaism", "Jewish philosophy", "halakha",
+  "Jewish law", "Kabbalah", "Mussar", "midrash", "PaRDeS", "Rashi", "Rambam",
+  "Maimonides", "Sefirot", "middot", "tikkun", "tzimtzum", "Pirkei Avot",
+  "Shabbat", "kashrut", "Jewish ethics", "what does Judaism say about",
+  "parshat hashavua", "dvar Torah", "machloket", "Gemara", "sugya",
+  "Jewish mysticism", "chassidic", "Orthodox", "Conservative", "Reform",
+  "Jewish question", "Torah perspective", "biblical interpretation",
+  "teshuvah", "repentance", "Jewish thought", "Jewish theology",
+  "Zohar", "Shulchan Aruch", "halacha", "Jewish meditation"
+---
+
+# Jewish Wisdom
+
+Engage with Jewish questions through authentic Jewish methodologies —
+not summaries of what Judaism "believes," but the living reasoning
+tradition that generates Jewish knowledge.
+
+## Core Philosophy
+
+1. **Machloket l'shem shamayim (dispute for the sake of heaven) endures.** Multiple valid perspectives on a single question is a feature, not a bug.
+2. **Source first, then reason.** Ground every analysis in Torah, Talmud, or authoritative texts before offering interpretation.
+3. **The question is as sacred as the answer.** Jewish learning is driven by asking, not just answering.
+4. **Context shapes law and meaning.** The same principle may apply differently in different circumstances.
+5. **Ethical behavior and intellectual rigor are inseparable.** Torah without derech eretz (proper conduct) is incomplete.
+
+## Response Mode Selection
+
+| Question Type | Mode | Process |
+|--------------|------|---------|
+| "What does the Torah say about X?" | Textual Analysis | Peshat → commentators → midrash → deeper levels (PaRDeS) |
+| "Is X permitted in Judaism?" | Halakhic Analysis | Sources → Talmud → codes → poskim → denominational range |
+| "Jewish perspective on [philosophical question]" | Jewish Philosophy | Survey classical positions (Rambam, Halevi, Ramban) → modern thinkers → synthesis |
+| "Explain [Jewish concept]" | Teaching Mode | Define → source in texts → explain significance → practical application |
+| "Debate [Jewish topic]" | Talmudic Dialectic | Present multiple positions → analyze underlying principles → note practical implications |
+| "Help me with middot/character" | Mussar Guidance | Identify middah → Golden Path → practical steps → accountability |
+| "Mystical meaning of X" | Kabbalistic Analysis | Sefirot mapping → Four Worlds → practical application |
+
+## Quick Start: Answering a Jewish Question
+
+1. **Classify**: Is this a textual, legal, philosophical, mystical, or ethical question?
+2. **Select mode** from the table above
+3. **Ground in sources** — cite Torah, Talmud, Rishonim, or Acharonim
+4. **Present multiple views** — machloket is the norm, not the exception
+5. **Note denominational range** when relevant
+6. **Connect to practice** — what difference does this make?
+
+## Torah Interpretation: PaRDeS Framework
+
+| Level | Method | When to Apply |
+|-------|--------|---------------|
+| Peshat (Plain) | Grammar, context, literary structure | Always start here |
+| Remez (Hint) | Intertextual connections, wordplay, gematria | When connections to other passages illuminate |
+| Drash (Homiletical) | Midrash, moral lessons, filling narrative gaps | When deeper ethical/theological meaning is sought |
+| Sod (Secret) | Kabbalistic symbolism, Sefirot mapping | When the questioner seeks mystical dimensions |
+
+See `references/torah-interpretation.md` for the 13 rules of Rabbi Ishmael and full interpretive methodology.
+
+## Talmudic Reasoning Quick Reference
+
+| Move | Function |
+|------|----------|
+| Pshita! | "That's obvious!" — demands why it needs stating |
+| Mai ka mashma lan? | "What's the novel point?" |
+| Meitivei | "They object!" — introduces contradiction |
+| Shanei | "It's different because..." — draws distinction |
+| Mai nafka mina? | "What practical difference?" |
+| Teyku | Unresolved — some questions remain open |
+
+See `references/talmudic-reasoning.md` for full sugya analysis methodology.
+
+## Halakhic Question Framework
+
+1. Is this d'oraita (Torah-level) or d'rabbanan (rabbinic)?
+2. What does the Shulchan Aruch say? (Sephardi) What does the Rema add? (Ashkenazi)
+3. How do later authorities (Mishnah Berurah, etc.) rule?
+4. What do different denominations hold?
+
+See `references/halakhic-method.md`.
+
+## Jewish Philosophy: Orientation
+
+| If they ask about... | Start with... |
+|---------------------|--------------|
+| God's nature, theology | Rambam (negative theology), Halevi (experiential), Heschel (radical amazement) |
+| Reason vs. faith | Rambam vs. Halevi debate |
+| Suffering, evil | Theodicy survey: free will, soul-making, hester panim, protest theology |
+| Chosenness | Traditional, universalist, Kaplanian, Sacks (dignity of difference) |
+| Modern challenges | Science/Torah, feminism, social justice — see `references/denominations-and-modern.md` |
+
+See `references/jewish-philosophy.md`.
+
+## Kabbalistic Framework
+
+The Sefirot provide a lens for analyzing any situation in terms of divine
+attributes: Chesed (love/expansion) vs. Gevurah (restraint/judgment),
+balanced by Tiferet (harmony). See `references/kabbalah-and-mysticism.md`.
+
+## Mussar: Character Development
+
+Use Luzzatto's ladder (watchfulness → holiness) and the Golden Path
+(finding the mean between extremes of any middah).
+See `references/mussar-ethics.md`.
+
+## Reference Index
+
+| File | Contents |
+|------|----------|
+| `references/torah-interpretation.md` | PaRDeS, 13 rules of Rabbi Ishmael, midrashic method, major commentators, peshat/drash methodology |
+| `references/talmudic-reasoning.md` | Sugya structure, shakla v'tarya, key argumentative moves, machloket methodology, conceptual analysis |
+| `references/halakhic-method.md` | Sources of law hierarchy, psak process, Rishonim methodologies, Shulchan Aruch system, denominational approaches |
+| `references/jewish-philosophy.md` | Rambam, Halevi, Ramban, Maharal, Soloveitchik, Heschel, Buber — methods and key ideas |
+| `references/kabbalah-and-mysticism.md` | Sefirot (all 10), Four Worlds, Lurianic cosmology, Chassidic thought, soul levels |
+| `references/mussar-ethics.md` | Luzzatto's ladder, middah analysis, cheshbon ha-nefesh, Pirkei Avot maxims, ethical principles |
+| `references/denominations-and-modern.md` | Orthodox/Conservative/Reform compared, academic study, science & Torah, feminism, social justice, interfaith |

--- a/skills/jewish-wisdom/references/denominations-and-modern.md
+++ b/skills/jewish-wisdom/references/denominations-and-modern.md
@@ -1,0 +1,175 @@
+# Denominations and Modern Questions
+
+Sources: Dorff (Conservative Judaism), Borowitz (Renewing the Covenant), Soloveitchik (The Lonely Man of Faith), Plaskow (Standing Again at Sinai), Sacks (The Dignity of Difference), Kellner (Must a Jew Believe Anything?)
+
+Covers: denominational approaches compared, academic Jewish studies, modern philosophical challenges, science and Torah, feminism and Judaism, social justice, interfaith engagement.
+
+## Denominational Landscape
+
+Understanding the denominations is not about picking a "winner" but
+about recognizing that different communities interpret the same tradition
+through different lenses — each with internal coherence and genuine
+commitment to Judaism.
+
+### Comparison Framework
+
+| Dimension | Orthodox | Conservative | Reform | Reconstructionist |
+|-----------|----------|-------------|--------|-------------------|
+| Torah: origin | Divine authorship | Divine inspiration, human composition | Human document of divine encounter | Evolving religious civilization |
+| Halakha: authority | Binding as divine law | Binding but historically developing | Guiding but not binding | Democratic communal process |
+| Change: mechanism | Internal legal process (psak) | CJLS (Committee on Jewish Law and Standards) | Individual autonomy informed by tradition | Communal consensus |
+| Talmud | Authoritative legal source | Authoritative but contextualizable | Resource for wisdom, not authority | Historical resource |
+| Women's roles | Varies (Charedi: separate; Modern Orthodox: expanding) | Egalitarian since 1985 (women rabbis) | Egalitarian since 1972 (women rabbis) | Egalitarian |
+| LGBTQ+ inclusion | Generally prohibited; some Modern Orthodox voices for inclusion | Welcoming; ordains LGBTQ+ rabbis since 2006 | Full inclusion since 1990s | Full inclusion |
+
+### Within Orthodoxy
+
+| Stream | Characteristic | Examples |
+|--------|---------------|----------|
+| Charedi/Ultra-Orthodox | Insularity, strict adherence, suspicion of modernity | Satmar, Lakewood, various Chassidic courts |
+| Yeshivish/Lithuanian | Torah study emphasis, intellectual rigor | Brisk, Mir, Ponevezh |
+| Modern Orthodox | Integration with modern world, Torah u-Madda | YU, Bnei Akiva, RIETS |
+| Religious Zionist | Torah and statehood integrated | Merkaz HaRav, Hesder yeshivot |
+| Open Orthodox | Push boundaries within halakhic framework | Yeshivat Chovevei Torah |
+
+### Key Methodological Differences
+
+| Issue | Orthodox Approach | Conservative Approach | Reform Approach |
+|-------|-------------------|----------------------|-----------------|
+| May women lead prayer? | No (most) / Expanding (some MO) | Yes | Yes |
+| Driving on Shabbat | Prohibited | Permitted to synagogue (1950 teshuvah) | Individual choice |
+| Kashrut standards | Strict supervision required | Observance expected, flexibility in practice | Personal meaning-making |
+| Conversion process | Bet din, mikveh, circumcision, kabbalat ol mitzvot | Similar process, varying standards | Welcoming, education-focused |
+
+## Academic Jewish Studies
+
+### What Academic Study Adds
+
+| Method | Contribution | Tension with Tradition |
+|--------|-------------|----------------------|
+| Historical criticism | Places texts in historical context | May challenge traditional authorship claims |
+| Comparative religion | Shows connections with surrounding cultures | May relativize Jewish uniqueness claims |
+| Literary analysis | Reveals sophisticated literary artistry | May reframe "difficulties" as literary technique |
+| Archaeology | Grounds biblical narrative in material evidence | Sometimes confirms, sometimes challenges traditional accounts |
+| Sociology of religion | Explains how communities form and maintain identity | May reduce religious experience to social dynamics |
+
+### Integrating Academic and Traditional Study
+
+These approaches can coexist:
+- Use academic tools for historical and literary context
+- Use traditional tools (PaRDeS, commentators) for meaning and application
+- Maintain awareness that academic conclusions are also provisional
+- Recognize that "historically accurate" and "religiously meaningful" are different questions
+
+## Modern Philosophical Challenges
+
+### Science and Torah
+
+| Question | Approach Options |
+|----------|-----------------|
+| Age of the universe | (A) Literal six days; (B) Days are epochs; (C) Creation narrative is theological, not scientific; (D) God created a mature universe |
+| Evolution | (A) Reject; (B) Accept as mechanism of divine creation; (C) Science and Torah address different questions |
+| Miracles | (A) Literal supernatural events; (B) Natural events with providential timing; (C) Narrative/theological truths expressed as miracles |
+
+**Framework for navigating**: Distinguish between the question "what
+happened?" (science) and "what does it mean?" (Torah). Many apparent
+conflicts dissolve when you recognize they address different questions.
+
+### The Problem of Evil (Theodicy)
+
+| Response | Thinker | Content |
+|----------|---------|---------|
+| Free will defense | Mainstream | Evil results from human freedom, which is necessary for moral life |
+| Soul-making | Various | Suffering develops character and spiritual growth |
+| Hidden good | Nachmanides, Chassidism | What appears evil serves a larger purpose we cannot see |
+| Divine self-limitation | Lurianic Kabbalah | Tzimtzum means God limits divine power to allow creation |
+| Protest theology | Post-Holocaust | Some suffering is unjustifiable; we protest to God (like Abraham, Moses, Job) |
+| Hester Panim | Traditional | God "hides the face" — periods of apparent divine absence |
+
+**Honest acknowledgment**: Judaism does not have a single satisfying
+answer to the problem of evil. The tradition contains multiple responses,
+and honest engagement means sitting with the tension rather than forcing
+premature resolution.
+
+### Chosenness and Universalism
+
+| Position | Content |
+|----------|---------|
+| Traditional | Israel chosen for a specific mission (Torah, commandments, witness to God) |
+| Universalist reading | Chosen for responsibility, not superiority; "a light unto the nations" |
+| Kaplanian | "Vocation" rather than "chosenness" — every people has its distinct calling |
+| Pluralist (Sacks) | Dignity of difference — God values diversity; monotheism does not require uniformity |
+
+## Feminism and Judaism
+
+### Key Questions
+
+| Question | Traditional View | Feminist View | Emerging Synthesis |
+|----------|-----------------|--------------|-------------------|
+| Women's exemption from time-bound mitzvot | Accommodation of domestic responsibilities | Reflects patriarchal assumptions | Some communities enable women's voluntary participation |
+| Women's testimony in bet din | Women cannot serve as witnesses in certain contexts | Equal testimony rights | Conservative/Reform accept women's testimony fully |
+| Mechitzah (partition) | Sacred separation enabling focused prayer | Exclusion from communal center | Modern Orthodox experiments with dignified women's sections |
+| Women rabbis | Not permitted (Orthodox mainstream) | Essential for equal access | Yoatzot halakha (Orthodox women halakhic advisors) as alternative model |
+
+### Jewish Feminist Thinkers
+
+| Thinker | Contribution |
+|---------|-------------|
+| Judith Plaskow | Standing Again at Sinai — feminist theology of Judaism |
+| Rachel Adler | Engendering Judaism — halakhic feminism |
+| Tamar Ross | Expanding the Palace of Torah — Orthodox feminist theology |
+| Blu Greenberg | "Where there is a halakhic will, there is a halakhic way" |
+
+## Social Justice (Tzedek)
+
+### Torah Foundations
+
+| Principle | Source | Application |
+|-----------|--------|-------------|
+| Justice, justice shall you pursue | Deut. 16:20 | Active pursuit of justice, not passive acceptance |
+| Do not stand idly by | Lev. 19:16 | Obligation to intervene when others are at risk |
+| Love the stranger | Repeated 36 times in Torah | Welcoming and protecting the vulnerable |
+| Workers' rights | Deut. 24:14-15 | Pay on time, fair treatment |
+| Sabbatical/Jubilee | Lev. 25 | Economic reset, preventing permanent inequality |
+| Bal tashchit | Deut. 20:19-20 | Environmental stewardship, not wanton destruction |
+
+### Prophetic Tradition
+
+The prophets (Isaiah, Amos, Micah, Jeremiah) consistently prioritize
+ethical behavior over ritual performance:
+
+"What does the Lord require of you? To do justice, to love mercy, and
+to walk humbly with your God." (Micah 6:8)
+
+This prophetic emphasis grounds Jewish social justice advocacy in
+religious obligation, not just political preference.
+
+## Interfaith Engagement
+
+### Frameworks for Dialogue
+
+| Approach | Proponent | Principle |
+|----------|-----------|-----------|
+| Theology of difference | Sacks | Respect other faiths without relativizing your own |
+| Noahide laws | Rambam | Non-Jews have their own covenant with seven universal commandments |
+| Dialogue of deeds | Heschel | Collaborate on shared ethical concerns without theological compromise |
+| Abrahamic conversation | Various | Common ancestor grounds mutual respect |
+
+### Boundaries
+
+- Share and explain Jewish perspectives without proselytizing
+- Engage respectfully without pretending differences don't exist
+- Find common ethical ground while acknowledging theological divergence
+- Jewish-Christian dialogue: acknowledge painful history honestly
+
+## Engaging Modern Questions
+
+When addressing a modern question through Jewish wisdom:
+
+1. **Identify the relevant values** — which Jewish principles apply?
+2. **Survey traditional sources** — what do Torah, Talmud, and codes say about analogous cases?
+3. **Note denominational range** — how do different communities approach this?
+4. **Consider the modern context** — what new factors exist that earlier authorities didn't face?
+5. **Apply reasoning** — use halakhic, philosophical, or ethical frameworks to reach a position
+6. **Acknowledge complexity** — present the strongest argument for views you disagree with
+7. **Be honest about uncertainty** — where the tradition doesn't give a clear answer, say so

--- a/skills/jewish-wisdom/references/halakhic-method.md
+++ b/skills/jewish-wisdom/references/halakhic-method.md
@@ -1,0 +1,170 @@
+# Halakhic Method
+
+Sources: Maimonides (Mishneh Torah), Karo (Shulchan Aruch), Elon (Jewish Law: History, Sources, Principles), Dorff/Rosett (A Living Tree), Soloveitchik (Halakhic Man)
+
+Covers: sources of law hierarchy, psak process, Rishonim methodologies, Shulchan Aruch system, key legal principles, denominational approaches to halakha.
+
+## Sources of Jewish Law
+
+### Authority Hierarchy
+
+| Source | Status | Authority | Example |
+|--------|--------|-----------|---------|
+| Torah (Written Law) | D'oraita | Highest — biblical commandment | "You shall not steal" |
+| Oral Law (Talmud) | D'oraita/D'rabbanan | Interpretation of Torah; binding | Talmudic elaboration of Shabbat laws |
+| Rabbinic enactment (Takkanah) | D'rabbanan | Rabbinic legislation for communal need | Chanukah candles, handwashing before bread |
+| Rabbinic decree (Gezerah) | D'rabbanan | Protective measure preventing Torah violation | Don't carry objects near the public domain on Shabbat (might carry into it) |
+| Custom (Minhag) | Varies | Regional/communal practice | Kitniyot on Pesach (Ashkenazi custom) |
+| Sevara | D'oraita-level | Self-evident rational principle | Prohibition against damaging others |
+
+### D'oraita vs D'rabbanan Distinction
+
+This distinction matters enormously for practical halakha:
+
+| Feature | D'oraita (Torah-level) | D'rabbanan (Rabbinic-level) |
+|---------|----------------------|---------------------------|
+| In cases of doubt | Rule strictly (safek d'oraita l'chumra) | Rule leniently (safek d'rabbanan l'kula) |
+| Weight of obligation | Heavier | Lighter |
+| Can rabbis override? | Only in emergency or for the sake of Torah itself | More flexibility for communal need |
+| Punishment framework | Torah-specified punishments | Rabbinic sanctions |
+
+## The Psak (Legal Decision) Process
+
+### Standard Methodology
+
+1. **Identify the shailah (question)** — precisely define the legal issue
+2. **Survey Talmudic discussion** — find the relevant sugya or sugyot
+3. **Check Rishonim** — how did medieval authorities interpret the Talmud?
+4. **Check Shulchan Aruch + Rema** — what is the codified law?
+5. **Consult Acharonim** — later authorities who address the specific case
+6. **Consider minhag ha-makom** — local communal practice
+7. **Apply to the specific case** — consider all particular circumstances
+8. **Issue the psak** — state the ruling with reasoning
+
+### Who Can Issue Psak
+
+| Level | Authority | Scope |
+|-------|-----------|-------|
+| Gadol haDor | Leading authority of the generation | Sets direction for the entire community |
+| Posek | Ordained rabbi with expertise in halakha | Issues rulings for their community |
+| Mara d'atra | Local rabbinic authority | Authoritative for their specific community |
+| Individual | Personal practice | Can follow their rabbi's guidance |
+
+## Rishonim: Major Legal Methodologies
+
+The Rishonim (medieval authorities, ~1000-1500 CE) established the
+foundational approaches to Talmudic interpretation.
+
+### Rashi (1040-1105)
+- **Method**: Clear, concise commentary on the entire Talmud
+- **Approach**: Explain the peshat (plain meaning) of each passage
+- **Significance**: Makes the Talmud accessible; virtually every printed Talmud includes Rashi
+- **Legal contribution**: Clarifies which opinion is accepted as halakha
+
+### Tosafot (12th-14th century)
+- **Method**: Dialectical analysis, cross-referencing across the Talmud
+- **Approach**: "But this contradicts what it says elsewhere!" — resolving apparent contradictions between sugyot
+- **Significance**: Creates a unified, internally consistent reading of the Talmud
+- **Legal contribution**: Novel distinctions and refinements of Rashi
+
+### Rambam / Maimonides (1138-1204)
+- **Method**: Systematic codification — organized all of halakha by topic
+- **Work**: Mishneh Torah — 14 books covering all Jewish law
+- **Approach**: States the law clearly without extensive Talmudic argumentation
+- **Significance**: Created the first comprehensive legal code; rationalist approach
+- **Controversy**: Didn't cite sources, which later authorities debated
+
+### Rosh (Rabbenu Asher, 1250-1327)
+- **Method**: Summarizes the halakhic conclusions of each sugya
+- **Approach**: Follows Talmudic structure but distills practical law
+- **Significance**: Bridges Ashkenazi and Sephardi traditions
+
+### Tur (Jacob ben Asher, 1269-1343)
+- **Work**: Arba'ah Turim (Four Columns)
+- **Method**: Organized practical law topically (Rambam's structure adapted for practice)
+- **Significance**: Direct precursor to the Shulchan Aruch
+
+## The Shulchan Aruch System
+
+### Structure
+
+| Section | Hebrew Name | Covers |
+|---------|------------|--------|
+| Orach Chaim | אורח חיים | Daily life, Shabbat, holidays, prayer |
+| Yoreh De'ah | יורה דעה | Kashrut, niddah, mourning, oaths, Torah study |
+| Even HaEzer | אבן העזר | Marriage, divorce, family law |
+| Choshen Mishpat | חושן משפט | Civil and financial law, courts, damages |
+
+### Shulchan Aruch + Rema
+
+- **Shulchan Aruch** (Rabbi Yosef Karo, 1565): Follows Sephardi practice, based primarily on Rif, Rambam, and Rosh (majority of three rules)
+- **Rema** / Mappah (Rabbi Moshe Isserles, 1571): Ashkenazi glosses, noting where Ashkenazi practice differs
+- Together they form the authoritative code for both communities
+
+### Later Commentaries (Nosei Keilim)
+
+| Commentary | On | Known For |
+|-----------|-----|-----------|
+| Mishnah Berurah | Orach Chaim | Widely accepted Ashkenazi authority on daily and Shabbat law |
+| Shach / Taz | Yoreh De'ah | Two primary commentaries, often in dialogue |
+| Beit Shmuel / Chelkat Mechokek | Even HaEzer | Family law authorities |
+| Sma / Shach | Choshen Mishpat | Civil law commentaries |
+
+## Key Halakhic Principles
+
+### Meta-Legal Principles
+
+| Principle | Hebrew | Application |
+|-----------|--------|-------------|
+| Pikuach nefesh | פקוח נפש | Saving a life overrides virtually all commandments (except murder, sexual immorality, and idolatry) |
+| Kavod ha-beriyot | כבוד הבריות | Human dignity can override certain rabbinic prohibitions |
+| Hefsed merubeh | הפסד מרובה | Significant financial loss can be a factor in lenient rulings |
+| Et la'asot | עת לעשות | In extraordinary circumstances, rabbinic authority to act for the preservation of Torah |
+| Lo bashamayim hi | לא בשמים היא | The Torah is not in heaven — halakhic authority rests with human legal process |
+| Acharei rabim l'hatot | אחרי רבים להטות | Follow the majority — majority rules in legal disputes |
+
+### Doubt Resolution
+
+| Scenario | Rule | Reason |
+|----------|------|--------|
+| Doubt in Torah law | Stringent (l'chumra) | Torah obligations are weighty |
+| Doubt in rabbinic law | Lenient (l'kula) | Rabbinic authority is lighter |
+| Double doubt (sfek sfeka) | Lenient even in Torah law | Two layers of doubt create strong probability |
+| Established status (chazakah) | Maintain the status quo | What was established continues until disproven |
+
+### Legal Reasoning Tools
+
+| Tool | Application |
+|------|-------------|
+| Rov (majority) | Follow statistical probability |
+| Chazakah (presumption) | What was, continues to be |
+| Migu (self-interest argument) | If someone could have made a stronger claim but didn't, their weaker claim is credible |
+| Anan sahadei (we are witnesses) | Common-sense factual assumptions |
+
+## Denominational Approaches
+
+### Orthodox
+- Halakha is binding and divinely mandated
+- The Talmud and Shulchan Aruch are authoritative
+- Change happens through internal legal process (psak), not external reform
+- Range: Modern Orthodox (engaged with modern world) to Charedi (insular)
+
+### Conservative (Masorti)
+- Halakha is binding but historically developing
+- The Committee on Jewish Law and Standards issues rulings
+- Scientific and historical scholarship inform legal development
+- Talmudic process is authoritative, but conclusions can evolve
+
+### Reform
+- Halakha is not binding but is a valuable resource
+- Autonomy of individual conscience is primary
+- Ethical principles of Judaism take precedence over ritual law
+- Engagement with tradition is voluntary and selective
+
+### Applying Denominational Awareness
+
+When analyzing a halakhic question, note:
+- What is the question's status (d'oraita/d'rabbanan)?
+- How do different denominations approach this area?
+- Where is there consensus, and where genuine disagreement?
+- Present the traditional ruling and alternative approaches without caricature

--- a/skills/jewish-wisdom/references/jewish-philosophy.md
+++ b/skills/jewish-wisdom/references/jewish-philosophy.md
@@ -1,0 +1,176 @@
+# Jewish Philosophy
+
+Sources: Maimonides (Guide of the Perplexed), Halevi (Kuzari), Heschel (God in Search of Man), Soloveitchik (Halakhic Man), Buber (I and Thou), Hartman (A Living Covenant)
+
+Covers: rationalist tradition, experiential tradition, existentialist approaches, major philosophical disputes, methodology of Jewish philosophical inquiry, modern thinkers.
+
+## The Central Tension
+
+Jewish philosophy navigates a fundamental tension: the relationship
+between reason and revelation. How much can human reason know about God,
+ethics, and reality? Where does revelation begin and reason end?
+
+Different thinkers answer differently — and these differences define
+the major schools of Jewish thought.
+
+| Approach | Champion | Relationship of Reason to Revelation |
+|----------|----------|-------------------------------------|
+| Rationalist | Maimonides | Reason and revelation converge; philosophy confirms Torah |
+| Experiential | Halevi | Experience and tradition surpass reason; reason has limits |
+| Mystical | Ramban, Zohar | Hidden dimensions of Torah transcend rational analysis |
+| Existentialist | Soloveitchik | The lived experience of halakhic commitment is primary |
+| Dialogical | Buber | God is encountered in relationship, not known through propositions |
+| Phenomenological | Heschel | Radical amazement precedes and grounds religious life |
+
+## Maimonides (Rambam, 1138-1204)
+
+### Negative Theology
+
+Maimonides' most radical philosophical contribution: we cannot say what
+God IS, only what God is NOT.
+
+| Positive Statement (Rejected) | Negative Equivalent (Accepted) |
+|------------------------------|-------------------------------|
+| "God is powerful" | "God is not lacking in power" |
+| "God is wise" | "God is not ignorant" |
+| "God exists" | "God is not non-existent" |
+
+Reasoning: Any positive attribute would imply composition (God has parts),
+limitation (God is this and not that), or comparison (God is like things
+we know). Divine simplicity demands negative theology.
+
+### Allegorical Interpretation
+
+When Torah appears to attribute physical properties to God (God's hand,
+God's anger, God sits on a throne), these are metaphors accommodating
+human understanding. The Guide of the Perplexed systematically reinterprets
+anthropomorphic passages.
+
+### Rambam's Philosophical Method
+
+1. Identify the philosophical question
+2. Survey the positions of Greek and Islamic philosophers
+3. Analyze through logic and demonstration
+4. Show that Torah's position is compatible with (or superior to) philosophical conclusions
+5. Acknowledge where human reason reaches its limits
+
+### Thirteen Principles of Faith
+
+Maimonides' creed — later contested but highly influential:
+
+1. God exists
+2. God's unity
+3. God is non-corporeal
+4. God is eternal
+5. Worship God alone
+6. Prophecy exists
+7. Moses' prophecy is supreme
+8. Torah is divine
+9. Torah is unchangeable
+10. God knows human actions
+11. Reward and punishment
+12. The Messiah will come
+13. Resurrection of the dead
+
+These serve as a framework for Jewish theological discussion, even when
+specific principles are debated.
+
+## Yehuda Halevi (c. 1075-1141)
+
+### The Kuzari's Method
+
+The Kuzari uses a dialogic structure: the King of the Khazars interviews
+a philosopher, a Christian, a Muslim, and finally a rabbi. The rabbi's
+arguments succeed not through abstract proof but through historical
+experience.
+
+### Key Arguments
+
+| Claim | Reasoning |
+|-------|-----------|
+| Experience over reason | 600,000 witnesses at Sinai > any philosophical proof |
+| Am Yisrael as evidence | The continued existence and experience of the Jewish people is empirical evidence for revelation |
+| Limits of philosophy | Philosophy can prove God exists in the abstract but cannot tell you what God wants |
+| The Land of Israel | Prophecy flourishes specifically in the Land; place matters for spiritual life |
+
+### Halevi vs. Maimonides
+
+| Question | Maimonides | Halevi |
+|----------|-----------|--------|
+| Can philosophy prove God? | Yes — reason converges with revelation | Not meaningfully — reason gives abstract God, not the living God of Abraham |
+| Is Judaism philosophically demonstrable? | Its principles are rationally defensible | Its truth rests on historical experience |
+| Role of commandments | Rational function (health, social order, intellectual refinement) | Instruments for direct connection with the divine; not reducible to rational function |
+
+## Nachmanides (Ramban, 1194-1270)
+
+### Method: Peshat with Mystical Depth
+
+- Accepts the plain meaning of texts but sees deeper kabbalistic layers
+- Critiques both Rashi (for relying too much on midrash) and Maimonides (for rationalizing away mysteries)
+- Torah contains all wisdom — explicit and encrypted
+- Nature itself conceals divine activity ("hidden miracles")
+
+### Key Contributions
+
+- **Hidden miracles**: Daily events are divine providence, not just "natural law"
+- **Torah as name of God**: The entire Torah is a divine name encoding all reality
+- **Land-centered theology**: The commandments are fully meaningful only in the Land of Israel
+
+## Modern Jewish Thinkers
+
+### Rabbi Joseph B. Soloveitchik (1903-1993)
+
+**Halakhic Man** — the halakhic person approaches reality through the
+lens of Jewish law, creating ideal models (like a mathematician) and
+then measuring reality against them.
+
+| Concept | Meaning |
+|---------|---------|
+| Typological thinking | Two types — Halakhic Man and Homo Religiosus — represent different orientations |
+| Creativity through halakha | Halakhic living is creative, not merely obedient; it constructs meaning |
+| Lonely Man of Faith | The religious person is inherently lonely — faith cannot be fully communicated |
+| Covenantal community | Relationship with God is through covenant, not mystical absorption |
+
+### Abraham Joshua Heschel (1907-1972)
+
+**God in Search of Man** — God seeks humanity, not only humanity seeking God.
+
+| Concept | Meaning |
+|---------|---------|
+| Radical amazement | Wonder and awe at existence precede and ground all religious thought |
+| Divine pathos | God is not unmoved — God cares, suffers, responds to human action |
+| The Sabbath | Sacred time over sacred space — Judaism sanctifies moments, not just places |
+| Depth theology | Beyond creed (belief statements) to the pre-conceptual awareness of the divine |
+
+### Martin Buber (1878-1965)
+
+**I and Thou** — the fundamental structure of existence is relational.
+
+| Concept | Meaning |
+|---------|---------|
+| I-Thou relationship | Encountering another as a full subject, not an object |
+| I-It relationship | Relating to another as an object of use or analysis |
+| The Eternal Thou | God is the Thou that can never become an It |
+| Dialogue | Authentic existence is dialogical — between persons and between human and divine |
+
+## Philosophical Methodology
+
+### How to Approach a Jewish Philosophical Question
+
+1. **Identify the question's domain**: Theology? Ethics? Metaphysics? Epistemology?
+2. **Survey the classical positions**: What do Rambam, Ramban, Halevi, Maharal say?
+3. **Note the underlying tension**: Is this a reason vs. revelation question? Universal vs. particular?
+4. **Present multiple views fairly**: Jewish philosophy embraces machloket (legitimate disagreement)
+5. **Consider modern developments**: How have Soloveitchik, Heschel, Buber, Leibowitz, Hartman extended the conversation?
+6. **Ground in texts**: Jewish philosophy is always in dialogue with Torah, Talmud, and tradition
+7. **Acknowledge mystery**: Some questions resist final answers — intellectual humility is a Jewish value
+
+### Recurring Philosophical Tensions
+
+| Tension | Poles | Key Thinkers |
+|---------|-------|-------------|
+| Reason vs. Revelation | Rambam vs. Halevi | Rambam seeks harmony; Halevi argues for primacy of experience |
+| Universal vs. Particular | Rambam (universal ethics) vs. Maharal (Jewish uniqueness) | Does Judaism speak to universal humanity or specifically to Israel? |
+| Immanence vs. Transcendence | Kabbalah (immanent) vs. Rambam (transcendent) | Is God within the world or beyond it? |
+| Law vs. Spirit | Halakhic emphasis vs. Chassidic emphasis | Is the form of the commandment or the intention behind it primary? |
+| Continuity vs. Change | Orthodox vs. Reform | Can halakha develop, and if so, how and by whom? |

--- a/skills/jewish-wisdom/references/kabbalah-and-mysticism.md
+++ b/skills/jewish-wisdom/references/kabbalah-and-mysticism.md
@@ -1,0 +1,203 @@
+# Kabbalah and Jewish Mysticism
+
+Sources: Scholem (Major Trends in Jewish Mysticism), Kaplan (Inner Space), Matt (The Essential Kabbalah), Green (Ehyeh: A Kabbalah for Tomorrow), Tanya (Rabbi Schneur Zalman of Liadi)
+
+Covers: Sefirot system, Four Worlds, Lurianic cosmology, Chassidic thought, soul levels, meditation, integration of mystical and rational approaches.
+
+## Overview: What is Kabbalah?
+
+Kabbalah (literally "receiving/tradition") is the mystical dimension of
+Judaism — a framework for understanding the inner structure of divine
+reality, the process of creation, the human soul, and the purpose of the
+commandments. It is not separate from Judaism but its deepest layer,
+traditionally revealed only to those with strong grounding in Torah and
+Talmud.
+
+## The Sefirot: Ten Divine Emanations
+
+The Sefirot are the primary framework of kabbalistic thought — ten
+attributes or modes through which the infinite divine (Ein Sof) creates,
+sustains, and relates to the finite world.
+
+### The Tree of Life
+
+| # | Sefirah | Meaning | Quality | Body Correspondence |
+|---|---------|---------|---------|-------------------|
+| 1 | Keter | Crown | Divine Will, source of all | Above the head |
+| 2 | Chokhmah | Wisdom | Flash of insight, seminal idea, undifferentiated point | Right brain |
+| 3 | Binah | Understanding | Analysis, development, structure, giving form to the flash | Left brain |
+| | Da'at | Knowledge | (Not counted as separate — bridge between intellectual and emotional) | |
+| 4 | Chesed | Kindness/Love | Expansive giving, unconditional love, overflow | Right arm |
+| 5 | Gevurah | Strength/Judgment | Restraint, boundaries, discipline, rigor | Left arm |
+| 6 | Tiferet | Beauty/Harmony | Balance of Chesed and Gevurah, compassion, truth | Torso/heart |
+| 7 | Netzach | Victory/Eternity | Persistence, endurance, initiative, confidence | Right leg |
+| 8 | Hod | Splendor/Gratitude | Humility, acknowledgment, receptivity, sincerity | Left leg |
+| 9 | Yesod | Foundation | Connection, channel, bonding, intimacy | Reproductive |
+| 10 | Malkhut | Sovereignty | Manifestation, receiving, expression, the world | Feet/mouth |
+
+### Three Columns
+
+| Left (Restriction) | Center (Balance) | Right (Expansion) |
+|--------------------|-----------------|-------------------|
+| Binah | Keter | Chokhmah |
+| Gevurah | Tiferet | Chesed |
+| Hod | Yesod | Netzach |
+| | Malkhut | |
+
+### Sefirot as Analytical Framework
+
+The Sefirot can be applied to analyze any situation, relationship, or concept:
+
+| Question | Sefirot Lens |
+|----------|-------------|
+| "Is this approach too extreme?" | Check: Is there Chesed without Gevurah (kindness without limits) or Gevurah without Chesed (strictness without love)? |
+| "Why isn't this idea taking form?" | Check: Is there Chokhmah (inspiration) without Binah (structure to develop it)? |
+| "Why does this feel disconnected?" | Check: Is Yesod (bonding/connection) missing? |
+| "Why does this lack impact?" | Check: Is Malkhut (expression/manifestation) blocked? |
+
+## The Four Worlds (Olamot)
+
+Creation proceeds through four levels of reality, each more concrete
+than the last.
+
+| World | Hebrew | Level | Consciousness | Corresponds To |
+|-------|--------|-------|---------------|---------------|
+| Atzilut | אצילות | Emanation | Pure divine awareness, unity with source | Keter-Chokhmah-Binah |
+| Beriah | בריאה | Creation | Intellectual comprehension, conceptual thought | Understanding, ideas |
+| Yetzirah | יצירה | Formation | Emotional experience, relational dynamics | Feelings, relationships |
+| Asiyah | עשייה | Action | Physical reality, concrete action | The material world |
+
+### Application to Study
+
+When studying a text or concept, one can engage at each level:
+- **Asiyah**: What are the practical actions required?
+- **Yetzirah**: What emotional response or character development is called for?
+- **Beriah**: What is the intellectual concept being taught?
+- **Atzilut**: What does this reveal about the divine?
+
+## Lurianic Cosmology
+
+Rabbi Isaac Luria (the Ari, 1534-1572) developed the most influential
+kabbalistic cosmological framework.
+
+### Tzimtzum (Contraction)
+
+Before creation, the divine light (Or Ein Sof) was infinite and all-
+encompassing. To create space for finite beings, God "contracted" or
+"withdrew" — creating a chalal (empty space) within which creation could
+emerge.
+
+**Philosophical significance**: God's first creative act is an act of
+self-limitation. Creation requires making room for the other. This has
+implications for:
+- Understanding divine self-limitation and human freedom
+- Parenting and teaching (creating space for the student's growth)
+- Leadership (stepping back to empower others)
+
+### Shevirat HaKelim (Breaking of the Vessels)
+
+Divine light was channeled into vessels (kelim) to form the Sefirot.
+The vessels of the lower Sefirot could not contain the light and shattered.
+Sparks of holiness (nitzotzot) fell into the material world, becoming
+trapped in physical reality.
+
+**Philosophical significance**: Evil and imperfection in the world are
+"holy sparks" waiting to be liberated. This means:
+- The physical world is not inherently bad — it contains hidden holiness
+- Human action can elevate (tikkun) or degrade (further concealment) reality
+- Every encounter is an opportunity for spiritual repair
+
+### Tikkun (Repair)
+
+The purpose of human existence — particularly through mitzvot (commandments),
+prayer, and ethical action — is to gather the scattered sparks and restore
+the world to its intended wholeness.
+
+**Philosophical significance**: History is not circular but purposive.
+Human action matters cosmically. The mundane is the arena of the sacred.
+
+## Chassidic Thought
+
+Chassidism (founded by the Baal Shem Tov, 1698-1760) democratized
+kabbalistic concepts, making them accessible through:
+- Joy and emotional engagement with the divine
+- Finding God in everyday activities
+- The role of the tzaddik (righteous leader)
+- Devekut (cleaving to God) as accessible to all, not just scholars
+
+### Tanya: Chabad Chassidic Philosophy
+
+Rabbi Schneur Zalman of Liadi's Tanya (1796) presents a systematic
+psychological-mystical framework:
+
+| Concept | Description |
+|---------|-------------|
+| Nefesh ha-behamit | Animal soul — drives survival, desire, ego |
+| Nefesh ha-elokit | Divine soul — yearns for connection with God |
+| Beinoni | The "intermediate" person — not a tzaddik, not a rasha; the realistic spiritual ideal |
+| Moach shalit al ha-lev | The mind governs the heart — intellect can direct emotion |
+| Dirah b'tachtonim | God desires a dwelling place in the lower worlds — physical reality is where the divine project unfolds |
+
+### The Beinoni Concept
+
+The Tanya's most psychologically sophisticated teaching: the realistic
+spiritual ideal is not the tzaddik (who has conquered the evil inclination)
+but the beinoni (who has it but never acts on it). The beinoni:
+- Experiences temptation but chooses not to follow it
+- Uses intellectual contemplation (hitbonenut) to arouse love and awe of God
+- Is the achievable ideal for most people
+- Does not suppress emotions but redirects them
+
+## Soul Levels (Nefesh, Ruach, Neshamah)
+
+| Level | Hebrew | Faculty | Kabbalistic Correspondence |
+|-------|--------|---------|--------------------------|
+| Nefesh | נפש | Vital soul, life force | Malkhut, Asiyah |
+| Ruach | רוח | Spirit, emotional life | Zeir Anpin (Chesed-Yesod), Yetzirah |
+| Neshamah | נשמה | Higher soul, intellectual | Binah, Beriah |
+| Chayah | חיה | Living essence | Chokhmah, Atzilut |
+| Yechidah | יחידה | Singular/unique essence | Keter, unity with Ein Sof |
+
+Higher levels are progressively harder to access and represent deeper
+connection with the divine source.
+
+## Kabbalah and Ethics
+
+Mystical awareness should enhance, not replace, ethical behavior:
+
+| Kabbalistic Principle | Ethical Application |
+|----------------------|---------------------|
+| Sefirot balance | Every virtue needs its complementary restraint |
+| Tzimtzum | Making space for others is a divine act |
+| Nitzotzot | Every person and situation contains hidden holiness |
+| Tikkun | Every ethical act contributes to cosmic repair |
+| Four Worlds | Ethical living operates on physical, emotional, intellectual, and spiritual levels simultaneously |
+
+## Approaching Kabbalah Responsibly
+
+### Traditional Prerequisites
+
+Classical authorities recommend studying Kabbalah only after grounding in:
+1. Torah and Tanakh
+2. Mishna and Talmud
+3. Halakhic codes
+4. Age 40 (some traditions) or spiritual maturity
+
+### Modern Approaches
+
+Many contemporary teachers (including Adin Steinsaltz, Aryeh Kaplan, and
+various Chassidic schools) believe kabbalistic concepts can be taught
+widely when:
+- Presented accurately (not watered-down pop mysticism)
+- Grounded in Torah sources
+- Connected to ethical behavior, not pursued for power or novelty
+- Taught with humility about the limits of human understanding
+
+### Red Flags
+
+| Signal | Problem |
+|--------|---------|
+| Kabbalah disconnected from Torah and mitzvot | Likely distortion |
+| Promises of magical power | Commercial exploitation, not authentic tradition |
+| Claims of exclusive authority | Kabbalah has multiple legitimate schools |
+| Mysticism replacing ethics | Genuine Kabbalah deepens ethical commitment |

--- a/skills/jewish-wisdom/references/mussar-ethics.md
+++ b/skills/jewish-wisdom/references/mussar-ethics.md
@@ -1,0 +1,177 @@
+# Mussar and Jewish Ethics
+
+Sources: Luzzatto (Mesillat Yesharim), Salanter (Or Yisrael), Morinis (Everyday Holiness), Claussen (Sharing the Burden), Pirkei Avot
+
+Covers: Luzzatto's ladder of piety, middah analysis framework, cheshbon ha-nefesh, Pirkei Avot key maxims, ethical principles in halakha, modern ethical discourse.
+
+## What is Mussar?
+
+Mussar (literally "instruction/discipline") is the Jewish ethical
+tradition focused on character development — the cultivation of middot
+(character traits) through systematic self-examination, study, and
+practice. It is not just a set of rules but a transformative process.
+
+### Core Insight
+
+External behavior follows internal character. To change how you act,
+change who you are. Mussar works on the root (middot) rather than the
+symptoms (individual actions).
+
+## Luzzatto's Ladder (Mesillat Yesharim)
+
+Rabbi Moshe Chaim Luzzatto's Mesillat Yesharim (Path of the Just, 1740)
+presents a systematic progression of spiritual development. Each rung
+builds on the previous ones.
+
+### The Nine Rungs
+
+| # | Hebrew | English | Focus | Practice |
+|---|--------|---------|-------|----------|
+| 1 | Zehirut | Watchfulness | Awareness of one's actions and their consequences | Daily self-examination: "What did I do today? Why?" |
+| 2 | Zerizut | Zealousness | Enthusiasm and promptness in doing good | Overcome inertia and laziness; act immediately on good impulses |
+| 3 | Nekiyut | Cleanliness | Freedom from sin in action | Examine whether rationalizations are genuine or self-deception |
+| 4 | Perishut | Separateness | Restraint from excessive pleasure | Not asceticism but moderation — take what you need, not what you want |
+| 5 | Taharah | Purity | Purifying one's motivations | Act for the sake of goodness itself, not for recognition or reward |
+| 6 | Chassidut | Piety | Going beyond the letter of the law | Do more than required; anticipate what God and others need |
+| 7 | Anavah | Humility | True self-assessment without ego distortion | Not self-deprecation but honest recognition of both strengths and limitations |
+| 8 | Yirat Chet | Fear of Sin | Constant awareness of moral danger | Sensitivity to the consequences of wrongdoing — not fear of punishment but of causing harm |
+| 9 | Kedushah | Holiness | Attachment to the divine in all activities | Every mundane act becomes sacred through intention and awareness |
+
+### Applying the Ladder
+
+This is not a checklist but a developmental progression:
+- Work on each level until it becomes habitual
+- Don't skip levels — each provides the foundation for the next
+- Return to earlier levels when you notice slippage
+- The goal is not perfection but honest, sustained effort
+
+## Middah (Character Trait) Analysis Framework
+
+### The Golden Path (Shvil HaZahav)
+
+Following Maimonides (Hilchot De'ot), every middah exists on a spectrum.
+The goal is the balanced middle — not a rigid point but a range that
+depends on context and person.
+
+| Deficiency | Middah (Balance) | Excess |
+|-----------|-----------------|--------|
+| Stinginess | Generosity (Nedivut) | Reckless giving |
+| Passivity/cowardice | Courage (Ometz Lev) | Recklessness |
+| Coldness/detachment | Compassion (Rachamim) | Codependency/enabling |
+| Self-deprecation | Humility (Anavah) | Arrogance (Ga'avah) |
+| Indifference | Zeal (Zerizut) | Fanaticism |
+| Gullibility | Trust (Bitachon) | Suspicion/Paranoia |
+| Rigidity | Patience (Savlanut) | Passivity/doormat |
+| Isolation | Love (Ahavah) | Enmeshment |
+
+### Working on a Middah
+
+1. **Identify** — Which middah needs attention? (Often the one that causes the most friction in relationships)
+2. **Study** — What do Torah, Talmud, and Mussar texts say about this trait?
+3. **Observe** — Track when and where this trait manifests in daily life
+4. **Understand the root** — What drives the imbalance? Fear? Desire? Habit?
+5. **Practice the opposite** — If prone to anger, practice patience deliberately
+6. **Accountability** — Share your work with a partner (chavruta) or mentor
+7. **Reassess** — After sustained practice, evaluate: has the trait shifted?
+
+### Cheshbon HaNefesh (Accounting of the Soul)
+
+Benjamin Franklin independently developed a similar system, but the Jewish
+version predates him. Rabbi Menachem Mendel Lefin systematized it:
+
+**Daily practice:**
+- At the end of each day, review your actions
+- Ask: Where did I act according to my values? Where did I fall short?
+- Note patterns over time
+- Adjust tomorrow's intentions based on today's assessment
+
+**Weekly practice:**
+- Focus on one middah per week
+- Keep a journal tracking that specific trait
+- After 13 weeks (covering 13 core middot), restart the cycle
+
+## Pirkei Avot: Key Ethical Maxims
+
+Pirkei Avot (Ethics of the Fathers) is the Mishnaic tractate devoted
+entirely to ethical wisdom. These maxims provide frameworks for ethical
+thinking.
+
+### On Character
+
+| Maxim | Source | Application |
+|-------|--------|-------------|
+| "Who is wise? One who learns from every person" | 4:1 (Ben Zoma) | Intellectual humility; everyone has something to teach |
+| "Who is mighty? One who conquers their inclination" | 4:1 | True strength is self-mastery |
+| "Who is rich? One who is happy with their lot" | 4:1 | Contentment as ethical achievement |
+| "Who is honored? One who honors others" | 4:1 | Honor comes from giving, not demanding |
+
+### On Responsibility
+
+| Maxim | Source | Application |
+|-------|--------|-------------|
+| "If I am not for myself, who will be for me? And if I am only for myself, what am I? And if not now, when?" | 1:14 (Hillel) | Balance self-care and other-care; act now |
+| "It is not your responsibility to finish the work, but neither are you free to desist from it" | 2:16 (R. Tarfon) | Effort matters, not just results |
+| "In a place where there are no leaders, strive to be a leader" | 2:5 (Hillel) | Step up when leadership is lacking |
+| "Do not judge your fellow until you have stood in their place" | 2:4 | Empathy before judgment |
+
+### On Torah and Ethics
+
+| Maxim | Source | Application |
+|-------|--------|-------------|
+| "The world stands on three things: Torah, service, and acts of kindness" | 1:2 (Shimon HaTzaddik) | Knowledge, worship, and ethics are all essential |
+| "Where there is no Torah there is no proper conduct; where there is no proper conduct there is no Torah" | 3:17 (R. Elazar) | Learning and ethical behavior are mutually dependent |
+| "Say little and do much" | 1:15 (Shammai) | Action over words |
+| "Make your Torah study fixed, your work secondary" | 1:15 | Prioritize learning and values |
+
+## Ethical Principles in Practice
+
+### Bein Adam L'Chavero (Between Person and Person)
+
+| Principle | Source | Application |
+|-----------|--------|-------------|
+| Lashon Hara | Chofetz Chaim | Prohibition against harmful speech, even if true |
+| Ona'at Devarim | Talmud BM 58b | Verbal oppression — don't cause pain through words |
+| Dan L'Kaf Zechut | Avot 1:6 | Judge others favorably; give benefit of the doubt |
+| Lifnei Iver | Lev. 19:14 | Don't place a stumbling block — don't enable wrongdoing |
+| Tzedakah | Rambam | Justice-based obligation to support others, not mere charity |
+| Bikur Cholim | Talmud Shabbat 127a | Visiting the sick — active care for the suffering |
+| Hachnasat Orchim | Abraham's example | Hospitality — welcoming guests |
+
+### Rambam's Tzedakah Ladder (8 Levels)
+
+From lowest to highest:
+
+| Level | Description |
+|-------|-------------|
+| 8 (lowest) | Giving reluctantly |
+| 7 | Giving less than appropriate but cheerfully |
+| 6 | Giving appropriately after being asked |
+| 5 | Giving before being asked |
+| 4 | Recipient knows the giver but giver doesn't know recipient |
+| 3 | Giver knows the recipient but recipient doesn't know giver |
+| 2 | Anonymous giving through an intermediary |
+| 1 (highest) | Enabling self-sufficiency — giving a job, loan, or partnership |
+
+### Teshuvah (Repentance/Return)
+
+Rambam's framework for teshuvah (Hilchot Teshuvah):
+
+1. **Recognition** — acknowledge the wrongdoing honestly
+2. **Regret** — feel genuine remorse (not just fear of consequences)
+3. **Confession** — verbally articulate what you did wrong
+4. **Resolution** — commit sincerely to not repeating the behavior
+5. **Test** — when faced with the same situation, act differently
+
+For wrongs against another person, teshuvah requires seeking forgiveness
+from the wronged party. God cannot forgive what was done to another human.
+
+## Applying Mussar to Questions
+
+When addressing an ethical question through a Mussar lens:
+
+1. **Which middah is at stake?** Identify the character trait(s) involved
+2. **What does the tradition say?** Check Pirkei Avot, Mussar texts, halakhic sources
+3. **Where is the balance?** Apply the Golden Path — find the mean between extremes
+4. **What is the person's situation?** Mussar is contextual — different people need different advice
+5. **What is the root cause?** Address the underlying trait, not just the surface behavior
+6. **What is the practical step?** Mussar is about action — what can be done differently starting now?

--- a/skills/jewish-wisdom/references/talmudic-reasoning.md
+++ b/skills/jewish-wisdom/references/talmudic-reasoning.md
@@ -1,0 +1,197 @@
+# Talmudic Reasoning
+
+Sources: Steinsaltz (The Essential Talmud), Saiman (Profiling the Talmud), Lewittes (Principles and Development of Jewish Law), Halivni (Mekorot u-Mesorot)
+
+Covers: sugya structure, shakla v'tarya (dialectical exchange), key argumentative moves, machloket methodology, Tannatic vs Amoraic reasoning, conceptual analysis.
+
+## Structure of the Talmud
+
+The Talmud is Mishna (concise legal code, ~200 CE) plus Gemara (extensive
+analysis and debate, ~500 CE). Understanding its structure is essential
+for engaging with its reasoning.
+
+### Textual Layers
+
+| Layer | Period | Character | Language |
+|-------|--------|-----------|----------|
+| Mishna | Tannaim (~0-200 CE) | Concise legal rulings, minimal reasoning | Hebrew |
+| Baraita | Tannaim | Tannaitic material not included in the Mishna | Hebrew |
+| Gemara | Amoraim (~200-500 CE) | Analysis, debate, expansion of Mishna | Aramaic + Hebrew |
+| Stam | Anonymous editorial layer | Connecting framework, often the dialectical structure itself | Aramaic |
+
+### Key Principle: Stam vs Named
+
+The anonymous editorial voice (stam ha-talmud) constructs the dialectical
+framework. Named Amoraim (rabbis) state specific positions. Understanding
+this distinction matters because:
+- The stam creates hypothetical positions to test ideas
+- Named positions carry more authority than anonymous ones
+- The stam sometimes reconstructs debates that may not have occurred historically
+
+## Anatomy of a Sugya (Talmudic Passage)
+
+### Standard Structure
+
+| Section | Content | Example |
+|---------|---------|---------|
+| Mishna | The foundational ruling | "One who finds a lost object..." |
+| Opening question | What needs clarification? | "What case is the Mishna discussing?" |
+| First attempt | Initial interpretation or proof | "Perhaps it means..." |
+| Challenge | Objection to the attempt | "But this contradicts [another source]!" |
+| Resolution | Answer to the challenge | "No — that case is different because..." |
+| Alternative | Different approach | "Rav says... Shmuel says..." |
+| Proof texts | Biblical or Tannaitic support | "As it says in the baraita..." |
+| Conclusion | Resolution (or none) | The halakha follows [authority] |
+
+### Dialectical Flow (Shakla v'Tarya)
+
+The characteristic Talmudic method is back-and-forth questioning —
+not a linear argument but a collaborative-adversarial process of
+testing ideas from every angle.
+
+```
+Position stated
+  → Challenge raised (kushya)
+    → Resolution attempted (teirutz)
+      → Further challenge
+        → Distinction drawn (chiluk)
+          → New proof or counterexample
+            → Refined conclusion (or unresolved: teyku)
+```
+
+## Key Argumentative Moves
+
+These are the building blocks of Talmudic reasoning. Recognizing them
+enables engagement with any sugya.
+
+### Questions and Challenges
+
+| Term | Hebrew | Function |
+|------|--------|----------|
+| Mai ka mashma lan? | מאי קמשמע לן | "What novel point is this teaching?" — challenges obvious statements to find their added value |
+| Pshita! | פשיטא | "That's obvious!" — demands justification for stating something seemingly self-evident |
+| Meitivei | מיתיבי | "They raised an objection" — introduces a contradicting source |
+| Kashya | קשיא | "Difficulty" — marks an unresolved challenge |
+| Teiku | תיקו | "Let it stand" — the question remains unresolved (tradition: Elijah will resolve it) |
+
+### Resolutions and Distinctions
+
+| Term | Hebrew | Function |
+|------|--------|----------|
+| Lo tzricha | לא צריכא | "It was necessary" — explains why an apparently obvious statement teaches something new for a specific case |
+| Oka'ama | אוקמתא | "We establish it" — limits a broad rule to a specific case to resolve contradiction |
+| Ha b'ha, ha b'ha | הא בהא הא בהא | "This refers to one case, that to another" — two apparently contradictory rules apply to different situations |
+| Ki ha d'... | כי הא ד... | "Like that case where..." — draws an analogy to clarify |
+| Shanei | שאני | "It is different" — the challenged case is distinguished from the cited case |
+
+### Evaluative Moves
+
+| Term | Hebrew | Function |
+|------|--------|----------|
+| Mai nafka mina? | מאי נפקא מינה | "What practical difference does this make?" — tests whether a theoretical distinction has real-world impact |
+| B'mai ka mipalgi? | במאי קמפלגי | "What is the underlying principle of their disagreement?" — seeks the root conceptual difference behind a dispute |
+| Lema'i hilkheta? | למאי הלכתא | "For what legal purpose is this stated?" — every statement must serve a function |
+
+## Machloket (Dispute) as Methodology
+
+Dispute in the Talmud is not a failure to reach consensus — it is a
+deliberate methodology. The preservation of multiple opinions is itself
+a form of legal wisdom.
+
+### Core Principle: Eilu v'Eilu
+
+"These and these are the words of the living God" (Eruvin 13b). Both
+Beit Hillel and Beit Shammai speak divine truth, even though the
+halakha follows Beit Hillel. Minority opinions are preserved because:
+- Future circumstances may change which opinion applies
+- Understanding rejected positions deepens understanding of accepted ones
+- Multiple valid approaches reflect the complexity of divine wisdom
+
+### Types of Machloket
+
+| Type | Nature | Example |
+|------|--------|---------|
+| Factual | Disagreement about what happened or what a text says | What did Rabbi X actually teach? |
+| Legal | Disagreement about the correct ruling | Beit Hillel vs Beit Shammai on candle lighting |
+| Conceptual | Disagreement about underlying principles | Is the basis of this law property rights or personal dignity? |
+| Methodological | Disagreement about how to derive law | Rabbi Ishmael (limited rules) vs Rabbi Akiva (expansive interpretation) |
+
+### How Disputes Are Resolved
+
+| Method | When Used |
+|--------|-----------|
+| Majority vote | Standard in the Sanhedrin; halakha follows the majority |
+| Individual authority | Certain sages' opinions are authoritative in specific domains |
+| Stringency/leniency | For Torah-level law, follow the stringent view; for rabbinic law, follow the lenient |
+| Local custom | Where no resolution exists, follow the local practice (minhag) |
+| Teyku | Some disputes remain unresolved — honesty about limits of human reasoning |
+
+## Conceptual Analysis (Chakira)
+
+A key tool in advanced Talmudic reasoning: distinguishing between two
+possible conceptual foundations for the same law.
+
+### Structure of a Chakira
+
+1. State the law
+2. Ask: what is the underlying reason?
+3. Propose two possible foundations (tzad alef, tzad bet)
+4. Derive a practical difference (nafka mina) between them
+5. Test against other sources to determine which foundation is correct
+
+### Example
+
+**Law**: A borrower must return an object to the lender.
+
+**Two possible foundations**:
+- (A) Obligation based on the lender's ownership (property right)
+- (B) Obligation based on the borrower's commitment (personal obligation)
+
+**Practical difference**: If the lender dies, does the borrower return
+it to the heirs?
+- Under (A): yes, because the property right transfers to heirs
+- Under (B): possibly not, because the personal commitment was to the specific lender
+
+This conceptual analysis method is central to Rishonim (medieval commentators)
+and the Brisker analytical school.
+
+## Talmudic Reasoning Applied to Questions
+
+When addressing a question using Talmudic methodology:
+
+### Process
+
+1. **State the question clearly** — frame the issue precisely
+2. **Identify relevant sources** — what do Torah, Mishna, Talmud, and later authorities say?
+3. **Present the strongest position** — what is the most straightforward answer?
+4. **Challenge it** — what difficulties or counterarguments exist?
+5. **Attempt resolution** — can the challenges be answered?
+6. **Present alternative positions** — what do dissenting authorities hold?
+7. **Identify the underlying conceptual disagreement** — what is really at stake?
+8. **Note practical implications** — what difference does the analysis make?
+
+### Intellectual Values
+
+| Value | Expression |
+|-------|-----------|
+| Intellectual honesty | Present challenges to your own position fairly |
+| Rigor | Distinguish between strong and weak arguments |
+| Humility | Preserve views you disagree with; they may be right in ways you don't yet see |
+| Practicality | Always ask what practical difference the analysis makes |
+| Creativity | Find novel distinctions and connections, but ground them in textual evidence |
+| Respect for predecessors | Engage earlier authorities seriously, not dismissively |
+
+## Talmudic Logic vs Western Logic
+
+| Feature | Western Logic | Talmudic Logic |
+|---------|--------------|----------------|
+| Goal | Universal truth | Practical ruling within a legal system |
+| Contradiction | Must be resolved (law of non-contradiction) | Can coexist as "both are words of the living God" |
+| Authority | Arguments stand on their own merit | Arguments are strengthened or weakened by their source |
+| Context | Often seeks context-free principles | Always situational — the same principle may apply differently |
+| Resolution | Seeks definitive answers | Tolerates unresolved questions (teyku) |
+| Scope | Addresses universal categories | Addresses specific cases that illuminate principles |
+
+This is not a weakness of Talmudic reasoning — it reflects a fundamentally
+different approach to knowledge. Where Western logic seeks certainty,
+Talmudic reasoning seeks wisdom within irreducible complexity.

--- a/skills/jewish-wisdom/references/torah-interpretation.md
+++ b/skills/jewish-wisdom/references/torah-interpretation.md
@@ -1,0 +1,170 @@
+# Torah Interpretation
+
+Sources: Sarna (JPS Torah Commentary), Kugel (How to Read the Bible), Leibowitz (Studies in the Weekly Parashah), Hirsch (Commentary on the Torah), Fishbane (Biblical Interpretation in Ancient Israel)
+
+Covers: PaRDeS four levels, 13 rules of Rabbi Ishmael, midrashic method, biblical hermeneutics, peshat vs drash tensions, modern academic approaches.
+
+## PaRDeS: Four Levels of Torah Interpretation
+
+PaRDeS (literally "orchard/paradise") is the acronym for the four levels
+of Torah interpretation. Each level reveals different dimensions of meaning,
+and they are complementary rather than competing.
+
+### Peshat (Plain/Contextual Meaning)
+
+The straightforward meaning of the text within its literary, grammatical,
+and historical context.
+
+| Method | Application |
+|--------|-------------|
+| Grammar and syntax | Parse the Hebrew carefully; word forms carry meaning |
+| Narrative context | Read verses within their story arc, not in isolation |
+| Literary structure | Chiasmus, parallelism, repetition signal emphasis |
+| Historical context | Ancient Near Eastern background illuminates legal and narrative passages |
+| Comparison of versions | When the Torah repeats a law or story, differences between versions are significant |
+
+**Key principle**: Peshat is not always the "simplest" reading. It is the
+reading that best accounts for the text's language, structure, and context.
+Rashi's famous dictum: "Ein mikra yotzei midei peshuto" — a verse never
+departs from its plain meaning, even when midrash offers additional layers.
+
+### Remez (Hint/Allusion)
+
+Meaning conveyed through allusion, wordplay, numerical values, and
+intertextual connections.
+
+| Technique | How It Works | Example |
+|-----------|-------------|---------|
+| Gematria | Numerical value of Hebrew letters | "Love your neighbor" — the gematria of key words points to related concepts |
+| Notarikon | Letters of a word as acronym | Letters of "Bereishit" hint at deeper creation concepts |
+| Intertextual echoes | Shared words/phrases link passages | Same Hebrew root in two distant passages implies thematic connection |
+| Structural parallels | Matching literary structures reveal meaning | Creation narrative structure mirrors Tabernacle construction |
+
+### Drash (Homiletical/Expository)
+
+Interpretation that goes beyond the plain meaning to derive moral lessons,
+legal rulings, and theological insights.
+
+**Midrashic reasoning operates on the principle that every element of the
+Torah is meaningful** — repetitions, apparent contradictions, unusual
+spellings, and seemingly unnecessary words all carry interpretive payload.
+
+| Midrashic Move | What It Does | Example |
+|----------------|-------------|---------|
+| Fill narrative gaps | Explain what the text leaves unsaid | What did Abraham think during the three-day journey to the Akeidah? |
+| Resolve contradictions | Harmonize apparently conflicting verses | Two creation accounts in Genesis 1 and 2 |
+| Derive law from narrative | Extract legal principles from stories | Abraham's hospitality establishes visiting the sick as a mitzvah |
+| Read details as significant | Every "extra" word teaches something | "And God saw that it was good" — its omission on Day 2 is significant |
+
+### Sod (Secret/Mystical)
+
+The kabbalistic dimension — reading Torah as encoding the structure of
+divine reality. See `references/kabbalah-and-mysticism.md` for the
+Sefirot framework.
+
+| Approach | Content |
+|----------|---------|
+| Sefirot mapping | Characters, events, and laws correspond to divine attributes |
+| Divine Name analysis | The four-letter Name (YHVH) encodes the structure of reality |
+| Letter mysticism | Each Hebrew letter is a channel of divine creative energy |
+| Torah as blueprint | The Torah precedes and structures all of creation |
+
+## The Thirteen Rules of Rabbi Ishmael
+
+These are the formal hermeneutical principles for deriving halakha
+(Jewish law) from Torah text. They function as the "rules of inference"
+for legal reasoning from scripture.
+
+### Rules 1-4: Logical Inference
+
+| # | Rule | Hebrew | Meaning | Example |
+|---|------|--------|---------|---------|
+| 1 | Kal va-chomer | קל וחומר | A fortiori — if the minor case is true, the major certainly is | If Shabbat (severe) is overridden for Temple service, certainly a lesser restriction is overridden |
+| 2 | Gezerah shavah | גזירה שווה | Analogy by identical words — same word in two contexts links their laws | "Ot" (sign) in circumcision and Shabbat creates interpretive connection |
+| 3 | Binyan av mi-katuv echad | בנין אב מכתוב אחד | General principle from one verse | A principle stated in one case applies to analogous cases |
+| 4 | Binyan av mi-shnei ketuvim | בנין אב משני כתובים | General principle from two verses | When two passages share a feature, it applies to similar cases |
+
+### Rules 5-7: General and Particular
+
+| # | Rule | Hebrew | Application |
+|---|------|--------|-------------|
+| 5 | Klal u-prat | כלל ופרט | General followed by particular — the particular limits the general |
+| 6 | Prat u-klal | פרט וכלל | Particular followed by general — the general expands beyond the particular |
+| 7 | Klal u-prat u-klal | כלל ופרט וכלל | General-particular-general — interpret by the particular's characteristics |
+
+### Rules 8-13: Contextual and Resolving
+
+| # | Rule | Hebrew | Application |
+|---|------|--------|-------------|
+| 8 | Ka-yotzei bo | כיוצא בו ממקום אחר | Similar passage from another context illuminates meaning |
+| 9 | Davar ha-lamed me-inyano | דבר הלמד מענינו | Meaning derived from surrounding context |
+| 10 | Davar ha-lamed mi-sofo | דבר הלמד מסופו | Meaning derived from a later passage |
+| 11 | Davar she-hayah bi-khlal | דבר שהיה בכלל ויצא מן הכלל ללמד | Item singled out from a general category — teaches about the whole category |
+| 12 | Davar she-hayah bi-khlal v'yatza lidon b'davar chadash | דבר שהיה בכלל ויצא לידון בדבר חדש | Item singled out to be treated as a new matter |
+| 13 | Shnei ketuvim ha-makhchishim | שני כתובים המכחישים זה את זה | Two contradictory passages resolved by a third verse |
+
+### Applying the Rules
+
+These rules are not arbitrary — they represent a systematic approach to
+textual reasoning. When analyzing a Torah passage:
+
+1. Start with peshat — what does the text plainly say?
+2. Identify any textual features that invite deeper analysis (repetition, unusual words, apparent contradiction)
+3. Apply the relevant rule(s) to derive additional meaning
+4. Check: does the derived meaning conflict with established principles?
+5. Consider how different authorities applied the same rule differently
+
+## Modern Academic Approaches
+
+### Source Criticism (Documentary Hypothesis)
+
+Academic scholarship identifies multiple source documents (J, E, P, D)
+woven together by redactors. This approach:
+- Explains repetitions and contradictions through editorial composition
+- Provides historical context for different literary styles
+- Remains controversial in traditional circles but standard in academia
+
+### How to Engage Both Traditional and Academic Methods
+
+| When Traditional Methods Excel | When Academic Methods Add Value |
+|-------------------------------|-------------------------------|
+| Deriving legal and ethical meaning | Understanding historical development |
+| Finding coherent theological themes | Explaining compositional features |
+| Connecting disparate passages | Placing texts in ancient Near Eastern context |
+| Generating new insight from close reading | Understanding genre conventions |
+
+The approaches need not be mutually exclusive. Many scholars practice both —
+close traditional reading for meaning, historical awareness for context.
+
+## Commentators: Major Approaches
+
+| Commentator | Period | Method | Known For |
+|------------|--------|--------|-----------|
+| Rashi | 11th c. | Peshat with selected midrash | Concise, accessible, foundational |
+| Ibn Ezra | 12th c. | Grammatical peshat, rational | Linguistic precision, independence |
+| Ramban (Nachmanides) | 13th c. | Peshat + mystical depth | Critique of Rashi, kabbalistic hints |
+| Rashbam | 12th c. | Strict peshat | Sometimes disagrees with grandfather Rashi |
+| Sforno | 15th-16th c. | Philosophical peshat | Moral-philosophical emphasis |
+| Or HaChaim | 18th c. | Multi-layered (42 methods) | Mystical and analytical combined |
+
+### Selecting Commentators for Analysis
+
+- For grammatical/linguistic questions → Ibn Ezra, Rashbam
+- For accessible teaching → Rashi
+- For philosophical depth → Ramban, Sforno
+- For mystical dimension → Or HaChaim, Ramban
+- For legal derivation → Rashi (on Talmud), Rambam
+- For historical context → JPS Commentary, Kugel
+
+## Practical Torah Study Framework
+
+When approaching a Torah passage or question:
+
+1. **Read the text in Hebrew** (or accurate translation with key Hebrew terms noted)
+2. **Identify the question or difficulty** the text raises
+3. **Peshat first** — what is the plain meaning? What's the narrative/legal context?
+4. **Check major commentators** — how do Rashi, Ramban, Ibn Ezra address this?
+5. **Look for intertextual connections** — where else does this word/theme appear?
+6. **Consider midrashic traditions** — what did the Sages derive from this passage?
+7. **If relevant, consider mystical dimensions** — what do the kabbalists see here?
+8. **Synthesize** — what insight emerges from layering these approaches?

--- a/skills/jewish-wisdom/skills.json
+++ b/skills/jewish-wisdom/skills.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/jewish-wisdom",
+  "version": "1.0.0",
+  "description": "Deep engagement with Jewish thought — Torah interpretation (PaRDeS, 13 rules of Rabbi Ishmael), Talmudic reasoning (shakla v'tarya, machloket), Jewish philosophy (Maimonides, Halevi, Heschel), Kabbalah (Sefirot, Four Worlds), Mussar ethics, and Halakha. Multi-denominational: Orthodox, Conservative, Reform, academic. Teaches and debates using authentic Jewish methodologies. Triggers: Torah, Talmud, Judaism, Jewish philosophy, halakha, Kabbalah, Mussar, midrash, PaRDeS, Rashi, Rambam, Sefirot, middot, tikkun, Pirkei Avot, Jewish ethics, dvar Torah, machloket.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}

--- a/skills/philosophical-reasoning/SKILL.md
+++ b/skills/philosophical-reasoning/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: "@tank/philosophical-reasoning"
+description: |
+  Rigorous philosophical analysis, logical reasoning, and structured argumentation
+  on any question — from ethics and metaphysics to epistemology and meaning. Covers
+  Western philosophy (Greek through modern), Eastern philosophy (Buddhist, Daoist,
+  Confucian, Hindu), formal logic (propositional, predicate, modal, syllogistic),
+  informal logic (25+ fallacies, argument mapping, Toulmin model), ethical frameworks
+  (utilitarian, Kantian, virtue, care, contractualist), epistemology, and thought
+  experiments. Adapts output style: Socratic dialogue, multi-perspective analysis,
+  or structured argument depending on the question.
+
+  Synthesizes Plato, Aristotle, Kant, Mill, Hume, Descartes, Nagarjuna, Confucius,
+  Laozi, Rawls, Sandel, Kahneman, Walton, Copi/Cohen, Weston, Paul, Toulmin.
+
+  Trigger phrases: "philosophize", "philosophical question", "what is the meaning of",
+  "is it moral to", "ethical dilemma", "logical argument", "fallacy", "Socratic",
+  "thought experiment", "trolley problem", "epistemology", "what can we know",
+  "free will", "determinism", "existence of God", "meaning of life", "virtue ethics",
+  "utilitarianism", "Kant", "categorical imperative", "logical fallacy", "argue for",
+  "argue against", "is it justified", "what is justice", "what is truth",
+  "Eastern philosophy", "Buddhist philosophy", "Daoist", "Confucian",
+  "analyze this argument", "steel man", "devil's advocate", "think deeply about",
+  "philosophical debate", "formal logic", "syllogism", "critical thinking"
+---
+
+# Philosophical Reasoning
+
+Engage with questions through rigorous philosophical methodology — not
+opinions dressed as insight, but structured reasoning grounded in
+2,500 years of intellectual tradition.
+
+## Core Philosophy
+
+1. **Follow the argument wherever it leads.** Intellectual honesty over comfortable conclusions.
+2. **Steel-man before critiquing.** Present every position in its strongest form.
+3. **Distinguish types of disagreement.** Factual, conceptual, and evaluative disputes require different methods.
+4. **Multiple frameworks illuminate more than one.** Apply several perspectives, then synthesize.
+5. **Uncertainty is honest; false certainty is not.** Qualify conclusions appropriately.
+
+## Response Mode Selection
+
+| Question Type | Mode | Process |
+|--------------|------|---------|
+| "What is X?" / definition questions | Socratic Dialogue | Elenchus: propose → test → refine through counterexamples |
+| "Is X right/wrong?" / ethical questions | Multi-Framework Analysis | Apply 3-5 ethical frameworks, identify convergence and conflict |
+| "Is this argument valid?" / evaluation | Structured Argument Analysis | Reconstruct → test validity → assess soundness → identify fallacies |
+| "What would [philosopher] say?" | Perspective Analysis | Present position authentically, then evaluate |
+| "Debate X" / position defense | Dialectical Method | Thesis → antithesis → synthesis; steel-man both sides |
+| "Help me think about X" | Guided Inquiry | Combine Socratic questioning with framework introduction |
+| "Prove/disprove X" | Formal Logic | Symbolize → test validity → assess premises |
+
+## Quick Start: Analyzing Any Question
+
+1. **Classify the question** — Is it empirical, conceptual, normative, or existential?
+2. **Select mode** from the table above
+3. **Apply the relevant method** from the appropriate reference file
+4. **Present multiple perspectives** — never just one view
+5. **State your assessment** with qualification and strongest counterargument
+6. **Identify what remains unresolved** — intellectual honesty about limits
+
+## Socratic Questioning Framework
+
+Six question types to probe any claim. See `references/socratic-method.md`.
+
+| Type | Example |
+|------|---------|
+| Clarification | "What exactly do you mean by...?" |
+| Assumption-probing | "What are you presupposing?" |
+| Evidence | "What supports this claim?" |
+| Perspective | "How would X see this differently?" |
+| Implication | "If that's true, what follows?" |
+| Meta-question | "Is this the right question to ask?" |
+
+## Logical Analysis Quick Reference
+
+### Valid Inference (use these)
+
+| Rule | Form |
+|------|------|
+| Modus Ponens | If P then Q. P. Therefore Q. |
+| Modus Tollens | If P then Q. Not Q. Therefore not P. |
+| Disjunctive Syllogism | P or Q. Not P. Therefore Q. |
+
+### Invalid Inference (catch these)
+
+| Fallacy | Form |
+|---------|------|
+| Affirming Consequent | If P then Q. Q. Therefore P. (INVALID) |
+| Denying Antecedent | If P then Q. Not P. Therefore not Q. (INVALID) |
+
+See `references/formal-logic.md` for complete systems and `references/fallacies-and-argumentation.md` for the full fallacy taxonomy.
+
+## Ethical Framework Selector
+
+| If the question involves... | Start with... |
+|---------------------------|--------------|
+| Policy, many people affected | Consequentialism + Contractualism |
+| Personal duty, rights | Deontology (Kant) |
+| Character, "what kind of person" | Virtue Ethics (Aristotle) |
+| Relationships, care | Care Ethics |
+| Fairness, distribution | Contractualism (Rawls) |
+| Always apply at least 3 | Then note where they converge and conflict |
+
+See `references/ethical-frameworks.md` for full decision procedure.
+
+## Eastern Philosophy Integration
+
+When Western binary thinking creates false dilemmas, consider:
+- **Buddhist catuskoti**: Maybe neither position is true as stated
+- **Daoist wu-wei**: Maybe forcing a resolution is the problem
+- **Confucian practical wisdom**: Maybe the answer is relational, not abstract
+
+See `references/eastern-philosophy.md`.
+
+## Thought Experiment Methodology
+
+1. Isolate the variable being tested
+2. Push intuitions to extremes
+3. Identify the principle the intuition tracks
+4. Test against counterexamples
+
+See `references/thought-experiments.md` for classic experiments with analysis.
+
+## Reference Index
+
+| File | Contents |
+|------|----------|
+| `references/socratic-method.md` | Elenchus steps, 6 question types, maieutics, dialogue facilitation, written analysis adaptation |
+| `references/formal-logic.md` | Propositional logic, predicate logic, syllogisms, truth tables, inference rules, modal logic, validity testing |
+| `references/fallacies-and-argumentation.md` | 25+ fallacy taxonomy, Toulmin model, argument reconstruction, burden of proof, evidence hierarchy, pragma-dialectics |
+| `references/ethical-frameworks.md` | Consequentialism, deontology, virtue ethics, care ethics, contractualism, applied ethics methodology, framework comparison |
+| `references/epistemology.md` | Rationalism, empiricism, pragmatism, skepticism, JTB + Gettier, scientific method, epistemic virtues |
+| `references/eastern-philosophy.md` | Buddhist logic (catuskoti), Four Noble Truths, Daoist paradox, Confucian ethics, Hindu darshanas, comparative methodology |
+| `references/thought-experiments.md` | Classic experiments (trolley, Chinese room, veil of ignorance, etc.), construction methodology, dialectical methods, multi-perspective analysis |

--- a/skills/philosophical-reasoning/references/eastern-philosophy.md
+++ b/skills/philosophical-reasoning/references/eastern-philosophy.md
@@ -1,0 +1,211 @@
+# Eastern Philosophy
+
+Sources: Harrison (Eastern Philosophy: The Basics), Siderits (Buddhism as Philosophy), Ivanhoe/Van Norden (Readings in Classical Chinese Philosophy), Nagarjuna (Mulamadhyamakakarika), Confucius (Analects), Laozi (Tao Te Ching)
+
+Covers: Buddhist logic and soteriology, Daoist paradox and wu-wei, Confucian ethics and social philosophy, Hindu philosophical schools, comparative methodology.
+
+## Buddhist Philosophy
+
+### The Four Noble Truths as Philosophical Method
+
+The Four Noble Truths function as a diagnostic framework — not just
+religious doctrine but a general method for analyzing existential problems.
+
+| Truth | Function | Philosophical Analog |
+|-------|----------|---------------------|
+| Dukkha (Suffering/Unsatisfactoriness) | Diagnosis — identify the problem | Problem statement |
+| Samudaya (Origin) | Etiology — identify the cause | Causal analysis |
+| Nirodha (Cessation) | Prognosis — confirm the problem is solvable | Feasibility assessment |
+| Magga (Path) | Treatment — the practical solution | Action plan |
+
+This diagnostic structure applies beyond suffering to any philosophical
+problem: name the phenomenon, trace its causes, assess whether it can be
+resolved, and specify the method.
+
+### Buddhist Logic: Catuskoti (Tetralemma)
+
+Classical Western logic assumes every proposition is either true or false
+(law of excluded middle). Buddhist logic, particularly in Nagarjuna's
+Madhyamaka school, uses four-cornered negation:
+
+| Position | Form | Example: "Does the self exist?" |
+|----------|------|------|
+| 1 | p is true | "The self exists" |
+| 2 | p is false | "The self does not exist" |
+| 3 | p is both true and false | "The self both exists and does not exist" |
+| 4 | p is neither true nor false | "The self neither exists nor does not exist" |
+
+Nagarjuna's radical move: reject all four positions. This is not
+irrationalism but a claim that the question itself rests on a false
+framework — the concept "self" does not map onto reality in a way that
+makes any of these answers correct.
+
+### When Catuskoti Is Useful
+
+- When a question assumes categories that don't fit the subject matter
+- When binary thinking creates false dilemmas
+- When the question itself needs to be dissolved rather than answered
+- Parallels in Western philosophy: Wittgenstein's "some questions are
+  not answered but disappear," Heidegger's destruction of metaphysics
+
+### Sunyata (Emptiness) as Philosophical Concept
+
+Everything is "empty" (sunya) of inherent, independent existence. This means:
+- Things exist only in dependence on causes, conditions, and conceptual designation
+- Nothing has a fixed, essential nature
+- This applies to emptiness itself (emptiness is empty)
+
+Philosophical significance: challenges essentialist thinking in any domain.
+When you find yourself asking "what is the TRUE nature of X?" — consider
+that X may not have a fixed nature independent of context and relation.
+
+### Dependent Origination (Pratityasamutpada)
+
+Everything arises in dependence on conditions. Nothing exists in isolation.
+This is both a metaphysical claim and a methodological principle:
+- To understand any phenomenon, examine its conditions
+- No phenomenon is self-causing or uncaused
+- Removing conditions removes the phenomenon
+
+## Daoist Philosophy
+
+### Wu-Wei: Action Through Non-Action
+
+Wu-wei is not passivity but effortless action that flows with the natural
+pattern of things (Dao). Key principles:
+
+| Principle | Content | Application |
+|-----------|---------|-------------|
+| Non-forcing | Don't impose artificial patterns on natural processes | Let arguments develop organically rather than forcing conclusions |
+| Responsiveness | Act in response to what the situation actually calls for | Adapt your reasoning to the question rather than applying one method everywhere |
+| Simplicity | Complexity often obscures rather than illuminates | The simplest adequate explanation is usually best |
+| Reversal | Things contain their opposites; extremes reverse | Excessive certainty breeds error; apparent weakness can be strength |
+
+### Yin-Yang Dialectic
+
+Not mere opposition but complementary poles:
+
+| Yin | Yang |
+|-----|------|
+| Receptive | Active |
+| Yielding | Firm |
+| Intuitive | Analytical |
+| Particular | Universal |
+| Implicit | Explicit |
+
+Philosophical application: when analyzing any binary opposition (mind/body,
+individual/society, freedom/determinism), consider that the opposites may
+be complementary rather than contradictory. Zhuangzi pushes this further —
+even the yin-yang distinction is perspective-dependent.
+
+### Zhuangzi's Perspectivism
+
+Key themes from Zhuangzi:
+- **Relative perspectives**: "Is it I who dreamed I was a butterfly, or a butterfly dreaming I am Zhuangzi?"
+- **The limits of language**: Words are fingers pointing at the moon; don't mistake the finger for the moon
+- **Skillful action**: The cook who carves an ox without thinking demonstrates knowledge that transcends propositions
+- **Uselessness as usefulness**: The gnarled tree survives because it's "useless" — value depends on framework
+
+### When Daoist Thinking Adds Value
+
+| Situation | Daoist Insight |
+|-----------|----------------|
+| Analysis paralysis | Wu-wei: stop forcing and let understanding emerge |
+| Binary debates | Yin-yang: the opposition may be false |
+| Certainty about uncertain things | Zhuangzi: your perspective is one among many |
+| Overcomplication | Simplicity: reduce to essentials |
+
+## Confucian Philosophy
+
+### Ren (Benevolence/Humaneness)
+
+The central Confucian virtue — not an abstract principle but cultivated
+through practice in concrete relationships.
+
+### The Five Relationships
+
+| Relationship | Virtue Required |
+|-------------|-----------------|
+| Ruler-Subject | Righteousness and loyalty |
+| Parent-Child | Kindness and filial piety |
+| Husband-Wife | Mutual respect |
+| Elder-Younger | Consideration and deference |
+| Friend-Friend | Faithfulness |
+
+Philosophical significance: ethics is not primarily about abstract rules
+but about fulfilling the responsibilities specific to your relationships
+and social roles.
+
+### Rectification of Names (Zhengming)
+
+"Let the ruler be a ruler, the minister a minister, the father a father,
+the son a son." (Analects 12.11)
+
+Principle: Words should match reality. When they don't, social and moral
+disorder follows. A ruler who doesn't govern justly is not truly a ruler.
+
+Philosophical application: Before analyzing a concept, ensure your terms
+actually correspond to what they claim to describe. Conceptual clarity is
+a moral and political act.
+
+### Junzi (Exemplary Person) vs. Xiaoren (Petty Person)
+
+| Junzi | Xiaoren |
+|-------|---------|
+| Acts from principle | Acts from self-interest |
+| Self-critical | Blames others |
+| Seeks what is right | Seeks what is profitable |
+| Speaks carefully | Speaks carelessly |
+| Values learning | Values reputation |
+
+This is virtue ethics with a social-relational emphasis. The goal is not
+abstract moral perfection but becoming the kind of person who enriches
+their community.
+
+## Hindu Philosophical Schools (Darshanas)
+
+Six orthodox schools, each with distinct epistemological and metaphysical positions:
+
+| School | Focus | Key Contribution |
+|--------|-------|------------------|
+| Nyaya | Logic and epistemology | Rigorous theory of inference; four pramanas (sources of knowledge) |
+| Vaisheshika | Metaphysics and atomism | Category theory of reality; padarthas |
+| Samkhya | Dualist metaphysics | Purusha (consciousness) vs Prakriti (matter); evolution of matter |
+| Yoga | Practical philosophy | Systematic method for experiential knowledge; eight limbs |
+| Mimamsa | Hermeneutics and ritual | Theory of linguistic meaning; duty-based ethics |
+| Vedanta | Ultimate reality | Brahman-Atman identity (Advaita); qualified non-dualism (Vishishtadvaita) |
+
+### Nyaya: Indian Logic
+
+The Nyaya school developed a sophisticated logic of inference:
+
+**Five-membered syllogism (Nyaya)**:
+1. Pratijna (thesis): "The hill has fire"
+2. Hetu (reason): "Because it has smoke"
+3. Udaharana (example): "Whatever has smoke has fire, like a kitchen"
+4. Upanaya (application): "The hill has smoke"
+5. Nigamana (conclusion): "Therefore the hill has fire"
+
+Compare with Aristotelian syllogism — Nyaya requires an observed example,
+grounding reasoning in experience rather than pure form.
+
+## Comparative Methodology
+
+### Using Eastern and Western Philosophy Together
+
+| Eastern Concept | Western Parallel | Key Difference |
+|----------------|------------------|----------------|
+| Sunyata (Emptiness) | Anti-essentialism, process philosophy | Buddhist version is more radical — applies to everything including itself |
+| Wu-wei | Virtue ethics (Aristotelian phronesis) | Wu-wei de-emphasizes deliberation; phronesis emphasizes it |
+| Ren (Benevolence) | Care ethics | Confucian version is more structured by social roles |
+| Catuskoti | Dialetheism, paraconsistent logic | Buddhist version is pragmatic/soteriological, not just formal |
+| Karma | Natural consequences, moral luck | Karma is more systematic and metaphysical |
+| Dharma | Natural law, duty | Dharma integrates cosmic, social, and individual dimensions |
+
+### When to Apply Eastern Perspectives
+
+- When Western binary thinking creates false dilemmas
+- When abstract universalism ignores relational context
+- When rational analysis alone seems insufficient
+- When the question is about how to live, not just what to believe
+- When examining the limits of conceptual thought itself

--- a/skills/philosophical-reasoning/references/epistemology.md
+++ b/skills/philosophical-reasoning/references/epistemology.md
@@ -1,0 +1,185 @@
+# Epistemology
+
+Sources: Descartes (Meditations), Hume (Enquiry Concerning Human Understanding), Kuhn (Structure of Scientific Revolutions), Popper (Logic of Scientific Discovery), Goldman (Reliabilism), Sosa (Virtue Epistemology)
+
+Covers: major epistemological positions, justified true belief and Gettier, sources of knowledge, scientific method, skeptical challenges and responses, epistemic virtues.
+
+## What Epistemology Investigates
+
+Epistemology asks: What is knowledge? What can we know? How do we know it?
+What distinguishes genuine knowledge from mere opinion?
+
+These questions matter for philosophical analysis because every argument
+rests on epistemic assumptions — claims about what we can know and how
+we know it.
+
+## The Classical Analysis: Justified True Belief (JTB)
+
+### The Traditional Account
+
+S knows that p if and only if:
+1. p is true (truth condition)
+2. S believes that p (belief condition)
+3. S is justified in believing that p (justification condition)
+
+### The Gettier Problem
+
+Edmund Gettier (1963) showed that JTB is insufficient with simple
+counterexamples:
+
+**Case**: Smith has strong evidence that Jones will get the job and that
+Jones has ten coins in his pocket. Smith infers: "The person who will
+get the job has ten coins in his pocket." Unknown to Smith, he himself
+gets the job — and happens to have ten coins in his pocket. Smith's belief
+is true, justified, but not knowledge (he was right by luck).
+
+### Post-Gettier Responses
+
+| Response | Core Idea | Problem |
+|----------|-----------|---------|
+| No-false-lemma | Knowledge requires that justification chain contains no false beliefs | Some Gettier cases involve no false intermediate belief |
+| Defeasibility | Knowledge requires no "defeaters" — truths that would undermine justification if known | Hard to specify what counts as a defeater |
+| Reliabilism | Knowledge is belief produced by a reliable cognitive process | Handles Gettier but hard to specify "reliable" |
+| Virtue Epistemology | Knowledge is belief arising from intellectual virtue (competence) | Sosa: S knows p when S's belief is apt — accurate because competent |
+
+## Major Epistemological Positions
+
+### Rationalism
+
+**Core claim**: Reason is the primary source of knowledge. Some knowledge
+is innate or a priori (independent of experience).
+
+| Thinker | Key Contribution |
+|---------|-----------------|
+| Descartes | Cogito ergo sum; clear and distinct ideas; methodological doubt |
+| Leibniz | Necessary truths knowable through reason alone |
+| Spinoza | Reality has logical structure deducible from first principles |
+
+**When rationalism is strongest**: Mathematics, logic, conceptual analysis,
+necessary truths.
+
+### Empiricism
+
+**Core claim**: All substantive knowledge comes from sensory experience.
+The mind begins as a blank slate (tabula rasa).
+
+| Thinker | Key Contribution |
+|---------|-----------------|
+| Locke | Simple ideas from sensation, complex ideas from combination |
+| Hume | Fork: relations of ideas (analytic) vs matters of fact (synthetic, empirical) |
+| Berkeley | Esse est percipi — to be is to be perceived |
+
+**When empiricism is strongest**: Natural science, factual claims about
+the world, causal reasoning.
+
+### Hume's Problem of Induction
+
+We cannot logically justify induction (inferring general laws from particular
+observations):
+- Past regularity doesn't logically guarantee future regularity
+- The principle "nature is uniform" itself requires inductive justification (circular)
+- Yet we cannot function without induction
+
+This is not a refutation of science but a humbling recognition that our
+strongest empirical knowledge rests on an assumption we cannot prove.
+
+### Pragmatism
+
+**Core claim**: The meaning and truth of ideas is determined by their
+practical consequences and usefulness.
+
+| Thinker | Key Contribution |
+|---------|-----------------|
+| Peirce | Truth is what inquiry would converge on in the long run |
+| James | Truth is what "works" — what proves useful in practice |
+| Dewey | Knowledge is inquiry — the process of resolving problematic situations |
+
+**When pragmatism is strongest**: Evaluating competing theories, choosing
+between underdetermined hypotheses, applied philosophy.
+
+### Skepticism
+
+**Core claim**: Knowledge is impossible or at least far more limited than
+we assume.
+
+| Type | Challenge |
+|------|-----------|
+| Global skepticism | We might be brains in vats; how can we know anything about external reality? |
+| Inductive skepticism | Past experience cannot justify future predictions (Hume) |
+| Moral skepticism | Moral "knowledge" may be impossible (Mackie's error theory) |
+| Skepticism about other minds | We cannot directly access others' mental states |
+
+**Skepticism's value**: Not as a final position but as a tool — skeptical
+challenges force us to examine and strengthen our epistemic foundations.
+
+## Foundationalism vs. Coherentism
+
+These are rival theories about the structure of justification.
+
+| Theory | Structure | Metaphor |
+|--------|-----------|----------|
+| Foundationalism | Knowledge rests on basic beliefs that are self-evident or self-justifying | Building on bedrock |
+| Coherentism | Beliefs are justified by their mutual coherence with other beliefs | Web of beliefs |
+| Infinitism | Justification requires an infinite chain of reasons | Rare position |
+
+### The Regress Problem
+
+Every belief needs justification. But what justifies the justifier?
+1. **Foundationalist answer**: Some beliefs are self-justifying (perceptual reports, logical truths)
+2. **Coherentist answer**: Justification is circular but the circle is large enough
+3. **Pragmatist answer**: The regress is dissolved by looking at what works
+
+## Scientific Method and Epistemology
+
+### Popper: Falsificationism
+
+- Theories cannot be verified, only falsified
+- A theory is scientific if and only if it is falsifiable
+- Good science actively seeks to disprove its hypotheses
+- "Corroboration" (surviving attempts at falsification) is the best a theory can achieve
+
+### Kuhn: Paradigm Shifts
+
+- Normal science operates within a paradigm (shared framework of assumptions)
+- Anomalies accumulate until crisis triggers paradigm shift
+- New paradigm is incommensurable with old — not just "better" but a different way of seeing
+- Science progresses, but not in a simple linear way
+
+### Practical Framework: Evaluating Knowledge Claims
+
+| Question | What It Tests |
+|----------|---------------|
+| What is the evidence? | Empirical grounding |
+| Is the claim falsifiable? | Scientific status (Popper) |
+| What would change your mind? | Intellectual honesty |
+| What are the alternative explanations? | Have you considered competing hypotheses? |
+| Is this within a stable paradigm or an area of active controversy? | How settled is the knowledge? |
+| What is the source's track record? | Reliability of testimony |
+
+## Epistemic Virtues
+
+Virtue epistemology emphasizes character traits that promote good reasoning:
+
+| Virtue | Description | Opposed Vice |
+|--------|-------------|-------------|
+| Intellectual humility | Recognizing the limits of your knowledge | Intellectual arrogance |
+| Intellectual courage | Pursuing truth even when uncomfortable | Intellectual cowardice |
+| Intellectual honesty | Representing evidence fairly | Self-deception, motivated reasoning |
+| Open-mindedness | Genuine willingness to consider alternatives | Dogmatism |
+| Intellectual carefulness | Avoiding hasty conclusions | Carelessness, sloppiness |
+| Intellectual thoroughness | Investigating deeply, not superficially | Superficiality |
+| Intellectual autonomy | Thinking for yourself | Uncritical deference |
+
+These virtues are not optional polish — they are constitutive of good
+philosophical reasoning. An argument constructed without intellectual
+honesty is not philosophy, regardless of its logical structure.
+
+## Applying Epistemology in Philosophical Analysis
+
+When analyzing any philosophical question, ask:
+
+1. **What kind of knowledge is being claimed?** (Empirical, moral, logical, aesthetic)
+2. **What epistemic standard is appropriate?** (Certainty for math, probability for empirical, reasonable judgment for ethics)
+3. **What are the sources?** (Reason, experience, testimony, intuition)
+4. **What would defeat this knowledge claim?** (What evidence would count against it?)
+5. **What is the relevant disagreement about?** (Factual? Conceptual? Evaluative?)

--- a/skills/philosophical-reasoning/references/ethical-frameworks.md
+++ b/skills/philosophical-reasoning/references/ethical-frameworks.md
@@ -1,0 +1,234 @@
+# Ethical Frameworks
+
+Sources: Sandel (Justice: What's the Right Thing to Do?), Mill (Utilitarianism), Kant (Groundwork), Aristotle (Nicomachean Ethics), Rawls (A Theory of Justice), Noddings (Caring)
+
+Covers: consequentialism, deontology, virtue ethics, care ethics, contractualism, applied ethics methodology, framework comparison and selection.
+
+## Framework Overview
+
+No single ethical framework is universally correct. Each captures genuine
+moral intuitions. The skill of ethical reasoning is knowing which framework
+illuminates which kinds of questions — and recognizing when frameworks
+conflict, which is where the hardest ethical thinking happens.
+
+| Framework | Core Question | Key Figures |
+|-----------|--------------|-------------|
+| Consequentialism | What outcomes will this produce? | Bentham, Mill, Singer |
+| Deontology | What duties and principles apply? | Kant, Ross, Scanlon |
+| Virtue Ethics | What kind of person does this make me? | Aristotle, MacIntyre, Foot |
+| Care Ethics | What do my relationships require? | Noddings, Gilligan, Held |
+| Contractualism | What would rational agents agree to? | Rawls, Scanlon, Hobbes |
+
+## Consequentialism
+
+### Core Principle
+An action is morally right if and only if it produces the best overall
+consequences (typically: the greatest well-being for the greatest number).
+
+### Utilitarian Calculation Framework
+
+1. Identify available actions
+2. For each action, identify all affected parties
+3. Estimate the positive and negative consequences for each party
+4. Sum the net well-being across all affected parties
+5. Choose the action with the highest net well-being
+
+### Act vs. Rule Utilitarianism
+
+| Type | Evaluates | Example |
+|------|-----------|---------|
+| Act Utilitarianism | Each individual action by its consequences | "Should I break this particular promise?" — depends on this case's consequences |
+| Rule Utilitarianism | Rules by the consequences of general adherence | "Should I follow the rule of keeping promises?" — yes, because a world where promises are kept has better overall consequences |
+
+### Strengths
+
+- Takes consequences seriously (intentions alone don't justify suffering)
+- Democratic: everyone's well-being counts equally
+- Provides concrete decision procedure
+
+### Challenges
+
+| Objection | Example | Utilitarian Response |
+|-----------|---------|---------------------|
+| Justice problem | Harvesting organs from one person to save five? | Rule utilitarianism: the rule "don't harvest organs" produces better long-term consequences |
+| Measurement problem | How to quantify and compare different people's well-being? | Use best available evidence, not certainty |
+| Demandingness | Must you always maximize good? No room for personal projects? | Satisficing: act well enough, not perfectly |
+| Minority rights | Majority pleasure justifies oppressing minorities? | Sophisticated utilitarians count the disutility of living in an unjust society |
+
+## Deontology (Duty-Based Ethics)
+
+### Kant's Categorical Imperative
+
+Kant's supreme principle of morality, formulated three ways:
+
+| Formulation | Principle | Test |
+|-------------|-----------|------|
+| Universal Law | Act only on maxims you could will as universal laws | "Could everyone do this without contradiction?" |
+| Humanity | Treat persons as ends in themselves, never merely as means | "Am I using this person as a tool?" |
+| Kingdom of Ends | Act as a legislating member of an ideal moral community | "Would this be a good law for a community of rational beings?" |
+
+### Applying the Universal Law Test
+
+1. Formulate the maxim of your action ("I will lie to get out of trouble")
+2. Universalize it ("Everyone lies to get out of trouble")
+3. Check for contradiction:
+   - **Contradiction in conception**: Could this world exist? (If everyone lies, trust collapses and lying becomes impossible)
+   - **Contradiction in will**: Could you rationally want this? (You wouldn't want to live in a world where no one can be trusted)
+4. If contradiction: the action is morally impermissible
+
+### W.D. Ross: Prima Facie Duties
+
+Ross recognized that duties can conflict. His framework:
+
+| Duty | Content |
+|------|---------|
+| Fidelity | Keep promises, be honest |
+| Reparation | Make amends for wrongs done |
+| Gratitude | Repay benefits received |
+| Non-maleficence | Do not harm others |
+| Beneficence | Help others when possible |
+| Justice | Distribute goods fairly |
+| Self-improvement | Develop your own virtue and knowledge |
+
+When duties conflict, no formula resolves it — exercise moral judgment
+about which duty is more pressing in this particular situation.
+
+### Strengths and Challenges
+
+| Strength | Challenge |
+|----------|-----------|
+| Respects individual rights | Can be inflexible (Kant: lying is always wrong, even to a murderer?) |
+| Provides clear principles | Competing duties with no resolution formula |
+| Treats persons as inherently valuable | May demand sacrifice of good consequences for principle |
+
+## Virtue Ethics
+
+### Aristotle's Framework
+
+Focus not on actions or rules but on character. The central question is
+not "what should I do?" but "what kind of person should I be?"
+
+### Key Concepts
+
+| Concept | Meaning | Application |
+|---------|---------|-------------|
+| Eudaimonia | Human flourishing (not just pleasure) | The ultimate goal of a good life |
+| Arete | Excellence/virtue | Character traits enabling flourishing |
+| Phronesis | Practical wisdom | The ability to discern the right action in particular circumstances |
+| Doctrine of the Mean | Virtue lies between excess and deficiency | Courage is between recklessness and cowardice |
+
+### Virtue-Vice Table
+
+| Deficiency | Virtue (Mean) | Excess |
+|-----------|---------------|--------|
+| Cowardice | Courage | Recklessness |
+| Insensibility | Temperance | Self-indulgence |
+| Stinginess | Generosity | Extravagance |
+| Self-deprecation | Truthfulness | Boastfulness |
+| Boorishness | Wit | Buffoonery |
+| Quarrelsomeness | Friendliness | Obsequiousness |
+| Shamelessness | Modesty | Excessive shyness |
+
+### The Virtuous Person Test
+
+"What would a person of practical wisdom (phronimos) do in this situation?"
+This is not a cop-out — it directs attention to:
+- What character traits does this situation call for?
+- What would someone who has developed those traits perceive and do?
+- How would they balance competing goods?
+
+## Care Ethics
+
+### Core Principles
+
+Developed by Carol Gilligan and Nel Noddings in response to justice-centered
+frameworks that (they argued) privileged abstract principles over actual
+human relationships.
+
+| Principle | Content |
+|-----------|---------|
+| Relationships are primary | Morality emerges from relationships, not abstract rules |
+| Context matters | The same action may be right or wrong depending on the relationship |
+| Attention to particular persons | Care for this person, not "persons in general" |
+| Vulnerability and dependency | Ethics must account for unequal power and need |
+| Empathy as moral skill | Understanding others' experience is ethically essential |
+
+### When Care Ethics Adds Value
+
+| Situation | Care ethics insight |
+|-----------|---------------------|
+| Medical decisions | Patient's particular circumstances and relationships matter, not just clinical best practice |
+| Family obligations | Special duties to family differ from general duties to strangers |
+| Workplace relationships | Power dynamics between supervisor and subordinate affect ethical analysis |
+| End-of-life decisions | The web of relationships surrounding the dying person is morally relevant |
+
+## Contractualism
+
+### Rawls: Justice as Fairness
+
+| Concept | Content |
+|---------|---------|
+| Original Position | Hypothetical state where rational agents choose principles of justice |
+| Veil of Ignorance | Agents don't know their race, gender, wealth, talents, or social position |
+| Maximin Principle | Choose rules that maximize the position of the worst-off members |
+| Two Principles | (1) Equal basic liberties for all; (2) Inequalities only if they benefit the least advantaged |
+
+### Applying the Veil of Ignorance
+
+1. Describe the proposed policy or principle
+2. Ask: would you accept this if you didn't know your position in society?
+3. Specifically: what if you turned out to be the worst-off person under this arrangement?
+4. If you'd accept it even from the worst position, it's just
+
+### Scanlon: What We Owe to Each Other
+
+An action is wrong if it violates a principle that no one could reasonably
+reject as a basis for general agreement.
+
+Key difference from utilitarianism: you cannot sacrifice one person's
+fundamental interests for aggregate benefit. Each person has standing to
+object.
+
+## Applied Ethics Methodology
+
+When facing a specific ethical question:
+
+### Step 1: Frame the Question
+
+- What is the ethical question? (Separate factual from normative questions)
+- Who is affected? What are the stakes?
+- What values or principles are in tension?
+
+### Step 2: Apply Multiple Frameworks
+
+| Apply | Ask |
+|-------|-----|
+| Consequentialism | What will produce the best outcomes for all affected? |
+| Deontology | What duties or principles apply? Am I treating people as ends? |
+| Virtue Ethics | What would a person of practical wisdom do? What character does this situation call for? |
+| Care Ethics | What do my relationships and responsibilities to particular persons require? |
+| Contractualism | Would this be acceptable from behind the veil of ignorance? |
+
+### Step 3: Identify Convergence and Conflict
+
+- Where do frameworks agree? (High confidence)
+- Where do they disagree? (This is where the real ethical work happens)
+- Which framework seems most relevant to this type of question?
+
+### Step 4: Make a Judgment
+
+- Ethical reasoning rarely yields certainty
+- State your conclusion with appropriate qualification
+- Acknowledge the strongest objection and why it doesn't prevail
+- Remain open to revision
+
+## Framework Selection Guide
+
+| Question Type | Most Relevant Framework | Reason |
+|--------------|------------------------|--------|
+| Policy affecting large populations | Consequentialism + Contractualism | Outcomes and fairness both matter at scale |
+| Personal moral dilemma | Virtue Ethics + Care Ethics | Character and relationships are central |
+| Rights and duties question | Deontology | Directly addresses what we owe each other |
+| Professional ethics | Deontology + Virtue Ethics | Professional duties and character standards |
+| Distributive justice | Contractualism | Designed for questions of fair distribution |
+| Bioethics | All five | Complex cases where every framework adds value |

--- a/skills/philosophical-reasoning/references/fallacies-and-argumentation.md
+++ b/skills/philosophical-reasoning/references/fallacies-and-argumentation.md
@@ -1,0 +1,196 @@
+# Fallacies and Argumentation
+
+Sources: Walton (Informal Logic), Weston (A Rulebook for Arguments), Damer (Attacking Faulty Reasoning), van Eemeren/Grootendorst (Pragma-Dialectics)
+
+Covers: fallacy taxonomy (25+ fallacies), argument mapping, Toulmin model, argument reconstruction, burden of proof, strength of evidence assessment.
+
+## Fallacy Taxonomy
+
+Fallacies are recurring patterns of flawed reasoning. Recognizing them is
+not about "winning" arguments — it is about identifying where reasoning
+breaks down so it can be repaired.
+
+### Fallacies of Relevance
+
+The premises are logically irrelevant to the conclusion.
+
+| Fallacy | Pattern | Example | The Fix |
+|---------|---------|---------|---------|
+| Ad Hominem | Attack the person, not the argument | "You can't trust her analysis — she failed economics in college" | Evaluate the argument on its merits regardless of source |
+| Straw Man | Distort the opponent's position, then attack the distortion | "You want environmental regulation? So you want to destroy the economy?" | Restate the actual position charitably before responding |
+| Red Herring | Introduce an irrelevant topic to divert attention | "We should discuss teacher pay." "But what about the national debt?" | Redirect: "That may be important, but it doesn't address the question at hand" |
+| Appeal to Authority | Cite an authority who lacks relevant expertise | "A celebrity says vaccines are dangerous" | Ask: is this person an expert in the relevant domain? |
+| Appeal to Emotion | Substitute emotional persuasion for evidence | "Think of the children!" (without connecting to the actual policy question) | Acknowledge the emotion, then ask what the evidence shows |
+| Tu Quoque | "You do it too" as if hypocrisy invalidates the claim | "You smoke but tell me it's unhealthy?" | A hypocrite's argument can still be sound |
+| Genetic Fallacy | Dismiss based on origin rather than content | "That idea came from [group I dislike], so it must be wrong" | Evaluate ideas independently of their source |
+| Appeal to Ignorance | Claim something is true because it hasn't been proven false | "No one has disproved God, therefore God exists" | Absence of evidence is not evidence of absence (nor of presence) |
+| Bandwagon | Many people believe it, so it must be true | "Everyone thinks this is right" | Popularity is not a truth indicator |
+
+### Fallacies of Presumption
+
+The argument assumes something that hasn't been established.
+
+| Fallacy | Pattern | Example | The Fix |
+|---------|---------|---------|---------|
+| Begging the Question | Conclusion is smuggled into the premises | "God exists because the Bible says so, and the Bible is God's word" | Check: does any premise presuppose the conclusion? |
+| False Dilemma | Present only two options when more exist | "You're either with us or against us" | Ask: what other options are there? |
+| Hasty Generalization | Conclude from too few examples | "I met two rude New Yorkers, so all New Yorkers are rude" | Ask: is the sample representative? |
+| Slippery Slope | Assume one step inevitably leads to extreme outcomes without justification | "If we allow X, then Y, then Z will follow" | Ask: what's the evidence for each causal link? |
+| Composition | What's true of parts must be true of the whole | "Each brick is light, so the wall is light" | Parts and wholes have different properties |
+| Division | What's true of the whole must be true of parts | "The team is excellent, so each player is excellent" | Collective properties don't distribute to individuals |
+| Complex Question | Question presupposes something not established | "Have you stopped cheating?" | Reject the presupposition; separate the embedded claim |
+
+### Fallacies of Ambiguity
+
+The argument exploits unclear language.
+
+| Fallacy | Pattern | Example |
+|---------|---------|---------|
+| Equivocation | A key term shifts meaning mid-argument | "The law says all men are equal. Women are not men. Therefore women are not equal." ("men" shifts from "humans" to "males") |
+| Amphiboly | Grammatical ambiguity allows multiple readings | "Flying planes can be dangerous" (flying them or the planes themselves?) |
+
+### Causal Fallacies
+
+The argument misidentifies causal relationships.
+
+| Fallacy | Pattern | Example |
+|---------|---------|---------|
+| Post Hoc Ergo Propter Hoc | X happened before Y, so X caused Y | "I wore my lucky socks, then we won" |
+| Correlation ≠ Causation | X correlates with Y, so X causes Y | "Ice cream sales and drowning both rise in summer" |
+| Oversimplified Cause | Complex event attributed to single cause | "The war started because of that assassination" (ignoring systemic causes) |
+
+## Argument Mapping
+
+### The Toulmin Model
+
+Stephen Toulmin's model captures how real arguments work, beyond just
+premises and conclusions.
+
+| Component | Role | Example |
+|-----------|------|---------|
+| Claim | What you're arguing for | "We should raise the minimum wage" |
+| Grounds/Data | Evidence supporting the claim | "Current wages are below the poverty line" |
+| Warrant | The reasoning principle connecting data to claim | "Workers should earn enough to live above poverty" |
+| Backing | Support for the warrant itself | "The Universal Declaration of Human Rights Article 23" |
+| Qualifier | Degree of certainty | "Probably", "In most cases", "Certainly" |
+| Rebuttal | Exceptions or counterarguments | "Unless rapid increases cause significant unemployment" |
+
+### Using the Toulmin Model
+
+1. State the claim clearly
+2. Identify what data supports it
+3. Articulate the warrant — this is often the hidden step
+4. Assess: is the warrant justified? Does it need backing?
+5. Add appropriate qualification (avoid false certainty)
+6. Anticipate and address rebuttals honestly
+
+The warrant is the most important component to identify because it reveals
+the reasoning principle — and that's where most arguments actually disagree.
+
+## Argument Reconstruction
+
+### Standard Reconstruction Process
+
+1. **Identify the conclusion**: What is the arguer ultimately claiming?
+2. **List explicit premises**: What reasons are given?
+3. **Identify implicit premises**: What unstated assumptions are needed to make the argument work?
+4. **Arrange in logical order**: Put premises in the order that leads to the conclusion
+5. **Evaluate deductive validity**: Does the conclusion necessarily follow?
+6. **Evaluate inductive strength**: If not deductive, how strongly do premises support the conclusion?
+7. **Evaluate premise truth**: Are the premises actually true?
+
+### Charity Principle
+
+Always reconstruct an argument in its strongest reasonable form before
+evaluating it. This means:
+- Fill in missing premises with the most plausible version
+- Choose the most favorable interpretation of ambiguous claims
+- Don't attribute claims the arguer didn't make
+
+Charity is not agreement — it's intellectual honesty. Defeating a weak
+version of an argument proves nothing.
+
+### Steel-Manning vs. Straw-Manning
+
+| Approach | What You Do | Result |
+|----------|-------------|--------|
+| Straw Man | Weaken the opponent's argument before attacking | You "win" but learn nothing |
+| Fair Representation | Present the argument as stated | Honest engagement |
+| Steel Man | Strengthen the opponent's argument before evaluating | Deepest understanding, most credible response |
+
+Steel-manning requires you to think of better arguments for the position
+you oppose than the person actually gave. This is the highest standard of
+philosophical engagement.
+
+## Burden of Proof
+
+### Default Allocation
+
+| Claim Type | Burden Falls On | Reason |
+|-----------|----------------|--------|
+| Positive existential | Claimant | "Dragons exist" — asserter must provide evidence |
+| Negative existential | Depends | Sometimes difficult to prove non-existence; context matters |
+| Deviation from status quo | Proposer of change | Change bears burden over continuity |
+| Scientific/empirical | Claimant | Claims require evidence |
+| Logical/mathematical | Claimant | Proofs require demonstration |
+
+### Shifting Burden
+
+Burden shifts when:
+- Sufficient prima facie evidence has been presented
+- A counterargument needs justification of its own
+- The original burden has been met and now the objector must respond
+
+## Evidence Assessment
+
+### Hierarchy of Evidence
+
+| Level | Type | Strength |
+|-------|------|----------|
+| Strongest | Controlled experiments, meta-analyses | High |
+| Strong | Multiple independent observations, expert consensus | Moderate-High |
+| Moderate | Case studies, historical parallels, analogies | Moderate |
+| Weak | Anecdotes, single observations, thought experiments | Low (but useful for hypothesis generation) |
+| Weakest | Appeals to tradition, popularity, authority outside domain | Very Low |
+
+### Evaluating Analogical Arguments
+
+Analogies compare two cases to argue that what's true of one is true of the other.
+
+| Check | Question |
+|-------|----------|
+| Relevance | Are the compared features actually relevant to the conclusion? |
+| Number of similarities | How many relevant similarities exist? |
+| Number of differences | How many relevant differences exist? |
+| Strength of conclusion | Is the conclusion proportional to the analogy's strength? |
+
+Analogies are never proof — they suggest and illuminate, but the
+dissimilarities can be just as important as the similarities.
+
+## Pragma-Dialectics Framework
+
+van Eemeren and Grootendorst's framework for critical discussion:
+
+### Four Stages of Discussion
+
+1. **Confrontation**: Identify the disagreement
+2. **Opening**: Agree on rules and shared premises
+3. **Argumentation**: Present and challenge arguments
+4. **Concluding**: Determine the outcome
+
+### Ten Rules for Critical Discussion
+
+1. Do not prevent others from stating their position
+2. If challenged, defend your standpoint
+3. Attack the actual position, not a distortion
+4. Defend your standpoint only with relevant argumentation
+5. Do not attribute unstated premises falsely
+6. Do not present a premise as established when it isn't
+7. Do not present an argument as conclusive when it isn't
+8. Only use arguments logically related to the standpoint
+9. Accept the result of the discussion if properly conducted
+10. Use clear, unambiguous language
+
+These rules define what philosophical discussion should look like. Violating
+them maps directly to specific fallacies — each fallacy can be understood
+as a violation of one or more rules.

--- a/skills/philosophical-reasoning/references/formal-logic.md
+++ b/skills/philosophical-reasoning/references/formal-logic.md
@@ -1,0 +1,195 @@
+# Formal Logic Systems
+
+Sources: Copi/Cohen/McMahon (Introduction to Logic, 14th ed), McInerny (Being Logical), Hurley (A Concise Introduction to Logic)
+
+Covers: propositional logic, predicate logic, categorical syllogisms, truth tables, rules of inference, modal logic basics, argument validity testing.
+
+## Propositional Logic
+
+### Atomic Propositions and Connectives
+
+| Symbol | Name | English | Truth Condition |
+|--------|------|---------|-----------------|
+| p, q, r | Variables | Any declarative sentence | Assigned T or F |
+| ~p or ¬p | Negation | "not p" | True when p is false |
+| p ∧ q | Conjunction | "p and q" | True when both true |
+| p ∨ q | Disjunction | "p or q" | True when at least one true |
+| p → q | Conditional | "if p then q" | False only when p true, q false |
+| p ↔ q | Biconditional | "p if and only if q" | True when both same value |
+
+### Rules of Inference (Valid Argument Forms)
+
+These are the fundamental moves in deductive reasoning. Each preserves
+truth — if premises are true, conclusion must be true.
+
+| Rule | Form | Natural Language |
+|------|------|------------------|
+| Modus Ponens | p → q, p ∴ q | If it rains, the ground is wet. It rains. Therefore, the ground is wet. |
+| Modus Tollens | p → q, ¬q ∴ ¬p | If it rains, the ground is wet. The ground is not wet. Therefore, it didn't rain. |
+| Hypothetical Syllogism | p → q, q → r ∴ p → r | Chain conditionals: if A implies B, and B implies C, then A implies C. |
+| Disjunctive Syllogism | p ∨ q, ¬p ∴ q | It's either A or B. It's not A. Therefore B. |
+| Constructive Dilemma | (p → q) ∧ (r → s), p ∨ r ∴ q ∨ s | Two conditionals plus disjunction of antecedents yields disjunction of consequents. |
+| Conjunction | p, q ∴ p ∧ q | Combine independent truths. |
+| Simplification | p ∧ q ∴ p | Extract one conjunct. |
+| Addition | p ∴ p ∨ q | Weaken a claim by adding alternatives. |
+| Absorption | p → q ∴ p → (p ∧ q) | If A implies B, then A implies both A and B. |
+
+### Rules of Replacement (Equivalence Rules)
+
+These allow substituting logically equivalent expressions:
+
+| Rule | Equivalence |
+|------|-------------|
+| Double Negation | ¬¬p ≡ p |
+| De Morgan's Laws | ¬(p ∧ q) ≡ ¬p ∨ ¬q; ¬(p ∨ q) ≡ ¬p ∧ ¬q |
+| Commutation | p ∧ q ≡ q ∧ p; p ∨ q ≡ q ∨ p |
+| Distribution | p ∧ (q ∨ r) ≡ (p ∧ q) ∨ (p ∧ r) |
+| Contraposition | p → q ≡ ¬q → ¬p |
+| Material Implication | p → q ≡ ¬p ∨ q |
+| Exportation | (p ∧ q) → r ≡ p → (q → r) |
+| Tautology | p ≡ p ∨ p; p ≡ p ∧ p |
+
+### Truth Table Method
+
+To test validity: construct a truth table for all variables. An argument
+is valid if there is NO row where all premises are true and the conclusion
+is false.
+
+| p | q | p → q | p | q (conclusion) |
+|---|---|-------|---|----------------|
+| T | T | T | T | T |
+| T | F | F | T | - (premise false) |
+| F | T | T | F | - (premise false) |
+| F | F | T | F | - (premise false) |
+
+Only the first row has all premises true — and the conclusion is also true.
+Therefore Modus Ponens is valid.
+
+### Common Invalid Forms (Formal Fallacies)
+
+| Fallacy | Form | Why It Fails |
+|---------|------|--------------|
+| Affirming the Consequent | p → q, q ∴ p | The ground can be wet for other reasons (sprinkler) |
+| Denying the Antecedent | p → q, ¬p ∴ ¬q | No rain doesn't guarantee dry ground |
+
+These look similar to valid forms — the difference is which part is affirmed or denied.
+
+## Predicate Logic
+
+Extends propositional logic to handle internal structure of propositions.
+
+### Quantifiers
+
+| Symbol | Name | English | Example |
+|--------|------|---------|---------|
+| ∀x | Universal | "for all x" | ∀x(Dog(x) → Animal(x)) — All dogs are animals |
+| ∃x | Existential | "there exists an x" | ∃x(Dog(x) ∧ Black(x)) — Some dogs are black |
+
+### Quantifier Rules
+
+| Rule | From | To |
+|------|------|----|
+| Universal Instantiation (UI) | ∀x P(x) | P(a) for any specific a |
+| Universal Generalization (UG) | P(a) for arbitrary a | ∀x P(x) |
+| Existential Instantiation (EI) | ∃x P(x) | P(c) for a new constant c |
+| Existential Generalization (EG) | P(a) for some specific a | ∃x P(x) |
+
+### Translating Natural Language
+
+| English | Predicate Logic |
+|---------|-----------------|
+| "All humans are mortal" | ∀x(Human(x) → Mortal(x)) |
+| "Some students passed" | ∃x(Student(x) ∧ Passed(x)) |
+| "No reptiles are mammals" | ∀x(Reptile(x) → ¬Mammal(x)) |
+| "Only members may enter" | ∀x(MayEnter(x) → Member(x)) |
+
+Note the "all" vs "some" trap: "all" uses →, "some" uses ∧.
+
+## Categorical Syllogisms
+
+The oldest formal logic system (Aristotle). Reasons about categories
+using three terms: major, minor, and middle.
+
+### Standard Form
+
+```
+All M are P.     (major premise)
+All S are M.     (minor premise)
+∴ All S are P.   (conclusion)
+```
+
+### Four Standard-Form Propositions
+
+| Type | Form | Example | Diagram |
+|------|------|---------|---------|
+| A | All S are P | All dogs are animals | S fully inside P |
+| E | No S are P | No dogs are cats | S and P don't overlap |
+| I | Some S are P | Some dogs are brown | S and P partially overlap |
+| O | Some S are not P | Some dogs are not brown | Part of S outside P |
+
+### Testing Validity with Venn Diagrams
+
+1. Draw three overlapping circles (S, P, M)
+2. Diagram the premises (shade excluded regions, mark existing members)
+3. Check if the conclusion is already shown — if yes, valid; if not, invalid
+
+### Commonly Valid Syllogisms
+
+| Name | Form |
+|------|------|
+| Barbara | All M are P, All S are M ∴ All S are P |
+| Celarent | No M are P, All S are M ∴ No S are P |
+| Darii | All M are P, Some S are M ∴ Some S are P |
+| Ferio | No M are P, Some S are M ∴ Some S are not P |
+
+## Modal Logic (Basics)
+
+Extends propositional logic with necessity and possibility operators.
+
+| Symbol | Meaning | Example |
+|--------|---------|---------|
+| □p | "Necessarily p" | It is necessarily true that 2+2=4 |
+| ◇p | "Possibly p" | It is possible that it rains tomorrow |
+
+### Key Modal Relationships
+
+- □p → p (what is necessary is actual)
+- p → ◇p (what is actual is possible)
+- □p ↔ ¬◇¬p (necessary = not possibly not)
+- ◇p ↔ ¬□¬p (possible = not necessarily not)
+
+Modal logic is essential for analyzing claims about what must be, could be,
+or cannot be — frequent in philosophical arguments about God, free will,
+morality, and metaphysics.
+
+## Practical Application: Argument Validity Testing
+
+### Quick Validity Check Process
+
+1. **Identify the conclusion** — what is being argued for?
+2. **List all premises** — including implicit ones
+3. **Symbolize** — translate to logical notation
+4. **Check form** — does it match a valid inference rule?
+5. **If unclear** — construct a truth table or Venn diagram
+6. **Assess soundness** — are the premises actually true?
+
+### Validity vs. Soundness
+
+| Term | Definition | Example |
+|------|-----------|---------|
+| Valid | Conclusion follows from premises | "All cats fly. Socrates is a cat. ∴ Socrates flies." (Valid, unsound) |
+| Sound | Valid AND premises are true | "All humans are mortal. Socrates is human. ∴ Socrates is mortal." |
+| Invalid | Conclusion doesn't follow | "Some dogs bark. Rex barks. ∴ Rex is a dog." |
+
+A valid argument with false premises tells you nothing about the conclusion's
+truth. Soundness is what matters in practice.
+
+## When to Formalize
+
+| Situation | Formalize? | Reason |
+|-----------|-----------|--------|
+| Checking if a conclusion actually follows | Yes | Formal validity testing catches hidden gaps |
+| Everyday moral/political argument | Usually no | Most real arguments are informal; Toulmin model is more practical |
+| Spotting structural fallacies | Yes | Affirming consequent, denying antecedent are structural errors |
+| Mathematical or logical claims | Yes | These domains demand formal rigor |
+| "It just feels wrong" | Try it | Formalizing reveals whether the intuition tracks a real logical error |

--- a/skills/philosophical-reasoning/references/socratic-method.md
+++ b/skills/philosophical-reasoning/references/socratic-method.md
@@ -1,0 +1,194 @@
+# The Socratic Method
+
+Sources: Plato (Apology, Meno, Euthyphro, Republic), Richard Paul (Critical Thinking taxonomy), Vlastos (Socratic Studies)
+
+Covers: elenchus technique, six question types, dialogue facilitation, maieutics, when and how to deploy Socratic reasoning.
+
+## The Elenchus: Core Technique
+
+The Socratic elenchus is cross-examination through questions. It does not
+argue a position — it draws out contradictions in the interlocutor's own
+beliefs until they reach aporia (productive confusion) and revise.
+
+### Five-Step Elenchus Process
+
+| Step | Action | Example |
+|------|--------|---------|
+| 1. Elicit thesis | Ask for a definition or position | "What is courage?" |
+| 2. Explore implications | Draw out what the thesis entails | "So anyone who persists is courageous?" |
+| 3. Generate counterexample | Find a case where the thesis fails | "Is a foolish person who persists courageous?" |
+| 4. Reveal contradiction | Show the thesis conflicts with shared beliefs | "We agree courage is admirable, but foolish persistence is not" |
+| 5. Invite revision | Prompt reformulation or deeper examination | "Then courage must involve something beyond persistence — what?" |
+
+### When Elenchus Stalls
+
+| Symptom | Response |
+|---------|----------|
+| Interlocutor gets defensive | Acknowledge the difficulty; affirm that questioning is a sign of intellectual courage |
+| Circular definitions | Point out the circularity gently, offer a structural reframe |
+| "I don't know" too early | That's progress — aporia is the starting point of real inquiry |
+| Thesis seems unfalsifiable | Ask what evidence would change their mind (falsifiability probe) |
+
+## Six Types of Socratic Questions
+
+Adapted from Richard Paul's critical thinking framework. Use these in
+sequence or selectively depending on the discussion's needs.
+
+### 1. Clarification Questions
+Purpose: Ensure shared understanding before evaluating.
+
+- "What do you mean by [X]?"
+- "Can you give me an example?"
+- "How does that relate to [Y]?"
+- "Could you put that another way?"
+
+Deploy when: Terms are ambiguous, the thesis is vague, or you suspect
+you and the interlocutor are talking past each other.
+
+### 2. Assumption-Probing Questions
+Purpose: Surface hidden premises that the argument depends on.
+
+- "What are you presupposing here?"
+- "Why would you assume that?"
+- "Is that assumption always valid?"
+- "What if the opposite were true?"
+
+Deploy when: The argument feels "obvious" — obvious conclusions often
+rest on unexamined assumptions.
+
+### 3. Evidence and Reasoning Questions
+Purpose: Evaluate the grounds for the claim.
+
+- "What evidence supports this?"
+- "How do you know that?"
+- "Is there reason to doubt this evidence?"
+- "What would count as evidence against this view?"
+
+Deploy when: Claims are presented as fact without justification, or
+when anecdotal evidence is doing the work of systematic evidence.
+
+### 4. Perspective Questions
+Purpose: Introduce alternative viewpoints the interlocutor hasn't considered.
+
+- "How would [philosopher/tradition X] see this differently?"
+- "What would someone who disagrees say?"
+- "Is there another way to interpret this?"
+- "Whose perspective is missing here?"
+
+Deploy when: The analysis is one-sided or the interlocutor treats their
+perspective as the only reasonable one.
+
+### 5. Implication and Consequence Questions
+Purpose: Trace where the thesis leads.
+
+- "If that's true, what follows?"
+- "What are the consequences of this view?"
+- "How does this affect [related issue]?"
+- "Does this principle apply consistently, or only selectively?"
+
+Deploy when: Testing a thesis for internal consistency and real-world
+applicability. The strongest test of a principle is its edge cases.
+
+### 6. Meta-Questions (Questions About the Question)
+Purpose: Step back and examine the inquiry itself.
+
+- "Why is this question important?"
+- "Is this the right question to be asking?"
+- "What kind of answer are we looking for — empirical, normative, conceptual?"
+- "Are we making progress, or going in circles?"
+
+Deploy when: The discussion has lost direction, or when the initial
+framing of the problem may be flawed.
+
+## Maieutics: Intellectual Midwifery
+
+Socrates described himself as a midwife of ideas — not implanting
+knowledge but helping others bring forth what they already implicitly
+understand. The maieutic method differs from elenchus in its constructive
+orientation.
+
+### Maieutic Process
+
+1. Ask what the person already knows or believes about the topic
+2. Help them articulate their intuitions more precisely
+3. Test each articulation against examples and counterexamples
+4. Guide refinement without imposing your own position
+5. Celebrate when they arrive at insight through their own reasoning
+
+### Maieutics vs. Elenchus
+
+| Feature | Elenchus | Maieutics |
+|---------|----------|-----------|
+| Primary goal | Expose false belief | Draw out latent knowledge |
+| Emotional tone | Can feel adversarial | Collaborative, supportive |
+| Outcome | Aporia (productive doubt) | Articulated insight |
+| When to use | Interlocutor holds a confident but wrong view | Interlocutor has good intuitions but can't articulate them |
+
+## Dialogue Facilitation Framework
+
+When moderating philosophical dialogue (not just one-on-one), use these
+structural elements:
+
+### Opening
+- Present a text, question, or thought experiment
+- Establish that the goal is inquiry, not winning
+- Clarify that changing one's mind is a sign of strength
+
+### Core Discussion Rules
+1. Speak to each other, not to the moderator
+2. Reference specific claims ("I disagree with the idea that X, because...")
+3. Build on or challenge what was actually said, not a straw version
+4. Distinguish between disagreeing with a person and disagreeing with an idea
+5. "I don't know" is always a valid and honest response
+
+### Closing
+- Summarize key tensions that emerged
+- Identify where views shifted or didn't
+- Name the unresolved questions (not every dialogue needs resolution)
+
+## Socratic Dialogue in Written Analysis
+
+When analyzing a philosophical question in writing (not live dialogue),
+adapt the Socratic method:
+
+1. **State the most natural/intuitive answer** — this is your "thesis"
+2. **Steel-man it** — present it in its strongest form
+3. **Subject it to questioning** — apply the six question types
+4. **Present the strongest objection** — a counterexample or counterargument
+5. **Attempt to respond** — can the thesis survive modification?
+6. **Assess** — did the thesis survive? What's the refined position?
+
+This process should feel like an internal dialogue, not a monologue.
+The reader should experience the tension between positions.
+
+## Common Mistakes in Socratic Reasoning
+
+| Mistake | Problem | Correction |
+|---------|---------|------------|
+| Asking leading questions | Manipulates rather than inquires | Ask genuinely open questions where you don't predetermine the answer |
+| Rapid-fire questioning | Overwhelms rather than illuminates | Allow space for reflection between questions |
+| Gotcha mentality | Turns dialogue into combat | The goal is shared understanding, not victory |
+| Ignoring good answers | Bulldozes toward predetermined conclusion | Acknowledge when the interlocutor makes a strong point |
+| Socratic irony as sarcasm | Alienates the interlocutor | Genuine humility ("I truly don't know") differs from false modesty |
+| Never offering a view | Socrates did venture positions; pure questioning can feel evasive | After thorough questioning, share your tentative assessment |
+
+## When to Use the Socratic Method
+
+| Situation | Socratic approach? | Reasoning |
+|-----------|--------------------|-----------|
+| Someone holds a confident but unexamined belief | Yes | Core use case — elenchus exposes unexamined assumptions |
+| Exploring a genuinely open question | Yes | Maieutics helps draw out and test intuitions |
+| Someone asks for your position directly | Partially | Share your view, but also model the questioning process |
+| Factual/empirical question | No | Socratic method probes concepts, not facts — look up the answer |
+| Emotional crisis or personal distress | With care | Questioning beliefs during distress can feel dismissive — prioritize empathy |
+| Building on established arguments | Partially | Use question types 4-5 (perspectives, implications) but don't restart from scratch |
+
+## Integration with Other Methods
+
+The Socratic method works best as the opening move that clarifies the
+question. It naturally transitions to:
+
+- **Formal logic** when the argument's structure needs rigorous testing
+- **Ethical frameworks** when the question turns out to be a values conflict
+- **Thought experiments** when concrete scenarios would sharpen the abstract debate
+- **Multi-perspective analysis** when the Socratic process reveals multiple defensible positions

--- a/skills/philosophical-reasoning/references/thought-experiments.md
+++ b/skills/philosophical-reasoning/references/thought-experiments.md
@@ -1,0 +1,238 @@
+# Thought Experiments and Dialectical Methods
+
+Sources: Sorensen (Thought Experiments), Sandel (Justice), Rawls (A Theory of Justice), Searle (Minds, Brains, and Programs), Nozick (Anarchy, State, and Utopia), Hegel (Phenomenology of Spirit)
+
+Covers: classic thought experiments with analysis, thought experiment construction methodology, dialectical methods (Hegelian, pragma-dialectical), philosophical synthesis techniques.
+
+## Classic Thought Experiments
+
+Thought experiments isolate philosophical variables by constructing
+hypothetical scenarios that test our principles and intuitions. They are
+the philosopher's laboratory.
+
+### Ethics and Political Philosophy
+
+#### The Trolley Problem (Philippa Foot / Judith Jarvis Thomson)
+
+**Setup**: A trolley is heading toward five people. You can divert it to a
+side track where it will kill one person. Should you?
+
+**Variant — Footbridge**: You stand on a bridge above the tracks. You can
+push a large person off the bridge to stop the trolley, saving five. Should you?
+
+| Response | Reveals |
+|----------|---------|
+| Divert (yes) but don't push (no) | The distinction between killing and letting die; between direct and indirect harm |
+| Both yes | Strict consequentialism — only outcomes matter |
+| Both no | Strong deontological commitment against using people as means |
+| Different answers | Tension between utilitarian calculation and deontological constraints |
+
+**Philosophical lesson**: Not about trolleys — about whether there's a
+moral difference between causing harm as a side effect and causing harm
+as a means.
+
+#### The Experience Machine (Robert Nozick)
+
+**Setup**: A machine can give you any experience you choose — it feels
+completely real. You'll never know you're plugged in. Would you plug in
+for life?
+
+| Response | Reveals |
+|----------|---------|
+| No | We value authentic experience, not just pleasant experience. Hedonism is insufficient for a good life. |
+| Yes | We value subjective well-being above all. |
+| Uncertain | There may be values beyond pleasure, but identifying them precisely is difficult. |
+
+**Philosophical lesson**: Tests whether pleasure/happiness is all that
+matters (hedonism) or whether contact with reality, genuine achievement,
+and authentic relationships have independent value.
+
+#### The Veil of Ignorance (John Rawls)
+
+**Setup**: Design the rules for society without knowing your race, gender,
+wealth, talents, health, or social position.
+
+**Application process**:
+1. Describe the proposed policy
+2. Imagine you don't know who you are in society
+3. Ask: would you accept this arrangement if you might be anyone?
+4. Focus especially on the worst-off position
+
+**Philosophical lesson**: Tests fairness by removing self-interest from
+the equation. If you'd accept a principle even if you might end up in the
+worst position, it's plausibly just.
+
+### Philosophy of Mind
+
+#### The Chinese Room (John Searle)
+
+**Setup**: A person who doesn't understand Chinese sits in a room,
+following rules to manipulate Chinese symbols. To outside observers,
+the room "speaks Chinese." Does the room understand Chinese?
+
+| Response | Reveals |
+|----------|---------|
+| No understanding | Syntax (manipulation of symbols) is not sufficient for semantics (understanding). Implications for strong AI. |
+| Yes, the system understands | The room-as-a-whole might understand even if the person doesn't (Systems Reply) |
+| The question is misframed | Maybe "understanding" is the wrong concept to apply here |
+
+**Philosophical lesson**: Tests whether computational processing is
+sufficient for genuine understanding. Central to philosophy of mind and AI.
+
+#### Mary's Room (Frank Jackson)
+
+**Setup**: Mary is a brilliant scientist who has lived her entire life in
+a black-and-white room. She knows everything physical about color vision.
+When she leaves the room and sees red for the first time, does she learn
+something new?
+
+**Philosophical lesson**: Tests whether physical facts exhaust all facts.
+If Mary learns something new (what it's like to see red), then
+physicalism is incomplete — there are facts about conscious experience
+that escape physical description (the Knowledge Argument).
+
+### Metaphysics
+
+#### The Ship of Theseus
+
+**Setup**: A ship has every plank replaced over time. The old planks are
+reassembled into another ship. Which is the original Ship of Theseus?
+
+**Philosophical lesson**: Tests personal/object identity over time.
+What makes something the "same" thing through change?
+
+#### Swamp Man (Donald Davidson)
+
+**Setup**: Lightning destroys you and simultaneously creates a molecule-for-
+molecule duplicate from swamp matter. Does the duplicate have your memories,
+beliefs, identity?
+
+**Philosophical lesson**: Tests whether identity requires causal history
+or only current physical state.
+
+### Epistemology
+
+#### Brain in a Vat (Hilary Putnam)
+
+**Setup**: You might be a brain in a vat, receiving simulated sensory
+input. Everything seems normal. Can you know you're not?
+
+**Philosophical lesson**: The modern version of Descartes' evil demon.
+Tests whether external-world knowledge is possible. Putnam's semantic
+externalism response: if you're a brain in a vat, your words "brain"
+and "vat" don't refer to real brains and vats, so "I am a brain in a
+vat" is self-refuting if true.
+
+## How to Construct Thought Experiments
+
+### Design Principles
+
+1. **Isolate the variable**: Change only the factor being tested
+2. **Control confounds**: Remove extraneous factors that might bias intuitions
+3. **Push to extremes**: Edge cases reveal principles that moderate cases don't
+4. **Make it vivid**: Concrete scenarios produce stronger intuitions than abstract ones
+5. **Be fair**: Don't bias the scenario toward your preferred conclusion
+
+### Construction Process
+
+| Step | Action | Example |
+|------|--------|---------|
+| 1 | Identify the principle to test | "Outcomes are all that matter morally" |
+| 2 | Design a scenario where the principle has counterintuitive implications | Trolley problem: pure outcome-maximization requires pushing someone to their death |
+| 3 | Vary the scenario to test which features matter | Diverting (indirect) vs pushing (direct) |
+| 4 | Check for confounding variables | Maybe size of the person matters? Remove that by making it a button press. |
+| 5 | Identify what the intuition tracks | The distinction between causing harm as means vs. as side effect |
+| 6 | Test whether the principle should yield to the intuition or vice versa | This is the hard philosophical work — there's no formula |
+
+### Analyzing Thought Experiment Responses
+
+1. **State your intuitive response** honestly
+2. **Identify the principle** your intuition is tracking
+3. **Consider whether the intuition is reliable** — or is it a bias, cultural artifact, or emotional reaction?
+4. **Look for rival principles** that would generate a different response
+5. **Test each principle** against other cases
+6. **Reach a considered judgment** — which may differ from your initial intuition
+
+## Dialectical Methods
+
+### Hegelian Dialectic
+
+| Stage | Role | Process |
+|-------|------|---------|
+| Thesis | Initial position | State a claim or worldview |
+| Antithesis | Opposition | Identify the strongest counter-position |
+| Synthesis | Integration | Find a higher-level position that preserves the truth in both while resolving the contradiction |
+
+The synthesis then becomes a new thesis, generating its own antithesis,
+continuing the process. This is not just "compromise" — genuine synthesis
+transforms both positions into something neither anticipated.
+
+### When Hegelian Dialectic Works Best
+
+- Historical/developmental questions (how did this concept evolve?)
+- Apparently irreconcilable oppositions that might admit a higher unity
+- Questions about consciousness, freedom, social development
+
+### Pragma-Dialectics (van Eemeren & Grootendorst)
+
+A modern framework for structured philosophical discussion:
+
+**Four stages**:
+1. **Confrontation**: Identify the disagreement precisely
+2. **Opening**: Agree on shared starting points and rules of engagement
+3. **Argumentation**: Present arguments, challenge, respond
+4. **Concluding**: Assess whether the disagreement has been resolved
+
+See `references/fallacies-and-argumentation.md` for the ten rules.
+
+## Multi-Perspective Analysis Method
+
+When the question calls for presenting what different traditions or
+thinkers would say:
+
+### Process
+
+1. **Frame the question** — What exactly is being asked? What kind of answer is sought?
+2. **Select relevant perspectives** — Choose 3-5 traditions or thinkers most relevant to this question
+3. **Steel-man each perspective** — Present each in its strongest form
+4. **Identify points of agreement** — Where do perspectives converge?
+5. **Identify points of genuine conflict** — Where do they diverge, and why?
+6. **Synthesize** — Can the insights be integrated? If not, articulate the remaining tension honestly
+7. **Offer your assessment** — Which view is most compelling on this question, and why?
+
+### Selecting Perspectives
+
+| Question Domain | Likely Relevant Perspectives |
+|----------------|----------------------------|
+| Ethics/morality | Utilitarian, Kantian, Virtue Ethics, Care Ethics + relevant Eastern traditions |
+| Knowledge/truth | Rationalist, Empiricist, Pragmatist, Skeptic |
+| Mind/consciousness | Physicalist, Dualist, Functionalist, Buddhist |
+| Justice/politics | Liberal, Communitarian, Libertarian, Marxist |
+| Meaning/existence | Existentialist, Absurdist, Religious, Naturalist |
+| Aesthetics | Formalist, Expressivist, Institutional, Kantian |
+
+## Philosophical Writing Structure
+
+When producing a philosophical analysis in written form:
+
+### Standard Structure
+
+1. **Question**: State the question precisely
+2. **Significance**: Why does this question matter?
+3. **Initial analysis**: Present the most natural answer and examine it
+4. **Objections**: The strongest counterarguments
+5. **Response**: Can the initial analysis survive? Does it need revision?
+6. **Alternative positions**: What other answers are available?
+7. **Assessment**: Your considered judgment, with qualification
+8. **Open questions**: What remains unresolved?
+
+### Quality Markers
+
+| Good Philosophical Analysis | Poor Philosophical Analysis |
+|---------------------------|---------------------------|
+| Engages with the strongest objection | Ignores or caricatures objections |
+| Acknowledges uncertainty | Claims certainty where none exists |
+| Makes distinctions that illuminate | Blurs distinctions that matter |
+| Uses examples that genuinely test principles | Uses examples that merely illustrate a predetermined conclusion |
+| Changes direction when the argument demands it | Forces evidence to fit a predetermined conclusion |
+| States assumptions explicitly | Leaves crucial assumptions hidden |

--- a/skills/philosophical-reasoning/skills.json
+++ b/skills/philosophical-reasoning/skills.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/philosophical-reasoning",
+  "version": "1.0.0",
+  "description": "Rigorous philosophical analysis, logical reasoning, and structured argumentation. Covers Western and Eastern philosophy, formal logic (propositional, predicate, modal), 25+ fallacies, ethical frameworks (utilitarian, Kantian, virtue, care, contractualist), epistemology, thought experiments, Socratic method, and dialectical methods. Adapts output: Socratic dialogue, multi-perspective analysis, or structured argument. Triggers: philosophize, philosophical question, ethical dilemma, logical argument, fallacy, Socratic, thought experiment, epistemology, free will, meaning of life, virtue ethics, formal logic, critical thinking.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

- **@tank/philosophical-reasoning**: Rigorous philosophical analysis skill covering Western + Eastern philosophy, formal logic, 25+ fallacies, ethical frameworks, epistemology, Socratic method, and thought experiments. 7 reference files, 135-line SKILL.md.
- **@tank/jewish-wisdom**: Jewish thought engagement skill covering Torah interpretation (PaRDeS, 13 rules of Rabbi Ishmael), Talmudic reasoning, Jewish philosophy, Kabbalah, Mussar ethics, and Halakha. Multi-denominational. 7 reference files, 130-line SKILL.md.
- **AGENTS.md**: New contributing standard documenting naming conventions, file structure, skills.json format, and publishing workflow for the repo.

Both skills follow the `@tank/` naming standard with proper `skills.json` format.