### PR TITLE
feat: create @tank/cooking-mastery skill

### DIFF
--- a/skills/cooking-mastery/SKILL.md
+++ b/skills/cooking-mastery/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: "@tank/cooking-mastery"
+description: |
+  Your AI agent becomes a personal chef — find any recipe by name, cuisine,
+  category, or ingredient via TheMealDB API (free, no auth). Extract structured
+  recipes from YouTube, TikTok, and Instagram video URLs with confidence scoring.
+  Plan weekly meals based on dietary preferences, pantry contents, and family
+  size. Generate organized shopping lists grouped by aisle with export to Bring!,
+  Apple Reminders, or plain text. Save and manage a personal cookbook with tags,
+  ratings, and persistent local storage.
+
+  Synthesizes TheMealDB API documentation, web recipe extraction patterns
+  (JSON-LD schema.org Recipe), USDA Dietary Guidelines, grocery organization
+  practices, and recipe management app patterns.
+
+  Trigger phrases: "find me a recipe", "what can I cook with",
+  "recipe for", "extract recipe from video", "meal plan",
+  "weekly meal plan", "shopping list", "add to cookbook",
+  "save this recipe", "random dinner idea", "Italian recipes",
+  "what should I cook", "recipe from URL", "grocery list",
+  "what's for dinner", "vegetarian recipes", "gluten free recipe",
+  "cooking with leftovers", "what can I make"
+---
+
+# Cooking Mastery
+
+Find recipes, extract them from videos, plan meals, build shopping lists,
+and manage a personal cookbook.
+
+## Core Philosophy
+
+1. **TheMealDB first, web fallback** — Free API covers the common case
+   (~300 meals, 29 cuisines, 14 categories). When it returns nothing,
+   fall back to web search + JSON-LD extraction from recipe sites.
+2. **Video is just another source** — YouTube, TikTok, Instagram URLs
+   produce the same structured recipe object as API results. Parse
+   description, transcript, and structured data; score confidence.
+3. **Recipes flow into actions** — A found recipe is not the end. Offer
+   next steps: save to cookbook, generate shopping list, add to meal plan.
+4. **Shopping lists are organized** — Group ingredients by grocery aisle,
+   merge duplicates across recipes, flag pantry staples the user likely has.
+5. **The cookbook remembers** — Saved recipes persist in
+   `~/.cooking-mastery/cookbook.json` with tags, ratings, notes, and
+   cooking history. Suggest recipes the user hasn't cooked recently.
+
+## Quick-Start: Common Tasks
+
+### "Find me a recipe for [X]"
+
+1. Search TheMealDB: `search.php?s={query}`
+2. If results, present as comparison table (name, cuisine, time)
+3. If no results, search the web for `"{query} recipe"` and extract JSON-LD
+4. Show full recipe on selection. Offer: save, shopping list, or plan.
+   -> See `references/recipe-search.md` for all API endpoints and query routing
+
+### "What can I cook with [ingredients]?"
+
+1. Filter TheMealDB by main ingredient: `filter.php?i={ingredient}`
+2. Fetch full recipes for results
+3. Score by overlap with user's available ingredients
+4. Present top 3 with missing ingredients highlighted
+   -> See `references/recipe-search.md` (pantry matching)
+   -> See `references/meal-planning.md` (pantry-based suggestions)
+
+### "Extract recipe from this video"
+
+1. Detect platform from URL (YouTube, TikTok, Instagram)
+2. Fetch page, look for JSON-LD first, then parse description/transcript
+3. Build structured recipe with confidence score
+4. Present with confidence warning if below 70%
+   -> See `references/video-recipe-extraction.md`
+
+### "Plan meals for the week"
+
+1. Gather: people count, dietary restrictions, preferences, time constraints
+2. Build 7-day plan with protein rotation, cuisine variety, effort balance
+3. Source each recipe from TheMealDB or web
+4. Present as weekly table. Offer shopping list generation.
+   -> See `references/meal-planning.md`
+
+### "Make a shopping list for [recipes]"
+
+1. Parse ingredients from all selected recipes
+2. Normalize units, merge duplicates
+3. Group by grocery aisle category
+4. Flag pantry staples separately
+5. Export: plain text (default), Bring!, Apple Reminders, or markdown table
+   -> See `references/shopping-lists.md`
+
+### "Save this recipe" / "Show my cookbook"
+
+1. Save: format recipe to schema, check duplicates, persist to JSON
+2. Search: match across title, tags, cuisine, ingredients
+3. Suggest: favor high-rated, not-recently-cooked recipes
+   -> See `references/personal-cookbook.md`
+
+## Decision Trees
+
+### Query Type Routing
+
+| User Intent | Action | Primary Reference |
+|-------------|--------|-------------------|
+| Search by name/cuisine/category | TheMealDB API | `recipe-search.md` |
+| Search by ingredient | TheMealDB filter + pantry match | `recipe-search.md` |
+| Random suggestion | TheMealDB random endpoint | `recipe-search.md` |
+| Extract from video URL | Scrape + parse | `video-recipe-extraction.md` |
+| Extract from recipe URL | Fetch + JSON-LD | `video-recipe-extraction.md` |
+| Weekly meal plan | Planning workflow | `meal-planning.md` |
+| Shopping list | Ingredient aggregation | `shopping-lists.md` |
+| Save/search/rate recipe | Cookbook CRUD | `personal-cookbook.md` |
+| "What should I cook?" | Cookbook suggestion engine | `personal-cookbook.md` |
+
+### Dietary Restriction Handling
+
+| Restriction | TheMealDB Support | Fallback |
+|-------------|-------------------|----------|
+| Vegetarian | Category filter | Direct |
+| Vegan | Category filter | Direct |
+| Gluten-free | No filter | Check ingredients list |
+| Dairy-free | No filter | Check ingredients list |
+| Nut-free | No filter | Check ingredients list |
+| Halal / Kosher | No filter | Check ingredients list |
+| Keto / Low-carb | No filter | Check ingredients + macros |
+
+See `references/meal-planning.md` for ingredient exclusion lists per restriction.
+
+### Data Flow Between Features
+
+```
+Search/Video → Recipe Object → Save to Cookbook
+                             → Generate Shopping List
+                             → Add to Meal Plan → Generate Shopping List
+```
+
+Every feature produces or consumes the same recipe object format, enabling
+seamless chaining between search, save, plan, and shop.
+
+## Permissions
+
+| Permission | Scope | Reason |
+|-----------|-------|--------|
+| Network | `themealdb.com` | Recipe search API |
+| Network | `*.youtube.com`, `*.tiktok.com`, `*.instagram.com` | Video recipe extraction |
+| Network | `api.getbring.com` | Shopping list export (optional) |
+| Filesystem | Read + Write `~/.cooking-mastery/` | Personal cookbook persistence |
+
+## Reference Index
+
+| File | Contents |
+|------|----------|
+| `references/recipe-search.md` | TheMealDB API endpoints, query routing, response parsing, web fallback, JSON-LD extraction |
+| `references/video-recipe-extraction.md` | URL detection, platform-specific scraping, structured output, confidence scoring |
+| `references/meal-planning.md` | Planning workflow, dietary restrictions, pantry suggestions, portion scaling, weekly plan format |
+| `references/shopping-lists.md` | Ingredient parsing, unit normalization, aisle grouping, multi-recipe aggregation, export formats |
+| `references/personal-cookbook.md` | Cookbook schema, CRUD operations, tagging, search, ratings, import/export |

