### PR TITLE
fix: exclude .pyc from flight-search tank package

### DIFF
--- a/skills/flight-search/.tankignore
+++ b/skills/flight-search/.tankignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/

--- a/skills/flight-search/tank.json
+++ b/skills/flight-search/tank.json
@@ -1,6 +1,6 @@
 {
   "name": "@tank/flight-search",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Search flights via fast-flights (no API key, ~3s, Google Flights protobuf). Live status via Flightradar24. Price tracking with watch list. Airport lookup (40+ cities). Optional SerpAPI/Amadeus. Triggers: find flights, cheap flights, flight prices, fly to, flights from, Skyscanner, compare flights, flight status, track flights, IATA code, airport code, airfare.",
   "permissions": {
     "network": {


### PR DESCRIPTION
Add .tankignore for __pycache__/*.pyc. Fixes 8 critical findings. Bump 1.0.1.