### PR TITLE
fix: trim skill descriptions under 500 chars

### DIFF
--- a/skills/jewish-wisdom/skills.json
+++ b/skills/jewish-wisdom/skills.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/jewish-wisdom",
   "version": "1.0.0",
-  "description": "Deep engagement with Jewish thought — Torah interpretation (PaRDeS, 13 rules of Rabbi Ishmael), Talmudic reasoning (shakla v'tarya, machloket), Jewish philosophy (Maimonides, Halevi, Heschel), Kabbalah (Sefirot, Four Worlds), Mussar ethics, and Halakha. Multi-denominational: Orthodox, Conservative, Reform, academic. Teaches and debates using authentic Jewish methodologies. Triggers: Torah, Talmud, Judaism, Jewish philosophy, halakha, Kabbalah, Mussar, midrash, PaRDeS, Rashi, Rambam, Sefirot, middot, tikkun, Pirkei Avot, Jewish ethics, dvar Torah, machloket.",
+  "description": "Jewish thought — Torah interpretation (PaRDeS, 13 rules), Talmudic reasoning, Jewish philosophy (Maimonides, Halevi, Heschel), Kabbalah (Sefirot), Mussar ethics, Halakha. Multi-denominational. Triggers: Torah, Talmud, Judaism, halakha, Kabbalah, Mussar, midrash, PaRDeS, Rashi, Rambam, Sefirot, middot, Pirkei Avot, Jewish ethics, dvar Torah, machloket.",
   "permissions": {
     "network": {
       "outbound": []

--- a/skills/philosophical-reasoning/skills.json
+++ b/skills/philosophical-reasoning/skills.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/philosophical-reasoning",
   "version": "1.0.0",
-  "description": "Rigorous philosophical analysis, logical reasoning, and structured argumentation. Covers Western and Eastern philosophy, formal logic (propositional, predicate, modal), 25+ fallacies, ethical frameworks (utilitarian, Kantian, virtue, care, contractualist), epistemology, thought experiments, Socratic method, and dialectical methods. Adapts output: Socratic dialogue, multi-perspective analysis, or structured argument. Triggers: philosophize, philosophical question, ethical dilemma, logical argument, fallacy, Socratic, thought experiment, epistemology, free will, meaning of life, virtue ethics, formal logic, critical thinking.",
+  "description": "Philosophical analysis and logical reasoning. Western and Eastern philosophy, formal logic, 25+ fallacies, ethical frameworks, epistemology, thought experiments, Socratic method. Adapts output style: Socratic dialogue, multi-perspective analysis, or structured argument. Triggers: philosophize, ethical dilemma, logical argument, fallacy, Socratic, thought experiment, epistemology, free will, meaning of life, virtue ethics, formal logic, critical thinking.",
   "permissions": {
     "network": {
       "outbound": []


### PR DESCRIPTION
Tank publish requires descriptions under 500 characters. Trimmed both new skills.