--- a/skills/cooking-mastery/references/meal-planning.md
+++ b/skills/cooking-mastery/references/meal-planning.md
@@ -1,0 +1,263 @@
+# Meal Planning
+
+Sources: USDA Dietary Guidelines (2020-2025), meal prep community patterns, nutritional balance frameworks
+
+Covers: weekly meal plan generation, dietary restriction handling, pantry-based
+suggestions, nutritional variety, portion scaling, and plan output formats.
+
+## Planning Workflow
+
+### Step 1: Gather Preferences
+
+Before generating a plan, collect:
+
+| Question | Why |
+|----------|-----|
+| How many people? | Portion scaling |
+| Any dietary restrictions? | Filter incompatible recipes |
+| What's already in your fridge/pantry? | Prioritize using what's available |
+| Cooking skill level? | Match recipe difficulty |
+| How many meals per day? | Scope the plan (dinner only vs full day) |
+| Any cuisine preferences? | Guide variety without monotony |
+| Time constraints? | Quick weekday meals, elaborate weekend cooking |
+| Budget considerations? | Favor economical ingredients |
+
+If user provides partial info, apply sensible defaults:
+- 2 adults, no restrictions, dinner only, mixed cuisines, moderate skill
+
+### Step 2: Build the Plan
+
+Planning rules for a balanced, enjoyable week:
+
+1. **Protein rotation** — Never repeat the same protein two days in a row
+2. **Cuisine variety** — Rotate through 3-4 cuisines across the week
+3. **Cooking method variety** — Mix baking, sautéing, grilling, slow-cooking
+4. **Effort distribution** — Heavier cooking on weekends, quick meals midweek
+5. **Leftover strategy** — Sunday roast → Monday's sandwiches or fried rice
+6. **Seasonal awareness** — Suggest lighter meals in summer, hearty in winter
+
+### Step 3: Source Recipes
+
+For each planned meal:
+1. Search TheMealDB first (see `references/recipe-search.md`)
+2. If no result, search the web for a matching recipe
+3. Include full ingredient lists for shopping list generation
+
+### Step 4: Present and Iterate
+
+Show the plan, then ask for swaps. Users frequently want to change 1-2 meals.
+
+## Dietary Restrictions
+
+### Common Restrictions and Filtering
+
+| Restriction | TheMealDB Filter | Additional Rules |
+|-------------|-----------------|------------------|
+| Vegetarian | `filter.php?c=Vegetarian` | Exclude meat, poultry, fish |
+| Vegan | `filter.php?c=Vegan` | Exclude all animal products |
+| Gluten-free | No filter — check ingredients | Exclude wheat, barley, rye, oats (unless certified GF) |
+| Dairy-free | No filter — check ingredients | Exclude milk, cheese, butter, cream, yogurt |
+| Nut-free | No filter — check ingredients | Exclude all tree nuts and peanuts |
+| Low-carb / Keto | No filter — check ingredients | Limit carbs to <50g per meal, favor proteins and fats |
+| Halal | No filter — check ingredients | Exclude pork, alcohol in cooking |
+| Kosher | No filter — check ingredients | Exclude pork, shellfish; no meat + dairy together |
+| Pescatarian | `filter.php?c=Seafood` + Vegetarian | Fish and seafood OK, no meat/poultry |
+
+### Ingredient Checking
+
+When TheMealDB doesn't have a category filter for a restriction, check
+each recipe's ingredients against exclusion lists:
+
+```
+Gluten sources: flour, bread, breadcrumbs, pasta (unless GF),
+  soy sauce (use tamari), beer, barley, rye, couscous, bulgur
+
+Dairy sources: milk, cream, butter, cheese, yogurt, whey,
+  casein, ghee (sometimes OK), sour cream, ice cream
+
+Nut sources: almonds, cashews, walnuts, pecans, pistachios,
+  pine nuts, peanuts, hazelnuts, macadamias, coconut (usually OK)
+```
+
+## Pantry-Based Suggestions
+
+When user says "what can I cook with what I have":
+
+### Collection Phase
+
+Ask: "What proteins, vegetables, and pantry staples do you have?"
+
+Organize into categories:
+- **Proteins**: chicken, beef, tofu, eggs, fish, etc.
+- **Vegetables**: onions, garlic, peppers, tomatoes, etc.
+- **Pantry staples**: rice, pasta, canned tomatoes, spices, oils
+- **Dairy**: cheese, milk, cream, butter
+
+### Matching Strategy
+
+1. Filter TheMealDB by primary ingredient: `filter.php?i={main_protein}`
+2. Fetch full recipes for results
+3. Score each recipe by ingredient overlap with user's pantry
+4. Rank by: (ingredients user has) / (total ingredients needed)
+5. Present top 3 with missing ingredients highlighted
+
+### Presentation
+
+```markdown
+## What You Can Cook
+
+### 1. Chicken Stir Fry (95% match)
+You have 9/10 ingredients. **Missing:** sesame oil
+
+### 2. Chicken Fajitas (80% match)
+You have 8/10 ingredients. **Missing:** tortillas, sour cream
+
+### 3. Chicken Curry (70% match)
+You have 7/10 ingredients. **Missing:** coconut milk, curry paste, lime
+```
+
+## Weekly Plan Format
+
+### Standard Output
+
+```markdown
+# Meal Plan: Week of January 20
+
+| Day | Dinner | Cuisine | Time | Protein |
+|-----|--------|---------|------|---------|
+| Monday | Chicken Stir Fry | Asian | 25 min | Chicken |
+| Tuesday | Spaghetti Bolognese | Italian | 40 min | Beef |
+| Wednesday | Fish Tacos | Mexican | 30 min | Fish |
+| Thursday | Vegetable Curry | Indian | 35 min | Chickpeas |
+| Friday | Pizza Night | Italian | 45 min | Varied |
+| Saturday | Grilled Salmon | Mediterranean | 30 min | Salmon |
+| Sunday | Roast Chicken | British | 90 min | Chicken |
+
+## Shopping List
+[Auto-generated from all recipes — see references/shopping-lists.md]
+
+---
+Want to swap any meals? I can also generate the full shopping list.
+```
+
+### Full Day Plan (when requested)
+
+```markdown
+# Full Day Meal Plan: Monday
+
+**Breakfast:** Greek Yogurt Parfait (10 min)
+- Greek yogurt, granola, berries, honey
+
+**Lunch:** Chicken Caesar Wrap (15 min)
+- Leftover chicken, romaine, parmesan, tortilla
+
+**Dinner:** Teriyaki Salmon Bowl (30 min)
+- Salmon, rice, edamame, avocado, teriyaki sauce
+
+**Snacks:** Apple slices with peanut butter | Trail mix
+```
+
+## Portion Scaling
+
+Scale recipes by family size:
+
+| Original Servings | Target | Multiplier |
+|-------------------|--------|------------|
+| 4 | 2 (couple) | 0.5x |
+| 4 | 4 (family) | 1x |
+| 4 | 6 (large family) | 1.5x |
+| 4 | 1 (solo) | 0.25x |
+
+Apply multiplier to all ingredient quantities. Round to practical amounts:
+- Don't say "0.25 onion" → say "1 small onion" or "half an onion"
+- Don't say "0.5 egg" → say "1 egg" (round up for baking)
+- Don't say "0.125 tsp" → say "a pinch"
+
+### Rounding Rules
+
+| Unit | Round to |
+|------|----------|
+| tsp / tbsp | Nearest 1/4 |
+| cups | Nearest 1/4 |
+| oz / g | Nearest whole number |
+| items (eggs, onions) | Round up |
+| "pinch" / "to taste" | Keep as-is |
+
+## Leftover Integration
+
+Plan for intentional leftovers to reduce cooking days:
+
+| Cook on | Leftover becomes |
+|---------|-----------------|
+| Sunday roast chicken | Monday chicken salad or wraps |
+| Big batch chili | Wednesday chili dogs or nachos |
+| Extra rice | Friday fried rice |
+| Roasted vegetables | Next day's frittata or grain bowl |
+
+When generating a plan, mark leftover reuse with "(L)" to indicate no extra
+cooking needed, reducing the perceived effort for the week.
+
+## Seasonal Considerations
+
+Suggest seasonally appropriate meals:
+
+| Season | Favored Styles | Avoid |
+|--------|---------------|-------|
+| Spring | Light salads, grilled fish, fresh herbs | Heavy stews |
+| Summer | Grilled meats, cold soups, salads, BBQ | Long oven roasts |
+| Autumn | Roasts, soups, squash dishes, comfort food | Light cold dishes |
+| Winter | Stews, casseroles, warm soups, baked dishes | Raw-heavy meals |
+
+Determine season from the current date and the user's hemisphere.
+
+## Budget-Conscious Planning
+
+When budget is a concern, apply these strategies:
+
+### Economical Ingredient Swaps
+
+| Expensive | Budget Alternative | Savings |
+|-----------|-------------------|---------|
+| Salmon | Canned tuna or tilapia | 60-70% |
+| Beef tenderloin | Chuck roast (slow-cook) | 50% |
+| Fresh herbs | Dried herbs | 80% |
+| Pine nuts | Sunflower seeds | 70% |
+| Parmesan | Pecorino or nutritional yeast | 40% |
+| Saffron | Turmeric + paprika | 95% |
+
+### Planning for Savings
+
+1. **Build around sales** — Ask what's on sale this week, plan meals around those proteins
+2. **Batch-cook staples** — Rice, beans, roasted vegetables last multiple meals
+3. **Use whole chickens** — Roast once, use in 3-4 meals through the week
+4. **Meatless days** — 2-3 vegetarian dinners per week significantly cuts cost
+5. **Seasonal produce** — In-season vegetables are 30-50% cheaper
+
+### Budget Meal Plan Template
+
+Aim for $50-75/week for 2 adults (dinner only):
+
+| Day | Meal Type | Budget Target |
+|-----|-----------|---------------|
+| Monday | Pasta or grain bowl | $5-7 |
+| Tuesday | Chicken + vegetables | $8-10 |
+| Wednesday | Vegetarian | $4-6 |
+| Thursday | Leftovers remix | $0 (already bought) |
+| Friday | Budget fish or eggs | $6-8 |
+| Saturday | Slow cooker or batch | $8-10 |
+| Sunday | Roast + sides | $10-12 |
+
+## Cooking Skill Adaptation
+
+Match recipe complexity to the user's stated skill level.
+
+| Skill Level | Recipe Characteristics | Avoid |
+|-------------|----------------------|-------|
+| Beginner | Under 10 ingredients, under 5 steps, common techniques (boil, sauté, bake) | Tempering chocolate, making roux, deboning fish |
+| Intermediate | Up to 15 ingredients, multi-step, some technique required | Soufflés, complex sauces, deep frying |
+| Advanced | Any complexity, specialized techniques welcome | Nothing — suggest everything |
+
+For beginners, add brief technique explanations:
+- "Sauté (cook in a pan with a little oil over medium-high heat)"
+- "Simmer (keep the liquid just below boiling — small bubbles)"
+- "Fold (gently mix by scooping from the bottom upward)"

