### PR TITLE
fix: trim descriptions for Tank publishing

### DIFF
--- a/skills/agents-md/skills.json
+++ b/skills/agents-md/skills.json
@@ -1,13 +1,15 @@
 {
   "name": "@tank/agents-md",
   "version": "1.0.0",
-  "description": "Write, audit, and manage AI coding agent instruction files (AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md, .windsurfrules, GEMINI.md). Covers the AGENTS.md standard (Linux Foundation AAIF), every major tool format, cross-tool compatibility, monorepo patterns, writing effective rules, and migration between formats. Triggers: AGENTS.md, CLAUDE.md, cursorrules, cursor rules, AI agent instructions, copilot instructions, windsurf rules, GEMINI.md, OpenCode rules, agent config, instruction file.",
+  "description": "AI coding instruction files across AGENTS.md, CLAUDE.md, Cursor rules, Copilot, Windsurf, Gemini, and OpenCode. Covers cross-tool compatibility, monorepo patterns, rule-writing, and migrations. Triggers: AGENTS.md, CLAUDE.md, cursorrules, cursor rules, copilot instructions, windsurf rules, GEMINI.md, agent config, instruction file.",
   "permissions": {
     "network": {
       "outbound": []
     },
     "filesystem": {
-      "read": ["**/*"],
+      "read": [
+        "**/*"
+      ],
       "write": []
     },
     "subprocess": false

--- a/skills/ai-agent-patterns/skills.json
+++ b/skills/ai-agent-patterns/skills.json
@@ -1,13 +1,15 @@
 {
   "name": "@tank/ai-agent-patterns",
   "version": "1.0.0",
-  "description": "AI agent architecture patterns for production. Covers ReAct, Plan-and-Execute, Reflexion, LATS, tool calling, multi-agent orchestration, memory systems, human-in-the-loop, guardrails, cost optimization, observability, evaluation, and deployment. Framework guidance for LangGraph, CrewAI, Mastra, OpenAI Agents SDK. Triggers: AI agent, build agent, agent architecture, ReAct, LangGraph, CrewAI, Mastra, multi-agent, agent memory, tool calling, human in the loop, agent observability, model routing, guardrails, structured output, agent evaluation.",
+  "description": "Production AI agent architecture patterns covering ReAct, Plan-and-Execute, Reflexion, LATS, tool calling, multi-agent orchestration, memory, human-in-the-loop, guardrails, observability, evaluation, and deployment. Triggers: AI agent, ReAct, LangGraph, CrewAI, multi-agent, tool calling, agent memory, guardrails, structured output, agent evaluation.",
   "permissions": {
     "network": {
       "outbound": []
     },
     "filesystem": {
-      "read": ["**/*"],
+      "read": [
+        "**/*"
+      ],
       "write": []
     },
     "subprocess": false

--- a/skills/docker-production-patterns/skills.json
+++ b/skills/docker-production-patterns/skills.json
@@ -1,13 +1,15 @@
 {
   "name": "@tank/docker-production-patterns",
   "version": "1.0.0",
-  "description": "Production Docker patterns for any stack. Dockerfile authoring (multi-stage builds, layer ordering, base images), BuildKit optimization (cache mounts, secrets, multi-platform), security hardening (non-root, distroless, scanning), Compose production (profiles, resource limits, secrets), container lifecycle (PID 1, SIGTERM, health checks), logging/observability, and CI/CD pipelines (GitHub Actions, tagging, registries). Includes language-specific Dockerfiles for Node.js, Python, Go, Rust, Java. Triggers: Dockerfile, docker, docker compose, multi-stage build, docker production, docker best practices, docker security, BuildKit, docker health check, docker secrets, docker CI/CD, docker github actions, distroless, docker non-root, docker logging, docker tagging.",
+  "description": "Production Docker patterns covering Dockerfiles, multi-stage builds, BuildKit, security hardening, Compose production usage, lifecycle/signals, logging, and CI/CD. Triggers: Dockerfile, docker production, BuildKit, docker security, health check, distroless, non-root, docker logging, tagging, docker CI/CD.",
   "permissions": {
     "network": {
       "outbound": []
     },
     "filesystem": {
-      "read": ["**/*"],
+      "read": [
+        "**/*"
+      ],
       "write": []
     },
     "subprocess": false

--- a/skills/drizzle-orm-mastery/skills.json
+++ b/skills/drizzle-orm-mastery/skills.json
@@ -1,13 +1,15 @@
 {
   "name": "@tank/drizzle-orm-mastery",
   "version": "1.0.0",
-  "description": "Drizzle ORM patterns for TypeScript. Schema definition, drizzle-kit migrations (generate/push/migrate), query builder (select/insert/join/subquery), relational queries, transactions, type inference, connection pooling, and framework integration (Next.js, Supabase, D1, Neon, Turso). Triggers: drizzle orm, drizzle schema, drizzle migrations, drizzle-kit, drizzle relations, drizzle query, drizzle select, drizzle join, drizzle transaction, drizzle supabase, drizzle next.js, drizzle vs prisma, drizzle push vs migrate, drizzle type inference.",
+  "description": "Drizzle ORM patterns for TypeScript covering schema design, drizzle-kit migrations, query builder usage, relations, transactions, type inference, pooling, and framework integration. Triggers: drizzle orm, drizzle schema, drizzle migrations, drizzle-kit, drizzle relations, drizzle query, drizzle join, drizzle transaction, drizzle vs prisma.",
   "permissions": {
     "network": {
       "outbound": []
     },
     "filesystem": {
-      "read": ["**/*"],
+      "read": [
+        "**/*"
+      ],
       "write": []
     },
     "subprocess": false

--- a/skills/fastapi-mastery/skills.json
+++ b/skills/fastapi-mastery/skills.json
@@ -1,13 +1,15 @@
 {
   "name": "@tank/fastapi-mastery",
   "version": "1.0.0",
-  "description": "Production-grade FastAPI development. Project structure, dependency injection (Depends, yield, overrides), Pydantic v2 models and settings, async SQLAlchemy 2.0, authentication (OAuth2, JWT, API keys), middleware, testing (TestClient, async, fixtures), deployment (Docker, uvicorn, Kubernetes), and performance (caching, streaming, WebSockets). Triggers: fastapi, fastapi best practices, fastapi production, fastapi dependency injection, fastapi pydantic, fastapi sqlalchemy, fastapi authentication, fastapi jwt, fastapi testing, fastapi docker, fastapi project structure, fastapi deployment, uvicorn.",
+  "description": "Production FastAPI patterns covering project structure, Depends-based DI, Pydantic v2, async SQLAlchemy, auth, middleware, testing, deployment, and performance. Triggers: fastapi, dependency injection, pydantic, sqlalchemy, jwt, testing, docker, uvicorn, project structure, websocket.",
   "permissions": {
     "network": {
       "outbound": []
     },
     "filesystem": {
-      "read": ["**/*"],
+      "read": [
+        "**/*"
+      ],
       "write": []
     },
     "subprocess": false

--- a/skills/github-actions-mastery/skills.json
+++ b/skills/github-actions-mastery/skills.json
@@ -1,13 +1,15 @@
 {
   "name": "@tank/github-actions-mastery",
   "version": "1.0.0",
-  "description": "GitHub Actions workflow authoring, optimization, and security. Covers workflow syntax, triggers, matrix strategies, caching, reusable workflows, composite actions, secrets/OIDC, self-hosted runners, security hardening (SHA pinning, supply chain), monorepo patterns, concurrency, and CI/CD recipes (test, deploy, release, Docker). Triggers: github actions, workflow, matrix, cache, secrets, OIDC, reusable workflow, composite action, self-hosted runner, security, deploy, docker, monorepo, concurrency, workflow_dispatch, CI/CD pipeline.",
+  "description": "GitHub Actions patterns covering workflow syntax, triggers, matrices, caching, reusable workflows, composite actions, secrets/OIDC, self-hosted runners, security hardening, monorepos, concurrency, and CI/CD recipes. Triggers: github actions, workflow, matrix, cache, reusable workflow, self-hosted runner, OIDC, concurrency, docker CI/CD.",
   "permissions": {
     "network": {
       "outbound": []
     },
     "filesystem": {
-      "read": ["**/*"],
+      "read": [
+        "**/*"
+      ],
       "write": []
     },
     "subprocess": false

--- a/skills/mcp-server-dev/skills.json
+++ b/skills/mcp-server-dev/skills.json
@@ -1,13 +1,15 @@
 {
   "name": "@tank/mcp-server-dev",
   "version": "1.0.0",
-  "description": "Build MCP servers in TypeScript and Python. Covers protocol architecture, tools/resources/prompts primitives, TypeScript SDK v2 (McpServer, Zod, Streamable HTTP), Python FastMCP 3 (decorators, Pydantic), tool design, OAuth 2.1 auth, OWASP security (tool poisoning, validation, sandboxing), transport selection (stdio/HTTP), MCP Inspector testing, and deployment (Vercel, Cloudflare Workers, Docker). Triggers: MCP server, build MCP server, MCP TypeScript, MCP Python, FastMCP, model context protocol, MCP tools, MCP resources, MCP security, tool poisoning, MCP Inspector, MCP deploy.",
+  "description": "Build MCP servers in TypeScript and Python. Covers tools/resources/prompts, TypeScript SDK v2, FastMCP, tool design, OAuth 2.1 auth, security, transports, inspector testing, and deployment. Triggers: MCP server, model context protocol, FastMCP, MCP tools, MCP resources, MCP security, MCP Inspector, MCP deploy.",
   "permissions": {
     "network": {
       "outbound": []
     },
     "filesystem": {
-      "read": ["**/*"],
+      "read": [
+        "**/*"
+      ],
       "write": []
     },
     "subprocess": false

--- a/skills/rag-production/skills.json
+++ b/skills/rag-production/skills.json
@@ -1,13 +1,15 @@
 {
   "name": "@tank/rag-production",
   "version": "1.0.0",
-  "description": "Production RAG pipeline architecture. Chunking strategies (recursive, semantic, document-aware), embedding models (OpenAI, Cohere, open-source), vector databases (pgvector, Pinecone, Weaviate, Qdrant, Chroma), hybrid search + reranking, advanced retrieval (HyDE, multi-query, agentic RAG, graph RAG), evaluation (RAGAS, DeepEval), and production operations (caching, streaming, cost). Triggers: RAG, retrieval augmented generation, vector database, embedding, chunking, hybrid search, reranking, agentic RAG, RAGAS, pgvector, Pinecone, RAG production, RAG best practices.",
+  "description": "Production RAG architecture covering chunking, embeddings, vector databases, hybrid search, reranking, advanced retrieval, evaluation, and production operations. Triggers: RAG, retrieval augmented generation, chunking, embeddings, vector database, hybrid search, reranking, RAGAS, pgvector, Pinecone.",
   "permissions": {
     "network": {
       "outbound": []
     },
     "filesystem": {
-      "read": ["**/*"],
+      "read": [
+        "**/*"
+      ],
       "write": []
     },
     "subprocess": false

--- a/skills/supabase-mastery/skills.json
+++ b/skills/supabase-mastery/skills.json
@@ -1,13 +1,15 @@
 {
   "name": "@tank/supabase-mastery",
   "version": "1.0.0",
-  "description": "Full-stack Supabase patterns for production apps. RLS policies (multi-tenant, CRUD, performance), Auth (email, OAuth, magic link, MFA, custom claims, hooks), Database (functions, triggers, migrations, type generation), Realtime (Postgres Changes, Broadcast, Presence), Edge Functions (Deno, webhooks, secrets), Storage (uploads, signed URLs, transforms, policies), supabase-js v2 client, CLI, Next.js integration (@supabase/ssr), and self-hosting. Triggers: supabase, supabase auth, supabase rls, row level security, supabase realtime, supabase edge functions, supabase storage, supabase next.js, supabase-js, supabase cli, supabase migration, auth.uid(), supabase gen types.",
+  "description": "Production Supabase patterns covering RLS, auth, database functions and migrations, realtime, edge functions, storage, supabase-js v2, CLI workflows, Next.js integration, and self-hosting. Triggers: supabase, RLS, auth, realtime, edge functions, storage, supabase-js, CLI, next.js, auth.uid().",
   "permissions": {
     "network": {
       "outbound": []
     },
     "filesystem": {
-      "read": ["**/*"],
+      "read": [
+        "**/*"
+      ],
       "write": []
     },
     "subprocess": false

--- a/skills/typescript-generics/skills.json
+++ b/skills/typescript-generics/skills.json
@@ -1,13 +1,15 @@
 {
   "name": "@tank/typescript-generics",
   "version": "1.0.0",
-  "description": "Advanced TypeScript generics and type-level programming. Covers generic constraints, conditional types, mapped types, template literal types, infer keyword, utility types deep dive, branded/opaque types, discriminated unions, variance, and real-world patterns (builder, factory, event emitter). Triggers: typescript generics, conditional type, mapped type, template literal type, infer, utility types, branded type, discriminated union, type narrowing, variance, generic constraint, type-level programming.",
+  "description": "Advanced TypeScript generics covering constraints, conditional and mapped types, template literal types, infer, utility types, branded types, discriminated unions, variance, and real-world generic patterns. Triggers: TypeScript generics, conditional type, mapped type, infer, utility types, branded type, variance, type-level programming.",
   "permissions": {
     "network": {
       "outbound": []
     },
     "filesystem": {
-      "read": ["**/*"],
+      "read": [
+        "**/*"
+      ],
       "write": []
     },
     "subprocess": false

--- a/skills/vibe-coding/skills.json
+++ b/skills/vibe-coding/skills.json
@@ -1,13 +1,15 @@
 {
   "name": "@tank/vibe-coding",
   "version": "1.0.0",
-  "description": "Vibe coding methodology for AI-assisted development. Rules file authoring (AGENTS.md, CLAUDE.md, .cursor/rules/), prompt engineering for code gen, context engineering, Research-Plan-Implement framework, tool selection (Cursor, Claude Code, OpenCode, Windsurf, Copilot, Aider), quality guardrails, prototype-to-production refactoring, and failure mode recovery. Triggers: vibe coding, vibe code, cursorrules, CLAUDE.md, AGENTS.md, context engineering, agentic coding, AI code generation, AI pair programming, vibe coding rules, vibe coding best practices, prompt engineering code.",
+  "description": "Vibe coding methodology for AI-assisted development covering rules files, prompt engineering, context engineering, research-plan-implement workflow, tool selection, quality guardrails, prototype-to-production refactoring, and failure recovery. Triggers: vibe coding, AGENTS.md, CLAUDE.md, context engineering, AI code generation, AI pair programming.",
   "permissions": {
     "network": {
       "outbound": []
     },
     "filesystem": {
-      "read": ["**/*"],
+      "read": [
+        "**/*"
+      ],
       "write": []
     },
     "subprocess": false

--- a/skills/vue-nuxt/skills.json
+++ b/skills/vue-nuxt/skills.json
@@ -1,13 +1,15 @@
 {
   "name": "@tank/vue-nuxt",
   "version": "1.0.0",
-  "description": "Vue 3 Composition API and Nuxt 3 patterns for production apps. Covers script setup, composables, reactive primitives, TypeScript integration (defineProps, defineEmits, defineModel), Pinia state management, Nuxt data fetching (useFetch, useAsyncData, server routes), middleware, plugins, rendering modes (SSR, SSG, ISR, hybrid routeRules), SEO, Nitro deployment, VueUse, and testing (Vitest, @vue/test-utils). Triggers: vue 3, nuxt 3, composable, pinia, script setup, useFetch, useAsyncData, vue typescript, defineProps, nuxt middleware, nuxt deployment, vue testing.",
+  "description": "Vue 3 and Nuxt 3 production patterns covering script setup, composables, reactive primitives, TypeScript integration, Pinia, data fetching, middleware, plugins, rendering modes, Nitro deployment, and testing. Triggers: vue 3, nuxt 3, composable, pinia, useFetch, useAsyncData, script setup, vue typescript, nuxt middleware.",
   "permissions": {
     "network": {
       "outbound": []
     },
     "filesystem": {
-      "read": ["**/*"],
+      "read": [
+        "**/*"
+      ],
       "write": []
     },
     "subprocess": false

--- a/skills/zod-patterns/skills.json
+++ b/skills/zod-patterns/skills.json
@@ -1,13 +1,15 @@
 {
   "name": "@tank/zod-patterns",
   "version": "1.0.0",
-  "description": "Zod schema validation patterns for TypeScript. Schema primitives, composition, transforms, pipes, refinements, error handling, type inference, branded types, coercion, Zod 4 features (Mini, metadata, JSON Schema). Integrations: React Hook Form, tRPC, Next.js, Express/Hono. Recipes: env vars, config parsing, API validation. Comparison: Zod vs Valibot vs ArkType vs Yup. Triggers: zod, zod schema, zod validation, zod infer, zod transform, zod refine, safeParse, zodResolver, zod trpc, zod cheat sheet.",
+  "description": "Zod validation patterns covering schema composition, transforms, refinements, error handling, type inference, coercion, Zod 4 features, and integrations with React Hook Form, tRPC, Next.js, and Express/Hono. Triggers: zod, zod schema, validation, infer, transform, refine, safeParse, zodResolver, tRPC, env parsing.",
   "permissions": {
     "network": {
       "outbound": []
     },
     "filesystem": {
-      "read": ["**/*"],
+      "read": [
+        "**/*"
+      ],
       "write": []
     },
     "subprocess": false


### PR DESCRIPTION
## Summary
- trim the remaining overlong skills.json descriptions that block `tank publish --dry-run`
- keep package metadata within Tank limits so the merged skills can be published cleanly