--- a/skills/cooking-mastery/references/personal-cookbook.md
+++ b/skills/cooking-mastery/references/personal-cookbook.md
@@ -1,0 +1,288 @@
+# Personal Cookbook
+
+Sources: Recipe management app patterns, JSON data persistence, tagging and search design
+
+Covers: recipe storage schema, local JSON persistence, tagging system, search
+and filter operations, ratings and notes, import/export, and cookbook management
+commands.
+
+## Storage Location
+
+Store the personal cookbook as a JSON file at a predictable location:
+
+```
+~/.cooking-mastery/cookbook.json
+```
+
+Create the directory and file on first use. The file contains a single JSON
+object with metadata and a recipes array.
+
+## Cookbook Schema
+
+```json
+{
+  "version": "1.0",
+  "lastModified": "2026-04-14T12:00:00Z",
+  "recipes": [
+    {
+      "id": "r_1713100800_abc123",
+      "title": "Spicy Arrabiata Penne",
+      "slug": "spicy-arrabiata-penne",
+      "source": {
+        "type": "themealdb",
+        "url": "https://www.themealdb.com/meal/52771",
+        "originalId": "52771"
+      },
+      "cuisine": "Italian",
+      "category": "Pasta",
+      "dietary": ["vegetarian"],
+      "difficulty": "easy",
+      "prepTime": "10 minutes",
+      "cookTime": "25 minutes",
+      "servings": 4,
+      "ingredients": [
+        {"quantity": "1", "unit": "lb", "item": "penne rigate"},
+        {"quantity": "1/4", "unit": "cup", "item": "olive oil"},
+        {"quantity": "3", "unit": "cloves", "item": "garlic, minced"},
+        {"quantity": "1", "unit": "can", "item": "crushed tomatoes (28 oz)"},
+        {"quantity": "1", "unit": "tsp", "item": "red pepper flakes"}
+      ],
+      "instructions": [
+        "Cook penne in salted boiling water until al dente.",
+        "Heat olive oil in a large skillet over medium heat.",
+        "Add garlic and red pepper flakes, cook 1 minute.",
+        "Pour in crushed tomatoes, simmer 15 minutes.",
+        "Toss drained pasta with sauce. Serve immediately."
+      ],
+      "tags": ["quick", "weeknight", "pasta", "spicy"],
+      "rating": 4,
+      "notes": "Added extra garlic — was even better.",
+      "timesCooked": 3,
+      "lastCooked": "2026-04-10",
+      "dateAdded": "2026-03-15T10:30:00Z",
+      "imageUrl": "https://www.themealdb.com/images/media/meals/..."
+    }
+  ]
+}
+```
+
+## Recipe ID Generation
+
+Generate unique IDs combining timestamp and random suffix:
+
+```
+r_{unix_timestamp}_{random_6_chars}
+```
+
+Example: `r_1713100800_f3k9x2`
+
+The slug is a URL-friendly version of the title: lowercase, spaces to hyphens,
+strip special characters.
+
+## Core Operations
+
+### Save a Recipe
+
+When user says "save this recipe" or "add to cookbook":
+
+1. Format the recipe into the schema above
+2. Read existing cookbook file (or create if not exists)
+3. Check for duplicates by title (case-insensitive) or source URL
+4. If duplicate found, ask: "This recipe is already saved. Update it?"
+5. Append to recipes array
+6. Write back to file
+7. Confirm: "Saved 'Spicy Arrabiata Penne' to your cookbook (tagged: quick, weeknight)"
+
+### Search Recipes
+
+When user says "find [X] in my cookbook" or "what pasta recipes do I have":
+
+Search across these fields (case-insensitive partial match):
+- `title`
+- `cuisine`
+- `category`
+- `tags` (array contains)
+- `ingredients[].item` (any ingredient matches)
+- `notes`
+
+Return results sorted by relevance (title match > tag match > ingredient match).
+
+### List Recipes
+
+When user says "show my cookbook" or "what recipes do I have":
+
+Present as a scannable table:
+
+```markdown
+## Your Cookbook (24 recipes)
+
+| # | Recipe | Cuisine | Tags | Rating | Last Cooked |
+|---|--------|---------|------|--------|-------------|
+| 1 | Spicy Arrabiata Penne | Italian | quick, pasta | 4/5 | Apr 10 |
+| 2 | Chicken Tikka Masala | Indian | comfort, spicy | 5/5 | Apr 8 |
+| 3 | Fish Tacos | Mexican | quick, seafood | 3/5 | Mar 28 |
+...
+
+Filter by: cuisine, tag, rating, or ingredient. What would you like to see?
+```
+
+### Update a Recipe
+
+When user wants to modify a saved recipe:
+
+1. Find recipe by title or ID
+2. Apply changes (update fields, add tags, change rating)
+3. Update `lastModified` timestamp
+4. Write back to file
+5. Confirm changes
+
+### Delete a Recipe
+
+1. Find recipe by title or ID
+2. Confirm: "Remove 'Spicy Arrabiata Penne' from your cookbook?"
+3. Remove from array
+4. Write back to file
+
+### Rate a Recipe
+
+When user says "rate [recipe] 4 stars" or after cooking:
+
+1. Find recipe by title
+2. Set `rating` field (1-5)
+3. Increment `timesCooked`
+4. Set `lastCooked` to today
+5. Confirm: "Rated 'Arrabiata Penne' 4/5 (cooked 3 times)"
+
+### Add Notes
+
+When user says "add a note to [recipe]":
+
+1. Find recipe by title
+2. Append to `notes` field (or replace)
+3. Confirm: "Note added to 'Arrabiata Penne'"
+
+## Tagging System
+
+### Suggested Tags
+
+Assign tags automatically based on recipe attributes, then let user customize.
+
+| Auto-Tag Condition | Tag |
+|-------------------|-----|
+| Total time ≤ 30 min | `quick` |
+| Total time ≤ 15 min | `express` |
+| No meat ingredients | `vegetarian` |
+| No animal products | `vegan` |
+| No gluten ingredients | `gluten-free` |
+| Category == Dessert | `dessert` |
+| Cooking method = oven | `baked` |
+| Cooking method = grill | `grilled` |
+| One-pot/pan recipe | `one-pot` |
+
+### User-Defined Tags
+
+Users can add any custom tags:
+- `meal-prep` — Good for batch cooking
+- `date-night` — Impressive dishes
+- `kids-love` — Family favorites
+- `budget` — Economical recipes
+- `holiday` — Special occasion dishes
+
+## Smart Features
+
+### "What Should I Cook?"
+
+When user asks without specifics:
+
+1. Check what they haven't cooked recently (sort by `lastCooked` ascending)
+2. Favor higher-rated recipes (4-5 stars)
+3. Consider the day (weekday → suggest `quick` tagged; weekend → any)
+4. Present 3 suggestions:
+
+```markdown
+Based on your cookbook, how about:
+
+1. **Chicken Tikka Masala** (5/5) — Last cooked 2 weeks ago
+2. **Honey Garlic Salmon** (4/5) — You haven't made this in a month
+3. **Mushroom Risotto** (4/5) — Perfect for a weeknight
+
+Pick one, or tell me what you're in the mood for.
+```
+
+### Recipe Statistics
+
+When user asks "show my cooking stats" or "what do I cook most":
+
+```markdown
+## Your Cooking Stats
+
+**Total recipes:** 24
+**Most cooked:** Chicken Stir Fry (8 times)
+**Highest rated:** Chicken Tikka Masala (5/5)
+**Favorite cuisine:** Italian (7 recipes)
+
+**Cuisine breakdown:**
+- Italian: 7 recipes
+- Asian: 5 recipes
+- Mexican: 4 recipes
+- Indian: 3 recipes
+- Other: 5 recipes
+
+**Cooking frequency:** ~3 times per week
+```
+
+## Import and Export
+
+### Import from URL
+
+When user shares a recipe URL (not video):
+
+1. Fetch the page
+2. Look for JSON-LD `@type: Recipe` structured data
+3. Parse into cookbook schema
+4. Present for confirmation before saving
+
+### Export Cookbook
+
+When user says "export my cookbook":
+
+Output options:
+- **JSON** — Full cookbook.json file
+- **Markdown** — Readable recipe book format
+- **Individual recipes** — One markdown file per recipe
+
+### Markdown Export Format
+
+```markdown
+# My Cookbook
+
+## Spicy Arrabiata Penne
+*Italian | Vegetarian | 4/5 | 35 min*
+
+### Ingredients (4 servings)
+- 1 lb penne rigate
+- 1/4 cup olive oil
+...
+
+### Instructions
+1. Cook penne in salted boiling water...
+...
+
+**Notes:** Added extra garlic — was even better.
+**Tags:** quick, weeknight, pasta, spicy
+
+---
+
+## Chicken Tikka Masala
+...
+```
+
+## Error Handling
+
+| Scenario | Response |
+|----------|----------|
+| Cookbook file doesn't exist | Create it with empty recipes array |
+| Cookbook file is corrupted JSON | Backup the corrupted file, create fresh |
+| Duplicate recipe detected | Ask user: update existing or save as new? |
+| Recipe not found in search | "No recipes matching '[query]' in your cookbook. Search online instead?" |
+| No recipes saved yet | "Your cookbook is empty! Search for a recipe to save your first one." |

--- a/skills/cooking-mastery/references/recipe-search.md
+++ b/skills/cooking-mastery/references/recipe-search.md
@@ -1,0 +1,264 @@
+# Recipe Search
+
+Sources: TheMealDB API documentation, web recipe search patterns, Gousto catalog structure
+
+Covers: TheMealDB API endpoints (search, filter, lookup, random), query routing
+by user intent, response parsing, fallback strategies when API lacks results.
+
+## TheMealDB API Reference
+
+Base URL: `https://www.themealdb.com/api/json/v1/1/`
+
+Free tier (API key `1`) supports all read operations with no authentication.
+Rate limit is generous for single-user agent use.
+
+### Core Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `search.php?s={name}` | GET | Search meals by name |
+| `search.php?f={letter}` | GET | List meals starting with letter |
+| `lookup.php?i={id}` | GET | Get full meal details by ID |
+| `random.php` | GET | Single random meal |
+| `randomselection.php` | GET | 10 random meals (paid key only) |
+| `filter.php?i={ingredient}` | GET | Filter by main ingredient |
+| `filter.php?c={category}` | GET | Filter by category |
+| `filter.php?a={area}` | GET | Filter by cuisine/area |
+| `categories.php` | GET | List all categories with descriptions |
+| `list.php?c=list` | GET | List all category names |
+| `list.php?a=list` | GET | List all area/cuisine names |
+| `list.php?i=list` | GET | List all ingredient names |
+
+### Search by Name
+
+```
+GET https://www.themealdb.com/api/json/v1/1/search.php?s=Arrabiata
+```
+
+Returns full meal objects with all fields. Supports partial matches —
+searching "chicken" returns all meals containing "chicken" in the name.
+
+Response structure:
+```json
+{
+  "meals": [
+    {
+      "idMeal": "52771",
+      "strMeal": "Spicy Arrabiata Penne",
+      "strCategory": "Vegetarian",
+      "strArea": "Italian",
+      "strInstructions": "...",
+      "strMealThumb": "https://...",
+      "strTags": "Pasta,Curry",
+      "strYoutube": "https://...",
+      "strIngredient1": "penne rigate",
+      "strMeasure1": "1 pound",
+      "strIngredient2": "olive oil",
+      "strMeasure2": "1/4 cup",
+      ...
+    }
+  ]
+}
+```
+
+If no results: `{"meals": null}`.
+
+### Filter Endpoints
+
+Filter returns lightweight objects (id, name, thumbnail only). Use `lookup.php`
+to get full details for selected meals.
+
+```
+GET filter.php?i=chicken_breast    # by ingredient (use underscores)
+GET filter.php?c=Seafood           # by category
+GET filter.php?a=Canadian          # by cuisine
+```
+
+Filter response (abbreviated):
+```json
+{
+  "meals": [
+    {
+      "strMeal": "Honey Teriyaki Salmon",
+      "strMealThumb": "https://...",
+      "idMeal": "52773"
+    }
+  ]
+}
+```
+
+After filtering, fetch full recipe with `lookup.php?i={idMeal}`.
+
+### Available Cuisines (Areas)
+
+American, British, Canadian, Chinese, Croatian, Dutch, Egyptian, Filipino,
+French, Greek, Indian, Irish, Italian, Jamaican, Japanese, Kenyan, Malaysian,
+Mexican, Moroccan, Norwegian, Polish, Portuguese, Russian, Spanish, Thai,
+Tunisian, Turkish, Ukrainian, Vietnamese.
+
+### Available Categories
+
+Beef, Breakfast, Chicken, Dessert, Goat, Lamb, Miscellaneous, Pasta, Pork,
+Seafood, Side, Starter, Vegan, Vegetarian.
+
+### Ingredient Parsing from Response
+
+Meals have 20 ingredient/measure pairs (`strIngredient1`–`strIngredient20`,
+`strMeasure1`–`strMeasure20`). Many are empty strings or null. Parse them:
+
+```
+For i in 1..20:
+  ingredient = meal[f"strIngredient{i}"]
+  measure = meal[f"strMeasure{i}"]
+  if ingredient and ingredient.strip():
+    add (measure.strip(), ingredient.strip()) to ingredients list
+```
+
+## Query Routing
+
+Match user intent to the right endpoint combination.
+
+| User Says | Strategy | Endpoints |
+|-----------|----------|-----------|
+| "Find a chicken recipe" | Search by name | `search.php?s=chicken` |
+| "What can I cook with salmon?" | Filter by ingredient | `filter.php?i=salmon` → `lookup.php` |
+| "Give me Italian food" | Filter by cuisine | `filter.php?a=Italian` → `lookup.php` |
+| "I want a dessert" | Filter by category | `filter.php?c=Dessert` → `lookup.php` |
+| "Surprise me" / "random dinner" | Random | `random.php` |
+| "What cuisines are available?" | List areas | `list.php?a=list` |
+| "Show me pasta recipes" | Filter by category | `filter.php?c=Pasta` → `lookup.php` |
+| "Vegetarian dinner ideas" | Filter by category | `filter.php?c=Vegetarian` → `lookup.php` |
+
+### Multi-Criteria Searches
+
+TheMealDB does not support compound filters (e.g., "Italian + chicken"). Strategy:
+
+1. Filter by the most restrictive criterion first (usually ingredient)
+2. Fetch full details for results
+3. Filter client-side by the second criterion (check `strArea`, `strCategory`)
+
+Example: "Italian chicken recipes"
+1. `filter.php?i=chicken` → list of chicken meals
+2. `lookup.php?i={id}` for each result
+3. Keep only where `strArea == "Italian"`
+
+### When TheMealDB Falls Short
+
+The API has ~300 meals. For queries that return null or too few results:
+
+1. **Web search fallback**: Search the web for `"{query} recipe site:allrecipes.com OR site:food.com OR site:bbcgoodfood.com"`
+2. **Scrape recipe page**: Fetch the URL and extract recipe from structured data (JSON-LD `@type: Recipe`) or from page content
+3. **Present with attribution**: Always link back to the source URL
+
+### JSON-LD Recipe Extraction
+
+Most major recipe sites embed structured data. Look for:
+
+```html
+<script type="application/ld+json">
+{
+  "@type": "Recipe",
+  "name": "...",
+  "recipeIngredient": ["1 cup flour", "2 eggs"],
+  "recipeInstructions": [{"text": "Preheat oven..."}],
+  "prepTime": "PT15M",
+  "cookTime": "PT30M",
+  "recipeYield": "4 servings",
+  "nutrition": { "calories": "350" }
+}
+</script>
+```
+
+Parse with standard JSON. The `recipeIngredient` array and `recipeInstructions`
+array map directly to the unified recipe format (see `references/personal-cookbook.md`).
+
+## Presenting Search Results
+
+### Comparison Table Format
+
+When showing multiple results, present as a scannable table:
+
+```markdown
+| # | Recipe | Cuisine | Category | Time |
+|---|--------|---------|----------|------|
+| 1 | Honey Teriyaki Salmon | Japanese | Seafood | 30 min |
+| 2 | Chicken Fajita Mac and Cheese | Mexican | Chicken | 35 min |
+| 3 | Fish Stew | Italian | Seafood | 45 min |
+
+Which one would you like? I can show the full recipe with ingredients.
+```
+
+### Full Recipe Format
+
+When showing a single recipe:
+
+```markdown
+## Spicy Arrabiata Penne
+**Cuisine:** Italian | **Category:** Vegetarian | **Servings:** 4
+
+### Ingredients
+- 1 pound penne rigate
+- 1/4 cup olive oil
+- 3 cloves garlic, minced
+...
+
+### Instructions
+1. Bring a large pot of salted water to a boil...
+2. Meanwhile, heat olive oil in a large skillet...
+...
+
+[Video](https://youtube.com/...) | [Photo](https://themealdb.com/...)
+```
+
+### Random Discovery
+
+For "surprise me" or "I don't know what to cook":
+
+1. Call `random.php` once
+2. Present the meal with full details
+3. Offer: "Want another suggestion? Or I can search for something specific."
+
+If user wants options: call `random.php` 3 times and present as comparison table.
+
+## Error Handling
+
+| Scenario | Response |
+|----------|----------|
+| `{"meals": null}` | "No recipes found for that. Try a broader search or different ingredient." |
+| Network error | "Can't reach TheMealDB right now. Let me search the web instead." |
+| Empty ingredient list | Skip — meal data is incomplete, note to user |
+| No YouTube link | Skip video link — not all meals have one |
+
+## Gousto as Supplementary Source
+
+Gousto offers 9,000+ recipes with richer metadata (nutritional info, prep time,
+difficulty, ratings, step-by-step instructions with photos). Access requires
+web scraping their recipe pages at `gousto.co.uk/cookbook/`.
+
+Use Gousto when:
+- User asks for nutritional information (calories, macros)
+- User wants difficulty ratings
+- TheMealDB returns no results for a specific query
+- User wants detailed step-by-step photos
+
+Scrape with web fetch tool → parse HTML → extract recipe data. Look for
+JSON-LD structured data first, fall back to HTML parsing.
+
+## Common Substitutions
+
+When a recipe calls for an unavailable ingredient, suggest substitutions
+to keep the user cooking rather than abandoning the recipe.
+
+| Missing | Substitute | Notes |
+|---------|-----------|-------|
+| Buttermilk | Milk + 1 tbsp lemon juice per cup | Let sit 5 min |
+| Heavy cream | Coconut cream (dairy-free) | Works in most sauces |
+| Egg (baking) | 1/4 cup applesauce per egg | Adds slight sweetness |
+| Fresh herbs | 1/3 amount dried herbs | Dried is more concentrated |
+| Wine (cooking) | Equal amount broth + splash vinegar | Lacks depth but works |
+| Sour cream | Greek yogurt | Nearly identical in cooking |
+| Breadcrumbs | Crushed crackers or oats | Adjust seasoning |
+| Lemon juice | Lime juice or white vinegar | 1:1 ratio |
+
+Offer substitutions when the user mentions missing ingredients or asks
+"what can I use instead of [X]?".

--- a/skills/cooking-mastery/references/shopping-lists.md
+++ b/skills/cooking-mastery/references/shopping-lists.md
@@ -1,0 +1,254 @@
+# Shopping Lists
+
+Sources: Grocery industry aisle organization, ingredient parsing patterns, Bring! API integration
+
+Covers: parsing ingredients from recipes, unit normalization, aisle/category
+grouping, multi-recipe aggregation, duplicate merging, and export to Bring!,
+Apple Reminders, or plain text formats.
+
+## Ingredient Parsing
+
+### From TheMealDB Format
+
+TheMealDB returns ingredient/measure pairs as separate fields:
+
+```
+strIngredient1: "chicken breast"    strMeasure1: "2"
+strIngredient2: "olive oil"         strMeasure2: "2 tbsp"
+strIngredient3: "garlic"            strMeasure3: "3 cloves"
+```
+
+Parse into structured format:
+
+```json
+{"quantity": "2", "unit": "", "item": "chicken breast"}
+{"quantity": "2", "unit": "tbsp", "item": "olive oil"}
+{"quantity": "3", "unit": "cloves", "item": "garlic"}
+```
+
+### From Free-Text Ingredients
+
+When parsing recipe text from web sources or video extraction:
+
+Common formats:
+```
+2 cups all-purpose flour
+1/2 teaspoon salt
+3 large eggs
+1 (14 oz) can diced tomatoes
+Salt and pepper to taste
+Cooking spray
+```
+
+Parsing rules:
+1. **Leading number** → quantity (support fractions: 1/2, 1/4, 3/4)
+2. **Unit word after number** → unit (see unit table below)
+3. **Remaining text** → item name
+4. **Parenthetical** → size/clarification, keep with item
+5. **"to taste"** → no quantity, mark as pantry staple
+6. **No number** → quantity is implicit 1 or "as needed"
+
+### Unit Recognition
+
+| Written As | Normalized |
+|-----------|-----------|
+| cup, cups, c | cup |
+| tablespoon, tablespoons, tbsp, Tbsp, T | tbsp |
+| teaspoon, teaspoons, tsp, t | tsp |
+| ounce, ounces, oz | oz |
+| pound, pounds, lb, lbs | lb |
+| gram, grams, g | g |
+| kilogram, kilograms, kg | kg |
+| milliliter, milliliters, ml, mL | ml |
+| liter, liters, l, L | L |
+| clove, cloves | clove |
+| piece, pieces, pc | piece |
+| can, cans | can |
+| bunch, bunches | bunch |
+| head, heads | head |
+| pinch | pinch |
+| dash | dash |
+| slice, slices | slice |
+| handful | handful |
+
+## Aisle Categorization
+
+Group ingredients by grocery store section for efficient shopping.
+
+### Category Map
+
+| Category | Items |
+|----------|-------|
+| Produce | Fruits, vegetables, fresh herbs, lettuce, avocado, lemon, lime, ginger, garlic, onion, potatoes, tomatoes, peppers, mushrooms, carrots, celery, broccoli, spinach |
+| Meat & Poultry | Chicken, beef, pork, lamb, turkey, ground meat, sausage, bacon |
+| Seafood | Salmon, shrimp, cod, tuna, tilapia, mussels, crab |
+| Dairy & Eggs | Milk, cream, butter, cheese, yogurt, sour cream, eggs, cream cheese |
+| Bakery & Bread | Bread, tortillas, pita, buns, rolls, croissants |
+| Pasta & Grains | Pasta, rice, quinoa, couscous, noodles, oats, bulgur, barley |
+| Canned & Jarred | Canned tomatoes, beans, coconut milk, broth, stock, tomato paste, olives, capers |
+| Oils & Vinegars | Olive oil, vegetable oil, sesame oil, coconut oil, balsamic vinegar, wine vinegar, soy sauce |
+| Spices & Seasonings | Salt, pepper, cumin, paprika, oregano, basil, thyme, cinnamon, chili flakes, curry powder, turmeric, garlic powder, bay leaves |
+| Baking | Flour, sugar, baking powder, baking soda, vanilla extract, chocolate chips, cocoa powder, cornstarch, yeast |
+| Frozen | Frozen vegetables, frozen fruit, frozen pizza dough, ice cream |
+| Snacks & Nuts | Almonds, walnuts, cashews, peanuts, pine nuts, breadcrumbs, crackers |
+| Condiments | Ketchup, mustard, mayonnaise, hot sauce, Worcestershire, fish sauce, hoisin, honey, maple syrup |
+| Beverages | Wine (for cooking), beer (for cooking), stock/broth (if liquid) |
+
+### Categorization Strategy
+
+1. Check item against known category keywords
+2. For ambiguous items, use the most common grocery placement
+3. Items like "garlic" could be produce or spices — put in produce (whole) or spices (powder)
+4. When uncertain, default to "Other"
+
+## Multi-Recipe Aggregation
+
+When building a shopping list from multiple recipes (e.g., a weekly meal plan),
+combine duplicate ingredients.
+
+### Merging Rules
+
+1. **Same item, same unit** → add quantities
+   - Recipe A: 2 cups flour + Recipe B: 1 cup flour → 3 cups flour
+
+2. **Same item, different units** → convert to common unit, then add
+   - 1 tbsp olive oil + 1/4 cup olive oil → 5 tbsp olive oil
+
+3. **Same item, no quantity** → keep single entry with "as needed"
+   - "Salt to taste" + "Salt to taste" → "Salt (to taste)"
+
+4. **Similar items, different forms** → keep separate
+   - "fresh basil" and "dried basil" are different items
+   - "chicken breast" and "chicken thighs" are different items
+
+### Common Conversions
+
+| From | To | Factor |
+|------|-----|--------|
+| 1 tbsp | 3 tsp | 3x |
+| 1 cup | 16 tbsp | 16x |
+| 1 cup | 8 fl oz | 8x |
+| 1 lb | 16 oz | 16x |
+| 1 kg | 2.2 lb | 2.2x |
+| 1 L | 4.2 cups | 4.2x |
+
+## Export Formats
+
+### Plain Text (default)
+
+```
+SHOPPING LIST (3 recipes, 12 items)
+
+PRODUCE
+□ 2 onions
+□ 4 cloves garlic
+□ 1 head broccoli
+□ 3 tomatoes
+
+MEAT & POULTRY
+□ 2 chicken breasts
+□ 1 lb ground beef
+
+DAIRY & EGGS
+□ 1 cup shredded cheese
+□ 6 eggs
+
+PASTA & GRAINS
+□ 1 lb spaghetti
+□ 2 cups rice
+
+CANNED & JARRED
+□ 1 can (14 oz) diced tomatoes
+□ 1 can coconut milk
+```
+
+### Markdown Table
+
+```markdown
+| Category | Item | Qty |
+|----------|------|-----|
+| Produce | Onions | 2 |
+| Produce | Garlic | 4 cloves |
+| Meat | Chicken breast | 2 |
+| Dairy | Eggs | 6 |
+```
+
+### Bring! Integration
+
+Bring! is a popular shared shopping list app. Integration via their unofficial API.
+
+Base URL: `https://api.getbring.com/rest/v2/`
+
+Workflow:
+1. User provides Bring! list UUID (from app settings or URL)
+2. For each ingredient, POST to add item:
+   ```
+   PUT /bringlists/{listUuid}
+   Content-Type: application/x-www-form-urlencoded
+
+   uuid={listUuid}&purchase={item_name}&specification={quantity_and_unit}
+   ```
+3. Items appear immediately in the user's Bring! app
+
+Item naming for Bring!:
+- Use the main ingredient name as `purchase` (e.g., "Chicken breast")
+- Use quantity + unit as `specification` (e.g., "2 pieces")
+- Bring! auto-categorizes most common grocery items
+
+### Apple Reminders
+
+Generate a list of reminders that can be added via Siri Shortcuts or the
+Reminders app URL scheme:
+
+```
+x-apple-reminderkit://REMCDReminder/create?title=2 onions&list=Shopping
+```
+
+Or provide the list as text for the user to paste into Reminders:
+
+```
+2 onions
+4 cloves garlic
+1 head broccoli
+2 chicken breasts
+```
+
+One item per line — Apple Reminders creates one reminder per line when pasting.
+
+## Pantry Staple Detection
+
+Some ingredients are common pantry staples that most people already have.
+Flag these separately so users can skip items they already own.
+
+### Common Pantry Staples
+
+Salt, pepper, olive oil, vegetable oil, flour, sugar, butter, garlic powder,
+onion powder, dried oregano, dried basil, soy sauce, vinegar, baking powder,
+baking soda, vanilla extract, paprika, cumin, cinnamon.
+
+### Presentation
+
+```
+SHOPPING LIST
+
+NEED TO BUY (10 items)
+□ 2 chicken breasts
+□ 1 lb spaghetti
+□ 3 tomatoes
+...
+
+PROBABLY HAVE (check your pantry)
+□ Olive oil
+□ Salt
+□ Garlic powder
+□ Dried oregano
+```
+
+## Smart Suggestions
+
+When generating a shopping list, add helpful notes:
+
+- **Bulk opportunities**: "You need onions for 3 recipes — buy a bag instead of individual"
+- **Substitution notes**: "No coconut milk? Heavy cream works as a substitute"
+- **Freshness tips**: "Buy the salmon for Thursday's dinner last — use within 2 days"
+- **Budget tips**: "Frozen broccoli works just as well here and costs less"

--- a/skills/cooking-mastery/references/video-recipe-extraction.md
+++ b/skills/cooking-mastery/references/video-recipe-extraction.md
@@ -1,0 +1,258 @@
+# Video Recipe Extraction
+
+Sources: YouTube Data API patterns, web scraping best practices, structured recipe schema (schema.org)
+
+Covers: detecting video URL platform, extracting recipe data from video pages
+(description, transcript, comments, structured data), building structured recipe
+output, confidence scoring for extraction quality.
+
+## URL Detection
+
+Identify the platform from the URL to route extraction strategy.
+
+| Platform | URL Patterns |
+|----------|-------------|
+| YouTube | `youtube.com/watch?v=`, `youtu.be/`, `youtube.com/shorts/` |
+| TikTok | `tiktok.com/@user/video/`, `vm.tiktok.com/` |
+| Instagram | `instagram.com/reel/`, `instagram.com/p/` |
+| Facebook | `facebook.com/watch/`, `fb.watch/` |
+| Generic | Any other URL — attempt JSON-LD extraction |
+
+## YouTube Extraction
+
+YouTube is the richest source because it often has: video description with
+ingredients, auto-generated transcript, comments with corrections, and
+sometimes JSON-LD recipe markup from the creator.
+
+### Strategy (ordered by reliability)
+
+1. **Fetch the page** — Use web fetch/scrape tool to get the YouTube page HTML
+2. **Check for JSON-LD** — Some food creators embed `@type: Recipe` structured data
+3. **Parse description** — Video descriptions often list ingredients and steps
+4. **Extract transcript** — Auto-captions contain spoken instructions
+5. **Combine sources** — Cross-reference description ingredients with transcript steps
+
+### Description Parsing
+
+Common patterns in cooking video descriptions:
+
+```
+INGREDIENTS:
+- 2 cups flour
+- 1 tsp salt
+- 3 eggs
+
+INSTRUCTIONS:
+1. Preheat oven to 350°F
+2. Mix dry ingredients
+3. Add eggs and stir
+```
+
+Parsing rules:
+- Look for headers: "ingredients", "recipe", "what you need", "you'll need"
+- Ingredient lines: start with `-`, `•`, `*`, or a quantity (number or fraction)
+- Instruction lines: start with numbers, or follow an "instructions"/"method"/"steps" header
+- Stop parsing at: "FOLLOW ME", "SUBSCRIBE", links section, sponsor text
+
+### Transcript Extraction
+
+YouTube auto-generates captions for most videos. Access via:
+
+1. Fetch page HTML
+2. Look for `timedtext` or `captions` data in the page source
+3. Alternative: use web search for `"{video_title} recipe transcript"`
+
+Transcript processing:
+- Remove timestamps
+- Identify cooking actions: "add", "mix", "stir", "bake", "chop", "sauté"
+- Group sequential cooking actions into numbered steps
+- Extract mentioned quantities and ingredients
+
+### Channel-Specific Patterns
+
+Some popular cooking channels have consistent formats:
+
+| Channel Style | Description Format | Extraction Approach |
+|--------------|-------------------|---------------------|
+| Professional (Bon Appétit, NYT) | Full recipe in description | Parse description directly |
+| Casual creator | Partial ingredients, refers to blog | Follow blog link, extract from there |
+| Short-form (Shorts) | Minimal description | Rely on transcript + comments |
+| Blog-linked | "Full recipe at [link]" | Follow the link, use JSON-LD extraction |
+
+## TikTok Extraction
+
+TikTok cooking videos are typically short (15-180 seconds) with minimal text.
+
+### Strategy
+
+1. **Fetch page** — Scrape the TikTok page (may need stealth scraping for anti-bot)
+2. **Parse caption** — The video caption sometimes contains ingredients
+3. **Check comments** — Creators often post recipes in pinned comments
+4. **Audio transcript** — TikTok auto-captions when available
+5. **Web search** — Search for `"{creator name} {recipe name} recipe"` to find blog post
+
+### Challenges
+
+- Anti-bot protections require stealth scraping or browser automation
+- Captions are often brief: "Viral pasta recipe" with no details
+- Recipe may only be shown visually in the video (text overlay)
+- Consider: ask user for any additional context they remember
+
+## Instagram Extraction
+
+Instagram Reels and posts often link to external recipe blogs.
+
+### Strategy
+
+1. **Fetch page** — May require authenticated scraping
+2. **Parse caption** — Recipes sometimes in post caption
+3. **Check for link** — "Link in bio" or direct URL to recipe blog
+4. **Follow link** — Extract structured recipe from the linked page
+
+### Caption Format
+
+Instagram recipes often use emoji bullets:
+
+```
+[emoji] 2 tbsp butter
+[emoji] 1 onion, diced
+[emoji] 2 chicken breasts
+[emoji] Salt and pepper to taste
+```
+
+Parse emoji-prefixed lines as ingredient lines (creators use food emoji as bullets).
+
+## Structured Output Format
+
+Extracted recipes follow a unified schema regardless of source.
+
+```json
+{
+  "title": "One-Pot Lemon Garlic Pasta",
+  "source": {
+    "platform": "youtube",
+    "url": "https://youtube.com/watch?v=...",
+    "creator": "Cooking With Me"
+  },
+  "servings": 4,
+  "prepTime": "10 minutes",
+  "cookTime": "20 minutes",
+  "totalTime": "30 minutes",
+  "difficulty": "easy",
+  "cuisine": "Italian",
+  "dietary": ["vegetarian"],
+  "ingredients": [
+    {"quantity": "1", "unit": "pound", "item": "spaghetti"},
+    {"quantity": "4", "unit": "cloves", "item": "garlic, minced"},
+    {"quantity": "2", "unit": "tbsp", "item": "olive oil"},
+    {"quantity": "1", "unit": "", "item": "lemon, juiced and zested"}
+  ],
+  "instructions": [
+    "Bring a large pot of salted water to a boil.",
+    "Cook spaghetti according to package directions.",
+    "Meanwhile, sauté garlic in olive oil until golden.",
+    "Toss drained pasta with garlic oil, lemon juice, and zest."
+  ],
+  "notes": "Creator suggests adding red pepper flakes for heat.",
+  "confidence": 0.85,
+  "extractionMethod": "description + transcript"
+}
+```
+
+## Confidence Scoring
+
+Not all extractions are equally reliable. Rate confidence to set user expectations.
+
+| Score | Meaning | Criteria |
+|-------|---------|----------|
+| 0.9–1.0 | High | JSON-LD structured data found, or full recipe in description |
+| 0.7–0.89 | Good | Ingredients from description + steps from transcript |
+| 0.5–0.69 | Moderate | Partial info — ingredients OR steps, not both |
+| 0.3–0.49 | Low | Mostly inferred from transcript, may have gaps |
+| < 0.3 | Unreliable | Only video title available, heavy guessing |
+
+### Factors That Raise Confidence
+
+- JSON-LD `@type: Recipe` present → +0.3
+- Explicit "INGREDIENTS" section in description → +0.2
+- Numbered steps in description → +0.2
+- Transcript available → +0.1
+- Quantities with units found → +0.1
+
+### Factors That Lower Confidence
+
+- No description text → -0.3
+- TikTok with only emoji caption → -0.2
+- No transcript available → -0.1
+- Ingredients without quantities → -0.1
+
+## Presenting Extracted Recipes
+
+When showing an extracted recipe to the user:
+
+```markdown
+## Extracted Recipe: One-Pot Lemon Garlic Pasta
+**Source:** [Cooking With Me on YouTube](https://youtube.com/...)
+**Confidence:** 4/5 (85% — from description + transcript)
+
+### Ingredients (4 servings)
+- 1 lb spaghetti
+- 4 cloves garlic, minced
+- 2 tbsp olive oil
+- 1 lemon, juiced and zested
+
+### Instructions
+1. Bring a large pot of salted water to a boil.
+2. Cook spaghetti according to package directions.
+...
+
+> NOTE: This recipe was extracted automatically. Some measurements
+> may be approximate. Watch the original video for visual guidance.
+
+Save to your cookbook? Add to shopping list?
+```
+
+Show the confidence warning when score is below 0.7. Offer next actions
+(save to cookbook, generate shopping list) to keep the workflow flowing.
+
+## Facebook and Generic URL Extraction
+
+### Facebook Watch / Reels
+
+Facebook cooking videos follow similar patterns to Instagram:
+
+1. Fetch the page (may require browser automation for anti-bot)
+2. Parse post text for recipe content
+3. Check comments for recipes shared by the creator
+4. Follow any external links to recipe blogs
+
+### Generic Recipe URLs
+
+For non-video URLs (recipe blogs, cooking sites):
+
+1. Fetch the page HTML
+2. Search for JSON-LD `@type: Recipe` — most recipe sites include this
+3. If no JSON-LD, look for `itemtype="http://schema.org/Recipe"` microdata
+4. If no structured data, parse the page content heuristically:
+   - Find headers containing "ingredient" or "instruction"/"direction"/"method"
+   - Extract lists following those headers
+5. Build structured recipe from extracted data
+
+### Multi-Language Considerations
+
+Cooking content comes in many languages. When extracting from non-English sources:
+
+- Ingredient quantities use universal number formats (1, 2, 1/2)
+- Unit abbreviations vary by language (tsp/cac/TL/кч)
+- Present the recipe in the user's language, translating where needed
+- Keep original ingredient names if translation is uncertain — the user can
+  recognize "mozzarella" or "tofu" in any language
+
+## Fallback When Extraction Fails
+
+If scraping fails or yields too little data:
+
+1. Search the web: `"{video title}" recipe ingredients`
+2. Check if the creator has a blog — search `"{creator name}" blog recipe`
+3. Ask the user: "I couldn't extract a full recipe from that video. Could you share any details you remember (main ingredient, cuisine type)?"
+4. Offer to search for a similar recipe: "Want me to find a similar [cuisine] recipe instead?"

--- a/skills/cooking-mastery/tank.json
+++ b/skills/cooking-mastery/tank.json
@@ -1,0 +1,19 @@
+{
+  "name": "@tank/cooking-mastery",
+  "version": "1.0.0",
+  "description": "Personal chef for AI agents — recipe search (TheMealDB, 29 cuisines, 14 categories), video-to-recipe extraction, weekly meal planning with dietary restrictions, shopping list generation grouped by aisle, and persistent personal cookbook. Triggers: find recipe, what can I cook with, recipe from video, meal plan, shopping list, save recipe, random dinner, grocery list, what's for dinner, cookbook.",
+  "permissions": {
+    "network": {
+      "outbound": [
+        "themealdb.com",
+        "api.getbring.com"
+      ]
+    },
+    "filesystem": {
+      "read": ["**/*"],
+      "write": ["~/.cooking-mastery/"]
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}

--- a/skills/markdown-renderer/scripts/prototype/.gitignore
+++ b/skills/markdown-renderer/scripts/prototype/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
## Summary

- Add `@tank/cooking-mastery` skill — personal chef for AI agents
- Recipe search via TheMealDB API (29 cuisines, 14 categories)
- Video-to-recipe extraction (YouTube/TikTok/Instagram)
- Weekly meal planning with dietary restrictions
- Shopping list generation grouped by aisle (Bring!, Apple Reminders, text export)
- Persistent personal cookbook with tags, ratings, and cooking history

## Files

- `skills/cooking-mastery/SKILL.md` (155 lines)
- `skills/cooking-mastery/tank.json`
- 5 reference files (recipe-search, video-recipe-extraction, meal-planning, shopping-lists, personal-cookbook)
- `skills/markdown-renderer/scripts/prototype/.gitignore` (excludes node_modules)