### PR TITLE
feat: add 5 new engineering skills and update react to v2.3.0

### DIFF
--- a/skills/app-architecture/SKILL.md
+++ b/skills/app-architecture/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: "@tank/app-architecture"
+description: |
+  Application-level architecture patterns for structuring code within a single
+  service or monolith. Covers layered architecture (traditional N-tier, when
+  it works, when it breaks), hexagonal architecture / ports and adapters
+  (dependency inversion, port/adapter taxonomy, testing benefits), clean
+  architecture (concentric circles, dependency rule, use cases, entities,
+  interface adapters), DDD tactical patterns (entities, value objects,
+  aggregates, domain events, repositories, domain services, application
+  services), CQRS (command/query separation at application level, read models,
+  eventual consistency), event sourcing (event store, projections, snapshots,
+  when to use vs avoid), modular monolith (module boundaries, internal APIs,
+  shared kernel), vertical slice architecture (feature-organized code,
+  MediatR-style), and feature flag architectural support.
+
+  Synthesizes Martin (Clean Architecture), Evans (Domain-Driven Design),
+  Vernon (Implementing DDD), Cockburn (Hexagonal Architecture), Young
+  (CQRS Journey), Ford & Richards (Fundamentals of Software Architecture,
+  Software Architecture: The Hard Parts), Fowler (Patterns of Enterprise
+  Application Architecture).
+
+  Trigger phrases: "app architecture", "application architecture",
+  "hexagonal architecture", "ports and adapters", "clean architecture",
+  "onion architecture", "layered architecture", "n-tier", "domain-driven
+  design", "DDD", "aggregate", "value object", "domain event", "DDD repository",
+  "data access layer", "CQRS", "event sourcing", "modular monolith", "vertical slice",
+  "how to structure my app", "project structure", "folder structure",
+  "dependency rule", "dependency inversion", "use case", "application service",
+  "domain service", "anemic domain model", "rich domain model",
+  "feature flags architecture", "trunk-based development",
+  "where does this code go", "which architecture pattern"
+---
+
+# Application Architecture
+
+## Core Philosophy
+
+1. **Dependencies point inward.** Business logic never depends on frameworks, databases, or HTTP. Infrastructure depends on the domain, never the reverse.
+2. **Boundaries are the architecture.** The placement and enforcement of module boundaries matters more than which pattern name you pick.
+3. **Match complexity to the problem.** CRUD apps do not need hexagonal architecture. Complex domains do not survive without explicit modeling. Select the lightest pattern that controls your actual complexity.
+4. **Make the implicit explicit.** Use cases, domain rules, and module contracts should be readable in code, not buried in service classes or controllers.
+5. **Delay distribution, enforce modularity now.** A well-bounded modular monolith can be split into services later. Poorly structured microservices cannot be easily merged back.
+
+## Quick-Start: Common Problems
+
+### "How should I structure this app?"
+
+1. Is the domain complex with rich business rules? -> Clean/Hexagonal + DDD tactical patterns
+2. Is it mostly CRUD with some validation? -> Layered architecture or vertical slices
+3. Do reads and writes have very different shapes/loads? -> Consider CQRS
+4. Will multiple teams work in this codebase? -> Modular monolith with enforced boundaries
+5. Is it a greenfield with unclear requirements? -> Vertical slices, refactor toward hexagonal as patterns emerge
+-> See `references/architecture-selection.md`
+
+### "Where does this code go?"
+
+1. Does it express a business rule independent of any use case? -> Domain layer (entity/value object)
+2. Does it orchestrate a user-facing workflow? -> Application layer (use case / application service)
+3. Does it translate between external format and internal model? -> Interface adapter (controller, presenter, mapper)
+4. Does it interact with a database, API, or file system? -> Infrastructure layer (driven adapter / repository impl)
+-> See `references/clean-architecture.md`
+
+### "Should I use DDD here?"
+
+1. Is the domain the primary source of complexity? -> Yes, DDD tactical patterns add value
+2. Is the complexity mostly technical (integrations, performance)? -> No, DDD adds overhead without payoff
+3. Can you access domain experts regularly? -> Essential for DDD to work
+4. Is the team willing to invest in a ubiquitous language? -> Required precondition
+-> See `references/ddd-tactical-patterns.md`
+
+### "My codebase is a big ball of mud"
+
+1. Identify the highest-value bounded context -> Draw a boundary around it first
+2. Define an explicit interface (internal API) for that module -> No direct database access from outside
+3. Move related code inside the boundary -> One module at a time
+4. Enforce the boundary with build tooling or access rules -> Prevent regression
+-> See `references/modular-monolith-vertical-slices.md`
+
+## Architecture Style Selection
+
+| Domain Complexity | Read/Write Asymmetry | Team Size | Recommendation |
+|---|---|---|---|
+| Low (CRUD-dominant) | Low | Any | Layered architecture or vertical slices |
+| Medium (some business rules) | Low | Small | Clean architecture (simplified) |
+| Medium | High | Any | Clean architecture + CQRS |
+| High (complex domain logic) | Low | Any | Hexagonal/Clean + DDD tactical patterns |
+| High | High | Any | Hexagonal/Clean + DDD + CQRS |
+| Any | Any | Multiple teams, one codebase | Modular monolith with enforced boundaries |
+| High + audit/compliance needs | High | Any | Event sourcing + CQRS (evaluate carefully) |
+
+## Dependency Direction Quick Reference
+
+| Layer | Depends On | Never Depends On |
+|---|---|---|
+| Domain (entities, value objects) | Nothing | Application, infrastructure, UI |
+| Application (use cases) | Domain | Infrastructure, UI |
+| Interface adapters (controllers, presenters) | Application, domain | Infrastructure details |
+| Infrastructure (DB, APIs, frameworks) | Application, domain (implements interfaces) | Nothing restricts it inward |
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|---|---|---|
+| Anemic domain model | Entities are data bags, logic scattered in services | Move behavior into entities/value objects |
+| Big ball of mud | No boundaries, everything depends on everything | Identify bounded contexts, extract modules |
+| Over-layering | 6 layers for a CRUD endpoint, pass-through delegation | Remove layers that add no logic; vertical slices for simple features |
+| Framework coupling | Domain logic imports Spring/Express/Django | Invert dependencies; domain defines interfaces, infrastructure implements |
+| Shared database across modules | Modules coupled through tables, no clear ownership | Each module owns its tables, communicate through APIs/events |
+| God service | One application service with 50 methods | Split by use case; one class per use case or feature |
+| Leaking domain logic | Validation and business rules in controllers | Push rules into domain objects, use application services to orchestrate |
+
+## Reference Index
+
+| File | Contents |
+|------|----------|
+| `references/layered-hexagonal.md` | Traditional layered architecture (N-tier, when it works, when it breaks), hexagonal architecture (ports, adapters, driven/driving distinction), dependency inversion mechanics |
+| `references/clean-architecture.md` | Clean architecture concentric circles, dependency rule, entities, use cases, interface adapters, frameworks layer, practical project structure |
+| `references/ddd-tactical-patterns.md` | Entities, value objects, aggregates, aggregate roots, domain events, repositories, domain services, application services, factories |
+| `references/cqrs-event-sourcing.md` | CQRS at application level, read/write model separation, eventual consistency, event sourcing fundamentals, event store, projections, snapshots, when to use vs avoid |
+| `references/modular-monolith-vertical-slices.md` | Module boundary enforcement, internal APIs, shared kernel, inter-module communication, vertical slice architecture, feature-organized code, MediatR patterns |
+| `references/architecture-selection.md` | Architecture style comparison matrix, migration paths between styles, feature flags as architectural enabler, trunk-based development support, incremental adoption strategies |

--- a/skills/app-architecture/references/architecture-selection.md
+++ b/skills/app-architecture/references/architecture-selection.md
@@ -1,0 +1,259 @@
+# Architecture Selection and Migration
+
+Sources: Richards & Ford (Fundamentals of Software Architecture), Ford et al. (Software Architecture: The Hard Parts), Martin (Clean Architecture), Evans (Domain-Driven Design)
+
+Covers: architecture style comparison, selection criteria, trade-off analysis, migration paths between styles, incremental adoption strategies, combining patterns, common mistakes in architecture selection.
+
+## Architecture Style Comparison
+
+### Overview Matrix
+
+| Style | Domain Complexity Support | Testability | Simplicity | Team Scalability | Infrastructure Independence |
+|---|---|---|---|---|---|
+| Layered (N-tier) | Low | Low-Medium | High | Low | Low |
+| Hexagonal (Ports/Adapters) | Medium-High | High | Medium | Medium | High |
+| Clean Architecture | High | High | Medium | Medium-High | High |
+| DDD Tactical | High | High | Low | High | High |
+| Vertical Slices | Low-Medium | Medium-High | High | Medium | Medium |
+| Modular Monolith | Medium-High | Medium-High | Medium | High | Medium |
+| CQRS | Medium-High | Medium-High | Low-Medium | Medium | Medium |
+| Event Sourcing | High | Medium | Low | Medium | Medium |
+
+### Cost-Benefit Summary
+
+| Style | Upfront Cost | Ongoing Maintenance Cost | Best Payoff Period |
+|---|---|---|---|
+| Layered | Very Low | Increases over time as complexity grows | Short-lived or simple apps |
+| Hexagonal | Medium | Stable (boundaries prevent degradation) | Medium to long-lived apps |
+| Clean Architecture | Medium-High | Stable to decreasing (easy to change internals) | Long-lived apps with evolving requirements |
+| DDD Tactical | High | Decreasing (domain model captures complexity explicitly) | Complex domains, long-lived systems |
+| Vertical Slices | Low | Low (features are independent) | Feature-heavy applications, rapid iteration |
+| Modular Monolith | Medium | Stable (boundaries scale with team) | Multi-team codebases |
+| CQRS | Medium-High | Medium (two models to maintain) | Read/write asymmetry |
+| Event Sourcing | High | High (event evolution, projection maintenance) | Audit-critical, temporal query needs |
+
+## Selection Decision Framework
+
+### Step 1: Assess Domain Complexity
+
+| Question | If Yes | If No |
+|---|---|---|
+| Are there complex business rules beyond validation? | Consider hexagonal, clean, or DDD | Layered or vertical slices |
+| Do business rules change frequently? | Isolate domain (hexagonal/clean) | Layered acceptable |
+| Is the domain the primary source of risk? | Invest in DDD tactical patterns | Focus architecture effort elsewhere |
+| Are there multiple bounded contexts? | Modular monolith | Single-module approaches |
+
+### Step 2: Assess Read/Write Patterns
+
+| Question | If Yes | If No |
+|---|---|---|
+| Do reads and writes have very different shapes? | Consider CQRS | Unified model |
+| Is read load much higher than write load (10:1+)? | CQRS with separate read store | Unified model |
+| Do you need multiple read model shapes for different consumers? | CQRS with projections | Single model |
+
+### Step 3: Assess Audit and Temporal Needs
+
+| Question | If Yes | If No |
+|---|---|---|
+| Is a complete audit trail a legal/business requirement? | Evaluate event sourcing | Skip event sourcing |
+| Do you need to reconstruct past states ("what was X at time T")? | Event sourcing adds value | Standard persistence |
+| Can you accept eventual consistency on reads? | Event sourcing feasible | Event sourcing may cause friction |
+
+### Step 4: Assess Team and Organizational Factors
+
+| Question | If Yes | If No |
+|---|---|---|
+| Will multiple teams work in this codebase? | Modular monolith with enforced boundaries | Single-team approaches |
+| Is the team experienced with DDD and event sourcing? | Advanced patterns feasible | Start simpler, evolve |
+| Does the team value rapid feature delivery? | Vertical slices as default | Layered or clean by preference |
+
+## Common Pattern Combinations
+
+| Combination | When to Use | How They Compose |
+|---|---|---|
+| Clean + DDD | Complex domain with infrastructure independence | DDD entities/aggregates in clean architecture's domain circle |
+| Modular Monolith + Vertical Slices | Multi-team, feature-heavy | Module boundaries at macro level, slices within each module |
+| Modular Monolith + Clean | Multi-team, complex domains | Module per bounded context, clean architecture within each |
+| CQRS + DDD | Complex domain + read/write asymmetry | DDD on command side, denormalized read models on query side |
+| CQRS + Event Sourcing | Audit + temporal queries + read flexibility | Events as write model, projections as read models |
+| Vertical Slices + Hexagonal | Feature-organized with infrastructure independence | Each slice uses ports/adapters for external dependencies |
+
+## Migration Paths
+
+### Layered to Hexagonal
+
+1. Identify the most complex service class
+2. Extract an interface for its data access dependency (create a port)
+3. Move the existing data access code into an adapter that implements the port
+4. Update the service to depend on the port interface, not the concrete implementation
+5. Write a test using an in-memory adapter to verify the refactoring
+6. Repeat for other services, one at a time
+
+Cost: Low per step. No big-bang rewrite.
+
+### Layered to Clean Architecture
+
+1. Start with the hexagonal migration above (dependency inversion)
+2. Identify domain logic in service classes
+3. Extract domain logic into entity methods and value objects
+4. Rename orchestration code as use cases (one per user intention)
+5. Establish the layer structure and dependency rule
+6. Add linting or build rules to enforce the dependency direction
+
+### Monolith to Modular Monolith
+
+1. Map the domain to bounded contexts (even informally)
+2. Pick the most independent area of code (fewest dependencies on the rest)
+3. Create a module with a public API facade
+4. Move related code into the module's internal structure
+5. Replace all external access to that code with calls through the public API
+6. Add build-time or CI enforcement of the boundary
+7. Repeat for the next most independent area
+
+### Unified Model to CQRS
+
+1. Identify a feature where read and write shapes diverge significantly
+2. Create a separate read model (DTO or view) for that feature's queries
+3. Create a query handler that reads from the database and returns the read model
+4. Keep the write side unchanged
+5. If reads need different optimization, introduce a denormalized read table updated by domain events
+6. Extend to other features as needed
+
+### Introducing Event Sourcing
+
+1. Pick a single aggregate where audit trail provides clear business value
+2. Implement an event store (use a library, not custom-built)
+3. Modify the aggregate to emit events on state changes
+4. Store events instead of (or in addition to) current state
+5. Build at least one projection to prove the pattern works
+6. Add snapshot support when event count per aggregate warrants it
+7. Do NOT migrate the entire application; event sourcing is per-aggregate
+
+## Architecture Selection Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|---|---|---|
+| Resume-driven architecture | Choosing patterns for learning, not for the problem | Evaluate trade-offs against actual requirements |
+| Copy the big company | "Netflix uses event sourcing, so we should too" | Your scale, team, and constraints differ |
+| Architecture astronaut | Abstracting everything before understanding the domain | Start concrete, abstract when patterns emerge |
+| All-or-nothing adoption | "We must be fully DDD or not at all" | Apply patterns selectively where they add value |
+| Ignoring team capability | Choosing event sourcing with a team that has never done it | Invest in training or choose a pattern the team can execute |
+| Premature CQRS | Separating read/write models when they are nearly identical | Wait until read/write shapes actually diverge |
+| Event sourcing everywhere | Applying event sourcing to CRUD-dominant areas | Reserve for aggregates with genuine audit or temporal needs |
+
+## Incremental Adoption Strategy
+
+The safest approach is incremental adoption — start simple, add structure as complexity demands it.
+
+### Recommended Evolution Path
+
+```
+Phase 1: Layered or Vertical Slices
+  Simple, fast to build, minimal ceremony.
+  Appropriate for: new projects, unclear requirements, prototypes.
+
+Phase 2: Extract Domain Model (Hexagonal/Clean)
+  When business logic tangles with infrastructure.
+  Trigger: difficulty testing without databases, logic in controllers.
+
+Phase 3: Modular Boundaries
+  When multiple teams or distinct business areas emerge.
+  Trigger: merge conflicts across unrelated features, unclear ownership.
+
+Phase 4: CQRS (if needed)
+  When read and write patterns diverge significantly.
+  Trigger: complex queries distort domain model, scaling asymmetry.
+
+Phase 5: Event Sourcing (if needed)
+  When audit trail or temporal queries become requirements.
+  Trigger: regulatory compliance, "how did we get here" questions.
+```
+
+Each phase is entered only when the preceding level shows strain. Not every application reaches Phase 5 — most stabilize at Phase 2 or 3.
+
+### Governance: Architecture Decision Records
+
+Document each architecture decision as an ADR (Architecture Decision Record):
+
+| Section | Content |
+|---|---|
+| Title | Short description of the decision |
+| Status | Proposed, accepted, deprecated, superseded |
+| Context | What forces are at play, what problem we face |
+| Decision | What we decided and why |
+| Consequences | What becomes easier, what becomes harder |
+
+ADRs prevent re-litigating settled decisions and help new team members understand why the architecture is shaped the way it is.
+
+### Fitness Functions
+
+Automated tests that verify architectural constraints hold over time.
+
+| Fitness Function | Verifies |
+|---|---|
+| No domain imports from infrastructure | Dependency rule is maintained |
+| No cross-module direct database access | Module boundaries are respected |
+| Cyclic dependency detection | No circular dependencies between modules |
+| Layer access rules | Controllers do not bypass services to access repositories |
+| Component coupling metrics | Coupling between modules stays below threshold |
+
+Implement fitness functions as part of CI. They catch architectural drift before it becomes technical debt.
+
+## Architecture Review Checklist
+
+Use this checklist when evaluating or proposing an application architecture.
+
+### Boundary Assessment
+
+| Question | Red Flag If |
+|---|---|
+| Can you test business logic without a database? | No — domain depends on infrastructure |
+| Can you replace the database without changing business logic? | No — persistence is coupled to domain |
+| Can you explain what each module does in one sentence? | No — unclear boundaries, mixed responsibilities |
+| Does each module have a single owner (person or team)? | No — shared ownership leads to diffuse responsibility |
+| Are there circular dependencies between modules? | Yes — indicates unclear boundary placement |
+
+### Complexity Assessment
+
+| Question | Implication |
+|---|---|
+| How many files must change for a typical feature? | High number (5+) suggests wrong layer/module decomposition |
+| How long does a new developer take to add a simple feature? | Long onboarding suggests over-engineering or poor documentation |
+| Are there areas of code that no one wants to touch? | Indicates accumulated technical debt or unclear architecture |
+| How often do changes in one area break another? | Frequently suggests insufficient boundary enforcement |
+
+### Trade-Off Documentation
+
+For each architectural decision, document:
+
+| Element | Content |
+|---|---|
+| Decision | What pattern or approach was chosen |
+| Context | What constraints, requirements, or forces led to this decision |
+| Alternatives considered | What other approaches were evaluated |
+| Consequences | What is now easier, what is now harder |
+| Review date | When to revisit this decision |
+
+### Technology-Specific Fitness Function Tools
+
+| Language/Framework | Tool | Enforces |
+|---|---|---|
+| Java | ArchUnit | Layer dependencies, naming conventions, annotation placement |
+| .NET | NetArchTest | Layer access rules, namespace dependency constraints |
+| TypeScript | dependency-cruiser | Module import rules, circular dependency detection |
+| TypeScript | eslint-plugin-import | Import ordering, no-restricted-paths |
+| Python | import-linter | Layer contracts, forbidden import paths |
+| Go | depguard | Package dependency rules |
+
+### Signs You Need to Evolve Your Architecture
+
+| Observation | Current Style | Consider Moving To |
+|---|---|---|
+| Business logic scattered across controllers and services | Layered | Hexagonal / Clean |
+| Cannot test without database | Layered | Hexagonal (dependency inversion) |
+| Service classes growing beyond 500 lines | Any | Vertical slices or use-case-per-class |
+| Merge conflicts between unrelated features | Any single-module | Modular monolith |
+| Reads and writes require very different data shapes | Unified model | CQRS |
+| Audit requirements appear ("who changed what, when?") | State-based | Event sourcing (for affected aggregates) |
+| Multiple teams stepping on each other | Monolith | Modular monolith with enforced boundaries |
+| Need independent deployment per team | Modular monolith | Selective service extraction |

--- a/skills/app-architecture/references/clean-architecture.md
+++ b/skills/app-architecture/references/clean-architecture.md
@@ -1,0 +1,250 @@
+# Clean Architecture
+
+Sources: Martin (Clean Architecture), Cockburn (Hexagonal Architecture), Palermo (Onion Architecture), Richards & Ford (Fundamentals of Software Architecture)
+
+Covers: concentric circle model, the dependency rule, entities layer, use cases layer, interface adapters layer, frameworks and drivers layer, practical project structure, mapping between layers, common implementation decisions.
+
+## The Concentric Circle Model
+
+Clean architecture organizes code in concentric rings. Inner rings know nothing about outer rings. Dependencies point strictly inward.
+
+```
++-----------------------------------------------------------+
+|  Frameworks & Drivers (outermost)                         |
+|  +-----------------------------------------------------+ |
+|  |  Interface Adapters                                  | |
+|  |  +-----------------------------------------------+  | |
+|  |  |  Application / Use Cases                      |  | |
+|  |  |  +-----------------------------------------+  |  | |
+|  |  |  |  Entities / Domain (innermost)          |  |  | |
+|  |  |  +-----------------------------------------+  |  | |
+|  |  +-----------------------------------------------+  | |
+|  +-----------------------------------------------------+ |
++-----------------------------------------------------------+
+```
+
+## The Dependency Rule
+
+All dependency arrows point toward the center of the diagram. Code in any given ring may only reference code in the same ring or a ring closer to the center — never outward toward infrastructure or delivery mechanisms.
+
+| Inner Circle | Can Reference | Cannot Reference |
+|---|---|---|
+| Entities | Only other entities, language primitives | Use cases, adapters, frameworks |
+| Use Cases | Entities, port interfaces | Adapters, frameworks, specific DB/API |
+| Interface Adapters | Use cases, entities | Specific framework internals |
+| Frameworks & Drivers | Anything inward | N/A (outermost ring) |
+
+Data crosses boundaries through simple data structures (DTOs), not by passing framework objects or ORM entities inward.
+
+## Layer Details
+
+### Entities (Innermost Circle)
+
+Core domain concepts that exist independently of any particular application. These rules belong to the business itself and would remain valid even if the software were rewritten from scratch or replaced entirely.
+
+| Component | Purpose | Example |
+|---|---|---|
+| Entity | Identity + behavior + business rules | `Order` with `addItem()`, `calculateTotal()` |
+| Value Object | Immutable, identity-less, equality by value | `Money`, `EmailAddress`, `DateRange` |
+| Domain Event | Record of something significant that happened | `OrderPlaced`, `PaymentReceived` |
+| Business Rule / Policy | Encapsulated rule, often a function or strategy | `DiscountPolicy`, `ShippingCalculator` |
+
+Entities have zero dependencies on frameworks, databases, or external libraries. They use only the programming language and standard library.
+
+### Use Cases (Application Business Rules)
+
+Application-specific business rules. Orchestrate the flow of data to and from entities. Each use case represents a single user intention.
+
+| Principle | Explanation |
+|---|---|
+| One class per use case | `CreateOrder`, `CancelOrder`, `GetOrderDetails` — not one `OrderService` with all methods |
+| Defines input/output ports | Declares what data it needs (input DTO) and what it returns (output DTO) |
+| Orchestrates, does not implement | Calls entity methods and port interfaces; contains no SQL, HTTP, or framework code |
+| Owns the transaction boundary | Decides when a unit of work begins and commits |
+
+#### Use Case Structure
+
+```
+class CreateOrderUseCase {
+  constructor(
+    private orderRepo: OrderRepository,      // output port
+    private paymentGateway: PaymentGateway,   // output port
+    private eventPublisher: EventPublisher     // output port
+  ) {}
+
+  execute(input: CreateOrderInput): CreateOrderOutput {
+    // 1. Validate input
+    // 2. Create domain objects (entities, value objects)
+    // 3. Execute business logic (entity methods)
+    // 4. Persist through port (orderRepo.save)
+    // 5. Publish domain events (eventPublisher.publish)
+    // 6. Return output DTO
+  }
+}
+```
+
+### Interface Adapters
+
+Bridge between the domain core and the outside world. Each adapter translates between the data shapes that use cases work with (DTOs, domain objects) and the shapes that a specific technology expects (HTTP payloads, SQL rows, gRPC messages).
+
+| Adapter Type | Direction | Responsibility |
+|---|---|---|
+| Controller | Inward (driving) | Convert HTTP request to use case input DTO, call use case |
+| Presenter | Outward (from use case) | Convert use case output DTO to view model for response |
+| Gateway implementation | Outward (driven) | Implement output port using a specific technology |
+| Repository implementation | Outward (driven) | Implement repository port with specific database |
+| Mapper | Both | Convert between domain entities and persistence/API models |
+
+### Frameworks and Drivers (Outermost Circle)
+
+Specific technology choices: web framework (Express, Spring, Django), ORM (Prisma, Hibernate, SQLAlchemy), message broker client, HTTP client library.
+
+This layer is where all the details go. Keep it thin — it should contain only glue code that wires the framework to the interface adapters.
+
+| Principle | Implication |
+|---|---|
+| Frameworks are details | The application works conceptually without any specific framework |
+| Keep framework code at the edge | Controller annotations, ORM decorators, route definitions — all outermost |
+| Framework lock-in is acceptable here | Inner layers are protected from framework changes |
+
+## Practical Project Structure
+
+### Feature-First (Recommended for Most Projects)
+
+```
+src/
+  features/
+    orders/
+      domain/
+        Order.ts              # Entity
+        OrderItem.ts           # Value object
+        OrderRepository.ts     # Port (interface)
+        OrderPlaced.ts         # Domain event
+      application/
+        CreateOrder.ts         # Use case
+        CancelOrder.ts         # Use case
+        GetOrderDetails.ts     # Query use case
+        dto/
+          CreateOrderInput.ts
+          CreateOrderOutput.ts
+      infrastructure/
+        PostgresOrderRepository.ts    # Adapter
+        OrderMapper.ts                # Entity <-> DB row mapping
+      interface/
+        OrderController.ts            # HTTP driving adapter
+        OrderRoutes.ts                # Framework routing
+    payments/
+      domain/ ...
+      application/ ...
+      infrastructure/ ...
+      interface/ ...
+  shared/
+    domain/
+      Money.ts                # Shared value objects
+      DomainEvent.ts          # Base event type
+    infrastructure/
+      EventPublisher.ts       # Shared infrastructure
+  main.ts                     # Composition root
+```
+
+### Layer-First (Simpler, for Small Applications)
+
+```
+src/
+  domain/
+    entities/
+    value-objects/
+    ports/
+    events/
+  application/
+    use-cases/
+    dto/
+  infrastructure/
+    repositories/
+    gateways/
+    mappers/
+  interface/
+    http/
+    cli/
+  main.ts
+```
+
+Feature-first scales better for larger applications. Layer-first is simpler for small ones.
+
+## Crossing Boundaries: Data Flow
+
+### Inward (Request)
+
+```
+HTTP Request
+  -> Controller (parse, validate format)
+    -> Input DTO (plain data object)
+      -> Use Case (orchestrate business logic)
+        -> Entity methods (execute rules)
+```
+
+### Outward (Response)
+
+```
+Entity state
+  -> Use Case (assemble output)
+    -> Output DTO (plain data object)
+      -> Presenter/Controller (format response)
+        -> HTTP Response
+```
+
+### Persistence Mapping
+
+The domain entity is NOT the ORM entity. Map between them:
+
+```
+Domain Entity  <-->  Mapper  <-->  Persistence Model (ORM entity / DB row)
+```
+
+| Rule | Why |
+|---|---|
+| Domain entity has no persistence annotations | ORM decorators create a dependency on the framework |
+| Persistence model can differ from domain model | Schema optimizations (denormalization) should not affect domain design |
+| Mapper handles conversion | Explicit, testable, keeps both models independent |
+
+In simple cases (no schema/domain mismatch), you may use the domain entity directly for persistence as a pragmatic shortcut. Document this as a conscious trade-off, not the default.
+
+## Common Implementation Decisions
+
+### When to Simplify
+
+Not every endpoint needs all four circles. Apply judgment:
+
+| Scenario | Pragmatic Approach |
+|---|---|
+| Simple CRUD with no business logic | Controller -> Repository directly (skip use case layer) |
+| Read-only query | Query handler that reads from DB and returns DTO — no domain entity involvement |
+| Single implementation of a port | Still define the interface; cost is low, flexibility and testability benefit is high |
+| Tiny application (< 5 endpoints) | Layer-first structure; avoid feature-first overhead |
+
+### Error Handling Across Boundaries
+
+| Layer | Error Type | Example |
+|---|---|---|
+| Domain | Domain exception (business rule violation) | `InsufficientFundsError`, `InvalidOrderStateError` |
+| Application | Application exception (workflow failure) | `OrderNotFoundError`, `PaymentDeclinedError` |
+| Interface adapter | Translate to appropriate external format | Domain error -> HTTP 422, not found -> HTTP 404 |
+| Infrastructure | Wrap technical errors, do not leak upward | Database timeout -> `RepositoryUnavailableError` |
+
+### Dependency Injection Approach
+
+| Approach | When to Use |
+|---|---|
+| Constructor injection | Default. Explicit, testable, compile-time safe |
+| Framework DI container | Large applications where manual wiring is tedious |
+| Composition root (manual wiring) | Small-medium apps, maximum control and transparency |
+
+## Clean Architecture Mistakes
+
+| Mistake | Problem | Fix |
+|---|---|---|
+| Skipping the dependency rule "just this once" | Erosion is incremental, eventually the domain depends on everything | Enforce with linting rules or module access restrictions |
+| Use case returning domain entity | Outer layers coupled to internal structure | Always return DTOs from use cases |
+| Fat use cases with business logic | Use case becomes a god class | Push logic into entities and domain services |
+| One-to-one entity/table mapping forced | Domain model mirrors database schema | Design domain model first, map to schema independently |
+| No tests for the domain layer | Defeats the primary benefit of clean architecture | Domain tests should be the majority of your test suite |

--- a/skills/app-architecture/references/cqrs-event-sourcing.md
+++ b/skills/app-architecture/references/cqrs-event-sourcing.md
@@ -1,0 +1,283 @@
+# CQRS and Event Sourcing
+
+Sources: Young (CQRS Journey), Fowler (CQRS pattern), Vernon (Implementing DDD), Kleppmann (Designing Data-Intensive Applications), Ford et al. (Software Architecture: The Hard Parts)
+
+Covers: CQRS at application level, command/query separation, read model design, eventual consistency, event sourcing fundamentals, event store, projections, snapshots, when to use vs avoid, combining CQRS with event sourcing.
+
+## CQRS: Command Query Responsibility Segregation
+
+### Core Concept
+
+Separate the write model (commands) from the read model (queries) into distinct models, possibly distinct data stores.
+
+| Side | Purpose | Optimized For |
+|---|---|---|
+| Command (write) | Accept changes, enforce business rules | Consistency, validation, transactional integrity |
+| Query (read) | Return data for display | Read performance, denormalized views, flexible shapes |
+
+### Why Separate Reads and Writes
+
+| Problem with Unified Model | How CQRS Solves It |
+|---|---|
+| Domain model is complex for reads | Read model is flat, denormalized, optimized for queries |
+| Reads and writes have different scaling needs | Scale read and write sides independently |
+| Query requirements distort domain model | Domain model stays pure; read model shaped for UI needs |
+| Complex joins for display | Read model pre-joins data at write time |
+
+### CQRS Levels of Separation
+
+| Level | Description | Complexity | When to Use |
+|---|---|---|---|
+| Code separation | Same database, separate command/query classes | Low | Default starting point when reads/writes diverge |
+| Schema separation | Same database, separate read tables/views | Medium | Read patterns differ significantly from write schema |
+| Database separation | Different databases for read and write | High | Extreme read/write ratio asymmetry or different storage needs |
+
+Start at the lowest level that solves the problem. Do not jump to separate databases without evidence.
+
+### Command Side Design
+
+| Component | Responsibility |
+|---|---|
+| Command | Data structure representing the user's intent: `PlaceOrderCommand { items, shippingAddress }` |
+| Command Handler | Validates, loads aggregate, executes domain logic, persists. One handler per command |
+| Write Model | Domain model (entities, aggregates, value objects) — optimized for invariant enforcement |
+
+#### Command Design Rules
+
+| Rule | Rationale |
+|---|---|
+| Commands are imperative: `PlaceOrder`, `CancelOrder` | Express user intent, not data mutation |
+| Commands carry only the data needed | Do not pass the entire entity — only the fields the operation requires |
+| One command, one handler | Single Responsibility — each handler is focused and testable |
+| Commands can be rejected | Validation failure, business rule violation, concurrency conflict |
+| Commands return minimal data | Success/failure + ID of created resource. Not the full entity |
+
+### Query Side Design
+
+| Component | Responsibility |
+|---|---|
+| Query | Data structure representing what the user wants to see: `GetOrderDetailsQuery { orderId }` |
+| Query Handler | Reads from the read store, returns a read model / view model. No business logic |
+| Read Model | Denormalized data structure shaped for a specific view or API response |
+
+#### Read Model Design Rules
+
+| Rule | Rationale |
+|---|---|
+| Read models are disposable | They can be rebuilt from the write side at any time |
+| Shape per use case | Dashboard view, list view, detail view — each gets its own read model |
+| No domain logic in queries | Read handlers are pure data retrieval. No validation, no state changes |
+| Pre-compute expensive operations | Aggregate counts, totals, derived fields — compute at write time, store in read model |
+
+### Synchronizing Read and Write Models
+
+| Strategy | Mechanism | Consistency | Complexity |
+|---|---|---|---|
+| Synchronous update | Write handler updates read model in same transaction | Strong | Low (but coupling) |
+| Domain events (in-process) | Write publishes event, read model handler updates asynchronously | Eventual (milliseconds) | Medium |
+| Domain events (message broker) | Event published to Kafka/RabbitMQ, consumer updates read store | Eventual (seconds) | High |
+| Change data capture | Database change log consumed by read model updater | Eventual (seconds) | Medium (infrastructure) |
+
+### Eventual Consistency in Practice
+
+When read and write models are separate, reads may lag behind writes.
+
+| Strategy | How |
+|---|---|
+| Read-your-own-writes | After a command, redirect to a page that reads from the write model or waits for sync |
+| Optimistic UI | UI assumes success immediately, reconciles if command fails |
+| Polling/websockets | Client polls read model until updated version appears |
+| Version tracking | Read model carries a version; client retries if version is stale |
+
+## Event Sourcing
+
+### Core Concept
+
+Instead of storing current state, store the sequence of events that led to the current state. The current state is derived by replaying events.
+
+```
+Traditional:  Save current state -> { id: 1, balance: 150, status: "active" }
+
+Event Sourced: Save events ->
+  AccountOpened { id: 1, initialBalance: 0 }
+  MoneyDeposited { id: 1, amount: 200 }
+  MoneyWithdrawn { id: 1, amount: 50 }
+  // Current state: replay all events -> balance: 150
+```
+
+### Event Store
+
+| Property | Description |
+|---|---|
+| Append-only | Events are never modified or deleted |
+| Ordered per aggregate | Events for an aggregate have a sequence number |
+| The source of truth | Current state is derived, events are authoritative |
+| Query by aggregate ID | Load all events for an aggregate to reconstruct its state |
+
+### Projections (Read Models)
+
+Event sourcing naturally pairs with CQRS. Projections consume the event stream and build read-optimized views.
+
+| Projection Type | Description | Example |
+|---|---|---|
+| Synchronous | Updated in same process after event is appended | In-memory read model for testing |
+| Asynchronous | Separate consumer subscribes to event stream | Elasticsearch index, reporting database |
+| Catch-up subscription | Consumer reads from a position and processes all subsequent events | Rebuilding a read model from scratch |
+
+### Rebuilding Projections
+
+One of event sourcing's strongest benefits: any projection can be rebuilt from the event stream.
+
+1. Create a new projection consumer
+2. Start reading from the beginning of the event stream
+3. Apply each event to build the new read model
+4. Once caught up, switch traffic to the new projection
+
+This enables adding new query capabilities without database migrations on the write side.
+
+### Snapshots
+
+Replaying thousands of events to reconstruct an aggregate is slow. Snapshots store the aggregate state at a point in time.
+
+| Concept | Description |
+|---|---|
+| Snapshot | Serialized aggregate state at event N |
+| Reconstruction | Load snapshot, then replay only events after N |
+| Frequency | Snapshot every N events (e.g., every 100) or on demand |
+| Storage | Same event store or separate snapshot store |
+
+Snapshots are an optimization. The event stream remains the source of truth.
+
+### Versioning Events
+
+Events are immutable facts. When the event schema needs to change:
+
+| Strategy | How | When |
+|---|---|---|
+| Upcasting | Transform old event format to new format at read time | Schema additions (new fields with defaults) |
+| New event type | Introduce `OrderPlacedV2` alongside `OrderPlaced` | Breaking schema changes |
+| Weak schema | Treat event data as a flexible map, handle missing fields gracefully | Evolving systems with many event types |
+
+Never modify existing events in the store. Upcasting or new versions preserve the historical record.
+
+### When to Use Event Sourcing
+
+| Signal | Event Sourcing Adds Value |
+|---|---|
+| Full audit trail is a business requirement | Every state change is recorded as an event |
+| Need to answer "how did we get here?" | Replay events to understand state transitions |
+| Complex state transitions with business rules | Events capture intent, not just result |
+| Multiple read model shapes needed | Build any view from the event stream |
+| Temporal queries ("what was the state at time T?") | Replay events up to time T |
+| Regulatory compliance (finance, healthcare) | Immutable, append-only event log |
+
+### When to Avoid Event Sourcing
+
+| Signal | Why Event Sourcing Hurts |
+|---|---|
+| Simple CRUD with no audit needs | Massive overhead for basic persistence |
+| Querying current state is the primary use case | Reconstructing state from events is slower than reading a row |
+| Team has no experience with event sourcing | Steep learning curve, subtle failure modes |
+| Delete/GDPR requirements | "Right to be forgotten" conflicts with immutable events (requires crypto-shredding or tombstones) |
+| High-frequency state changes on same aggregate | Thousands of events per aggregate, snapshot overhead |
+
+### Event Sourcing Pitfalls
+
+| Pitfall | Problem | Mitigation |
+|---|---|---|
+| Event schema evolution | Changing event structure breaks replay | Upcasting strategy from day one |
+| Large event streams per aggregate | Slow reconstruction, memory pressure | Snapshots, aggregate size limits |
+| Eventual consistency confusion | Developers expect immediate read-your-writes | Explicit consistency strategy in UI/API |
+| Event granularity too fine | Noise drowns signal, slow projections | Events represent domain-meaningful state changes, not field-level diffs |
+| Event granularity too coarse | Lost information, cannot build needed projections | Each event should capture one business-meaningful fact |
+| Missing idempotency in projections | Duplicate events cause incorrect read models | Idempotent projection handlers, track processed event position |
+
+## CQRS Without Event Sourcing
+
+CQRS and event sourcing are independent patterns. Use CQRS without event sourcing when:
+
+| Scenario | Approach |
+|---|---|
+| Read/write shape asymmetry | CQRS with separate read model, traditional state persistence on write side |
+| Different scaling needs | CQRS with read replicas, no event store |
+| Simple domain, complex query patterns | CQRS with materialized views or denormalized read tables |
+
+CQRS without event sourcing is far simpler to implement and operate. Start here unless you have a clear need for event sourcing.
+
+## CQRS + Event Sourcing Together
+
+When combined: commands produce events (write side), events are stored in an event store, projections consume events to build read models (read side).
+
+```
+Command -> Command Handler -> Aggregate -> Events -> Event Store
+                                                        |
+                                                        v
+                                              Projection Handler -> Read Database -> Query Handler -> Response
+```
+
+This combination gives maximum flexibility but maximum complexity. Reserve for core domains where both the audit trail and read model flexibility are genuine requirements.
+
+## Implementation Guidance
+
+### Command Bus Implementation
+
+A command bus dispatches commands to their handlers and optionally applies pipeline behaviors.
+
+```
+interface CommandBus {
+  dispatch<T>(command: Command): Promise<T>;
+}
+
+class SimpleCommandBus implements CommandBus {
+  private handlers: Map<string, CommandHandler>;
+  private middleware: Middleware[];
+
+  async dispatch<T>(command: Command): Promise<T> {
+    const handler = this.handlers.get(command.constructor.name);
+    const pipeline = this.middleware.reduceRight(
+      (next, mw) => () => mw.execute(command, next),
+      () => handler.handle(command)
+    );
+    return pipeline();
+  }
+}
+```
+
+### Read Model Storage Options
+
+| Storage | Best For | Trade-Off |
+|---|---|---|
+| Same relational database (materialized view) | Simple CQRS, same-transaction consistency | Limited denormalization flexibility |
+| Separate relational tables | Different schema than write side, still relational queries | Eventual consistency, schema migration for both sides |
+| Elasticsearch | Full-text search, complex filtering, analytics | Operational complexity, eventual consistency |
+| Redis | Low-latency key-value lookups, counters | Limited query flexibility, memory-bound |
+| MongoDB | Flexible document shapes per read model | Another database to operate |
+
+### Event Store Technology Options
+
+| Technology | Type | Strengths | Considerations |
+|---|---|---|---|
+| EventStoreDB | Purpose-built | Built for event sourcing, subscriptions, projections | Operational overhead of another database |
+| PostgreSQL (append-only table) | Relational | Familiar, transactional, no new infrastructure | Must implement subscription and snapshot logic |
+| DynamoDB | Managed NoSQL | Serverless, scales automatically | Limited querying without streams + Lambda |
+| Kafka (as event store) | Log-based | High throughput, natural event streaming | Compaction semantics differ from true event store |
+| Marten (.NET) | Library on PostgreSQL | Integrated event sourcing + document storage | .NET ecosystem only |
+
+### Testing CQRS Systems
+
+| Component | Test Strategy |
+|---|---|
+| Command handler | Unit test with in-memory repository. Assert events emitted or state changed |
+| Query handler | Unit test against seeded read store. Assert correct data shape returned |
+| Projection handler | Unit test: given events, assert read model state. Idempotency test: replay events twice, assert same result |
+| End-to-end | Send command, wait for projection update, query read model, assert consistency |
+
+### CQRS Monitoring Checklist
+
+| Metric | Why |
+|---|---|
+| Projection lag (time between event and read model update) | Detect growing eventual consistency window |
+| Command rejection rate | Detect validation or concurrency issues |
+| Event store growth rate | Capacity planning, snapshot frequency tuning |
+| Projection rebuild time | Ensure rebuilds complete within maintenance windows |
+| Dead letter queue depth | Detect events that projections cannot process |

--- a/skills/app-architecture/references/ddd-tactical-patterns.md
+++ b/skills/app-architecture/references/ddd-tactical-patterns.md
@@ -1,0 +1,267 @@
+# DDD Tactical Patterns
+
+Sources: Evans (Domain-Driven Design), Vernon (Implementing Domain-Driven Design), Millett & Tune (Patterns, Principles, and Practices of Domain-Driven Design), Fowler (Patterns of Enterprise Application Architecture)
+
+Covers: entities, value objects, aggregates and aggregate roots, domain events, repositories, domain services, application services, factories, the anemic domain model problem. Focuses on tactical (in-code) patterns, not strategic (organizational) DDD.
+
+## When to Apply DDD Tactical Patterns
+
+| Signal | Apply DDD | Skip DDD |
+|---|---|---|
+| Complex, evolving business rules | Yes | |
+| Domain experts available for collaboration | Yes | |
+| Core domain (competitive advantage) | Yes | |
+| CRUD with minimal logic | | Yes |
+| Generic subdomain (solved problem) | | Yes |
+| Integration-heavy, logic-light | | Yes |
+
+DDD tactical patterns have a cost: more classes, more indirection, more modeling effort. Apply them where the domain is the primary source of complexity.
+
+## Entities
+
+Objects defined by their identity, not their attributes. Two entities with the same attributes but different identities are different objects.
+
+| Property | Explanation |
+|---|---|
+| Has a unique identity | UUID, database ID, or natural key — persists across state changes |
+| Mutable | State changes over time through defined behaviors |
+| Encapsulates behavior | Business rules live as methods on the entity, not in external services |
+| Enforces invariants | Constructor and methods guarantee the entity is always in a valid state |
+
+### Entity Design Rules
+
+| Rule | Example |
+|---|---|
+| No public setters | Expose methods that express intent: `order.cancel()` not `order.setStatus("cancelled")` |
+| Constructor validates | `new Order(items)` throws if items list is empty |
+| Methods enforce rules | `order.addItem(item)` checks max items, duplicate detection |
+| State transitions are explicit | `order.ship()` validates that order is in "paid" state before transitioning |
+
+### Entity vs Data Record
+
+```
+// Anemic (data record with no behavior):
+class Order {
+  id: string;
+  items: OrderItem[];
+  status: string;
+  total: number;
+}
+
+// Rich entity (encapsulates behavior):
+class Order {
+  private constructor(private id: OrderId, private items: OrderItem[], private status: OrderStatus) {
+    if (items.length === 0) throw new EmptyOrderError();
+  }
+
+  addItem(item: OrderItem): void { /* validates, updates total */ }
+  cancel(): void { /* validates state transition */ }
+  ship(): void { /* validates state transition, emits event */ }
+  get total(): Money { /* calculates from items */ }
+}
+```
+
+## Value Objects
+
+Objects defined by their attributes, not identity. Two value objects with the same attributes are interchangeable.
+
+| Property | Explanation |
+|---|---|
+| No identity | Compared by attribute equality, not reference |
+| Immutable | Once created, cannot change. Operations return new instances |
+| Self-validating | Constructor rejects invalid state |
+| Replaces primitive obsession | `Money` instead of `number`, `EmailAddress` instead of `string` |
+
+### Common Value Objects
+
+| Value Object | Replaces | Validation |
+|---|---|---|
+| `Money(amount, currency)` | `number` | Non-negative, valid currency code |
+| `EmailAddress(value)` | `string` | RFC-compliant format |
+| `DateRange(start, end)` | Two `Date` fields | Start before end |
+| `Address(street, city, zip, country)` | Multiple strings | Non-empty required fields, valid postal code |
+| `Quantity(value)` | `number` | Positive integer |
+| `OrderId(value)` | `string` | Valid UUID format |
+
+### Value Object Design Rules
+
+| Rule | Rationale |
+|---|---|
+| All fields set in constructor | Immutability from creation |
+| No setters | Mutation returns a new instance: `money.add(other)` returns new `Money` |
+| Override equality | Two `Money(100, "USD")` instances are equal |
+| Make invalid states unrepresentable | `Quantity(-5)` throws at construction time |
+
+## Aggregates
+
+A cluster of domain objects treated as a single unit for data changes. One entity is the aggregate root — the entry point for all external access.
+
+### Aggregate Rules
+
+| Rule | Explanation |
+|---|---|
+| External access through the root only | Outside code never reaches into the aggregate to modify an inner entity |
+| One transaction per aggregate | A single database transaction modifies one aggregate. Cross-aggregate consistency is eventual |
+| Reference other aggregates by ID | Do not hold object references to other aggregates. Store `customerId: CustomerId`, not `customer: Customer` |
+| Keep aggregates small | Large aggregates cause contention. Prefer smaller, focused aggregates |
+
+### Identifying Aggregate Boundaries
+
+| Question | If Yes |
+|---|---|
+| Must these objects change together in a single transaction? | Same aggregate |
+| Can these objects change independently? | Separate aggregates |
+| Does a business rule span both objects? | Consider same aggregate (but evaluate contention cost) |
+| Will concurrent users modify the same data? | Smaller aggregates reduce lock contention |
+
+### Example: Order Aggregate
+
+```
+Order (Aggregate Root)
+  |-- OrderId (value object)
+  |-- OrderItem[] (entity, contained within aggregate)
+  |     |-- ProductId (value object, reference to Product aggregate)
+  |     |-- Quantity (value object)
+  |     |-- Price (value object)
+  |-- ShippingAddress (value object)
+  |-- OrderStatus (value object / enum)
+  |-- CustomerId (value object, reference to Customer aggregate)
+```
+
+`Order` is the root. External code calls `order.addItem()`, never `orderItem.setQuantity()` directly. `ProductId` and `CustomerId` are references by ID to other aggregates, not object references.
+
+### Aggregate Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|---|---|---|
+| Giant aggregate (entire order + customer + inventory) | Lock contention, slow persistence, large transaction scope | Break into smaller aggregates linked by ID |
+| Object references between aggregates | Lazy loading, accidental modification of another aggregate | Store ID only, load other aggregate when needed |
+| Multiple aggregates in one transaction | Violates consistency boundary, couples aggregates | Use domain events for cross-aggregate coordination |
+| Aggregate without invariants | No business reason for the grouping | Reevaluate boundaries; maybe it is just an entity |
+
+## Domain Events
+
+A record that something significant happened in the domain. Expressed in past tense using ubiquitous language.
+
+| Property | Explanation |
+|---|---|
+| Immutable | Events represent facts that happened; they cannot change |
+| Named in past tense | `OrderPlaced`, `PaymentReceived`, `ItemShipped` |
+| Contains relevant data | Event carries the data needed by handlers: `OrderPlaced { orderId, items, total, timestamp }` |
+| Produced by aggregates | Aggregates emit events as side effects of state changes |
+
+### Event Handling Patterns
+
+| Pattern | Scope | Example |
+|---|---|---|
+| In-process handler | Same bounded context, same transaction | Update read model after order placed |
+| Async handler | Same bounded context, separate transaction | Send confirmation email |
+| Cross-context event | Different bounded context, async | Billing context reacts to order placed |
+
+### Raising Events
+
+```
+class Order {
+  private events: DomainEvent[] = [];
+
+  place(): void {
+    this.validateCanBePlaced();
+    this.status = OrderStatus.Placed;
+    this.events.push(new OrderPlaced(this.id, this.items, this.total));
+  }
+
+  pullEvents(): DomainEvent[] {
+    const events = [...this.events];
+    this.events = [];
+    return events;
+  }
+}
+```
+
+The application service (use case) retrieves events after the operation and dispatches them.
+
+## Repositories
+
+Abstraction over data access. The calling code interacts with the repository as if it were a simple collection — `add`, `find`, `remove` — while the implementation hides the actual persistence mechanism behind that interface.
+
+| Rule | Explanation |
+|---|---|
+| One repository per aggregate root | `OrderRepository`, not `OrderItemRepository` |
+| Interface in domain, implementation in infrastructure | Port/adapter pattern |
+| Works with domain objects, not persistence models | `save(order: Order)` not `save(row: OrderRow)` |
+| Encapsulates query logic | `findByCustomer(customerId)` not raw SQL in use cases |
+
+### Repository Interface Design
+
+```
+interface OrderRepository {
+  save(order: Order): void;
+  findById(id: OrderId): Order | null;
+  findByCustomer(customerId: CustomerId): Order[];
+  nextIdentity(): OrderId;
+}
+```
+
+Keep repository interfaces narrow. Complex reporting queries belong in a separate read model or query service, not in the domain repository.
+
+## Domain Services
+
+Operations that do not naturally belong to any single entity or value object.
+
+| Signal | Use a Domain Service |
+|---|---|
+| Logic involves multiple aggregates | `TransferFundsService(fromAccount, toAccount, amount)` |
+| Business rule does not belong to one entity | `PricingService.calculatePrice(product, customer, promotions)` |
+| Stateless operation on domain concepts | `PasswordPolicy.validate(password)` |
+
+Domain services are part of the domain layer. They use domain types and express domain concepts. Do not confuse with application services.
+
+## Application Services (Use Cases)
+
+Orchestrate domain objects to fulfill a user intention. Application services live in the application layer, above the domain.
+
+| Domain Service | Application Service |
+|---|---|
+| Contains business logic | Contains workflow orchestration |
+| Uses domain types only | Uses ports to interact with infrastructure |
+| Part of the domain layer | Part of the application layer |
+| `PricingService.calculate()` | `PlaceOrderUseCase.execute()` |
+| Stateless business computation | Manages transaction boundaries, calls repositories, publishes events |
+
+### Application Service Responsibilities
+
+1. Accept input DTO (not domain objects) from the driving adapter
+2. Load required aggregates from repositories
+3. Call domain methods (entity methods, domain services)
+4. Persist changes through repositories
+5. Dispatch domain events
+6. Return output DTO
+
+Application services must not contain business rules. If a conditional or calculation appears in the application service, it probably belongs in a domain entity or domain service.
+
+## Factories
+
+Encapsulate complex object creation logic. Use when constructing an aggregate requires more than simple parameter assignment.
+
+| Use Factory When | Example |
+|---|---|
+| Creation logic is complex | Building an order from a cart involves validation, pricing, inventory checks |
+| Creation spans multiple objects | Creating an account requires a user, profile, and default settings |
+| Different creation paths exist | Creating an order from web vs from bulk import has different rules |
+
+Factories can be static methods on the aggregate root (`Order.createFromCart(cart)`) or standalone factory classes for complex cases.
+
+## The Anemic Domain Model Problem
+
+An anemic domain model looks like DDD (entities, value objects, repositories) but all behavior lives in services. Entities are data bags with getters and setters.
+
+| Symptom | Indicates Anemia |
+|---|---|
+| Entities have only getters/setters | No encapsulated behavior |
+| Services contain all business logic | Logic is procedural, not object-oriented |
+| Validation in services, not entities | Invalid entity states are possible |
+| "Manager" or "Helper" classes | Logic that should be on the entity is displaced |
+
+### The Fix
+
+Move behavior into entities and value objects. Start by identifying where the domain rules are enforced (usually in service classes) and relocate them to the objects that own the data those rules operate on.

--- a/skills/app-architecture/references/layered-hexagonal.md
+++ b/skills/app-architecture/references/layered-hexagonal.md
@@ -1,0 +1,289 @@
+# Layered and Hexagonal Architecture
+
+Sources: Fowler (Patterns of Enterprise Application Architecture), Cockburn (Hexagonal Architecture), Richards & Ford (Fundamentals of Software Architecture), Martin (Clean Architecture)
+
+Covers: traditional layered architecture, N-tier variants, when layers work and when they break, hexagonal architecture (ports and adapters), driving vs driven adapters, dependency inversion mechanics, testing advantages.
+
+## Traditional Layered Architecture
+
+### The Classic N-Tier Stack
+
+| Layer | Responsibility | Typical Contents |
+|---|---|---|
+| Presentation | Accept user input, render output | Controllers, views, serializers, API endpoints |
+| Business Logic | Domain rules, validation, orchestration | Services, domain objects, validators |
+| Data Access | Persistence, external data retrieval | Repositories, ORM mappings, query objects |
+| Database | Storage | Tables, indexes, stored procedures |
+
+Request flow is strictly top-to-bottom: Presentation -> Business -> Data Access -> Database.
+
+### When Layered Architecture Works
+
+| Signal | Why Layers Fit |
+|---|---|
+| CRUD-dominant application | Layers map cleanly to read/validate/persist flow |
+| Small team, low complexity | Easy to understand, minimal ceremony |
+| Well-understood domain | Business logic is thin, no need for complex modeling |
+| Rapid prototyping | Fastest path to working software |
+| Framework provides layers naturally | Rails, Django, Spring MVC already impose this structure |
+
+### When Layered Architecture Breaks
+
+| Signal | Why Layers Fail |
+|---|---|
+| Business logic leaks into controllers | Layer discipline erodes under deadline pressure |
+| Data access layer drives design | Database schema dictates domain model (tail wags dog) |
+| Cross-cutting concerns span all layers | Logging, auth, caching bypass layer boundaries |
+| Testing requires the database | Business logic cannot be tested without infrastructure |
+| Changes cascade through all layers | Adding a field requires changes in 4+ files across layers |
+
+### The Layer Leakage Problem
+
+In practice, traditional layers create a gravitational pull toward the database. The ORM entity becomes the domain model. Business rules end up in SQL queries. The presentation layer formats data shaped by the database schema, not by user needs.
+
+This happens because the dependency direction points downward — business logic depends on the data access layer, which depends on the database. The database becomes the center of the architecture.
+
+## Hexagonal Architecture (Ports and Adapters)
+
+### Core Concept
+
+The application has an inside (business logic) and an outside (everything else). The inside defines ports — interfaces that describe what it needs. The outside provides adapters — implementations that satisfy those ports.
+
+The critical inversion: the domain does not depend on infrastructure. Infrastructure depends on the domain by implementing its interfaces.
+
+### Terminology
+
+| Term | Definition | Example |
+|---|---|---|
+| Domain / Core | Business logic, entities, rules | `Order`, `calculateShipping()`, `applyDiscount()` |
+| Port | Interface defined by the domain | `OrderRepository`, `PaymentGateway`, `NotificationSender` |
+| Adapter | Implementation of a port | `PostgresOrderRepository`, `StripePaymentGateway` |
+| Driving adapter | Initiates interaction with the domain (input) | HTTP controller, CLI handler, message consumer, test harness |
+| Driven adapter | Called by the domain through a port (output) | Database adapter, email sender, external API client |
+
+### Driving vs Driven Distinction
+
+```
+[Driving Adapter]  -->  [Port (Input)]  -->  [Domain Core]  -->  [Port (Output)]  -->  [Driven Adapter]
+   HTTP Controller       OrderService          Order logic        OrderRepository        PostgreSQL
+   CLI Command           interface             pure logic         interface              adapter
+   Test Harness                                                   PaymentGateway         Stripe adapter
+   Message Consumer                                               interface
+```
+
+Driving adapters call INTO the application. They know about the application's input ports.
+
+Driven adapters are called BY the application. They implement the application's output ports. The domain defines what it needs; the adapter provides the how.
+
+### Port Design Guidelines
+
+| Guideline | Rationale |
+|---|---|
+| Name ports by domain intent, not technology | `OrderRepository` not `PostgresOrderStore` |
+| Keep port interfaces small and focused | Follow Interface Segregation — split read and write ports if consumers differ |
+| Ports belong to the domain, not infrastructure | The interface file lives in the domain module |
+| Ports use domain types, not infrastructure types | Parameters and return types are domain objects, not ORM entities or DTOs |
+| One port per external concern | Separate `PaymentGateway` from `NotificationSender` even if both are HTTP calls |
+
+### Adapter Implementation Rules
+
+| Rule | Explanation |
+|---|---|
+| Adapters import domain types | The adapter converts between external format and domain objects |
+| Domain never imports adapters | Dependency points inward always |
+| Adapters are replaceable | Swapping PostgreSQL for MongoDB means writing a new adapter, not changing domain code |
+| Adapters handle translation | Convert HTTP requests to domain commands, ORM rows to domain entities |
+| Test adapters are first-class | In-memory repository implementations enable fast, isolated domain testing |
+
+### Dependency Inversion in Practice
+
+Without inversion (traditional layered):
+```
+Controller --> Service --> Repository --> Database
+  (each layer depends on the layer below)
+```
+
+With inversion (hexagonal):
+```
+Controller --> [Port: OrderService] <-- OrderServiceImpl
+                                          |
+                                          v
+                                   [Port: OrderRepository] <-- PostgresOrderRepository
+```
+
+The `OrderServiceImpl` depends on the `OrderRepository` interface (defined in the domain). The `PostgresOrderRepository` implements that interface. The dependency arrow from `PostgresOrderRepository` points toward the domain, not away from it.
+
+### Testing Advantages
+
+| Scenario | Traditional Layered | Hexagonal |
+|---|---|---|
+| Test business logic | Requires database (or mock ORM) | Inject in-memory adapter, test pure logic |
+| Test controller | Requires running service + database | Inject mock service (implements port) |
+| Test integration | Full stack, slow, brittle | Replace one adapter at a time, test contract |
+| Add new database | Rewrite service layer | Write new adapter, existing tests still pass |
+
+The hexagonal approach makes the "test pyramid" achievable: many fast unit tests (domain + in-memory adapters), fewer integration tests (real adapters), minimal end-to-end tests.
+
+### Common Implementation Patterns
+
+#### Project Structure (TypeScript Example)
+
+```
+src/
+  domain/
+    model/           # Entities, value objects
+    ports/            # Input and output port interfaces
+    services/         # Domain services (pure business logic)
+  application/
+    use-cases/        # Application services / use case orchestrators
+    dto/              # Input/output data structures for use cases
+  infrastructure/
+    persistence/      # Database adapters (implements repository ports)
+    messaging/        # Message broker adapters
+    external-apis/    # Third-party API adapters
+  interface/
+    http/             # Controllers, routes, middleware (driving adapter)
+    cli/              # CLI commands (driving adapter)
+    consumers/        # Message consumers (driving adapter)
+```
+
+#### Dependency Registration
+
+Use dependency injection (constructor injection preferred) to wire adapters to ports at the composition root — the single place where the application is assembled.
+
+```
+// Composition root (application startup)
+const orderRepo = new PostgresOrderRepository(dbConnection);
+const paymentGateway = new StripePaymentGateway(stripeConfig);
+const createOrder = new CreateOrderUseCase(orderRepo, paymentGateway);
+const orderController = new OrderController(createOrder);
+```
+
+The composition root is the only place that knows about concrete implementations. Every other module works with interfaces.
+
+### Hexagonal Architecture Mistakes
+
+| Mistake | Problem | Fix |
+|---|---|---|
+| Defining ports in the infrastructure layer | Dependency direction violated | Ports live in the domain module |
+| Using ORM entities as domain model | Domain coupled to persistence | Separate domain model, map in adapter |
+| Skipping the port for "simple" cases | Incremental erosion of boundaries | Always define the interface, even if only one implementation exists |
+| Too many ports for trivial operations | Over-engineering for CRUD | Use hexagonal for complex domains; layered is fine for simple cases |
+| Adapter doing business logic | Logic bleeds into infrastructure | Adapters translate only; business rules stay in domain |
+
+## Layered vs Hexagonal Decision
+
+| Signal | Use Layered | Use Hexagonal |
+|---|---|---|
+| Domain complexity | Low (CRUD) | Medium to High |
+| Need to swap infrastructure | Unlikely | Likely or testability demands it |
+| Testing strategy | Integration tests are acceptable | Unit testing domain in isolation is critical |
+| Team size | Small, same mental model | Growing, need enforced boundaries |
+| Expected lifespan | Short/medium | Long-lived, will evolve |
+
+Start with layered if the application is simple. Migrate toward hexagonal when you observe: business logic tangled with infrastructure, difficulty testing without databases, or the need to support multiple adapters for the same port.
+
+## Hexagonal Architecture by Language
+
+### Java / Kotlin (Spring)
+
+```
+src/main/java/com/example/orders/
+  domain/
+    model/        # Entities, value objects (plain POJOs, no Spring annotations)
+    ports/
+      inbound/    # Input port interfaces (OrderService)
+      outbound/   # Output port interfaces (OrderRepository, PaymentGateway)
+  application/
+    services/     # Implements inbound ports, orchestrates domain
+  infrastructure/
+    adapters/
+      inbound/
+        rest/     # @RestController classes (driving adapter)
+        messaging/ # @KafkaListener classes (driving adapter)
+      outbound/
+        persistence/ # @Repository JPA implementations (driven adapter)
+        http/     # External API client implementations (driven adapter)
+    config/       # Spring @Configuration, bean wiring (composition root)
+```
+
+Spring's `@Configuration` classes serve as the composition root. Define beans that wire adapters to ports.
+
+### TypeScript (NestJS)
+
+```
+src/orders/
+  domain/
+    Order.ts                    # Entity (plain class, no decorators)
+    OrderRepository.ts          # Port interface
+  application/
+    PlaceOrder.usecase.ts       # Use case implementation
+  infrastructure/
+    TypeOrmOrderRepository.ts   # Adapter (uses @InjectRepository)
+  interface/
+    OrderController.ts          # NestJS @Controller (driving adapter)
+  orders.module.ts              # NestJS module (composition root)
+```
+
+NestJS modules act as the composition root. Use `providers` to bind port interfaces to adapter implementations.
+
+### Python (FastAPI / Django)
+
+```
+src/orders/
+  domain/
+    models.py           # Entities, value objects (plain dataclasses)
+    ports.py            # Port interfaces (Protocol classes or ABCs)
+  application/
+    use_cases.py        # Use case functions or classes
+  infrastructure/
+    sqlalchemy_repo.py  # SQLAlchemy adapter (implements repository port)
+    stripe_gateway.py   # Stripe API adapter
+  interface/
+    routes.py           # FastAPI route handlers (driving adapter)
+  container.py          # Dependency injection wiring
+```
+
+Use `dependency-injector` or manual constructor injection. Python's duck typing and Protocol classes provide port interfaces without framework coupling.
+
+## Adapter Composition Patterns
+
+### Multi-Adapter Selection at Runtime
+
+A single port can have multiple adapters. Select the appropriate one based on configuration or context.
+
+| Scenario | Adapters | Selection Mechanism |
+|---|---|---|
+| Environment-based | `PostgresRepo` (prod), `InMemoryRepo` (test) | Dependency injection profile |
+| Feature flag | `OldPaymentGateway`, `NewPaymentGateway` | Feature flag evaluation at composition root |
+| Regional | `UsEmailAdapter`, `EuEmailAdapter` | Configuration by deployment region |
+
+### Decorator Pattern for Cross-Cutting Concerns
+
+Wrap adapters with decorators that add behavior without modifying the adapter or the port interface.
+
+```
+interface OrderRepository {
+  save(order: Order): void;
+  findById(id: OrderId): Order | null;
+}
+
+class CachingOrderRepository implements OrderRepository {
+  constructor(private inner: OrderRepository, private cache: Cache) {}
+
+  findById(id: OrderId): Order | null {
+    const cached = this.cache.get(id);
+    if (cached) return cached;
+    const order = this.inner.findById(id);
+    if (order) this.cache.set(id, order);
+    return order;
+  }
+
+  save(order: Order): void {
+    this.inner.save(order);
+    this.cache.invalidate(order.id);
+  }
+}
+```
+
+The caching concern is separate from both the domain and the persistence adapter. Stack multiple decorators: logging, caching, metrics — all transparent to the use case.

--- a/skills/app-architecture/references/modular-monolith-vertical-slices.md
+++ b/skills/app-architecture/references/modular-monolith-vertical-slices.md
@@ -1,0 +1,298 @@
+# Modular Monolith and Vertical Slice Architecture
+
+Sources: Ford et al. (Software Architecture: The Hard Parts), Richards & Ford (Fundamentals of Software Architecture), Palermo (Vertical Slice Architecture), Bogard (MediatR and vertical slices), Evans (Domain-Driven Design)
+
+Covers: modular monolith structure, module boundary enforcement, internal APIs, shared kernel, inter-module communication, vertical slice architecture, feature-organized code, MediatR/Mediator patterns, comparing modular monolith with microservices, migration paths.
+
+## Modular Monolith
+
+### Core Concept
+
+A single deployable unit with strict internal module boundaries. Each module encapsulates a bounded context or business capability. Modules communicate through well-defined internal APIs, not by reaching into each other's internals.
+
+The modular monolith captures the organizational benefits of microservices (clear ownership, encapsulation, independent development) without the operational complexity of distribution (network failures, service discovery, distributed transactions).
+
+### Module Structure
+
+| Component | Purpose | Example |
+|---|---|---|
+| Public API | The only way other modules interact with this module | `OrderModule.placeOrder(command)`, `OrderModule.getOrderStatus(id)` |
+| Internal domain | Entities, value objects, business rules — not accessible from outside | `Order`, `OrderItem`, `OrderStatus` |
+| Internal persistence | Module's database tables or schema — not queried by other modules | `orders` table, `order_items` table |
+| Internal infrastructure | Module-specific adapters, integrations | Module's email sender, payment adapter |
+
+### Module Boundary Enforcement
+
+| Mechanism | How | Strength |
+|---|---|---|
+| Package/namespace visibility | Use language access modifiers (`internal` in C#, package-private in Java) | Medium — enforced by compiler |
+| Build module boundaries | Separate build modules/projects per domain module | Strong — compile-time enforcement |
+| ArchUnit / dependency-cruiser | Automated tests that verify dependency rules | Strong — CI-enforced |
+| Linting rules | Custom ESLint/TSLint rules that block cross-module imports | Medium — enforceable in CI |
+| Code review conventions | Team agreement on import rules | Weak — relies on human discipline |
+
+Prefer compiler-enforced or CI-enforced boundaries. Convention-only enforcement degrades under deadline pressure.
+
+### Practical Project Structure
+
+```
+src/
+  modules/
+    orders/
+      public/                     # Module's public API
+        OrderModule.ts             # Facade: the ONLY entry point for other modules
+        OrderDTO.ts                # Data types exposed to other modules
+      internal/                    # Hidden from other modules
+        domain/
+          Order.ts
+          OrderItem.ts
+          OrderRepository.ts
+        application/
+          PlaceOrder.ts
+          CancelOrder.ts
+        infrastructure/
+          PostgresOrderRepository.ts
+    payments/
+      public/
+        PaymentModule.ts
+        PaymentDTO.ts
+      internal/
+        domain/ ...
+        application/ ...
+        infrastructure/ ...
+    shipping/
+      public/ ...
+      internal/ ...
+  shared/                          # Shared kernel
+    types/
+      Money.ts
+      Address.ts
+    events/
+      DomainEvent.ts
+      EventBus.ts
+  main.ts                          # Composition root, wires modules together
+```
+
+### Inter-Module Communication
+
+| Pattern | Mechanism | Coupling | When to Use |
+|---|---|---|---|
+| Direct method call via public API | Module A calls `OrderModule.getOrderStatus(id)` | Synchronous, tightest | Query another module's data, low latency needed |
+| In-process events (event bus) | Module A publishes `OrderPlaced`, Module B subscribes | Async, loose | Side effects: send email, update read model, trigger next step |
+| Shared database view (read only) | Module B reads a view/table that Module A maintains | Data coupling | Reporting, dashboards (pragmatic but watch for schema coupling) |
+
+#### Event Bus for Module Communication
+
+```
+// orders module publishes:
+eventBus.publish(new OrderPlaced({ orderId, customerId, total }));
+
+// payments module subscribes:
+eventBus.subscribe(OrderPlaced, (event) => {
+  paymentModule.initiatePayment(event.orderId, event.total);
+});
+```
+
+Events decouple modules. The orders module does not know or care that the payments module exists. Adding new consumers requires no changes to the publisher.
+
+### Shared Kernel
+
+A small set of types, interfaces, or utilities shared across all modules.
+
+| Include in Shared Kernel | Exclude from Shared Kernel |
+|---|---|
+| Fundamental value objects (`Money`, `Address`, `DateRange`) | Domain-specific entities |
+| Base domain event type | Module-specific events (those belong in the publishing module) |
+| Common error types | Business logic of any kind |
+| Event bus interface | Module-specific persistence |
+
+Keep the shared kernel minimal. It is a coupling point — changes to it affect all modules.
+
+### Database Strategy
+
+| Strategy | Description | Trade-Off |
+|---|---|---|
+| Shared database, separate schemas | Each module owns a schema; no cross-schema queries | Moderate isolation; same DB instance |
+| Shared database, separate tables | Each module owns tables, enforced by convention or tooling | Weakest isolation; easy to violate |
+| Separate databases per module | Each module gets its own database | Strongest isolation; operational overhead |
+
+For most modular monoliths, shared database with separate schemas provides a good balance. Enforce that modules only access their own schema.
+
+## Vertical Slice Architecture
+
+### Core Concept
+
+Organize code by feature (vertical slice), not by technical layer (horizontal). Each slice contains everything needed for one feature: handler, validation, data access, response shaping.
+
+```
+Traditional (horizontal layers):
+  Controllers/     -> OrderController, ProductController, UserController
+  Services/        -> OrderService, ProductService, UserService
+  Repositories/    -> OrderRepository, ProductRepository, UserRepository
+
+Vertical slices:
+  Features/
+    PlaceOrder/    -> PlaceOrderHandler, PlaceOrderValidator, PlaceOrderQuery
+    CancelOrder/   -> CancelOrderHandler, CancelOrderValidator
+    GetOrderList/  -> GetOrderListHandler, GetOrderListQuery
+```
+
+### Why Vertical Slices
+
+| Problem with Horizontal Layers | Vertical Slice Solution |
+|---|---|
+| One feature change touches 4+ files across layers | All code for a feature is co-located in one folder |
+| Service classes grow into god classes | Each feature has its own handler — small, focused, testable |
+| Hard to understand a feature (code scattered everywhere) | Open one folder, see the entire feature |
+| Difficulty deleting features | Delete one folder; no orphaned code in other layers |
+| All features share the same abstraction level | Each slice can use the right level of abstraction for its complexity |
+
+### Slice Structure
+
+```
+Features/
+  PlaceOrder/
+    PlaceOrderCommand.ts       # Input data structure
+    PlaceOrderHandler.ts       # Business logic + data access
+    PlaceOrderValidator.ts     # Input validation
+    PlaceOrderResponse.ts      # Output data structure
+    PlaceOrder.test.ts         # Tests for this feature
+  GetOrderDetails/
+    GetOrderDetailsQuery.ts
+    GetOrderDetailsHandler.ts
+    GetOrderDetailsResponse.ts
+    GetOrderDetails.test.ts
+```
+
+### The Mediator Pattern (MediatR-Style)
+
+Vertical slices often use a mediator to decouple the entry point (controller) from the handler.
+
+```
+// Controller:
+router.post('/orders', async (req, res) => {
+  const result = await mediator.send(new PlaceOrderCommand(req.body));
+  res.status(201).json(result);
+});
+
+// Handler (registered with mediator):
+class PlaceOrderHandler implements Handler<PlaceOrderCommand, PlaceOrderResponse> {
+  async handle(command: PlaceOrderCommand): Promise<PlaceOrderResponse> {
+    // validate, create domain objects, persist, return response
+  }
+}
+```
+
+The controller does not know which handler serves the command. The mediator resolves it. This enables cross-cutting concerns (logging, validation, authorization) as pipeline behaviors.
+
+### Pipeline Behaviors (Cross-Cutting Concerns)
+
+| Behavior | Responsibility | Position in Pipeline |
+|---|---|---|
+| Logging | Log command name, execution time, success/failure | First (wraps everything) |
+| Validation | Validate command input | Before handler |
+| Authorization | Check user permissions for this command | Before handler |
+| Transaction | Wrap handler in a database transaction | Around handler |
+| Caching | Cache query results | Around handler (queries only) |
+
+### When Vertical Slices Work Best
+
+| Signal | Good Fit |
+|---|---|
+| Features are independent with little shared logic | Each slice is self-contained |
+| Team works on features, not layers | Feature ownership maps to slice ownership |
+| Fast iteration, frequent feature additions | Adding a feature is adding a folder |
+| Mixed complexity across features | Complex features get more structure, simple ones stay minimal |
+
+### When Vertical Slices Are Not Enough
+
+| Signal | Augment With |
+|---|---|
+| Shared business rules across features | Extract domain layer with entities/value objects |
+| Cross-feature transactions | Application service or saga coordination |
+| Complex invariants | Aggregate pattern from DDD |
+| Growing codebase, multiple teams | Modular monolith boundaries around groups of slices |
+
+## Combining Approaches
+
+### Modular Monolith + Vertical Slices
+
+Use modular monolith boundaries at the macro level (module per bounded context) and vertical slices within each module.
+
+```
+modules/
+  orders/
+    features/
+      PlaceOrder/
+      CancelOrder/
+      GetOrderList/
+    domain/             # Shared domain objects within the module
+      Order.ts
+      OrderItem.ts
+    public/
+      OrderModule.ts    # Module facade
+  payments/
+    features/
+      ProcessPayment/
+      RefundPayment/
+    domain/
+      Payment.ts
+    public/
+      PaymentModule.ts
+```
+
+### Modular Monolith + Clean Architecture
+
+Use module boundaries at the macro level, clean architecture within each module.
+
+```
+modules/
+  orders/
+    domain/             # Entities, value objects, ports
+    application/        # Use cases
+    infrastructure/     # Adapters
+    interface/          # Controllers
+    public/             # Module facade
+```
+
+### Migration Path: Monolith to Microservices
+
+1. Structure the monolith as modules with enforced boundaries
+2. Ensure modules communicate only through public APIs or events
+3. Ensure each module owns its data (no cross-module database access)
+4. When deployment independence is needed, extract a module into a service
+5. Replace in-process calls with network calls, in-process events with message broker
+
+If steps 1-3 are done well, step 4-5 is mechanical. The hard work is getting the boundaries right.
+
+## Feature Flags as Architectural Support
+
+Feature flags enable trunk-based development and incremental rollout within any architecture style.
+
+| Use Case | How |
+|---|---|
+| Incomplete feature behind a flag | Merge to main, flag is off in production |
+| Gradual rollout | Enable for 5% of users, monitor, increase |
+| A/B testing | Flag controls which variant a user sees |
+| Kill switch | Disable a problematic feature without deployment |
+| Module extraction | Flag routes traffic between old and new module during migration |
+
+### Architectural Placement
+
+Place flag evaluation at the entry point (controller or use case), not deep in domain logic. Feature flags are infrastructure concerns — keep them out of the domain model.
+
+```
+// In controller or use case (acceptable):
+if (featureFlags.isEnabled('newPricing', user)) {
+  return newPricingUseCase.execute(input);
+} else {
+  return legacyPricingUseCase.execute(input);
+}
+
+// In domain entity (avoid):
+class Order {
+  calculateTotal() {
+    if (featureFlags.isEnabled('newPricing')) { ... }  // domain depends on infrastructure
+  }
+}
+```

--- a/skills/app-architecture/tank.json
+++ b/skills/app-architecture/tank.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/app-architecture",
+  "version": "1.0.0",
+  "description": "Application-level architecture patterns for structuring code within a service or monolith. Layered, hexagonal, clean architecture, DDD tactical patterns, CQRS, event sourcing, modular monolith, vertical slices. Triggers: app architecture, hexagonal, ports and adapters, clean architecture, DDD, aggregate, value object, CQRS, event sourcing, modular monolith, vertical slice, project structure, dependency rule, where does this code go.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}

--- a/skills/design-patterns/SKILL.md
+++ b/skills/design-patterns/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: "@tank/design-patterns"
+description: |
+  JavaScript and TypeScript design patterns catalog for production applications.
+  Covers GoF patterns adapted for modern JS/TS (Singleton, Observer, Factory,
+  Strategy, Command, Mediator, Proxy, Decorator, Adapter, Iterator, State,
+  Builder, Facade, Flyweight, Prototype, Chain of Responsibility), plus
+  modern JS-native patterns (Module, Provider, Middleware/Pipeline, Repository,
+  Unit of Work, Pub/Sub, Plugin/Hook). Each pattern includes intent, when to
+  use, when NOT to use, TypeScript implementation, and real-world examples.
+  Synthesizes Gamma et al. (Design Patterns), Freeman (Head First Design
+  Patterns), Osmani (Learning JavaScript Design Patterns), Fowler (Patterns
+  of Enterprise Application Architecture), Vlissides (Pattern Hatching), and
+  modern JS/TS community patterns.
+
+  Trigger phrases: "design pattern", "which pattern", "factory pattern",
+  "singleton", "observer pattern", "strategy pattern", "decorator pattern",
+  "adapter pattern", "proxy pattern", "command pattern", "state machine",
+  "builder pattern", "mediator", "middleware pattern", "plugin system",
+  "pub/sub", "event emitter", "chain of responsibility", "repository pattern",
+  "data access pattern",
+  "facade pattern", "flyweight", "prototype pattern", "provider pattern",
+  "how to structure this", "pattern for this problem", "GoF in TypeScript",
+  "creational pattern", "structural pattern", "behavioral pattern"
+---
+
+# Design Patterns
+
+Structural solutions for recurring problems in JavaScript and TypeScript applications.
+
+## Core Philosophy
+
+1. **Patterns are tools, not goals.** Apply a pattern to solve a specific problem. If the problem does not exist, the pattern is overhead.
+2. **Favor composition over inheritance.** JS/TS excels at object composition, closures, and higher-order functions. Most GoF inheritance hierarchies collapse into simpler functional forms.
+3. **Match the pattern to the language.** A Java-style Singleton is an anti-pattern in JS modules. Adapt patterns to closures, first-class functions, Proxies, and ES module scope.
+4. **Prefer the simplest pattern that solves the problem.** If a function suffices, do not introduce a class hierarchy. Escalate complexity only when requirements demand it.
+5. **Name the pattern in your code.** When you use a pattern, name it explicitly (e.g., `UserFactory`, `RetryStrategy`). This communicates intent to future readers.
+
+## Pattern Selection Decision Tree
+
+| Problem Signal | Recommended Pattern | Category |
+| --- | --- | --- |
+| Need to create objects without specifying exact class | Factory / Abstract Factory | Creational |
+| Complex object with many optional fields | Builder | Creational |
+| Need exactly one shared instance | Module Scope / Singleton | Creational |
+| Need to clone expensive-to-create objects | Prototype | Creational |
+| Incompatible interface between two systems | Adapter | Structural |
+| Need to add behavior without modifying source | Decorator | Structural |
+| Simplify a complex subsystem API | Facade | Structural |
+| Intercept or control access to an object | Proxy | Structural |
+| Many similar objects consuming too much memory | Flyweight | Structural |
+| One-to-many notifications on state change | Observer / Pub-Sub | Behavioral |
+| Swap algorithms at runtime | Strategy | Behavioral |
+| Encapsulate actions as objects (undo/redo, queues) | Command | Behavioral |
+| Object behavior changes based on internal state | State | Behavioral |
+| Decouple many-to-many communication | Mediator | Behavioral |
+| Sequential processing with bail-out | Chain of Responsibility | Behavioral |
+| Request/response pipeline with transforms | Middleware / Pipeline | Modern |
+| Extensible system with third-party hooks | Plugin / Hook | Modern |
+| Decouple data access from business logic | Repository | Modern |
+| Cross-cutting shared context (React, DI) | Provider | Modern |
+
+## Quick-Start: Common Problems
+
+### "I need to create objects but the type varies at runtime"
+
+1. Start with Factory Method for a single product family.
+2. Escalate to Abstract Factory when multiple related families exist.
+   -> See `references/creational-patterns.md`
+
+### "I need to add logging/caching/retry without changing existing code"
+
+1. Use Decorator for wrapping individual instances.
+2. Use Proxy for transparent interception (access control, lazy loading).
+   -> See `references/structural-patterns.md`
+
+### "I have complex conditional logic that changes based on state"
+
+1. Use Strategy if the algorithm is selected once per operation.
+2. Use State if the object transitions between modes over its lifetime.
+   -> See `references/behavioral-patterns.md`
+
+### "I need a request pipeline (auth, validation, logging, handler)"
+
+1. Use Middleware/Pipeline for linear request processing.
+2. Use Chain of Responsibility if handlers can stop propagation.
+   -> See `references/modern-patterns.md`
+
+### "I am not sure which pattern fits my problem"
+
+1. Consult the decision tree above.
+2. Read the anti-patterns section below to rule out misapplications.
+   -> See `references/pattern-selection-guide.md`
+
+## Anti-Patterns: Pattern Misuse
+
+| Misuse | Symptom | Remedy |
+| --- | --- | --- |
+| Singleton for dependency sharing | Hidden global state, untestable | Use Dependency Injection |
+| Factory for one concrete type | Unnecessary indirection | Use `new` directly |
+| Observer with 20+ listeners | Spaghetti event flow, debug hell | Use Mediator or explicit wiring |
+| Decorator stacking 5+ layers | Unreadable, hard to debug | Flatten into a single composed function |
+| Strategy with one strategy | Over-engineering | Use a plain function |
+| Abstract Factory for 1 product | Premature abstraction | Use simple Factory Method |
+| Builder for 2-field objects | Ceremony without benefit | Use plain constructor or object literal |
+
+## Pattern Categories At a Glance
+
+| Category | Patterns | Focus |
+| --- | --- | --- |
+| Creational | Factory, Abstract Factory, Builder, Prototype, Singleton | Object creation mechanisms |
+| Structural | Adapter, Decorator, Facade, Proxy, Flyweight | Object composition and interface design |
+| Behavioral | Observer, Strategy, Command, State, Mediator, Chain of Responsibility, Iterator | Communication and responsibility distribution |
+| Modern JS/TS | Module, Provider, Middleware, Pipeline, Repository, Unit of Work, Pub/Sub, Plugin/Hook | Patterns native to JS/TS ecosystems |
+
+## Reference Index
+
+| File | Contents |
+| --- | --- |
+| `references/creational-patterns.md` | Factory, Abstract Factory, Builder, Prototype, Singleton — intent, JS/TS implementation, when to use, when not to use |
+| `references/structural-patterns.md` | Adapter, Decorator, Facade, Proxy, Flyweight — intent, JS/TS implementation, real-world examples |
+| `references/behavioral-patterns.md` | Observer, Strategy, Command, State, Mediator, Chain of Responsibility, Iterator — intent, JS/TS implementation |
+| `references/modern-patterns.md` | Module, Provider, Middleware/Pipeline, Repository, Unit of Work, Pub/Sub, Plugin/Hook — JS/TS-native patterns |
+| `references/pattern-selection-guide.md` | Decision matrices, pattern combination recipes, migration paths, complexity comparison, when-not-to-use tables |

--- a/skills/design-patterns/references/behavioral-patterns.md
+++ b/skills/design-patterns/references/behavioral-patterns.md
@@ -1,0 +1,375 @@
+# Behavioral Patterns
+
+Sources: Gamma et al. (Design Patterns), Osmani (Learning JavaScript Design Patterns), Freeman (Head First Design Patterns), Fowler (Patterns of Enterprise Application Architecture)
+
+Covers: Observer, Strategy, Command, State, Mediator, Chain of Responsibility, Iterator — adapted for JavaScript and TypeScript using closures, generics, and native language features.
+
+## 1. Observer
+
+**Intent:** Define a one-to-many dependency so that when one object changes state, all dependents are notified automatically.
+
+**When to Use:**
+- UI components reacting to data changes
+- Event-driven architectures (domain events, webhooks)
+- Decoupling producers from consumers
+
+**When NOT to Use:**
+- Only one subscriber — direct callback is simpler
+- Order of notification matters (Observer does not guarantee order)
+- Too many observers (>10) make debugging difficult — consider Mediator
+
+**Real-world:** EventEmitter, React state updates, RxJS Observables, DOM events.
+
+```ts
+type Listener<T> = (data: T) => void;
+
+class EventEmitter<Events extends Record<string, unknown>> {
+  private listeners = new Map<keyof Events, Set<Listener<any>>>();
+
+  on<K extends keyof Events>(event: K, listener: Listener<Events[K]>): () => void {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(listener);
+    return () => this.listeners.get(event)?.delete(listener); // unsubscribe
+  }
+
+  emit<K extends keyof Events>(event: K, data: Events[K]): void {
+    this.listeners.get(event)?.forEach((fn) => fn(data));
+  }
+}
+
+// Type-safe usage
+interface AppEvents {
+  "user:created": { id: string; email: string };
+  "order:placed": { orderId: string; total: number };
+}
+
+const bus = new EventEmitter<AppEvents>();
+const unsub = bus.on("user:created", (user) => console.log(user.email));
+bus.emit("user:created", { id: "1", email: "a@b.com" });
+unsub(); // cleanup
+```
+
+## 2. Strategy
+
+**Intent:** Define a family of algorithms, encapsulate each one, and make them interchangeable at runtime.
+
+**When to Use:**
+- Multiple algorithms for the same task (sorting, pricing, validation, compression)
+- Algorithm selection based on runtime conditions (user tier, locale, config)
+- Eliminating large switch/if-else blocks on algorithm type
+
+**When NOT to Use:**
+- Only one algorithm exists — a plain function is enough
+- Algorithms never change at runtime — compile-time selection suffices
+
+**Real-world:** Payment processing strategies, compression algorithms, pricing tiers, authentication providers.
+
+```ts
+// Strategy as a function type — idiomatic JS/TS
+type PricingStrategy = (basePrice: number, quantity: number) => number;
+
+const regularPricing: PricingStrategy = (price, qty) => price * qty;
+const premiumPricing: PricingStrategy = (price, qty) => price * qty * 0.8;
+const wholesalePricing: PricingStrategy = (price, qty) =>
+  qty >= 100 ? price * qty * 0.6 : price * qty * 0.75;
+
+// Context holds a strategy reference
+class ShoppingCart {
+  constructor(private pricing: PricingStrategy) {}
+
+  setPricing(strategy: PricingStrategy) { this.pricing = strategy; }
+
+  calculateTotal(items: { price: number; quantity: number }[]): number {
+    return items.reduce((sum, item) => sum + this.pricing(item.price, item.quantity), 0);
+  }
+}
+
+const cart = new ShoppingCart(regularPricing);
+cart.setPricing(premiumPricing); // swap at runtime
+```
+
+**Strategy Map pattern — clean runtime selection:**
+
+```ts
+const strategies: Record<string, PricingStrategy> = {
+  regular: regularPricing,
+  premium: premiumPricing,
+  wholesale: wholesalePricing,
+};
+
+function getPricing(tier: string): PricingStrategy {
+  const strategy = strategies[tier];
+  if (!strategy) throw new Error(`Unknown pricing tier: ${tier}`);
+  return strategy;
+}
+```
+
+## 3. Command
+
+**Intent:** Encapsulate a request as an object, allowing parameterization, queuing, logging, and undo/redo.
+
+**When to Use:**
+- Undo/redo functionality
+- Task queues and job scheduling
+- Macro recording (sequence of operations replayed later)
+- Decoupling the invoker from the operation
+
+**When NOT to Use:**
+- Simple one-shot operations with no need for undo, queuing, or logging
+
+**Real-world:** Text editor undo/redo, CLI command history, transaction logs, CQRS command side.
+
+```ts
+interface Command {
+  execute(): void;
+  undo(): void;
+}
+
+class InsertTextCommand implements Command {
+  constructor(
+    private document: { content: string },
+    private position: number,
+    private text: string,
+  ) {}
+
+  execute() {
+    const { content } = this.document;
+    this.document.content = content.slice(0, this.position) + this.text + content.slice(this.position);
+  }
+
+  undo() {
+    const { content } = this.document;
+    this.document.content = content.slice(0, this.position) + content.slice(this.position + this.text.length);
+  }
+}
+
+class CommandHistory {
+  private history: Command[] = [];
+  private pointer = -1;
+
+  execute(cmd: Command) {
+    this.history.length = this.pointer + 1; // discard redo stack
+    cmd.execute();
+    this.history.push(cmd);
+    this.pointer++;
+  }
+
+  undo() {
+    if (this.pointer < 0) return;
+    this.history[this.pointer].undo();
+    this.pointer--;
+  }
+
+  redo() {
+    if (this.pointer >= this.history.length - 1) return;
+    this.pointer++;
+    this.history[this.pointer].execute();
+  }
+}
+```
+
+## 4. State
+
+**Intent:** Allow an object to alter its behavior when its internal state changes, appearing to change its class.
+
+**When to Use:**
+- Object behavior varies by mode (draft/published/archived, idle/loading/error)
+- Complex conditional logic based on current state
+- State transitions follow explicit rules (finite state machine)
+
+**When NOT to Use:**
+- Only 2 simple states — a boolean flag suffices
+- No behavioral difference between states — just data
+
+**Real-world:** UI component states (form submission flow), order processing, media players, TCP connections.
+
+```ts
+interface ConnectionState {
+  open(ctx: Connection): void;
+  close(ctx: Connection): void;
+  send(ctx: Connection, data: string): void;
+}
+
+class DisconnectedState implements ConnectionState {
+  open(ctx: Connection) {
+    console.log("Opening connection...");
+    ctx.setState(new ConnectedState());
+  }
+  close() { console.log("Already disconnected"); }
+  send() { throw new Error("Cannot send: not connected"); }
+}
+
+class ConnectedState implements ConnectionState {
+  open() { console.log("Already connected"); }
+  close(ctx: Connection) {
+    console.log("Closing connection...");
+    ctx.setState(new DisconnectedState());
+  }
+  send(_ctx: Connection, data: string) {
+    console.log(`Sending: ${data}`);
+  }
+}
+
+class Connection {
+  private state: ConnectionState = new DisconnectedState();
+
+  setState(state: ConnectionState) { this.state = state; }
+  open()             { this.state.open(this); }
+  close()            { this.state.close(this); }
+  send(data: string) { this.state.send(this, data); }
+}
+```
+
+**Lightweight alternative — state map:**
+
+```ts
+type State = "idle" | "loading" | "success" | "error";
+type Action = "fetch" | "resolve" | "reject" | "reset";
+
+const transitions: Record<State, Partial<Record<Action, State>>> = {
+  idle:    { fetch: "loading" },
+  loading: { resolve: "success", reject: "error" },
+  success: { reset: "idle", fetch: "loading" },
+  error:   { reset: "idle", fetch: "loading" },
+};
+
+function transition(current: State, action: Action): State {
+  return transitions[current]?.[action] ?? current;
+}
+```
+
+## 5. Mediator
+
+**Intent:** Define an object that encapsulates how a set of objects interact, promoting loose coupling.
+
+**When to Use:**
+- Many objects communicate in complex, many-to-many patterns
+- Changes to one component cascade unpredictably to others
+- Centralizing communication logic (chat rooms, form field dependencies, UI panels)
+
+**When NOT to Use:**
+- Simple one-to-one communication — direct reference is clearer
+- The mediator becomes a god object (split into multiple mediators by domain)
+
+**Real-world:** Chat servers, form validation coordinators, air traffic control, Redux store.
+
+```ts
+interface FormField {
+  name: string;
+  value: unknown;
+  setDisabled(disabled: boolean): void;
+}
+
+class FormMediator {
+  private fields = new Map<string, FormField>();
+
+  register(field: FormField) {
+    this.fields.set(field.name, field);
+  }
+
+  notify(sender: string, event: string) {
+    if (sender === "country" && event === "change") {
+      const country = this.fields.get("country");
+      const state = this.fields.get("state");
+      const zip = this.fields.get("zip");
+      // Enable/disable fields based on country selection
+      if (country?.value === "US") {
+        state?.setDisabled(false);
+        zip?.setDisabled(false);
+      } else {
+        state?.setDisabled(true);
+        zip?.setDisabled(true);
+      }
+    }
+  }
+}
+```
+
+## 6. Chain of Responsibility
+
+**Intent:** Pass a request along a chain of handlers. Each handler decides either to process or forward.
+
+**When to Use:**
+- Multiple handlers that can process a request, but the handler is unknown at compile time
+- Processing pipeline where handlers can short-circuit
+- Decoupling sender from receiver
+
+**When NOT to Use:**
+- Guaranteed single handler — use direct dispatch
+- Order does not matter — use Observer
+
+**Real-world:** Express middleware, DOM event bubbling, logging level filters, approval workflows.
+
+```ts
+type Handler<T> = (request: T, next: () => void) => void;
+
+function createChain<T>(...handlers: Handler<T>[]): (request: T) => void {
+  return (request: T) => {
+    let index = 0;
+    function next() {
+      if (index < handlers.length) {
+        const handler = handlers[index++];
+        handler(request, next);
+      }
+    }
+    next();
+  };
+}
+
+// Usage: approval chain
+interface Expense { amount: number; approved: boolean }
+
+const managerApproval: Handler<Expense> = (req, next) => {
+  if (req.amount <= 1000) { req.approved = true; return; }
+  next();
+};
+
+const directorApproval: Handler<Expense> = (req, next) => {
+  if (req.amount <= 10000) { req.approved = true; return; }
+  next();
+};
+
+const cfoApproval: Handler<Expense> = (req, _next) => {
+  req.approved = req.amount <= 100000;
+};
+
+const approve = createChain(managerApproval, directorApproval, cfoApproval);
+```
+
+## 7. Iterator
+
+**Intent:** Provide a way to access elements of a collection sequentially without exposing the underlying representation.
+
+**When to Use:**
+- Custom data structures that need `for...of` support
+- Lazy evaluation of sequences (pagination, infinite streams)
+- Uniform traversal across different collection types
+
+**When NOT to Use:**
+- Standard arrays/maps — built-in iterators already exist
+
+**Real-world:** Database cursor pagination, file line readers, tree traversal, range generators.
+
+```ts
+async function* paginate<T>(fetchPage: (cursor: string) => Promise<{ data: T[]; next?: string }>) {
+  let cursor = "";
+  while (true) {
+    const page = await fetchPage(cursor);
+    yield* page.data;
+    if (!page.next) break;
+    cursor = page.next;
+  }
+}
+```
+
+## Behavioral Pattern Comparison
+
+| Pattern | Complexity | Key Mechanism | JS/TS Idiom |
+| --- | --- | --- | --- |
+| Observer | Low | Callback registry | EventEmitter, custom typed emitter |
+| Strategy | Low | Swappable function | Function types, strategy map |
+| Command | Medium | Request as object | Command interface with execute/undo |
+| State | Medium | Delegated behavior | State interface or transition map |
+| Mediator | Medium | Centralized coordination | Mediator class or event bus |
+| Chain of Resp. | Low-Med | Handler chain with next() | Composed handler functions |
+| Iterator | Low | Sequential access protocol | Generators, Symbol.iterator |

--- a/skills/design-patterns/references/creational-patterns.md
+++ b/skills/design-patterns/references/creational-patterns.md
@@ -1,0 +1,315 @@
+# Creational Patterns
+
+Sources: Gamma et al. (Design Patterns), Freeman (Head First Design Patterns), Osmani (Learning JavaScript Design Patterns), Vlissides (Pattern Hatching)
+
+Covers: Factory Method, Abstract Factory, Builder, Prototype, Singleton — adapted for modern JavaScript and TypeScript with closures, modules, and generics.
+
+## 1. Factory Method
+
+**Intent:** Define an interface for creating objects, but let subclasses or functions decide which class to instantiate.
+
+**When to Use:**
+- Object type determined at runtime by input data (e.g., parsing config, API responses)
+- You want to decouple creation from usage
+- Multiple product types share a common interface
+
+**When NOT to Use:**
+- Only one concrete type exists — use `new` directly
+- The creation logic is trivial (no branching)
+
+**Real-world:** UI component factories, notification channel selection, database driver instantiation.
+
+```ts
+interface Logger {
+  log(message: string): void;
+}
+
+class ConsoleLogger implements Logger {
+  log(message: string) { console.log(message); }
+}
+
+class FileLogger implements Logger {
+  log(message: string) { fs.appendFileSync("app.log", message + "\n"); }
+}
+
+// Factory function — preferred in JS/TS over class-based factory
+function createLogger(type: "console" | "file"): Logger {
+  switch (type) {
+    case "console": return new ConsoleLogger();
+    case "file":    return new FileLogger();
+    default:        throw new Error(`Unknown logger type: ${type}`);
+  }
+}
+
+const logger = createLogger(config.logTarget);
+```
+
+**JS/TS Adaptation:** Prefer factory functions over class hierarchies. Use a `Record<string, () => T>` registry for open-ended extension:
+
+```ts
+const loggerRegistry: Record<string, () => Logger> = {
+  console: () => new ConsoleLogger(),
+  file:    () => new FileLogger(),
+};
+
+function createLogger(type: string): Logger {
+  const factory = loggerRegistry[type];
+  if (!factory) throw new Error(`Unknown logger: ${type}`);
+  return factory();
+}
+
+// Third-party code can register new loggers
+loggerRegistry.sentry = () => new SentryLogger();
+```
+
+## 2. Abstract Factory
+
+**Intent:** Create families of related objects without specifying their concrete classes.
+
+**When to Use:**
+- Multiple related products must be created together (e.g., themed UI: Button + Input + Modal)
+- Swapping entire families at once (light theme vs dark theme, SQL vs NoSQL)
+
+**When NOT to Use:**
+- Single product type — use Factory Method
+- Families never change — over-engineering
+
+**Real-world:** Cross-platform UI toolkits, database abstraction layers, test fixture generators.
+
+```ts
+interface UIFactory {
+  createButton(): Button;
+  createInput(): Input;
+}
+
+class MaterialUIFactory implements UIFactory {
+  createButton() { return new MaterialButton(); }
+  createInput()  { return new MaterialInput(); }
+}
+
+class AntDesignFactory implements UIFactory {
+  createButton() { return new AntButton(); }
+  createInput()  { return new AntInput(); }
+}
+
+function buildForm(factory: UIFactory) {
+  const button = factory.createButton();
+  const input = factory.createInput();
+  // Both are guaranteed to be from the same family
+}
+```
+
+## 3. Builder
+
+**Intent:** Construct complex objects step by step, separating construction from representation.
+
+**When to Use:**
+- Object has 4+ optional fields or complex construction sequences
+- Need to build different representations of the same type
+- Construction involves validation across multiple fields
+
+**When NOT to Use:**
+- Object has 1-3 fields — use constructor or object literal
+- No optional fields or construction steps
+
+**Real-world:** Query builders (Knex, Prisma), HTTP request builders, config objects, test data factories.
+
+```ts
+class QueryBuilder {
+  private table = "";
+  private conditions: string[] = [];
+  private orderField?: string;
+  private limitVal?: number;
+
+  from(table: string): this {
+    this.table = table;
+    return this;
+  }
+
+  where(condition: string): this {
+    this.conditions.push(condition);
+    return this;
+  }
+
+  orderBy(field: string): this {
+    this.orderField = field;
+    return this;
+  }
+
+  limit(n: number): this {
+    this.limitVal = n;
+    return this;
+  }
+
+  build(): string {
+    if (!this.table) throw new Error("Table required");
+    let sql = `SELECT * FROM ${this.table}`;
+    if (this.conditions.length) sql += ` WHERE ${this.conditions.join(" AND ")}`;
+    if (this.orderField) sql += ` ORDER BY ${this.orderField}`;
+    if (this.limitVal) sql += ` LIMIT ${this.limitVal}`;
+    return sql;
+  }
+}
+
+const query = new QueryBuilder()
+  .from("users")
+  .where("active = true")
+  .where("age > 18")
+  .orderBy("created_at")
+  .limit(10)
+  .build();
+```
+
+**JS/TS Adaptation:** For simple cases, prefer the options object pattern over a Builder class:
+
+```ts
+interface QueryOptions {
+  table: string;
+  where?: string[];
+  orderBy?: string;
+  limit?: number;
+}
+
+function buildQuery(opts: QueryOptions): string {
+  let sql = `SELECT * FROM ${opts.table}`;
+  if (opts.where?.length) sql += ` WHERE ${opts.where.join(" AND ")}`;
+  if (opts.orderBy) sql += ` ORDER BY ${opts.orderBy}`;
+  if (opts.limit) sql += ` LIMIT ${opts.limit}`;
+  return sql;
+}
+```
+
+Use a class Builder when: construction is multi-step, validation spans steps, or you need method chaining with IDE autocomplete.
+
+## 4. Prototype
+
+**Intent:** Create new objects by cloning an existing instance rather than constructing from scratch.
+
+**When to Use:**
+- Object creation is expensive (DB fetches, heavy computation)
+- Need copies with minor variations from a template
+- Configuration objects with many defaults
+
+**When NOT to Use:**
+- Objects are cheap to create
+- Deep cloning is complex (circular references, non-serializable fields)
+
+**Real-world:** Game entity spawning, document template systems, configuration presets.
+
+```ts
+interface Cloneable<T> {
+  clone(): T;
+}
+
+class ServerConfig implements Cloneable<ServerConfig> {
+  constructor(
+    public host: string,
+    public port: number,
+    public ssl: boolean,
+    public timeout: number,
+    public retries: number,
+  ) {}
+
+  clone(): ServerConfig {
+    return new ServerConfig(this.host, this.port, this.ssl, this.timeout, this.retries);
+  }
+}
+
+const production = new ServerConfig("api.example.com", 443, true, 30000, 3);
+const staging = production.clone();
+staging.host = "staging.example.com";
+staging.ssl = false;
+```
+
+**JS/TS Adaptation:** For plain objects, use structured clone or spread:
+
+```ts
+const defaults = { host: "localhost", port: 3000, ssl: false, timeout: 5000 };
+const custom = { ...defaults, port: 8080, ssl: true }; // shallow clone + override
+
+// Deep clone for nested objects
+const deepCopy = structuredClone(complexObject);
+```
+
+## 5. Singleton
+
+**Intent:** Ensure a class or module has exactly one instance and provide a global point of access.
+
+**When to Use:**
+- Resource that is expensive to create and must be shared (DB connection pool, logger)
+- Configuration that must be consistent across the application
+
+**When NOT to Use:**
+- Sharing state between tests (causes coupling, flaky tests)
+- Hiding dependencies (use explicit DI instead)
+- Any case where you want testability — Singletons resist mocking
+
+**Real-world:** Database connection pools, application-wide config, caches.
+
+**The JS Module IS a Singleton.** In Node.js/ESM, each module is evaluated once and cached. Exporting an instance from a module is the idiomatic JS Singleton:
+
+```ts
+// db.ts — this IS the singleton pattern in JS
+import { Pool } from "pg";
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  max: 20,
+});
+
+export default pool;
+```
+
+Every import of `db.ts` receives the same `pool` instance. No class ceremony needed.
+
+**When you must use class-based Singleton** (rare — framework constraints, lazy initialization):
+
+```ts
+class AppConfig {
+  private static instance: AppConfig;
+  private data: Map<string, unknown> = new Map();
+
+  private constructor() {}
+
+  static getInstance(): AppConfig {
+    if (!AppConfig.instance) {
+      AppConfig.instance = new AppConfig();
+    }
+    return AppConfig.instance;
+  }
+
+  get<T>(key: string): T | undefined {
+    return this.data.get(key) as T;
+  }
+
+  set(key: string, value: unknown): void {
+    this.data.set(key, value);
+  }
+}
+```
+
+**Prefer DI over Singleton.** Instead of `AppConfig.getInstance()`, inject the config:
+
+```ts
+function createApp(config: AppConfig) {
+  // config is injected — testable, mockable, explicit
+}
+```
+
+## Creational Pattern Comparison
+
+| Pattern | Complexity | Use When | Avoid When |
+| --- | --- | --- | --- |
+| Factory Method | Low | Runtime type selection | Single concrete type |
+| Abstract Factory | Medium | Related product families | One product type |
+| Builder | Medium | Complex multi-step construction | Simple 1-3 field objects |
+| Prototype | Low | Cloning with minor variations | Cheap-to-create objects |
+| Singleton | Low | Shared resource, one instance | Testability matters (use DI) |
+
+## JS/TS-Specific Guidelines
+
+1. **Factory functions over factory classes.** Functions are simpler, compose better, and avoid `this` confusion.
+2. **Options objects over Builder classes.** When construction is a single step, `buildThing(opts)` beats `new ThingBuilder().setA().setB().build()`.
+3. **Module scope over Singleton class.** ES modules already provide single-instance semantics.
+4. **`structuredClone` over manual Prototype.** For plain data objects, use the platform primitive.
+5. **Generics for type-safe factories.** Use `<T>` to preserve concrete return types through factory indirection.

--- a/skills/design-patterns/references/modern-patterns.md
+++ b/skills/design-patterns/references/modern-patterns.md
@@ -1,0 +1,394 @@
+# Modern JavaScript/TypeScript Patterns
+
+Sources: Osmani (Learning JavaScript Design Patterns), Fowler (Patterns of Enterprise Application Architecture), Express.js/Koa documentation, React documentation, Webpack/Rollup plugin APIs, community patterns (2020-2026)
+
+Covers: Module, Provider, Middleware/Pipeline, Repository, Unit of Work, Pub/Sub, Plugin/Hook — patterns native to the JavaScript and TypeScript ecosystem that extend or replace classical GoF patterns.
+
+## 1. Module Pattern
+
+**Intent:** Encapsulate private state and expose a public API using language-level module boundaries.
+
+**When to Use:**
+- Encapsulating internal implementation details
+- Providing a clean public API from a package or feature
+- Replacing classical Singleton and Namespace patterns
+
+**When NOT to Use:**
+- Everything is public — no encapsulation benefit
+- Module is a single exported function — no pattern needed
+
+**Real-world:** Every ES module, Node.js packages, library entry points.
+
+**ES Module — the native Module pattern:**
+
+```ts
+// counter.ts — private state, public API
+let count = 0;
+
+export function increment(): number { return ++count; }
+export function decrement(): number { return --count; }
+export function getCount(): number { return count; }
+// `count` is inaccessible from outside — true encapsulation
+```
+
+**Revealing Module with closure — pre-ESM or runtime modules:**
+
+```ts
+function createCounter(initial = 0) {
+  let count = initial;
+
+  return {
+    increment: () => ++count,
+    decrement: () => --count,
+    getCount: () => count,
+  };
+}
+
+const counter = createCounter(10);
+counter.increment(); // 11
+// counter.count — undefined, private
+```
+
+**Barrel re-export as Facade + Module:**
+
+```ts
+// features/auth/index.ts — curated public API
+export { login, logout } from "./auth-service";
+export { AuthProvider } from "./auth-provider";
+export type { AuthState, User } from "./types";
+// Internal implementation files are NOT exported
+```
+
+## 2. Provider Pattern
+
+**Intent:** Share cross-cutting data or services through a component tree or dependency graph without explicit prop passing.
+
+**When to Use:**
+- Theme, locale, auth state shared across many components
+- Dependency injection in component-based frameworks
+- Avoiding prop drilling in deep component hierarchies
+
+**When NOT to Use:**
+- Data used by only 1-2 components — pass directly
+- Frequently changing data causing unnecessary re-renders (use targeted state)
+
+**Real-world:** React Context, Vue provide/inject, Angular dependency injection, InversifyJS.
+
+```tsx
+// React Provider pattern
+interface ThemeContext {
+  colors: { primary: string; background: string };
+  spacing: { sm: number; md: number; lg: number };
+}
+
+const ThemeCtx = React.createContext<ThemeContext | null>(null);
+
+function useTheme(): ThemeContext {
+  const ctx = React.useContext(ThemeCtx);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+}
+
+function ThemeProvider({ theme, children }: { theme: ThemeContext; children: React.ReactNode }) {
+  return <ThemeCtx.Provider value={theme}>{children}</ThemeCtx.Provider>;
+}
+```
+
+**DI Container — framework-agnostic Provider:**
+
+```ts
+class Container {
+  private registry = new Map<string, () => unknown>();
+
+  register<T>(token: string, factory: () => T): void {
+    this.registry.set(token, factory);
+  }
+
+  resolve<T>(token: string): T {
+    const factory = this.registry.get(token);
+    if (!factory) throw new Error(`No provider for: ${token}`);
+    return factory() as T;
+  }
+}
+
+const container = new Container();
+container.register("logger", () => new ConsoleLogger());
+container.register("userService", () => new UserService(container.resolve("logger")));
+```
+
+## 3. Middleware / Pipeline Pattern
+
+**Intent:** Process requests through a linear sequence of composable handlers, where each can transform, short-circuit, or pass to the next.
+
+**When to Use:**
+- HTTP request processing (auth, validation, logging, parsing, handling)
+- Data transformation pipelines (ETL, build tool plugins)
+- Any sequential processing where steps are composable and reorderable
+
+**When NOT to Use:**
+- Single-step processing — a function call suffices
+- Steps have complex interdependencies (use a directed graph, not a pipeline)
+
+**Real-world:** Express/Koa/Hono middleware, Webpack loaders, Redux middleware, Fastify hooks.
+
+```ts
+type Context = { req: Request; res: Response; user?: User; startTime?: number };
+type Next = () => Promise<void>;
+type Middleware = (ctx: Context, next: Next) => Promise<void>;
+
+function compose(middlewares: Middleware[]): Middleware {
+  return async (ctx, next) => {
+    let index = -1;
+    async function dispatch(i: number): Promise<void> {
+      if (i <= index) throw new Error("next() called multiple times");
+      index = i;
+      const fn = i === middlewares.length ? next : middlewares[i];
+      if (fn) await fn(ctx, () => dispatch(i + 1));
+    }
+    await dispatch(0);
+  };
+}
+
+// Usage
+const timing: Middleware = async (ctx, next) => {
+  ctx.startTime = Date.now();
+  await next();
+  console.log(`${Date.now() - ctx.startTime!}ms`);
+};
+
+const auth: Middleware = async (ctx, next) => {
+  const token = ctx.req.headers.get("authorization");
+  if (!token) { ctx.res = new Response("Unauthorized", { status: 401 }); return; }
+  ctx.user = await verifyToken(token);
+  await next();
+};
+
+const pipeline = compose([timing, auth]);
+```
+
+**Type-safe Pipeline for data transforms:**
+
+```ts
+type Transform<TIn, TOut> = (input: TIn) => TOut;
+
+function pipe<A, B>(fn1: Transform<A, B>): Transform<A, B>;
+function pipe<A, B, C>(fn1: Transform<A, B>, fn2: Transform<B, C>): Transform<A, C>;
+function pipe<A, B, C, D>(fn1: Transform<A, B>, fn2: Transform<B, C>, fn3: Transform<C, D>): Transform<A, D>;
+function pipe(...fns: Transform<any, any>[]): Transform<any, any> {
+  return (input) => fns.reduce((acc, fn) => fn(acc), input);
+}
+
+const processUser = pipe(
+  (raw: RawUser) => validateUser(raw),
+  (valid) => normalizeEmail(valid),
+  (normalized) => enrichWithDefaults(normalized),
+);
+```
+
+## 4. Repository Pattern
+
+**Intent:** Mediate between the domain and data mapping layers using a collection-like interface for accessing domain objects.
+
+**When to Use:**
+- Decoupling business logic from data access (ORM, API, file system)
+- Swapping storage implementations (in-memory for tests, DB for production)
+- Centralizing query logic and caching
+
+**When NOT to Use:**
+- Simple CRUD with no business logic — direct ORM usage is fine
+- Only one data source that will never change
+
+**Real-world:** Data access layers in backend services, offline-first apps, multi-tenant systems.
+
+```ts
+interface UserRepository {
+  findById(id: string): Promise<User | null>;
+  findByEmail(email: string): Promise<User | null>;
+  save(user: User): Promise<void>;
+  delete(id: string): Promise<void>;
+}
+
+class PostgresUserRepository implements UserRepository {
+  constructor(private db: Pool) {}
+
+  async findById(id: string): Promise<User | null> {
+    const { rows } = await this.db.query("SELECT * FROM users WHERE id = $1", [id]);
+    return rows[0] ? this.toDomain(rows[0]) : null;
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    const { rows } = await this.db.query("SELECT * FROM users WHERE email = $1", [email]);
+    return rows[0] ? this.toDomain(rows[0]) : null;
+  }
+
+  async save(user: User): Promise<void> {
+    await this.db.query(
+      "INSERT INTO users (id, email, name) VALUES ($1, $2, $3) ON CONFLICT (id) DO UPDATE SET email = $2, name = $3",
+      [user.id, user.email, user.name],
+    );
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.db.query("DELETE FROM users WHERE id = $1", [id]);
+  }
+
+  private toDomain(row: any): User {
+    return { id: row.id, email: row.email, name: row.name };
+  }
+}
+
+// Test implementation
+class InMemoryUserRepository implements UserRepository {
+  private users = new Map<string, User>();
+
+  async findById(id: string) { return this.users.get(id) ?? null; }
+  async findByEmail(email: string) {
+    return [...this.users.values()].find((u) => u.email === email) ?? null;
+  }
+  async save(user: User) { this.users.set(user.id, user); }
+  async delete(id: string) { this.users.delete(id); }
+}
+```
+
+## 5. Unit of Work
+
+**Intent:** Maintain a list of objects affected by a business transaction and coordinate writing out changes as a single atomic operation.
+
+**When to Use:**
+- Multiple entities must be saved or rolled back together
+- Batch database operations for performance
+- Tracking which objects are dirty, new, or deleted
+
+**When NOT to Use:**
+- Single entity operations — direct save is simpler
+- Your ORM already provides Unit of Work (e.g., TypeORM, Prisma transactions)
+
+```ts
+class UnitOfWork {
+  private operations: Array<() => Promise<void>> = [];
+
+  registerNew<T>(repo: { save: (entity: T) => Promise<void> }, entity: T) {
+    this.operations.push(() => repo.save(entity));
+  }
+
+  registerDeleted<T>(repo: { delete: (id: string) => Promise<void> }, id: string) {
+    this.operations.push(() => repo.delete(id));
+  }
+
+  async commit(db: { transaction: (fn: () => Promise<void>) => Promise<void> }) {
+    await db.transaction(async () => {
+      for (const op of this.operations) await op();
+    });
+    this.operations = [];
+  }
+}
+```
+
+## 6. Pub/Sub (Publish-Subscribe)
+
+**Intent:** Decouple publishers from subscribers through a message broker, allowing many-to-many communication without direct references.
+
+**When to Use:**
+- Microservice event communication
+- Cross-module communication where Observer creates tight coupling
+- Event sourcing and CQRS read-model updates
+
+**When NOT to Use:**
+- Same-module communication — Observer is simpler and more traceable
+- Synchronous, ordered processing required
+
+Difference from Observer: Pub/Sub has a broker (topic-based routing, possible persistence). Observer has direct subscription.
+
+```ts
+class MessageBroker {
+  private topics = new Map<string, Set<(msg: unknown) => void>>();
+
+  subscribe<T>(topic: string, handler: (msg: T) => void): () => void {
+    if (!this.topics.has(topic)) this.topics.set(topic, new Set());
+    this.topics.get(topic)!.add(handler as any);
+    return () => this.topics.get(topic)?.delete(handler as any);
+  }
+
+  publish<T>(topic: string, message: T): void {
+    this.topics.get(topic)?.forEach((handler) => handler(message));
+  }
+}
+```
+
+## 7. Plugin / Hook Pattern
+
+**Intent:** Allow third-party code to extend or modify application behavior at predefined extension points without changing core code.
+
+**When to Use:**
+- Build tools, editors, frameworks that need extensibility
+- Applications with user-customizable behavior
+- Open-closed principle at the architecture level
+
+**When NOT to Use:**
+- Internal code with no external consumers
+- Extension points are speculative (add when requested)
+
+**Real-world:** Webpack plugins, Babel plugins, ESLint rules, Vite plugins, VS Code extensions.
+
+```ts
+interface Plugin {
+  name: string;
+  setup(hooks: PluginHooks): void;
+}
+
+interface PluginHooks {
+  beforeBuild: Hook<{ config: BuildConfig }>;
+  afterBuild: Hook<{ output: BuildOutput }>;
+  onError: Hook<{ error: Error }>;
+}
+
+class Hook<T> {
+  private taps: Array<(arg: T) => void | Promise<void>> = [];
+
+  tap(fn: (arg: T) => void | Promise<void>) { this.taps.push(fn); }
+
+  async call(arg: T) {
+    for (const fn of this.taps) await fn(arg);
+  }
+}
+
+// Plugin registration
+class BuildSystem {
+  private hooks: PluginHooks = {
+    beforeBuild: new Hook(),
+    afterBuild: new Hook(),
+    onError: new Hook(),
+  };
+
+  use(plugin: Plugin) { plugin.setup(this.hooks); }
+
+  async build(config: BuildConfig) {
+    await this.hooks.beforeBuild.call({ config });
+    const output = await this.runBuild(config);
+    await this.hooks.afterBuild.call({ output });
+    return output;
+  }
+}
+
+// Third-party plugin
+const timingPlugin: Plugin = {
+  name: "timing",
+  setup(hooks) {
+    let start: number;
+    hooks.beforeBuild.tap(() => { start = Date.now(); });
+    hooks.afterBuild.tap(() => { console.log(`Build: ${Date.now() - start}ms`); });
+  },
+};
+```
+
+## Modern Pattern Comparison
+
+| Pattern | Replaces | Key Benefit | JS/TS Mechanism |
+| --- | --- | --- | --- |
+| Module | Namespace, Revealing Module | Native encapsulation | ES modules, closures |
+| Provider | Service Locator | Scoped dependency sharing | Context, DI container |
+| Middleware | Chain of Responsibility | Composable request pipeline | async/await, compose() |
+| Repository | Direct data access | Testable, swappable storage | Interface + implementations |
+| Unit of Work | Ad-hoc transactions | Atomic multi-entity commits | Transaction wrapper |
+| Pub/Sub | Tightly-coupled Observer | Decoupled cross-boundary events | Topic-based broker |
+| Plugin/Hook | Subclassing for extension | Open-closed architecture | Tapable hooks, lifecycle callbacks |

--- a/skills/design-patterns/references/pattern-selection-guide.md
+++ b/skills/design-patterns/references/pattern-selection-guide.md
@@ -1,0 +1,283 @@
+# Pattern Selection Guide
+
+Sources: Gamma et al. (Design Patterns), Osmani (Learning JavaScript Design Patterns), Fowler (Patterns of Enterprise Application Architecture), Vlissides (Pattern Hatching), 2020-2026 JS/TS community practice
+
+Covers: Decision matrices for selecting the right pattern, pattern complexity ranking, combination recipes, migration paths between patterns, and comprehensive when-not-to-use tables.
+
+## Pattern Selection by Problem Domain
+
+### Object Creation Problems
+
+| Problem | First Choice | Escalation | Avoid |
+| --- | --- | --- | --- |
+| Type varies at runtime | Factory Method | Abstract Factory (multiple families) | Builder (wrong domain) |
+| Many optional config fields | Options Object | Builder (multi-step, validation) | Factory (wrong domain) |
+| Need exact copies with tweaks | Spread/structuredClone | Prototype class (complex objects) | Factory (overhead) |
+| Shared singleton resource | Module-scoped export | Class Singleton (lazy init) | Global variable |
+| Test data generation | Factory function | Builder (complex test objects) | Manual construction |
+
+### Interface and Composition Problems
+
+| Problem | First Choice | Escalation | Avoid |
+| --- | --- | --- | --- |
+| Incompatible third-party API | Adapter function | Adapter class (stateful) | Modifying library source |
+| Add behavior without modifying source | Higher-order function | Decorator class (interface compliance) | Subclassing |
+| Complex subsystem, simple caller needs | Facade service | Facade module re-export | Exposing all internals |
+| Control/intercept access | ES Proxy | Proxy class (typed interface) | Modifying target object |
+| 10,000+ similar objects in memory | Flyweight + cache | Object pool | Premature optimization |
+
+### Communication and Behavior Problems
+
+| Problem | First Choice | Escalation | Avoid |
+| --- | --- | --- | --- |
+| React to state changes | Observer (EventEmitter) | Pub/Sub (cross-boundary) | Polling |
+| Swap algorithm at runtime | Strategy function | Strategy class (stateful) | Switch statement |
+| Undo/redo, command queuing | Command | Command + Memento (state snapshots) | Direct mutation |
+| Object behavior varies by mode | State map (transitions) | State class (complex actions) | Nested if/else |
+| Many-to-many communication | Mediator | Pub/Sub (decoupled, async) | Direct references |
+| Sequential processing, bail-out | Chain of Responsibility | Middleware (bidirectional) | Monolithic handler |
+
+### Architecture-Level Problems
+
+| Problem | First Choice | Escalation | Avoid |
+| --- | --- | --- | --- |
+| Request pipeline (HTTP, CLI) | Middleware compose | Plugin system (lifecycle hooks) | Monolithic handler |
+| Cross-cutting context (theme, auth) | Provider (Context/DI) | Module-scoped state | Prop drilling |
+| Decouple data access | Repository interface | Repository + Unit of Work | Direct ORM in business logic |
+| Third-party extensibility | Plugin/Hook system | Event-based plugins | Subclassing |
+| Cross-service events | Pub/Sub broker | Event sourcing | Direct service calls |
+
+## Complexity Ranking
+
+Ranked from simplest to most complex. Start from the top; move down only when the simpler option is insufficient.
+
+| Rank | Pattern | Lines of Code (typical) | When to Upgrade |
+| --- | --- | --- | --- |
+| 1 | Module (ES export) | 5-20 | Need runtime encapsulation |
+| 2 | Strategy (function) | 10-30 | Need stateful strategy selection |
+| 3 | Factory (function) | 15-40 | Need multiple product families |
+| 4 | Observer (EventEmitter) | 20-50 | Need cross-boundary decoupling |
+| 5 | Adapter (function) | 10-30 | Need stateful adaptation |
+| 6 | Decorator (HOF) | 15-40 | Need interface-compliant wrapping |
+| 7 | Facade (class) | 20-60 | Subsystem grows further |
+| 8 | Chain of Responsibility | 20-50 | Need bidirectional flow (middleware) |
+| 9 | Builder | 30-70 | Construction needs cross-field validation |
+| 10 | Command | 30-80 | Need macro/composite commands |
+| 11 | State | 40-100 | State count exceeds 5 (use state library) |
+| 12 | Proxy (ES Proxy) | 20-60 | Interception points multiply |
+| 13 | Mediator | 40-100 | Mediator grows too large (split by domain) |
+| 14 | Middleware (compose) | 30-80 | Need lifecycle hooks (plugin system) |
+| 15 | Repository + UoW | 60-150 | Multiple data sources, complex transactions |
+| 16 | Plugin/Hook system | 50-150 | Hook surface area grows (document carefully) |
+| 17 | Abstract Factory | 50-120 | Product families stabilize (rare in JS/TS) |
+| 18 | Pub/Sub broker | 40-100 | Need persistence, replay (use message queue) |
+
+## Pattern Combination Recipes
+
+Patterns frequently work together. These combinations solve common architectural needs.
+
+### Factory + Strategy
+**Problem:** Create objects that behave differently based on type, and each type has swappable algorithms.
+```
+PaymentFactory.create("stripe") -> StripePayment
+  uses RetryStrategy | FailFastStrategy
+```
+
+### Repository + Unit of Work
+**Problem:** Multiple entities must be persisted atomically.
+```
+UnitOfWork tracks changes across UserRepository + OrderRepository
+  -> commit() wraps all in a single transaction
+```
+
+### Observer + Command
+**Problem:** React to events and support undo.
+```
+UI emits events (Observer)
+  -> each event creates a Command
+  -> CommandHistory enables undo/redo
+```
+
+### Middleware + Strategy
+**Problem:** Request pipeline where individual steps are swappable.
+```
+Middleware pipeline: [auth, rateLimit, handler]
+  auth uses Strategy: JWTAuth | APIKeyAuth | OAuth
+```
+
+### Facade + Adapter
+**Problem:** Simplify a complex subsystem that includes incompatible third-party APIs.
+```
+PaymentFacade
+  -> StripeAdapter (adapts Stripe SDK)
+  -> PayPalAdapter (adapts PayPal SDK)
+  -> exposes: charge(), refund(), subscribe()
+```
+
+### Factory + Decorator
+**Problem:** Create objects and then wrap them with cross-cutting concerns.
+```
+Factory creates Logger
+  -> Decorator adds timestamp prefix
+  -> Decorator adds log-level filtering
+```
+
+### Provider + Repository
+**Problem:** Share a repository instance across a component tree.
+```
+RepositoryProvider wraps components
+  -> useRepository() hook accesses the shared instance
+  -> swappable: InMemoryRepo (tests) vs PostgresRepo (prod)
+```
+
+## Migration Paths
+
+When a pattern outgrows its usefulness, migrate to the next level.
+
+| From | To | Signal |
+| --- | --- | --- |
+| Switch/if-else on type | Factory Method | 3+ branches, adding new types |
+| Factory Method | Abstract Factory | Multiple related product families |
+| Simple boolean flag | State pattern | 3+ states with different behaviors |
+| Direct function calls | Observer | 3+ callers need notification |
+| Observer | Pub/Sub | Cross-module or cross-service boundary |
+| Observer | Mediator | Many-to-many communication causing cycles |
+| Callback nesting | Middleware pipeline | 3+ sequential processing steps |
+| Middleware | Plugin/Hook | Need lifecycle events, not just request flow |
+| Direct DB calls | Repository | Business logic mixed with queries |
+| Repository | Repository + UoW | Multi-entity transactions required |
+| Inheritance hierarchy | Strategy + Composition | Subclass explosion, diamond problems |
+| God class | Facade + extracted services | Class exceeds 300 lines |
+
+## When NOT to Use: Comprehensive Table
+
+| Pattern | Do NOT Use When | Use Instead |
+| --- | --- | --- |
+| Singleton | Need testability, multiple instances in tests | Dependency Injection |
+| Factory Method | Only one concrete type ever | Direct `new` or function call |
+| Abstract Factory | One product type, families never change | Factory Method |
+| Builder | Object has 1-3 fields, no validation | Constructor or options object |
+| Prototype | Objects are cheap to create | Direct construction |
+| Adapter | You control both interfaces | Change the source interface |
+| Decorator | Stacking 5+ layers | Compose into single function |
+| Facade | Callers need full subsystem access | Export subsystem directly |
+| Proxy | Hot path with nanosecond budget | Direct access |
+| Flyweight | Fewer than 1,000 instances | Regular objects |
+| Observer | One subscriber | Direct callback |
+| Strategy | One algorithm, never changes | Inline the logic |
+| Command | No undo, no queuing, no logging | Direct function call |
+| State | Two states with trivial behavior | Boolean flag |
+| Mediator | Two components communicating | Direct reference |
+| Chain of Resp. | One handler always processes | Direct dispatch |
+| Iterator | Standard array/map traversal | Built-in iterators |
+| Middleware | One processing step | Single function |
+| Plugin/Hook | No external consumers | Internal function calls |
+| Repository | Simple CRUD, no business logic | Direct ORM usage |
+| Pub/Sub | Same-module communication | Observer |
+
+## Pattern Smell Detection
+
+Signs that a pattern is misapplied:
+
+| Smell | Likely Cause | Fix |
+| --- | --- | --- |
+| Pattern adds code but no flexibility | Premature application | Remove pattern, use direct code |
+| Cannot explain why pattern is here | Cargo culting | Delete and simplify |
+| Pattern name not in any class/function | Pattern is invisible to readers | Name it explicitly or remove |
+| 3+ patterns interacting in one file | Over-engineering | Flatten; keep at most 2 patterns per module |
+| Tests require elaborate mocking of pattern infrastructure | Pattern is too heavy | Simplify; patterns should make testing easier, not harder |
+| Adding a new feature requires touching pattern boilerplate | Pattern fights the change | Wrong pattern for the problem; reassess |
+| Team members cannot explain the pattern | Knowledge silo | Simplify or document; if neither helps, remove |
+
+## The Pattern Application Checklist
+
+Before introducing any pattern, answer:
+
+1. **Is the problem real?** Have I seen it cause bugs, confusion, or duplication? (Not hypothetical.)
+2. **Is this the simplest pattern that solves it?** Consult the complexity ranking above.
+3. **Can I name it?** The class/function/module should contain the pattern name.
+4. **Will it survive 3 requirement changes?** If the pattern fights likely changes, it is the wrong one.
+5. **Can a junior understand it in 5 minutes?** If not, the complexity cost exceeds the benefit.
+6. **Does it make testing easier?** Patterns should improve testability. If mocking becomes harder, reconsider.
+
+All YES: apply the pattern. Any NO: defer or choose a simpler alternative.
+
+## Pattern-to-Framework Mapping
+
+Common frameworks already implement these patterns. Recognize them to avoid re-inventing.
+
+| Framework / Library | Built-in Pattern | Do NOT Rebuild |
+| --- | --- | --- |
+| React Context | Provider | Custom prop-drilling solution |
+| React `useReducer` | State + Command | Manual state machine class |
+| Redux / Zustand | Mediator + Observer + Command | Custom event bus for state |
+| Express / Koa / Hono | Middleware (Chain of Resp.) | Custom request pipeline |
+| Prisma / TypeORM | Repository + Unit of Work | Manual SQL builder |
+| Webpack / Vite | Plugin/Hook (Tapable) | Custom build extensibility |
+| RxJS | Observer + Iterator + Strategy | Custom reactive streams |
+| InversifyJS / tsyringe | Provider (DI Container) | Manual service locator |
+| Zod / Yup | Builder (schema builder) | Custom validation chain |
+| TanStack Query | Repository + Observer + Cache | Manual fetch + cache layer |
+
+## Refactoring Toward Patterns
+
+Patterns are not introduced upfront. They emerge through refactoring when complexity demands them.
+
+### Step-by-Step: Switch Statement to Strategy
+
+1. Identify the switch/if-else that branches on type or mode.
+2. Extract each branch body into a standalone function with the same signature.
+3. Create a `Record<string, Function>` mapping type keys to handler functions.
+4. Replace the switch with a lookup: `strategies[type](args)`.
+5. Name the type: `type PricingStrategy = (price: number, qty: number) => number`.
+
+### Step-by-Step: God Function to Facade
+
+1. Identify the 200+ line function doing multiple unrelated things.
+2. Group lines by concern (validation, transformation, persistence, notification).
+3. Extract each group into a separate service class or module.
+4. Create a Facade function that calls the extracted services in sequence.
+5. The original call site now calls the Facade — same API, decomposed internals.
+
+### Step-by-Step: Callback Spaghetti to Observer
+
+1. Identify functions that accept multiple callbacks or notify multiple callers.
+2. Create a typed EventEmitter with named events.
+3. Replace callback parameters with event subscriptions.
+4. Move notification logic from the source to the emitter: `emitter.emit("change", data)`.
+5. Subscribers register independently: `emitter.on("change", handler)`.
+
+### Step-by-Step: Prop Drilling to Provider
+
+1. Identify data passed through 3+ component levels without being used in intermediate levels.
+2. Create a Context with `createContext<T>(defaultValue)`.
+3. Create a Provider component that wraps the subtree needing access.
+4. Create a custom hook `useX()` that calls `useContext` with a null-check.
+5. Replace all intermediate prop passing with direct `useX()` calls at consumption points.
+
+### Step-by-Step: Direct DB Calls to Repository
+
+1. Identify business logic files that import the ORM or database client directly.
+2. Define an interface with the query methods the business logic actually uses.
+3. Create a class implementing that interface with the current ORM calls.
+4. Replace all direct ORM imports in business logic with the interface.
+5. Inject the implementation via constructor or Provider.
+6. Create an `InMemoryRepository` implementing the same interface for tests.
+
+## Patterns and Testing
+
+Patterns should make testing easier. If they make it harder, the pattern is misapplied.
+
+| Pattern | Testing Benefit | Testing Approach |
+| --- | --- | --- |
+| Factory | Swap production factory for test factory | Inject factory function |
+| Strategy | Test each algorithm in isolation | Unit test each strategy function |
+| Repository | Swap real DB for in-memory implementation | Interface-based injection |
+| Observer | Verify events emitted with correct data | Subscribe in test, assert on callback |
+| Command | Test execute and undo independently | Unit test each command |
+| Middleware | Test each middleware in isolation | Call with mock context and next |
+| Decorator | Test wrapped and unwrapped behavior | Test base, then test decorated version |
+| State | Test each state and transition | Assert state transitions given actions |
+| Adapter | Test adaptation logic without real service | Mock the external interface |
+| Provider | Override context value in test tree | Wrap test component with test Provider |
+| Plugin | Test plugin in isolation with mock hooks | Call plugin.setup with stub hooks |

--- a/skills/design-patterns/references/structural-patterns.md
+++ b/skills/design-patterns/references/structural-patterns.md
@@ -1,0 +1,316 @@
+# Structural Patterns
+
+Sources: Gamma et al. (Design Patterns), Osmani (Learning JavaScript Design Patterns), Freeman (Head First Design Patterns), MDN Web Docs (Proxy, Reflect)
+
+Covers: Adapter, Decorator, Facade, Proxy, Flyweight — adapted for JavaScript and TypeScript using closures, higher-order functions, ES Proxy, and module patterns.
+
+## 1. Adapter
+
+**Intent:** Convert the interface of a class or module into another interface that clients expect.
+
+**When to Use:**
+- Integrating a third-party library whose API does not match your internal interface
+- Migrating from one service to another (old API to new API)
+- Normalizing multiple data sources into a uniform shape
+
+**When NOT to Use:**
+- Interfaces are already compatible
+- You control both sides and can change the source
+
+**Real-world:** Payment gateway adapters (Stripe/PayPal behind one interface), ORM adapters, API versioning layers.
+
+```ts
+// External SDK with incompatible interface
+interface ExternalAnalytics {
+  trackEvent(name: string, meta: Record<string, string>): void;
+}
+
+// Your internal interface
+interface Analytics {
+  track(event: string, properties: Record<string, unknown>): void;
+}
+
+class AnalyticsAdapter implements Analytics {
+  constructor(private external: ExternalAnalytics) {}
+
+  track(event: string, properties: Record<string, unknown>): void {
+    const meta: Record<string, string> = {};
+    for (const [key, val] of Object.entries(properties)) {
+      meta[key] = String(val);
+    }
+    this.external.trackEvent(event, meta);
+  }
+}
+```
+
+**Functional Adapter — preferred for simple cases:**
+
+```ts
+function adaptAnalytics(external: ExternalAnalytics): Analytics {
+  return {
+    track(event, properties) {
+      const meta = Object.fromEntries(
+        Object.entries(properties).map(([k, v]) => [k, String(v)])
+      );
+      external.trackEvent(event, meta);
+    },
+  };
+}
+```
+
+## 2. Decorator
+
+**Intent:** Attach additional responsibilities to an object dynamically, without modifying its source.
+
+**When to Use:**
+- Adding cross-cutting concerns (logging, caching, retry, timing) to functions or services
+- Wrapping behavior around an existing interface at specific call sites
+- When subclassing would create a combinatorial explosion of classes
+
+**When NOT to Use:**
+- Stacking more than 3-4 decorators (debug difficulty)
+- The base object interface changes frequently (all decorators must update)
+
+**Real-world:** Express/Koa middleware (each is a decorator), caching wrappers, auth guards, React higher-order components.
+
+**Function Decorator — idiomatic JS/TS:**
+
+```ts
+type AsyncFn<T> = (...args: unknown[]) => Promise<T>;
+
+function withRetry<T>(fn: AsyncFn<T>, retries = 3): AsyncFn<T> {
+  return async (...args) => {
+    let lastError: unknown;
+    for (let i = 0; i <= retries; i++) {
+      try {
+        return await fn(...args);
+      } catch (err) {
+        lastError = err;
+        if (i < retries) await new Promise((r) => setTimeout(r, 2 ** i * 100));
+      }
+    }
+    throw lastError;
+  };
+}
+
+function withLogging<T>(fn: AsyncFn<T>, label: string): AsyncFn<T> {
+  return async (...args) => {
+    console.log(`[${label}] start`);
+    const result = await fn(...args);
+    console.log(`[${label}] done`);
+    return result;
+  };
+}
+
+// Compose decorators
+const fetchUser = withLogging(withRetry(api.getUser, 3), "fetchUser");
+```
+
+**Class Decorator — when interface compliance matters:**
+
+```ts
+interface DataSource {
+  read(key: string): Promise<string | null>;
+  write(key: string, value: string): Promise<void>;
+}
+
+class CachingDataSource implements DataSource {
+  private cache = new Map<string, string>();
+
+  constructor(private wrapped: DataSource) {}
+
+  async read(key: string): Promise<string | null> {
+    if (this.cache.has(key)) return this.cache.get(key)!;
+    const value = await this.wrapped.read(key);
+    if (value !== null) this.cache.set(key, value);
+    return value;
+  }
+
+  async write(key: string, value: string): Promise<void> {
+    this.cache.set(key, value);
+    await this.wrapped.write(key, value);
+  }
+}
+```
+
+**TC39 Decorators (Stage 3) — for class methods:**
+
+```ts
+function logged(originalMethod: Function, context: ClassMethodDecoratorContext) {
+  return function (this: unknown, ...args: unknown[]) {
+    console.log(`Calling ${String(context.name)}`);
+    return originalMethod.apply(this, args);
+  };
+}
+
+class UserService {
+  @logged
+  async findById(id: string) { /* ... */ }
+}
+```
+
+## 3. Facade
+
+**Intent:** Provide a simplified interface to a complex subsystem.
+
+**When to Use:**
+- Subsystem has many classes/functions and callers only need common operations
+- Hiding third-party library complexity behind your own API
+- Creating a high-level API for a module that internally uses multiple services
+
+**When NOT to Use:**
+- Subsystem is already simple
+- Callers need full access to subsystem internals (Facade becomes a bottleneck)
+
+**Real-world:** ORM query facades, payment processing (hides tokenization, gateway, fraud check), media upload (hides resize, compress, store, CDN).
+
+```ts
+// Complex subsystem
+class VideoEncoder { encode(file: string) { /* ... */ } }
+class ThumbnailGenerator { generate(file: string) { /* ... */ } }
+class CDNUploader { upload(file: string, bucket: string) { /* ... */ } }
+class MetadataExtractor { extract(file: string) { /* ... */ } }
+
+// Facade
+class VideoService {
+  private encoder = new VideoEncoder();
+  private thumbs = new ThumbnailGenerator();
+  private cdn = new CDNUploader();
+  private meta = new MetadataExtractor();
+
+  async publish(file: string): Promise<{ url: string; thumbnail: string }> {
+    const metadata = this.meta.extract(file);
+    const encoded = await this.encoder.encode(file);
+    const thumbnail = await this.thumbs.generate(encoded);
+    const url = await this.cdn.upload(encoded, "videos");
+    const thumbUrl = await this.cdn.upload(thumbnail, "thumbnails");
+    return { url, thumbnail: thumbUrl };
+  }
+}
+
+// Callers only interact with the simple facade
+const video = new VideoService();
+const result = await video.publish("/uploads/raw-video.mp4");
+```
+
+## 4. Proxy
+
+**Intent:** Provide a surrogate or placeholder for another object to control access to it.
+
+**When to Use:**
+- Lazy initialization of expensive resources (virtual proxy)
+- Access control (protection proxy)
+- Logging, metering, or caching transparent to callers
+- Remote service abstraction (remote proxy)
+
+**When NOT to Use:**
+- No access control or lazy loading needed — direct reference is simpler
+- Performance-critical hot paths (proxy adds indirection overhead)
+
+**Real-world:** API rate limiters, lazy-loaded images, Vue.js reactivity system, validation proxies.
+
+**ES Proxy — the JS-native implementation:**
+
+```ts
+function createValidatingProxy<T extends object>(target: T, rules: Record<string, (v: unknown) => boolean>): T {
+  return new Proxy(target, {
+    set(obj, prop, value) {
+      const key = String(prop);
+      if (rules[key] && !rules[key](value)) {
+        throw new Error(`Invalid value for ${key}: ${value}`);
+      }
+      return Reflect.set(obj, prop, value);
+    },
+  });
+}
+
+const user = createValidatingProxy(
+  { name: "", age: 0 },
+  {
+    age: (v) => typeof v === "number" && v >= 0 && v <= 150,
+    name: (v) => typeof v === "string" && (v as string).length > 0,
+  },
+);
+
+user.name = "Alice"; // OK
+user.age = -5;       // throws: Invalid value for age
+```
+
+**Lazy-loading Proxy:**
+
+```ts
+function lazyInit<T extends object>(factory: () => T): T {
+  let instance: T | null = null;
+  return new Proxy({} as T, {
+    get(_, prop, receiver) {
+      if (!instance) instance = factory();
+      return Reflect.get(instance, prop, receiver);
+    },
+  });
+}
+
+const db = lazyInit(() => connectToDatabase()); // Connection only created on first access
+```
+
+## 5. Flyweight
+
+**Intent:** Share fine-grained objects efficiently to minimize memory usage.
+
+**When to Use:**
+- Large number of similar objects (10,000+) consuming significant memory
+- Most object state can be shared (intrinsic) while a small portion varies (extrinsic)
+- Object creation is a measurable memory bottleneck
+
+**When NOT to Use:**
+- Small number of objects — optimization not needed
+- Objects have mostly unique state — nothing to share
+- Premature optimization without profiling
+
+**Real-world:** Text editor character rendering, game particle systems, icon/sprite caches, DOM element pooling.
+
+```ts
+class Icon {
+  constructor(
+    public readonly name: string,
+    public readonly svgData: string, // large, shareable
+  ) {}
+}
+
+class IconFactory {
+  private cache = new Map<string, Icon>();
+
+  getIcon(name: string): Icon {
+    if (!this.cache.has(name)) {
+      const svgData = loadSvgFromDisk(name); // expensive
+      this.cache.set(name, new Icon(name, svgData));
+    }
+    return this.cache.get(name)!;
+  }
+}
+
+// Extrinsic state (position, size) stays outside the flyweight
+interface PlacedIcon {
+  icon: Icon;    // shared flyweight
+  x: number;     // extrinsic
+  y: number;     // extrinsic
+  size: number;  // extrinsic
+}
+```
+
+## Structural Pattern Comparison
+
+| Pattern | Complexity | Key Mechanism | JS/TS Idiom |
+| --- | --- | --- | --- |
+| Adapter | Low | Interface translation | Wrapper function or class |
+| Decorator | Low-Med | Wrapping with same interface | Higher-order functions, class wrapping |
+| Facade | Low | Simplified entry point | Service class or module re-export |
+| Proxy | Medium | Transparent interception | ES `Proxy` object, wrapper class |
+| Flyweight | Medium | Object sharing via cache | `Map` cache with factory access |
+
+## JS/TS-Specific Guidelines
+
+1. **Higher-order functions ARE decorators.** `withRetry(fn)` is more idiomatic than a `RetryDecorator` class.
+2. **ES `Proxy` is a first-class pattern.** Use it for validation, reactivity, lazy loading. Avoid in hot loops.
+3. **Module re-exports as Facade.** An `index.ts` that re-exports a curated API from internal modules is a Facade.
+4. **Adapter functions over adapter classes.** When the adaptation is stateless, a function is cleaner.
+5. **`Map` or `WeakMap` for Flyweight caches.** `WeakMap` prevents memory leaks when flyweight keys are objects.

--- a/skills/design-patterns/tank.json
+++ b/skills/design-patterns/tank.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/design-patterns",
+  "version": "1.0.0",
+  "description": "JavaScript and TypeScript design patterns catalog. Covers GoF creational, structural, and behavioral patterns (Factory, Singleton, Observer, Strategy, Command, Decorator, Adapter, Proxy, State, Builder, Facade, Iterator) plus modern JS/TS patterns (Module, Provider, Middleware, Pipeline, Repository, Pub/Sub, Plugin/Hook). Synthesizes Gamma et al., Freeman, Osmani, Fowler, Vlissides.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}

--- a/skills/react/SKILL.md
+++ b/skills/react/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "@tank/react"
-description: "Expert React patterns for production apps. Covers linting with React Doctor. Triggers: react, component, hook, useState, useEffect, useReducer, useMemo, useCallback, context, render, JSX, props, state, state management, server state, TanStack Query, suspense, memo, performance, testing, React 19, server component, react-doctor, linter, health score, dead code."
+description: "Expert React patterns for production apps. Covers component composition (compound, polymorphic, slots), hooks, state architecture, performance, React 19 (use, Actions, useActionState, useFormStatus, ref as prop), React Compiler, Vite-era tooling, TanStack Query, and linting with React Doctor. Triggers: react, component, hook, useState, useEffect, useReducer, useMemo, useCallback, context, render, JSX, props, state, state management, server state, TanStack Query, suspense, memo, React performance, component performance, testing, React 19, React Compiler, server component, React Server Components, RSC, Vite, compound component, polymorphic, useActionState, react-doctor, linter, health score, dead code."
 ---
 # React
 
@@ -18,6 +18,7 @@ description: "Expert React patterns for production apps. Covers linting with Rea
 | --- | --- | --- | --- |
 | Static UI with simple props | Simple component | Lowest overhead | Keep props shallow |
 | Shared state across related pieces | Compound component | Implicit coordination | Use context + slots |
+| Element-agnostic styling | Polymorphic (`as` prop) | Unified API across elements | Type `as` for safety |
 | Behavior injection into layout | Render prop | Flexible control | Prefer stable function identity |
 | Wrap a 3rd-party API | HOC | Encapsulate wiring | Avoid for new component APIs |
 | Reuse logic without UI | Custom hook | Share behavior | Return data + actions |
@@ -48,7 +49,23 @@ description: "Expert React patterns for production apps. Covers linting with Rea
 | `use()` | Read promises/context in render | Server and client data boundaries | Requires Suspense |
 | Actions | Async mutations with form integration | Form submissions | Avoid manual loading flags |
 | `useOptimistic` | Instant UI while awaiting server | Mutations with predictable rollback | Ensure reconciliation |
+| `useActionState` | Form action result + pending flag | Server/client form actions | Replaces deprecated useFormState |
+| `useFormStatus` | Read parent form pending state | Submit buttons, progress indicators | Must be child of `<form>` |
+| `ref` as prop | Pass refs without forwardRef | Any component exposing DOM | Drop forwardRef boilerplate |
 | Server Components | Zero-bundle UI on server | Read-only, data-heavy views | Requires boundary discipline |
+| Context as provider | `<Ctx>` replaces `<Ctx.Provider>` | All context usage | Drop `.Provider` suffix |
+
+## Modern React Stack (2026)
+| Layer | Tool | Why | Note |
+| --- | --- | --- | --- |
+| Bundler | Vite | Fast HMR, ESM-native | `plugin-react-swc` for speed |
+| Memoization | React Compiler | Auto-memoizes pure renders | Remove manual memo when adopted |
+| Server state | TanStack Query | Cache, invalidation, optimistic UI | Replaces useEffect fetch patterns |
+| Data loading | Suspense + `use()` | Declarative async boundaries | Boundaries at latency points |
+| Client state | useState / useReducer | Local-first, lift only when needed | External stores for cross-route |
+| Routing | TanStack Router / React Router | Type-safe, loaders prevent waterfalls | File-based or config-based |
+
+-> See `references/modern-react-2026.md` for setup guides and detailed patterns.
 
 ## Anti-Patterns
 | Don't | Do Instead | Why |
@@ -60,8 +77,9 @@ description: "Expert React patterns for production apps. Covers linting with Rea
 | Overuse `React.memo` | Memoize only hotspots | Extra work otherwise |
 | Inline object props every render | Memoize or hoist | Stabilize referential equality |
 | One global Context for everything | Split by domain | Reduce rerenders |
-| Event handlers that depend on stale state | Use functional updates | Avoid stale closure bugs |
+| Event handlers with stale state | Use functional updates | Avoid stale closure bugs |
 | Keys from array index | Stable domain IDs | Preserve item identity |
+| Wrap in `forwardRef` (React 19+) | Pass `ref` as regular prop | Less boilerplate |
 
 ## Component API Checklist
 - Expose the minimum props needed to express intent.
@@ -123,6 +141,7 @@ description: "Expert React patterns for production apps. Covers linting with Rea
 - Avoid re-render cascades by splitting context providers.
 - Use virtualization when list size > 200 or rendering cost is high.
 - Treat `memo` and `useCallback` as opt-in tools, not defaults.
+- When React Compiler is active, remove redundant manual memoization.
 - Split bundles by route first, then by heavy widget.
 - Inspect bundle output to validate tree-shaking.
 - Defer non-critical work with `useTransition` or Actions.
@@ -147,94 +166,14 @@ description: "Expert React patterns for production apps. Covers linting with Rea
 - Teams repeatedly add exceptions to the API.
 
 ## Linting with React Doctor
-React Doctor is a CLI linter that scans React codebases for anti-patterns and outputs a 0–100 health score with actionable diagnostics. It auto-detects your framework (Next.js, Vite, Remix, React Native) and React version.
-
-### Quick Start
-```bash
-npx -y react-doctor@latest .
-```
-
-### Key CLI Flags
-| Flag | Purpose |
-| --- | --- |
-| `--verbose` | Show file paths and line numbers per rule |
-| `--diff main` | Scan only files changed vs base branch |
-| `--score` | Output only the numeric score (CI-friendly) |
-| `--no-lint` | Skip lint checks, run dead code only |
-| `--no-dead-code` | Skip dead code detection, run lint only |
-| `--fix` | Open Ami to auto-fix issues |
-| `-y` | Skip prompts, scan all workspace projects |
-
-### Configuration
-Create `react-doctor.config.json` at project root:
-```json
-{
-  "ignore": {
-    "rules": ["react/no-danger", "knip/exports"],
-    "files": ["src/generated/**"]
-  },
-  "lint": true,
-  "deadCode": true,
-  "verbose": false,
-  "diff": "main"
-}
-```
-Or use the `reactDoctor` key in `package.json`.
-
-### Rule Categories Overview
-| Category | Focus | Example Rules |
-| --- | --- | --- |
-| State & Effects | Derived state, fetch in effect, cascading setState | `no-derived-state-effect`, `no-fetch-in-effect` |
-| Architecture | Giant components, render-in-render | `no-giant-component`, `no-nested-component-definition` |
-| Performance | Memoization misuse, layout animations, hydration | `no-usememo-simple-expression`, `no-layout-property-animation` |
-| Security | eval usage, hardcoded secrets | `no-eval`, `no-secrets-in-client-code` |
-| Bundle Size | Barrel imports, full lodash, moment.js | `no-barrel-import`, `no-full-lodash-import`, `no-moment` |
-| Correctness | Array index keys, conditional rendering | `no-array-index-as-key`, `rendering-conditional-render` |
-| Next.js | Image, link, metadata, server data | `nextjs-no-img-element`, `nextjs-missing-metadata` |
-| React Native | Raw text, deprecated modules, Reanimated | `rn-no-raw-text`, `rn-prefer-reanimated` |
-
-### Score Interpretation
-| Range | Label | Action |
-| --- | --- | --- |
-| 75–100 | Great | Maintain current quality |
-| 50–74 | Needs work | Address errors first, then warnings |
-| 0–49 | Critical | Prioritize security and correctness rules |
-
-### CI/CD Integration (GitHub Actions)
-```yaml
-- uses: actions/checkout@v5
-  with:
-    fetch-depth: 0
-- uses: millionco/react-doctor@main
-  with:
-    diff: main
-    github-token: ${{ secrets.GITHUB_TOKEN }}
-```
-
-### Programmatic API
-```ts
-import { diagnose } from "react-doctor/api";
-
-const result = await diagnose("./path/to/project", {
-  lint: true,
-  deadCode: true,
-});
-
-console.log(result.score);       // { score: 82, label: "Good" }
-console.log(result.diagnostics); // Array of Diagnostic objects
-console.log(result.project);     // Detected framework, React version
-```
-
-### When to Suppress Rules
-- `react/no-danger`: When rendering trusted sanitized HTML.
-- `knip/exports`: For public library entry points consumed externally.
-- `no-barrel-import`: For small internal barrels with few re-exports.
-- Add suppressions to `ignore.rules` in config, not inline comments.
-
-See `skills/react/references/react-doctor.md` for the full rule reference.
+React Doctor scans for anti-patterns and outputs a 0-100 health score. Run `npx -y react-doctor@latest .` to scan. Use `--diff main` for CI, `--fix` to auto-fix, `--score` for CI-friendly numeric output.
+-> See `references/react-doctor.md` for the full rule reference, CI integration, and configuration.
 
 ## Reference Index
-- `skills/react/references/component-patterns.md`
-- `skills/react/references/hooks-and-state.md`
-- `skills/react/references/performance.md`
-- `skills/react/references/react-doctor.md`
+| File | Contents |
+| --- | --- |
+| `references/component-patterns.md` | Compound, polymorphic, slots, render props, controlled/uncontrolled |
+| `references/hooks-and-state.md` | Custom hooks, useReducer patterns, effects, React 19 hooks |
+| `references/performance.md` | Memo, code splitting, virtualization, React Compiler, profiling |
+| `references/modern-react-2026.md` | Vite setup, React Compiler adoption, TanStack Query, React 19 API |
+| `references/react-doctor.md` | Full rule reference, CI setup, configuration, programmatic API |

--- a/skills/react/references/component-patterns.md
+++ b/skills/react/references/component-patterns.md
@@ -1,6 +1,8 @@
 # Component Patterns
 
-Sources: React documentation; Kent C. Dodds Advanced React Patterns.
+Sources: React documentation; Kent C. Dodds Advanced React Patterns; Radix UI source.
+
+Covers: composition patterns for building flexible, type-safe, and accessible component APIs.
 
 ## Compound Components (Context-Based Accordion)
 Use a shared context to coordinate child pieces without prop threading.
@@ -30,6 +32,94 @@ export function AccordionPanel({ id, children }: { id: string; children: React.R
 }
 ```
 
+## Compound Components (Radix-Style Dot Notation)
+Attach sub-components as static properties on the root for a discoverable API.
+Consumers compose structure while the root manages shared state.
+Throw if sub-components are used outside their root provider.
+Use display names for dev tools and error messages.
+```tsx
+type SelectCtx = {
+  value: string;
+  onChange: (v: string) => void;
+  open: boolean;
+  setOpen: (o: boolean) => void;
+};
+const SelectContext = React.createContext<SelectCtx | null>(null);
+
+function useSelectContext() {
+  const ctx = React.useContext(SelectContext);
+  if (!ctx) throw new Error("Select.* components must be used within <Select>");
+  return ctx;
+}
+
+function Root({
+  value,
+  onChange,
+  children,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const ctx = React.useMemo(() => ({ value, onChange, open, setOpen }), [value, onChange, open]);
+  return <SelectContext.Provider value={ctx}>{children}</SelectContext.Provider>;
+}
+Root.displayName = "Select";
+
+function Trigger({ children }: { children: React.ReactNode }) {
+  const { open, setOpen, value } = useSelectContext();
+  return (
+    <button aria-expanded={open} onClick={() => setOpen(!open)}>
+      {value || children}
+    </button>
+  );
+}
+Trigger.displayName = "Select.Trigger";
+
+function Content({ children }: { children: React.ReactNode }) {
+  const { open } = useSelectContext();
+  if (!open) return null;
+  return <ul role="listbox">{children}</ul>;
+}
+Content.displayName = "Select.Content";
+
+function Option({ value, children }: { value: string; children: React.ReactNode }) {
+  const { onChange, setOpen } = useSelectContext();
+  return (
+    <li
+      role="option"
+      onClick={() => {
+        onChange(value);
+        setOpen(false);
+      }}
+    >
+      {children}
+    </li>
+  );
+}
+Option.displayName = "Select.Option";
+
+export const Select = Object.assign(Root, { Trigger, Content, Option });
+// Usage:
+// <Select value={val} onChange={setVal}>
+//   <Select.Trigger>Pick one</Select.Trigger>
+//   <Select.Content>
+//     <Select.Option value="a">Alpha</Select.Option>
+//     <Select.Option value="b">Beta</Select.Option>
+//   </Select.Content>
+// </Select>
+```
+
+### When to use dot notation vs named exports
+
+| Signal | Pattern |
+| --- | --- |
+| Sub-components only make sense together | Dot notation (`Select.Option`) |
+| Sub-components are reusable independently | Named exports (`AccordionHeader`) |
+| Library authoring with strict API surface | Dot notation for discoverability |
+| Internal feature code | Named exports for simplicity |
+
 ## Render Props (Behavior Injection)
 Use render props when consumers must control layout.
 Pass state and actions to a function so the caller decides placement.
@@ -51,6 +141,57 @@ export function Mouse({ children }: { children: (s: MouseState) => React.ReactNo
 }
 // Usage
 <Mouse>{({ x, y }) => <span>{x},{y}</span>}</Mouse>;
+```
+
+## Render Delegation
+Delegate rendering to consumers while retaining behavior and state.
+Use when a component owns orchestration but consumers own presentation.
+Combine with hooks to separate logic from layout entirely.
+Keep the render function type narrow for maximum consumer flexibility.
+```tsx
+type RenderFn<T> = (state: T) => React.ReactNode;
+type PaginationState = {
+  page: number;
+  totalPages: number;
+  next: () => void;
+  prev: () => void;
+  canNext: boolean;
+  canPrev: boolean;
+};
+function usePagination(total: number, perPage: number): PaginationState {
+  const [page, setPage] = React.useState(1);
+  const totalPages = Math.ceil(total / perPage);
+  return {
+    page,
+    totalPages,
+    next: () => setPage((p) => Math.min(p + 1, totalPages)),
+    prev: () => setPage((p) => Math.max(p - 1, 1)),
+    canNext: page < totalPages,
+    canPrev: page > 1,
+  };
+}
+export function Pagination({
+  total,
+  perPage,
+  children,
+}: {
+  total: number;
+  perPage: number;
+  children: RenderFn<PaginationState>;
+}) {
+  const state = usePagination(total, perPage);
+  return <>{children(state)}</>;
+}
+// Usage:
+// <Pagination total={100} perPage={10}>
+//   {({ page, totalPages, next, prev, canNext }) => (
+//     <nav>
+//       <button onClick={prev}>Prev</button>
+//       <span>{page} / {totalPages}</span>
+//       <button onClick={next} disabled={!canNext}>Next</button>
+//     </nav>
+//   )}
+// </Pagination>
 ```
 
 ## Slots Pattern (Named Children)
@@ -126,6 +267,34 @@ export function Button<E extends React.ElementType = "button">(
   const Comp = as || "button";
   return <Comp className={`btn btn--${variant}`} {...rest}>{children}</Comp>;
 }
+```
+
+## Polymorphic Components with Ref (React 19)
+In React 19, `ref` is a regular prop. Combine with polymorphism for full flexibility.
+No `forwardRef` wrapper needed. Type `ref` alongside `as` for safety.
+```tsx
+type PolyProps<E extends React.ElementType> = {
+  as?: E;
+  variant?: "solid" | "outline";
+  children: React.ReactNode;
+  ref?: React.Ref<React.ElementRef<E>>;
+} & Omit<React.ComponentPropsWithoutRef<E>, "as" | "variant" | "children" | "ref">;
+
+export function Button<E extends React.ElementType = "button">({
+  as,
+  variant = "solid",
+  ref,
+  children,
+  ...rest
+}: PolyProps<E>) {
+  const Comp = as || "button";
+  return (
+    <Comp ref={ref} className={`btn btn--${variant}`} {...rest}>
+      {children}
+    </Comp>
+  );
+}
+// Usage: <Button as="a" href="/home" ref={linkRef}>Home</Button>
 ```
 
 ## Composition Over Inheritance

--- a/skills/react/references/modern-react-2026.md
+++ b/skills/react/references/modern-react-2026.md
@@ -1,0 +1,432 @@
+# Modern React Stack (2026)
+
+Sources: React documentation (react.dev); React Compiler RFC; TanStack Query v5 documentation; Vite documentation.
+
+Covers: Vite setup, React Compiler adoption, TanStack Query patterns, and React 19 full API reference.
+
+## Vite + React Setup
+
+### Scaffold a new project
+
+```bash
+npm create vite@latest my-app -- --template react-ts
+cd my-app && npm install
+```
+
+### Plugin selection
+
+| Plugin | When to use | HMR speed | JSX transform |
+| --- | --- | --- | --- |
+| `@vitejs/plugin-react` | Need Babel plugins (e.g., styled-components) | Fast | Babel |
+| `@vitejs/plugin-react-swc` | Default choice for new projects | Fastest | SWC |
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 3000 },
+  build: { sourcemap: true },
+});
+```
+
+### Environment variables
+Vite exposes env vars prefixed with `VITE_` to client code via `import.meta.env`.
+Never put secrets in `VITE_` variables -- they are bundled into client output.
+
+```ts
+// .env
+VITE_API_URL=https://api.example.com
+
+// src/config.ts
+export const API_URL = import.meta.env.VITE_API_URL;
+```
+
+### Path aliases
+
+```ts
+// vite.config.ts
+import path from "node:path";
+export default defineConfig({
+  resolve: {
+    alias: { "@": path.resolve(__dirname, "./src") },
+  },
+});
+```
+
+```json
+// tsconfig.json (for IDE support)
+{ "compilerOptions": { "paths": { "@/*": ["./src/*"] } } }
+```
+
+### Production build checklist
+- Enable `build.sourcemap` for error monitoring.
+- Set `build.target` to match your browser support.
+- Use `build.rollupOptions.output.manualChunks` for vendor splitting.
+- Run `npx vite-bundle-visualizer` to inspect output.
+
+## React Compiler
+
+### What it does
+React Compiler auto-memoizes component renders and hook return values at build time.
+It analyzes data flow to insert memoization equivalent to `React.memo`, `useMemo`, and `useCallback` automatically.
+Manual memoization becomes unnecessary for pure components.
+
+### What it auto-memoizes
+
+| Pattern | Before compiler | After compiler |
+| --- | --- | --- |
+| Pure component render | Needs `React.memo` wrapper | Auto-skipped when props unchanged |
+| Derived value in render | Needs `useMemo` | Auto-memoized |
+| Callback passed to child | Needs `useCallback` | Auto-stabilized |
+| JSX expression tree | Re-created every render | Cached when inputs stable |
+
+### When manual memo is still needed
+- Components with side effects in render (non-pure).
+- Components using refs that change between renders.
+- Third-party components that mutate props internally.
+- Performance-critical paths where compiler heuristics are insufficient (rare).
+
+### Adoption guide
+
+1. Install the compiler plugin:
+```bash
+npm install -D babel-plugin-react-compiler
+```
+
+2. Configure with Vite (requires Babel plugin, so use `@vitejs/plugin-react`):
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [
+    react({
+      babel: {
+        plugins: [["babel-plugin-react-compiler", {}]],
+      },
+    }),
+  ],
+});
+```
+
+3. Validate with eslint plugin:
+```bash
+npm install -D eslint-plugin-react-compiler
+```
+
+```js
+// eslint.config.js
+import reactCompiler from "eslint-plugin-react-compiler";
+export default [
+  { plugins: { "react-compiler": reactCompiler }, rules: { "react-compiler/react-compiler": "error" } },
+];
+```
+
+4. Incremental adoption -- opt in per file or directory:
+```ts
+// vite.config.ts
+react({
+  babel: {
+    plugins: [
+      ["babel-plugin-react-compiler", {
+        sources: (filename) => filename.includes("src/components"),
+      }],
+    ],
+  },
+})
+```
+
+### Migration checklist
+- Remove `React.memo` wrappers from pure components.
+- Remove `useMemo` for inline derivations.
+- Remove `useCallback` where the only consumer is a child component.
+- Keep `useMemo` for genuinely expensive computations (>1ms).
+- Keep `useCallback` for callbacks passed to non-React code (event listeners, third-party libs).
+- Run profiler before and after to verify equivalent performance.
+
+## TanStack Query (React Query v5)
+
+### Setup
+
+```tsx
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60_000,
+      retry: 1,
+    },
+  },
+});
+
+function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Router />
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}
+```
+
+### Basic query
+
+```tsx
+import { useQuery } from "@tanstack/react-query";
+
+function Users() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["users"],
+    queryFn: () => fetch("/api/users").then((r) => r.json()),
+  });
+
+  if (isLoading) return <Spinner />;
+  if (error) return <ErrorMessage error={error} />;
+  return <UserList users={data} />;
+}
+```
+
+### Mutations with optimistic updates
+
+```tsx
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+function useCreateTodo() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (newTodo: { text: string }) =>
+      fetch("/api/todos", { method: "POST", body: JSON.stringify(newTodo) }).then((r) => r.json()),
+    onMutate: async (newTodo) => {
+      await queryClient.cancelQueries({ queryKey: ["todos"] });
+      const previous = queryClient.getQueryData(["todos"]);
+      queryClient.setQueryData(["todos"], (old: Todo[]) => [
+        ...old,
+        { id: "temp", text: newTodo.text },
+      ]);
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      queryClient.setQueryData(["todos"], context?.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["todos"] });
+    },
+  });
+}
+```
+
+### Prefetching
+
+```tsx
+function UserLink({ userId }: { userId: string }) {
+  const queryClient = useQueryClient();
+
+  return (
+    <a
+      href={`/users/${userId}`}
+      onMouseEnter={() => {
+        queryClient.prefetchQuery({
+          queryKey: ["user", userId],
+          queryFn: () => fetchUser(userId),
+          staleTime: 30_000,
+        });
+      }}
+    >
+      View User
+    </a>
+  );
+}
+```
+
+### Suspense integration
+
+```tsx
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+function UserProfile({ userId }: { userId: string }) {
+  const { data } = useSuspenseQuery({
+    queryKey: ["user", userId],
+    queryFn: () => fetchUser(userId),
+  });
+  return <div>{data.name}</div>;
+}
+
+// Wrap in Suspense at route or feature level
+function UserPage({ userId }: { userId: string }) {
+  return (
+    <React.Suspense fallback={<ProfileSkeleton />}>
+      <UserProfile userId={userId} />
+    </React.Suspense>
+  );
+}
+```
+
+### Cache invalidation patterns
+
+| Pattern | When to use | Example |
+| --- | --- | --- |
+| `invalidateQueries` | After mutation success | `queryClient.invalidateQueries({ queryKey: ["todos"] })` |
+| `setQueryData` | Optimistic update before server responds | `queryClient.setQueryData(["todo", id], updatedTodo)` |
+| `prefetchQuery` | Preload on hover or route transition | `queryClient.prefetchQuery({ queryKey: [...] })` |
+| `removeQueries` | Clear stale data on logout | `queryClient.removeQueries({ queryKey: ["user"] })` |
+| `resetQueries` | Reset to initial state | `queryClient.resetQueries({ queryKey: ["filters"] })` |
+
+## Server State vs Client State
+
+### Clear separation
+
+| Category | Examples | Tool | Storage |
+| --- | --- | --- | --- |
+| Server state | User profile, todos, orders | TanStack Query | Query cache |
+| Client UI state | Open panels, selected tab, draft text | useState / useReducer | Component tree |
+| Client app state | Theme, auth token, locale | Context or external store | Memory / localStorage |
+| URL state | Search filters, pagination, sort | URL search params | Browser URL |
+
+### Rules
+- Never copy server data into `useState`. Use the query cache as the single source.
+- Mutations go through `useMutation`, not manual fetch + setState.
+- Client state that does not need persistence stays in components.
+- URL state is the source of truth for anything linkable or shareable.
+
+```tsx
+// Server state: TanStack Query owns it
+const { data: todos } = useQuery({ queryKey: ["todos"], queryFn: fetchTodos });
+
+// Client UI state: local to component
+const [selectedId, setSelectedId] = useState<string | null>(null);
+
+// URL state: search params own it
+const [searchParams, setSearchParams] = useSearchParams();
+const filter = searchParams.get("status") ?? "all";
+```
+
+## React 19 Full API Reference
+
+### use()
+Read a promise or context value during render. Suspends the component until the promise resolves.
+```tsx
+// Read a promise (must be wrapped in Suspense)
+function UserCard({ userPromise }: { userPromise: Promise<User> }) {
+  const user = React.use(userPromise);
+  return <div>{user.name}</div>;
+}
+
+// Read context (replaces useContext)
+function ThemedButton() {
+  const theme = React.use(ThemeContext);
+  return <button style={{ color: theme.primary }}>Click</button>;
+}
+```
+
+### Actions and useActionState
+Actions are async functions passed to `<form action={...}>` or `startTransition`.
+`useActionState` provides the action result and pending state.
+```tsx
+async function createTodo(prevState: State, formData: FormData) {
+  "use server";
+  const text = formData.get("text") as string;
+  await db.todos.create({ text });
+  return { message: "Created" };
+}
+
+function TodoForm() {
+  const [state, formAction, isPending] = React.useActionState(createTodo, { message: "" });
+  return (
+    <form action={formAction}>
+      <input name="text" />
+      <button disabled={isPending}>{isPending ? "Adding..." : "Add"}</button>
+      {state.message && <p>{state.message}</p>}
+    </form>
+  );
+}
+```
+
+### useFormStatus
+Read the pending state of the nearest parent `<form>`. Must be a child component of the form.
+```tsx
+function SubmitButton() {
+  const { pending, data, method, action } = React.useFormStatus();
+  return (
+    <button type="submit" disabled={pending}>
+      {pending ? "Submitting..." : "Submit"}
+    </button>
+  );
+}
+```
+
+### useOptimistic
+Show optimistic state while an async action is in flight.
+```tsx
+function Messages({ messages }: { messages: Message[] }) {
+  const [optimistic, addOptimistic] = React.useOptimistic(
+    messages,
+    (state, newMsg: string) => [...state, { id: "temp", text: newMsg, sending: true }],
+  );
+
+  async function send(formData: FormData) {
+    const text = formData.get("text") as string;
+    addOptimistic(text);
+    await postMessage(text);
+  }
+
+  return (
+    <div>
+      {optimistic.map((m) => (
+        <div key={m.id} style={{ opacity: m.sending ? 0.6 : 1 }}>{m.text}</div>
+      ))}
+      <form action={send}>
+        <input name="text" />
+      </form>
+    </div>
+  );
+}
+```
+
+### ref as prop
+In React 19, `ref` is a regular prop. No `forwardRef` wrapper needed.
+```tsx
+function Input({ ref, ...props }: { ref?: React.Ref<HTMLInputElement> } & React.InputHTMLAttributes<HTMLInputElement>) {
+  return <input ref={ref} {...props} />;
+}
+// Usage: <Input ref={inputRef} placeholder="Name" />
+```
+
+### Context as provider
+`<Context>` can be used directly as a provider. No `.Provider` suffix needed.
+```tsx
+const ThemeContext = React.createContext("light");
+// React 19: <ThemeContext value="dark"><Page /></ThemeContext>
+```
+
+### Document metadata
+React 19 hoists `<title>`, `<meta>`, and `<link>` to `<head>` automatically.
+```tsx
+function BlogPost({ post }: { post: Post }) {
+  return (
+    <article>
+      <title>{post.title}</title>
+      <meta name="description" content={post.excerpt} />
+      <h1>{post.title}</h1>
+    </article>
+  );
+}
+```
+
+## Decision Tree: Choosing the Right Data Pattern
+
+| Question | Answer | Pattern |
+| --- | --- | --- |
+| Does the data come from a server? | Yes | TanStack Query |
+| Is it a form submission? | Yes | Actions + useActionState |
+| Do you need instant feedback? | Yes | useOptimistic |
+| Is it local UI state? | Yes | useState / useReducer |
+| Does it need to survive navigation? | Yes | URL search params or external store |
+| Is it shared across many components? | Yes | Context or external store |
+| Is it derived from other state? | Yes | Compute inline or useMemo |

--- a/skills/react/tank.json
+++ b/skills/react/tank.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/react",
-  "version": "2.2.0",
-  "description": "React patterns for production apps. Covers component composition, hooks (custom, useReducer, useEffect), state architecture, performance (memo, useMemo, code splitting), React 19 features, linting with React Doctor, and testing. Triggers: react, component, hook, useState, useEffect, useReducer, context, render, JSX, props, state management, React 19, server component, suspense, memo, performance, testing, custom hook, react-doctor, linter, health score, dead code.",
+  "version": "2.3.0",
+  "description": "React patterns for production apps. Component composition (compound, polymorphic, slots), hooks, state architecture, performance, React 19 (use, Actions, useActionState, useFormStatus, ref as prop), React Compiler auto-memoization, Vite-era tooling, TanStack Query server state, Suspense-first data loading, and linting with React Doctor.",
   "permissions": {
     "network": {
       "outbound": []

--- a/skills/rendering-patterns/SKILL.md
+++ b/skills/rendering-patterns/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: "@tank/rendering-patterns"
+description: |
+  Framework-agnostic rendering and hydration patterns for the modern web.
+  Covers Client-Side Rendering (SPA architecture, tradeoffs, when appropriate),
+  Server-Side Rendering (request-time HTML, streaming SSR, chunked transfer),
+  Static Site Generation (build-time HTML, limitations), Incremental Static
+  Regeneration (on-demand + timed revalidation), Progressive Hydration (partial,
+  lazy, scheduled hydration), Islands Architecture (isolated interactive regions
+  in static pages), React Server Components (server-only rendering without
+  hydration cost), Selective Hydration (priority-based with concurrent features),
+  Resumability (serialize state instead of replay, Qwik model), and the View
+  Transitions API (cross-document and same-document transitions).
+
+  Synthesizes Osmani (Learning JavaScript Design Patterns), Google Chrome team articles,
+  web.dev performance guides, Astro documentation, Qwik documentation,
+  React documentation, Archibald (Streaming rendering), Miller & Patterson
+  (Islands Architecture), and Kleppmann (data-intensive applications).
+
+  Trigger phrases: "rendering pattern", "SSR vs CSR", "SSG vs SSR",
+  "server-side rendering", "client-side rendering", "static site generation",
+  "incremental static regeneration", "ISR", "streaming SSR",
+  "progressive hydration", "partial hydration", "islands architecture",
+  "React Server Components", "RSC", "selective hydration",
+  "resumability", "Qwik", "View Transitions", "hydration cost",
+  "time to interactive", "which rendering strategy",
+  "SPA vs MPA", "multi-page app", "single-page app",
+  "slow first load", "too much JavaScript", "hydration mismatch",
+  "TTFB optimization", "FCP optimization", "LCP optimization",
+  "rendering tradeoffs", "when to use SSR", "when to use SSG"
+---
+
+# Web Rendering and Hydration Patterns
+
+## Core Philosophy
+
+1. **Rendering is a spectrum, not a binary.** No application is purely "CSR" or "SSR." Modern architectures mix strategies per route, per component, and per interaction boundary.
+2. **Ship less JavaScript to the client.** Every kilobyte of client JS has a hydration cost, a parse cost, and an interactivity delay. Minimize what the browser must execute.
+3. **Match the pattern to the content's dynamism.** Static content deserves build-time rendering. Personalized content needs server rendering. Interactive widgets need client hydration. Apply each where it fits.
+4. **Measure real user impact.** Core Web Vitals (LCP, FID/INP, CLS) are the arbiters. A pattern that improves TTFB but worsens INP is not a net win.
+
+## Quick-Start: Common Problems
+
+### "My app is slow to load"
+
+1. Profile with Lighthouse and WebPageTest to identify the bottleneck (TTFB? FCP? LCP? TTI?)
+2. High TTFB? -> Server is slow or no edge caching. Consider SSG/ISR for cacheable pages.
+3. High FCP but low TTFB? -> HTML is fast but render-blocking JS. Consider streaming SSR.
+4. High TTI with good FCP? -> Too much hydration JS. Consider islands, progressive hydration, or RSC.
+5. Large JS bundle? -> Audit client components. Move data-fetching to server, use code splitting.
+-> See `references/strategy-selection.md`
+
+### "When should I use SSR vs SSG?"
+
+1. Does every user see the same content? -> SSG (build-time) or ISR (stale-while-revalidate)
+2. Is the data user-specific or real-time? -> SSR (request-time)
+3. Can you tolerate stale data for seconds/minutes? -> ISR with revalidation interval
+4. Do you have thousands of pages? -> On-demand SSG (generate on first request, cache after)
+-> See `references/server-rendering.md`
+
+### "My SPA has poor SEO and slow initial loads"
+
+1. Add SSR or SSG for the initial paint, then hydrate for interactivity
+2. Use streaming SSR to send HTML progressively while data loads
+3. Consider islands architecture if most of the page is static
+4. Evaluate RSC to eliminate hydration cost for non-interactive parts
+-> See `references/client-rendering.md` and `references/hydration-patterns.md`
+
+### "Hydration is making my page janky"
+
+1. Audit which components actually need client-side interactivity
+2. Apply progressive hydration to defer non-visible component hydration
+3. Use selective hydration to prioritize user-interacted regions
+4. Consider islands architecture to hydrate only interactive widgets
+5. Evaluate resumability (Qwik) to eliminate replay entirely
+-> See `references/hydration-patterns.md`
+
+## Decision Trees
+
+### Rendering Strategy Selection
+
+| Content Type | Update Frequency | Personalized | Recommended Pattern |
+|---|---|---|---|
+| Marketing pages, docs, blog | Rarely | No | SSG |
+| Product listings, CMS pages | Hourly/daily | No | ISR |
+| Dashboards, feeds | Real-time | Yes | SSR (streaming) |
+| Interactive tools, editors | N/A (client state) | Yes | CSR with SSR shell |
+| Mixed (static layout + dynamic widgets) | Varies | Partial | Islands or RSC |
+| E-commerce PDP | Minutes | Partial | ISR + client-side personalization |
+
+### Hydration Strategy Selection
+
+| Scenario | Pattern | Why |
+|---|---|---|
+| Mostly static page, few interactive widgets | Islands | Hydrate only what needs it |
+| Large app, many components, prioritize above-fold | Progressive hydration | Defer below-fold hydration |
+| User clicks before hydration completes | Selective hydration | Prioritize interacted component |
+| Server-heavy data fetching, minimal client interaction | RSC | No hydration for server components |
+| Extreme performance requirements, no hydration budget | Resumability | No replay, instant interactivity |
+| Full interactivity needed everywhere | Full hydration | Standard, but minimize JS payload |
+
+### Framework Alignment
+
+| Pattern | Framework Examples |
+|---|---|
+| SSR + streaming | Next.js, Nuxt 3, SvelteKit, Remix, SolidStart |
+| SSG + ISR | Next.js, Nuxt 3, Astro, Eleventy |
+| Islands | Astro, Fresh (Deno), Marko |
+| RSC | Next.js (App Router), Waku |
+| Resumability | Qwik, QwikCity |
+| View Transitions | Astro, any MPA with the API, SPA frameworks via router |
+| CSR (SPA) | React (CRA/Vite), Vue (Vite), Angular, Svelte (SPA mode) |
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|---|---|---|
+| Full CSR for content sites | Poor SEO, slow FCP, blank screen | SSG or SSR for initial HTML |
+| SSR everything including static content | Unnecessary server load per request | SSG/ISR for static, SSR for dynamic |
+| Hydrating the entire page | TTI blocked by full JS bundle parse | Islands, progressive hydration, or RSC |
+| Ignoring streaming | Users wait for slowest data query | Stream HTML, use Suspense boundaries |
+| ISR with no fallback strategy | First visitor gets a cache miss | Use fallback: "blocking" or stale-while-revalidate |
+| Client-side data fetching for above-fold | Layout shift, waterfall requests | Fetch on server, stream the result |
+| Hydration mismatch | Console errors, visual flicker | Ensure server and client render identical initial HTML |
+
+## Reference Index
+
+| File | Contents |
+|------|----------|
+| `references/server-rendering.md` | SSR request flow, streaming SSR (chunked transfer, out-of-order streaming, Suspense boundaries), SSG build-time generation, ISR (timed + on-demand revalidation), edge rendering, cache strategies |
+| `references/hydration-patterns.md` | Full hydration cost model, progressive hydration (idle-until-urgent, visible, interaction), selective hydration (concurrent React), islands architecture (Astro model), resumability (Qwik model), RSC server/client boundaries |
+| `references/client-rendering.md` | SPA architecture, CSR tradeoffs, code splitting, lazy loading, shell pattern, SEO mitigation, when CSR is the right choice, performance optimization for SPAs |
+| `references/view-transitions.md` | View Transitions API (same-document, cross-document), animation control, fallback strategies, MPA vs SPA transitions, framework integration patterns, accessibility |
+| `references/strategy-selection.md` | Detailed tradeoff matrix (TTFB, FCP, LCP, TTI, SEO, server cost, complexity), decision flowchart, migration paths between patterns, hybrid architectures, Core Web Vitals impact per pattern |

--- a/skills/rendering-patterns/references/client-rendering.md
+++ b/skills/rendering-patterns/references/client-rendering.md
@@ -1,0 +1,253 @@
+# Client-Side Rendering and SPA Patterns
+
+Sources: Osmani (Learning JavaScript Design Patterns), Google Chrome team (web.dev), MDN Web Docs, Grigorik (High Performance Browser Networking), Miller (Web Performance in Action)
+
+Covers: SPA architecture, CSR tradeoffs, when CSR is appropriate, code splitting, lazy loading, app shell pattern, SEO strategies for SPAs, and client-side performance optimization.
+
+## Client-Side Rendering (CSR)
+
+CSR renders the entire application in the browser. The server sends a minimal HTML document with a JavaScript bundle. The browser executes the JS to build the DOM, fetch data, and render content.
+
+### CSR Request Flow
+
+1. Browser requests the page
+2. Server returns a minimal HTML shell (often just a `<div id="root">`)
+3. Browser downloads the JavaScript bundle(s)
+4. JS executes, renders the application into the DOM
+5. Application makes API calls to fetch data
+6. Content renders after data returns (First Contentful Paint)
+7. Application is immediately interactive (no hydration gap)
+
+### CSR Performance Characteristics
+
+| Metric | CSR Behavior |
+|---|---|
+| TTFB | Fast (tiny HTML document) |
+| FCP | Slow (blocked by JS download + execution + data fetch) |
+| LCP | Slow (content depends on JS + API calls) |
+| TTI | Once FCP occurs, TTI is immediate (no hydration) |
+| CLS | Risk of layout shift as data loads asynchronously |
+| INP | Good (full client-side interactivity, no server round-trips) |
+
+### CSR Tradeoffs
+
+| Advantage | Cost |
+|---|---|
+| No server runtime needed (static hosting) | Blank page until JS loads and executes |
+| Rich, app-like interactivity | Poor SEO for content-dependent pages |
+| Smooth client-side navigation (no full page reload) | Slow initial load (JS bundle + data waterfall) |
+| Simplified deployment (CDN only) | Heavy JS burden on low-end devices |
+| No hydration mismatch possible | Accessibility depends entirely on client JS |
+| Full control over rendering timing | Crawlers may not execute JS reliably |
+
+## When CSR Is the Right Choice
+
+CSR is appropriate when the following conditions align:
+
+### Strong Signals for CSR
+
+| Signal | Why CSR Fits |
+|---|---|
+| Behind authentication | No SEO needed; user waits for login anyway |
+| Highly interactive (dashboards, editors, tools) | Continuous state management benefits from client-side model |
+| Real-time collaborative features | WebSocket/SSE state lives client-side |
+| Offline-capable (PWA) | Service worker caches the app shell and data |
+| Internal enterprise tools | Controlled environment, predictable devices |
+| Canvas/WebGL applications | Rendering is inherently client-side |
+
+### Weak Signals (Reconsider CSR)
+
+| Signal | Better Alternative |
+|---|---|
+| Content must be indexed by search engines | SSR or SSG |
+| Fast first load is critical (e-commerce, media) | SSR with streaming or SSG |
+| Target audience uses low-end mobile devices | SSR to reduce client JS |
+| Marketing/landing pages | SSG for fastest possible load |
+| Content-heavy with minimal interactivity | SSG or islands architecture |
+
+## The App Shell Pattern
+
+The app shell pattern separates the UI shell (navigation, layout, chrome) from the dynamic content. The shell is cached aggressively, providing instant visual structure while content loads.
+
+### App Shell Architecture
+
+```
+App Shell (cached in Service Worker)
+  |-- Navigation bar (static, cached)
+  |-- Sidebar (static, cached)
+  |-- Content area (dynamic, loaded per route)
+  |-- Footer (static, cached)
+```
+
+### App Shell Implementation
+
+1. Pre-render or inline the shell HTML in the initial document
+2. Register a Service Worker that caches the shell and core assets
+3. On subsequent visits, the shell loads from cache instantly
+4. Route-specific content loads dynamically into the content area
+5. Offline mode displays the shell with a "no connection" message in content area
+
+### App Shell Tradeoffs
+
+| Advantage | Cost |
+|---|---|
+| Instant repeat-visit loading | First visit still requires full download |
+| Offline capability | Service Worker complexity |
+| Perceived performance (shell appears immediately) | Content area still depends on network |
+| Cacheable static assets | Cache invalidation for shell updates |
+
+## Code Splitting Strategies
+
+Code splitting divides the JavaScript bundle into smaller chunks loaded on demand. This is the most impactful optimization for CSR applications.
+
+### Splitting Strategies
+
+| Strategy | How | When to Use |
+|---|---|---|
+| Route-based splitting | Each route is a separate chunk | Default for most SPAs |
+| Component-based splitting | Heavy components loaded on demand | Modals, charts, editors, admin panels |
+| Vendor splitting | Third-party libraries in a separate chunk | When vendor code changes less than app code |
+| Feature-based splitting | Feature flags determine which code loads | A/B testing, progressive rollout |
+
+### Dynamic Import Pattern
+
+```javascript
+// Route-based: load component when route is visited
+const Dashboard = lazy(() => import('./pages/Dashboard'));
+
+// Component-based: load heavy library on interaction
+const openEditor = async () => {
+  const { Editor } = await import('./components/Editor');
+  mountEditor(Editor);
+};
+```
+
+### Code Splitting Targets
+
+| Target | Threshold | Action |
+|---|---|---|
+| Initial JS bundle | > 200KB compressed | Split aggressively |
+| Individual chunk | > 100KB compressed | Consider further splitting |
+| Third-party dependency | > 50KB | Evaluate alternatives or lazy load |
+| Total page JS | > 500KB compressed | Audit necessity of each dependency |
+
+## Lazy Loading Patterns
+
+### Component Lazy Loading
+
+| Pattern | Implementation | Use Case |
+|---|---|---|
+| Route-level lazy | Dynamic import at router level | Every route after the initial one |
+| Below-fold lazy | IntersectionObserver triggers import | Long scrolling pages |
+| Interaction-triggered | Import on hover, click, or focus | Heavy widgets (chat, video, maps) |
+| Conditional lazy | Import based on feature flag or user role | Admin panels, premium features |
+
+### Image Lazy Loading
+
+| Approach | Method | Browser Support |
+|---|---|---|
+| Native lazy loading | `loading="lazy"` attribute | All modern browsers |
+| IntersectionObserver | JS-based, more control | All modern browsers |
+| CSS `content-visibility` | Defers rendering of off-screen content | Chromium-based |
+
+### Prefetching and Preloading
+
+| Technique | When | Effect |
+|---|---|---|
+| `<link rel="prefetch">` | Idle time | Fetch resource for likely next navigation |
+| `<link rel="preload">` | Immediately | Fetch critical resource for current page |
+| `<link rel="modulepreload">` | Immediately | Preload JS module with dependency resolution |
+| Route prefetch on hover | User hovers a link | Load the route chunk before click |
+| Predictive prefetch | Based on analytics | Preload likely next pages |
+
+## SEO Strategies for SPAs
+
+### SEO Mitigation Options
+
+| Strategy | How | Tradeoff |
+|---|---|---|
+| Pre-rendering | Generate static HTML at build time for known routes | Only works for routes known at build time |
+| Dynamic rendering | Serve pre-rendered HTML to bots, SPA to users | Cloaking risk, maintenance burden |
+| SSR for critical pages | Hybrid: SSR for landing/product pages, CSR for app | Architecture complexity |
+| Meta framework migration | Move to Next.js, Nuxt, SvelteKit | Full SSR/SSG with SPA-like navigation |
+
+### Search Engine JS Rendering
+
+| Search Engine | JS Rendering Support |
+|---|---|
+| Google | Renders JS but with delay (hours to days for indexing) |
+| Bing | Limited JS rendering |
+| DuckDuckGo | Relies on Bing's index |
+| Social crawlers (Twitter, Facebook) | No JS rendering (Open Graph tags must be in initial HTML) |
+
+### Minimum SEO for SPAs
+
+1. Set unique `<title>` and `<meta name="description">` per route (via document head management)
+2. Use `history.pushState` for clean URLs (no hash routing)
+3. Provide a sitemap.xml for all indexable routes
+4. Include Open Graph and Twitter Card meta tags in server-rendered HTML or pre-rendered pages
+5. Implement canonical URLs to prevent duplicate content
+
+## Client-Side Performance Optimization
+
+### Rendering Performance
+
+| Technique | Effect |
+|---|---|
+| Virtualize long lists | Only render visible items (react-window, TanStack Virtual) |
+| Debounce expensive renders | Avoid re-rendering on every keystroke |
+| Memoize computed values | Prevent redundant calculations |
+| Use CSS transforms for animations | Avoid layout/paint triggers |
+| Batch DOM updates | Minimize reflows |
+| Avoid forced synchronous layouts | Read layout properties before writing |
+
+### Network Performance
+
+| Technique | Effect |
+|---|---|
+| Request deduplication | Avoid redundant API calls for the same data |
+| Stale-while-revalidate | Show cached data, refresh in background |
+| Optimistic updates | Update UI before server confirms |
+| Request batching | Combine multiple API calls into one |
+| Compression (Brotli/gzip) | Reduce transfer size |
+| CDN for static assets | Serve from nearest edge |
+
+### Bundle Size Management
+
+| Practice | Why |
+|---|---|
+| Analyze with bundlephobia or bundlewatch | Know what you ship |
+| Tree-shake unused exports | Remove dead code |
+| Replace heavy libraries with lighter alternatives | moment -> date-fns/dayjs, lodash -> native |
+| Use `sideEffects: false` in package.json | Enable tree shaking for your code |
+| Set size budgets in CI | Prevent bundle regression |
+
+### Client-Side Data Caching
+
+| Pattern | Implementation | Use Case |
+|---|---|---|
+| In-memory cache | TanStack Query, SWR, Apollo Client | API response caching with staleness |
+| Service Worker cache | Cache API in SW | Offline-first, repeat visits |
+| IndexedDB | Structured client-side storage | Large datasets, offline data |
+| LocalStorage | Key-value string storage | Small config, user preferences |
+
+## SPA Navigation Patterns
+
+### Client-Side Routing
+
+| Pattern | Characteristic |
+|---|---|
+| History API (`pushState`) | Clean URLs, SEO-friendly, requires server fallback |
+| Hash routing (`#/path`) | No server config needed, not SEO-friendly |
+| File-system routing | Convention-based (Next.js, Nuxt, SvelteKit) |
+
+### Navigation Performance
+
+| Technique | Effect |
+|---|---|
+| Route-level code splitting | Only load JS for the target route |
+| Prefetch on link hover | Start loading before click |
+| Skeleton screens during transition | Perceived instant navigation |
+| Optimistic navigation | Show target layout before data loads |
+| Back/forward cache | Restore previous page state from memory |
+| View Transitions API | Animated transitions between navigations |

--- a/skills/rendering-patterns/references/hydration-patterns.md
+++ b/skills/rendering-patterns/references/hydration-patterns.md
@@ -1,0 +1,255 @@
+# Hydration Patterns
+
+Sources: Osmani (Learning JavaScript Design Patterns), Miller & Patterson (Islands Architecture), Qwik documentation (Hevery), React documentation (Server Components), Astro documentation, Google Chrome team (web.dev), Archibald (hydration analysis)
+
+Covers: full hydration cost model, progressive hydration, selective hydration, islands architecture, React Server Components, resumability, and hydration optimization techniques.
+
+## The Hydration Problem
+
+Hydration is the process of attaching JavaScript event listeners and restoring component state to server-rendered HTML. It is the primary bottleneck between First Contentful Paint (FCP) and Time to Interactive (TTI).
+
+### Full Hydration Cost
+
+When a page is fully hydrated, the browser must:
+
+1. Download the entire JavaScript bundle for the page
+2. Parse and compile the JavaScript
+3. Execute the component tree top-down to rebuild the virtual DOM
+4. Diff the virtual DOM against the server-rendered HTML
+5. Attach event listeners to every interactive element
+
+This replays the entire rendering logic client-side, even for components that will never change or respond to user interaction.
+
+### Cost Factors
+
+| Factor | Impact |
+|---|---|
+| Total JS bundle size | Download time, parse time, memory |
+| Number of components | Virtual DOM reconstruction time |
+| Component complexity | Execution time per component |
+| Third-party scripts | Compete for main thread |
+| Device capability | Low-end mobile devices are 5-10x slower than desktop |
+
+### The TTI Gap
+
+The time between FCP (user sees content) and TTI (user can interact) is the hydration gap. During this window:
+
+- Buttons appear but do not respond to clicks
+- Forms render but do not submit
+- Links look clickable but navigation does not work
+- Users perceive the page as broken or laggy
+
+## Progressive Hydration
+
+Progressive hydration defers the hydration of non-critical components, reducing the initial JS execution and closing the TTI gap for above-fold content.
+
+### Hydration Triggers
+
+| Trigger | When Component Hydrates | Use Case |
+|---|---|---|
+| Idle | When the main thread is idle (requestIdleCallback) | Below-fold content, non-urgent UI |
+| Visible | When the component enters the viewport (IntersectionObserver) | Long pages, lazy sections |
+| Interaction | When the user hovers, clicks, or focuses | Heavy widgets the user may never reach |
+| Media query | When a viewport condition is met | Mobile-only or desktop-only components |
+| Never | Component is never hydrated (static HTML only) | Purely presentational content |
+
+### Implementation Pattern
+
+```
+Server renders full HTML
+  -> Browser paints immediately (FCP)
+  -> Critical above-fold components hydrate first
+  -> Below-fold components register IntersectionObserver
+  -> When scrolled into view, lazy-load JS chunk and hydrate
+  -> Components the user never scrolls to are never hydrated
+```
+
+### Progressive Hydration Tradeoffs
+
+| Advantage | Cost |
+|---|---|
+| Faster TTI for above-fold content | Complexity in defining hydration boundaries |
+| Less initial JS execution | Brief non-interactive window for deferred components |
+| Reduced main thread blocking | Must handle interaction before hydration (queue or ignore) |
+| Works with existing component models | Framework support varies |
+
+## Selective Hydration
+
+Selective hydration, introduced with React 18's concurrent features, prioritizes hydrating components that the user is actively interacting with.
+
+### How It Works
+
+1. React streams server-rendered HTML with Suspense boundaries
+2. JavaScript chunks load asynchronously per Suspense boundary
+3. React begins hydrating components in tree order
+4. If the user clicks a component that is not yet hydrated:
+   - React interrupts current hydration
+   - Prioritizes hydrating the clicked component
+   - Resumes other hydration after the priority component is interactive
+
+### Selective Hydration vs Progressive Hydration
+
+| Aspect | Progressive | Selective |
+|---|---|---|
+| Trigger | Developer-defined (visible, idle, interaction) | User interaction (automatic) |
+| Priority | Static priority order | Dynamic, responds to user intent |
+| Framework coupling | Can be framework-agnostic | React 18+ specific (concurrent mode) |
+| Granularity | Per component/section | Per Suspense boundary |
+| Developer effort | Must configure triggers | Automatic with Suspense boundaries |
+
+## Islands Architecture
+
+Islands architecture renders a static HTML page with isolated interactive "islands." Each island is an independent component that hydrates separately. The rest of the page is pure HTML with zero JavaScript.
+
+### Core Model
+
+```
+Static HTML Page (no JS)
+  |-- [Static Header]        <- pure HTML, no hydration
+  |-- [Static Hero]           <- pure HTML, no hydration
+  |-- [Interactive Carousel]  <- island, independent JS bundle, hydrates
+  |-- [Static Content]        <- pure HTML, no hydration
+  |-- [Interactive Comments]  <- island, independent JS bundle, hydrates
+  |-- [Static Footer]         <- pure HTML, no hydration
+```
+
+### Islands Characteristics
+
+| Aspect | Detail |
+|---|---|
+| JS payload | Only for interactive islands (often 10-30% of full hydration) |
+| Hydration scope | Each island hydrates independently, no shared state |
+| Static content | Zero JS cost, rendered once at build time or server time |
+| Component framework | Islands can use different frameworks on the same page |
+| State sharing | Not built-in; requires explicit mechanisms (events, stores) |
+| SEO | Full HTML available to crawlers |
+
+### Islands Tradeoffs
+
+| Advantage | Cost |
+|---|---|
+| Minimal JS shipped to client | No automatic state sharing between islands |
+| Each island is independently cacheable | Requires rethinking component architecture |
+| Static content has zero JS overhead | Complex interactions spanning multiple islands are harder |
+| Progressive enhancement by default | Framework ecosystem is smaller (Astro, Fresh, Marko) |
+| Fast TTI for mostly-static pages | Not suitable for highly interactive applications |
+
+### When to Use Islands
+
+- Content-heavy sites with isolated interactive widgets
+- Marketing pages with a few dynamic elements (forms, carousels)
+- Documentation sites with interactive code playgrounds
+- Blogs with comment sections or search
+
+### When Islands Are Not Appropriate
+
+- Highly interactive dashboards where most components have state
+- Applications with extensive cross-component state (use progressive hydration or RSC)
+- Real-time collaborative tools
+
+## React Server Components (RSC)
+
+RSC introduces a new component type that renders exclusively on the server and sends rendered output (not JS) to the client. Server Components have zero hydration cost.
+
+### Server vs Client Components
+
+| Aspect | Server Component | Client Component |
+|---|---|---|
+| Renders on | Server only | Server (SSR) + Client (hydration) |
+| JavaScript sent | None (rendered to RSC payload) | Full component JS bundle |
+| Can use hooks (useState, useEffect) | No | Yes |
+| Can access server resources (DB, filesystem) | Yes | No |
+| Can handle user interaction | No | Yes |
+| Hydration cost | Zero | Normal |
+| Re-renders on | Server action or navigation | State/prop changes |
+
+### RSC Architecture
+
+```
+Component Tree:
+  ServerLayout (server) -> no JS, renders to HTML
+    ServerNav (server) -> no JS, can query DB directly
+    ClientSearchBar (client) -> JS shipped, hydrates, handles input
+    ServerContent (server) -> no JS, renders markdown from filesystem
+    ClientComments (client) -> JS shipped, hydrates, handles posting
+    ServerFooter (server) -> no JS, renders links
+```
+
+Only `ClientSearchBar` and `ClientComments` contribute to the JS bundle.
+
+### RSC Tradeoffs
+
+| Advantage | Cost |
+|---|---|
+| Zero JS for server components | New mental model (server/client boundary) |
+| Direct server resource access (DB, APIs) | Cannot use browser APIs in server components |
+| Reduced bundle size | Framework-specific (React ecosystem only) |
+| Composable with client components | Serialization constraints at the boundary |
+| Server components can pass data to client components as props | Client components cannot import server components |
+
+### RSC vs Islands
+
+| Aspect | RSC | Islands |
+|---|---|---|
+| Granularity | Component-level server/client split | Page-level static/interactive split |
+| State sharing | Props flow from server to client components | Explicit (events, stores) |
+| Framework | React only | Framework-agnostic (Astro, Fresh, Marko) |
+| Nesting | Client inside server, server inside client (via children) | Islands are top-level, not nested |
+| Data fetching | Server components fetch directly | Islands fetch client-side or via page props |
+
+## Resumability
+
+Resumability, pioneered by Qwik, eliminates hydration entirely. Instead of replaying the application on the client, the server serializes the application state and event listener locations into the HTML. The client resumes from that state without re-executing component code.
+
+### How Resumability Works
+
+1. Server renders HTML and serializes component state, event handlers, and closures into HTML attributes
+2. HTML is sent to the client with a tiny (~1KB) runtime loader
+3. No JavaScript executes on page load (TTI equals FCP)
+4. When the user interacts with an element, the runtime:
+   - Reads the serialized handler reference from the HTML
+   - Lazy-loads only the specific handler code
+   - Executes the handler
+5. Only the code needed for the interaction is ever downloaded
+
+### Resumability vs Hydration
+
+| Aspect | Hydration (React, Vue, etc.) | Resumability (Qwik) |
+|---|---|---|
+| Startup JS execution | Replay entire component tree | Zero (state serialized in HTML) |
+| TTI | Delayed by hydration time | Instant (equals FCP) |
+| First interaction cost | Near-zero (already hydrated) | Small (lazy-load handler) |
+| JS download | Eager (full bundle or chunks) | Lazy (per-interaction) |
+| Serialization overhead | None (state in JS memory) | HTML is larger (serialized state) |
+| Framework maturity | Mature, large ecosystem | Newer, growing ecosystem |
+
+### When to Consider Resumability
+
+- Performance-critical pages where TTI must equal FCP
+- Mobile-first applications targeting low-end devices
+- Pages with many interactive elements but low interaction probability
+- Applications where hydration cost exceeds acceptable thresholds
+
+## Hydration Optimization Techniques
+
+### Reducing Hydration Cost (Framework-Agnostic)
+
+| Technique | Effect |
+|---|---|
+| Mark non-interactive components as static | Exclude from hydration tree |
+| Code split by route | Only load JS for current page |
+| Lazy load below-fold components | Defer hydration until needed |
+| Minimize third-party scripts | Reduce main thread contention |
+| Use CSS instead of JS for animations | Remove components from hydration scope |
+| Audit `useEffect` usage | Remove unnecessary client-side effects |
+| Avoid hydration mismatches | Ensure server and client render identical output |
+
+### Measuring Hydration Performance
+
+| Metric | Tool | Target |
+|---|---|---|
+| Total Blocking Time (TBT) | Lighthouse | < 200ms |
+| Time to Interactive (TTI) | Lighthouse | < 3.8s on mobile |
+| Interaction to Next Paint (INP) | CrUX, web-vitals | < 200ms |
+| JS execution time | DevTools Performance panel | Minimize long tasks > 50ms |
+| Hydration time | Custom performance marks | As close to zero as achievable |

--- a/skills/rendering-patterns/references/server-rendering.md
+++ b/skills/rendering-patterns/references/server-rendering.md
@@ -1,0 +1,267 @@
+# Server Rendering Strategies
+
+Sources: Osmani (Learning JavaScript Design Patterns), Archibald (Streaming rendering), Google Chrome team (web.dev), React documentation, Vercel engineering blog, Kleppmann (Designing Data-Intensive Applications)
+
+Covers: Server-Side Rendering (SSR), Streaming SSR, Static Site Generation (SSG), Incremental Static Regeneration (ISR), edge rendering, and server-side caching strategies.
+
+## Server-Side Rendering (SSR)
+
+SSR generates HTML on the server for each incoming request. The browser receives a fully rendered document, improving First Contentful Paint (FCP) and SEO compared to client-only rendering.
+
+### Request Flow
+
+1. Browser sends HTTP request to the server
+2. Server executes application code and data fetching
+3. Server renders the component tree to an HTML string
+4. Server sends the complete HTML response
+5. Browser paints the HTML immediately (FCP)
+6. Browser downloads and executes the JavaScript bundle
+7. Hydration attaches event listeners and restores interactivity (TTI)
+
+### SSR Tradeoffs
+
+| Advantage | Cost |
+|---|---|
+| Fast FCP for content-heavy pages | Server compute cost per request |
+| Full SEO crawlability | TTFB depends on server speed + data fetching |
+| Access to request context (cookies, headers) | Requires a running server (not just CDN) |
+| Consistent rendering across devices | Hydration gap between FCP and TTI |
+| No client-side data fetching waterfall | Server-side failures affect entire page |
+
+### When to Use SSR
+
+- Content is personalized per user (dashboards, authenticated views)
+- Data changes frequently and must be fresh on every request
+- SEO is critical and content depends on request-time data
+- The page requires access to request headers, cookies, or geo-location
+
+### When to Avoid SSR
+
+- Content is identical for all users (use SSG or ISR instead)
+- The page is purely interactive with no meaningful initial HTML
+- Server infrastructure costs are a constraint and traffic is high
+
+## Streaming SSR
+
+Streaming SSR sends HTML to the browser in chunks as the server renders, rather than waiting for the entire page to be ready. This dramatically improves TTFB and perceived performance.
+
+### How Streaming Works
+
+The server uses HTTP chunked transfer encoding to flush HTML progressively:
+
+1. Send the `<head>` and page shell immediately (TTFB is fast)
+2. Start rendering components top-to-bottom
+3. When a component's data is ready, flush its HTML chunk
+4. For components still loading, send a placeholder (Suspense fallback)
+5. When data resolves, send the completed HTML with an inline `<script>` that swaps it in
+
+### Out-of-Order Streaming
+
+Standard streaming sends HTML in document order. Out-of-order streaming (used by React 18+) allows resolved components to stream regardless of position:
+
+```
+Time 0: Shell + header + fallback placeholders
+Time 50ms: Footer data resolves -> stream footer HTML + swap script
+Time 200ms: Main content resolves -> stream main HTML + swap script
+Time 500ms: Sidebar data resolves -> stream sidebar HTML + swap script
+```
+
+The browser sees content appear progressively, and the slowest data source does not block faster ones.
+
+### Suspense Boundaries
+
+Suspense boundaries define the granularity of streaming. Each boundary is an independent streaming unit:
+
+| Boundary Granularity | Effect |
+|---|---|
+| One boundary wrapping the entire page | No benefit over non-streaming SSR |
+| One boundary per major section | Good balance of streaming and simplicity |
+| One boundary per data-fetching component | Maximum streaming granularity, more complexity |
+| Nested boundaries | Outer shell streams first, inner content fills in progressively |
+
+### Streaming SSR Tradeoffs
+
+| Advantage | Cost |
+|---|---|
+| Fast TTFB (shell streams immediately) | Requires Suspense-aware framework |
+| Progressive content reveal | Headers (status code, redirects) must be set before first flush |
+| Slow queries do not block fast ones | Error handling is more complex (partial page already sent) |
+| Better perceived performance | Response is not cacheable in traditional CDN (chunked) |
+
+## Static Site Generation (SSG)
+
+SSG renders pages to HTML at build time. The output is static files served directly from a CDN with no server runtime.
+
+### Build-Time Flow
+
+1. Build process runs the application for each route
+2. Data is fetched once during build
+3. HTML files are generated and written to disk
+4. Files are deployed to CDN edge locations
+5. Every request is served from CDN cache (TTFB is fastest possible)
+
+### SSG Tradeoffs
+
+| Advantage | Cost |
+|---|---|
+| Fastest TTFB (CDN-served static files) | Content is stale until next build |
+| No server runtime cost | Build time grows with page count |
+| Inherently cacheable and scalable | Cannot use request-time data (no cookies, headers) |
+| Works with any static hosting | Personalization requires client-side fetching |
+| Maximum reliability (no server to fail) | Dynamic routes need enumeration at build time |
+
+### When to Use SSG
+
+- Content changes infrequently (docs, marketing, blog posts)
+- All users see the same content
+- Page count is manageable (hundreds, not millions)
+- Maximum performance and reliability are priorities
+
+### SSG Limitations
+
+- **Build time scaling:** Thousands of pages create long build times. Mitigate with on-demand generation.
+- **Stale content:** Data is frozen at build time. Users may see outdated information.
+- **No request context:** Cannot tailor content based on cookies, authentication, or geo-location without client-side fetching.
+- **Dynamic routes:** Pages with URL parameters that cannot be enumerated at build time require fallback strategies.
+
+## Incremental Static Regeneration (ISR)
+
+ISR combines the performance of SSG with the freshness of SSR. Pages are statically generated but can be revalidated after deployment without a full rebuild.
+
+### Revalidation Strategies
+
+#### Time-Based Revalidation
+
+Set a `revalidate` interval (in seconds). After the interval expires:
+
+1. The next request serves the stale page immediately (fast)
+2. In the background, the server regenerates the page with fresh data
+3. Subsequent requests receive the updated page
+
+This is a stale-while-revalidate pattern applied at the page level.
+
+#### On-Demand Revalidation
+
+Trigger revalidation programmatically via an API endpoint or webhook:
+
+1. CMS publishes new content and calls the revalidation endpoint
+2. The server regenerates the specific page immediately
+3. The CDN cache is purged for that path
+4. Next request gets the fresh page
+
+### ISR Tradeoffs
+
+| Advantage | Cost |
+|---|---|
+| CDN-served (fast TTFB after first generation) | First request on uncached page may be slow |
+| Pages update without full rebuild | Requires server runtime for regeneration |
+| Scales to millions of pages | Brief window of stale content (time-based) |
+| Per-page revalidation granularity | More complex deployment infrastructure |
+
+### ISR vs SSG vs SSR Decision
+
+| Factor | SSG | ISR | SSR |
+|---|---|---|---|
+| Data freshness | Build time only | Seconds to minutes stale | Real-time |
+| TTFB (after cache) | Fastest | Fast | Depends on server |
+| Server cost | None | Low (regeneration only) | Per-request |
+| Personalization | None (server-side) | None (server-side) | Full |
+| Build time | Grows with pages | Initial build only | No build |
+| Cache strategy | CDN, immutable | CDN with revalidation | CDN with vary headers |
+
+## Edge Rendering
+
+Edge rendering executes server logic at CDN edge locations close to the user, reducing latency compared to origin-based SSR.
+
+### Edge SSR Characteristics
+
+| Aspect | Detail |
+|---|---|
+| Latency | Lower TTFB (server is geographically close) |
+| Runtime constraints | Limited compute time, memory, and API access |
+| Cold starts | Fast (lightweight runtimes like V8 isolates) |
+| Data locality | Data source may still be in one region (latency for DB queries) |
+| Use cases | Personalization at edge, A/B testing, geo-targeted content |
+
+### Edge vs Origin Rendering
+
+| Scenario | Recommended |
+|---|---|
+| Simple personalization (geo, cookies) | Edge |
+| Heavy data processing, complex queries | Origin |
+| Latency-sensitive, global audience | Edge |
+| Access to regional database | Origin (or edge with data replication) |
+| Static with minor dynamic elements | Edge (compute-at-edge for the dynamic parts) |
+
+## Server-Side Caching Strategies
+
+### Page-Level Caching
+
+| Strategy | Headers | Use Case |
+|---|---|---|
+| Full static cache | `Cache-Control: public, max-age=31536000, immutable` | SSG assets, versioned files |
+| Stale-while-revalidate | `Cache-Control: public, s-maxage=60, stale-while-revalidate=3600` | ISR pages |
+| Private, no cache | `Cache-Control: private, no-store` | Personalized SSR pages |
+| Short TTL | `Cache-Control: public, s-maxage=10` | Frequently changing pages |
+
+### Fragment Caching
+
+Cache individual page sections independently rather than entire pages. Useful when a page mixes static and dynamic content:
+
+- Cache the navigation, footer, and sidebar permanently
+- Cache the product listing for 60 seconds
+- Never cache the user greeting or cart count
+
+Fragment caching enables SSR pages to serve mostly-cached content with only the dynamic sections computed per request.
+
+### Cache Invalidation Patterns
+
+| Pattern | Mechanism | Tradeoff |
+|---|---|---|
+| TTL-based expiry | Time-based, automatic | Simple but stale window is fixed |
+| Event-driven purge | Webhook on content change | Fresh but requires pub/sub infrastructure |
+| Tag-based invalidation | Purge all pages tagged with a content ID | Granular but CDN must support tags |
+| Versioned URLs | Append content hash to URL | Immutable cache, but requires URL management |
+
+## SSR Error Handling
+
+### Error Boundaries in Server Rendering
+
+| Error Type | SSR Behavior | Streaming SSR Behavior |
+|---|---|---|
+| Data fetch failure | Return error page or fallback HTML | Stream fallback for failed Suspense boundary |
+| Component render error | Catch with error boundary, render fallback | Catch per-boundary, other sections unaffected |
+| Timeout | Return 504 or cached stale version | Flush what is ready, timeout remaining sections |
+| Partial failure | Entire page fails (all-or-nothing) | Only the failed section shows fallback |
+
+### Graceful Degradation Strategies
+
+1. Wrap data-dependent sections in error boundaries with meaningful fallbacks
+2. Set timeouts on all data fetches to prevent indefinite server hangs
+3. Use circuit breakers for downstream services to fail fast under load
+4. Return stale cached content when the origin is unavailable
+5. Log server rendering errors with request context for debugging
+6. Return appropriate HTTP status codes (500 for errors, 503 for overload)
+
+## SSR Performance Optimization
+
+### Server Render Time Reduction
+
+| Technique | Effect |
+|---|---|
+| Component-level caching | Cache rendered HTML fragments for repeated components |
+| Data fetch parallelization | Fetch all independent data sources concurrently |
+| Database connection pooling | Reduce connection overhead per request |
+| Avoid synchronous I/O in render path | Prevent blocking the event loop |
+| Pre-compute expensive derivations | Move computation to build or background workers |
+| Use streaming to unblock fast sections | Slow queries do not delay the entire response |
+
+### Monitoring SSR Performance
+
+| Metric | What to Track | Alert Threshold |
+|---|---|---|
+| Server render time (P50, P99) | Time from request to response complete | P99 > 500ms |
+| TTFB distribution | Time to first byte across all pages | P75 > 800ms |
+| Cache hit ratio | Percentage of requests served from cache | < 80% for cacheable pages |
+| Error rate | Percentage of failed server renders | > 1% |
+| Concurrent connections | Active SSR requests in flight | Near server capacity |

--- a/skills/rendering-patterns/references/strategy-selection.md
+++ b/skills/rendering-patterns/references/strategy-selection.md
@@ -1,0 +1,275 @@
+# Rendering Strategy Selection Guide
+
+Sources: Osmani (Learning JavaScript Design Patterns), Google Chrome team (web.dev), Vercel engineering blog, Shopify engineering blog, Kleppmann (Designing Data-Intensive Applications), Grigorik (High Performance Browser Networking)
+
+Covers: detailed tradeoff matrices, Core Web Vitals impact per pattern, decision flowcharts, hybrid architectures, migration paths between patterns, and capacity/cost analysis.
+
+## Core Web Vitals Impact by Pattern
+
+Each rendering pattern affects Core Web Vitals differently. Use this matrix to select a pattern based on which metrics matter most for the use case.
+
+### Metric Impact Matrix
+
+| Pattern | TTFB | FCP | LCP | TTI/INP | CLS | SEO |
+|---|---|---|---|---|---|---|
+| CSR (SPA) | Excellent | Poor | Poor | Good (post-load) | Risk | Poor |
+| SSR | Moderate | Good | Good | Moderate (hydration gap) | Low | Excellent |
+| Streaming SSR | Good | Excellent | Good | Moderate | Low | Excellent |
+| SSG | Excellent | Excellent | Excellent | Good | Low | Excellent |
+| ISR | Good (cached) | Excellent | Excellent | Good | Low | Excellent |
+| Islands | Excellent | Excellent | Excellent | Excellent | Low | Excellent |
+| RSC | Good | Good | Good | Good | Low | Excellent |
+| Resumability | Good | Good | Good | Excellent | Low | Excellent |
+
+### Rating Definitions
+
+| Rating | Meaning |
+|---|---|
+| Excellent | Consistently meets "good" thresholds with minimal effort |
+| Good | Meets thresholds with standard implementation |
+| Moderate | May need optimization to meet thresholds |
+| Poor | Difficult to meet thresholds without significant mitigation |
+| Risk | Prone to issues without explicit handling |
+
+## Decision Flowchart
+
+Follow this sequence to select a rendering strategy:
+
+### Step 1: Content Dynamism
+
+| Question | If Yes | If No |
+|---|---|---|
+| Is content identical for all users? | Go to Step 2 (static path) | Go to Step 3 (dynamic path) |
+
+### Step 2: Static Content Path
+
+| Question | If Yes | If No |
+|---|---|---|
+| Does content change less than daily? | SSG | ISR |
+| Are there more than 10,000 pages? | ISR (on-demand generation) | SSG |
+| Must content update within seconds of source change? | ISR (on-demand revalidation) | SSG or ISR (time-based) |
+
+### Step 3: Dynamic Content Path
+
+| Question | If Yes | If No |
+|---|---|---|
+| Is the page primarily interactive (dashboard, editor, tool)? | CSR or SSR + heavy client | SSR or streaming SSR |
+| Is the page behind authentication? | CSR is acceptable; SSR if SEO/FCP matters | SSR or streaming SSR |
+| Is the page content-heavy with isolated interactive elements? | Islands architecture | Continue |
+| Does the page have server-heavy data with minimal client interaction? | RSC | Continue |
+| Must TTI equal FCP (zero hydration budget)? | Resumability (Qwik) | SSR with progressive hydration |
+
+### Step 4: Hybrid Considerations
+
+| Scenario | Hybrid Approach |
+|---|---|
+| Static layout with personalized widget | SSG/ISR for page + client-side fetch for personalization |
+| Dashboard with cacheable overview | ISR for overview + SSR for real-time drilldowns |
+| E-commerce product page | ISR for product info + client-side for cart, reviews |
+| Content site with interactive features | Islands (static content + interactive islands) |
+| Large app with mixed interactivity | RSC (server components for data, client components for interaction) |
+
+## Detailed Pattern Tradeoff Analysis
+
+### Server Cost
+
+| Pattern | Server Requirement | Cost Profile |
+|---|---|---|
+| CSR | Static file hosting only | Lowest (CDN cost only) |
+| SSG | Build server + static hosting | Low (build cost only) |
+| ISR | Runtime server + CDN | Moderate (regeneration compute) |
+| SSR | Runtime server, always on | Higher (per-request compute) |
+| Streaming SSR | Runtime server with streaming support | Higher (per-request, longer connections) |
+| Edge SSR | Edge compute (V8 isolates) | Moderate (per-request, but distributed) |
+| Islands | Build server + static hosting | Low (similar to SSG) |
+| RSC | Runtime server with RSC support | Moderate (server component rendering) |
+
+### Complexity
+
+| Pattern | Implementation Complexity | Why |
+|---|---|---|
+| CSR | Low | Standard SPA, well-understood |
+| SSG | Low | Build step generates static files |
+| ISR | Moderate | Revalidation logic, cache management |
+| SSR | Moderate | Server runtime, state management, caching |
+| Streaming SSR | High | Suspense boundaries, error handling, header management |
+| Islands | Moderate | Component boundary decisions, inter-island communication |
+| RSC | High | Server/client boundary, serialization rules, mental model |
+| Resumability | Moderate (framework handles it) | Qwik framework, different mental model from React/Vue |
+
+### Scalability
+
+| Pattern | Scaling Characteristic |
+|---|---|
+| CSR | Scales infinitely (static files on CDN) |
+| SSG | Scales infinitely (static files on CDN), build time is the bottleneck |
+| ISR | Scales well (CDN-served after first generation, regeneration is bounded) |
+| SSR | Scales with server capacity (requires auto-scaling, caching, edge) |
+| Streaming SSR | Similar to SSR, but longer-lived connections increase concurrency needs |
+| Islands | Scales like SSG (static pages with cached islands) |
+| RSC | Scales with server capacity (server components add rendering load) |
+
+## Per-Route Strategy (Hybrid Architecture)
+
+Modern frameworks support per-route rendering configuration. Apply the right pattern to each route:
+
+### Example Application Architecture
+
+| Route | Content Type | Pattern | Why |
+|---|---|---|---|
+| `/` | Marketing landing | SSG | Static, cached, fastest possible |
+| `/blog/:slug` | Blog posts | SSG or ISR | Content changes infrequently |
+| `/products` | Product listing | ISR (60s) | Changes with inventory, staleness acceptable |
+| `/products/:id` | Product detail | ISR (on-demand) | Update on CMS publish webhook |
+| `/dashboard` | User dashboard | SSR (streaming) | Personalized, real-time data |
+| `/editor` | Rich text editor | CSR | Purely interactive, no SEO needed |
+| `/docs` | Documentation | SSG | Static content, maximum performance |
+| `/search` | Search results | SSR | Query-dependent, must be fresh |
+
+### Route Configuration Pattern
+
+```
+// Conceptual (framework-agnostic)
+routes:
+  - path: "/"
+    rendering: static
+    revalidate: false
+
+  - path: "/blog/:slug"
+    rendering: static
+    revalidate: 3600  // ISR: 1 hour
+
+  - path: "/dashboard"
+    rendering: server
+    streaming: true
+
+  - path: "/editor"
+    rendering: client
+```
+
+## Migration Paths
+
+### CSR to SSR
+
+| Step | Action | Risk |
+|---|---|---|
+| 1 | Audit client-side data fetching | Low |
+| 2 | Move data fetching to server (getServerSideProps, loader, etc.) | Medium (API refactoring) |
+| 3 | Handle server/client state differences | Medium (hydration mismatches) |
+| 4 | Add streaming for slow data sources | Low (incremental improvement) |
+| 5 | Optimize server response caching | Low |
+
+### SSR to SSG/ISR
+
+| Step | Action | Risk |
+|---|---|---|
+| 1 | Identify pages that do not need request-time data | Low |
+| 2 | Move those pages to static generation | Low |
+| 3 | Add ISR for pages that need periodic freshness | Low |
+| 4 | Keep SSR only for pages that require request context | Low |
+| 5 | Add on-demand revalidation for CMS-driven content | Low |
+
+### Monolithic CSR to Islands
+
+| Step | Action | Risk |
+|---|---|---|
+| 1 | Identify interactive vs static regions | Low |
+| 2 | Extract interactive regions into island components | Medium (architecture change) |
+| 3 | Render the page as static HTML with island placeholders | Medium |
+| 4 | Each island loads its own JS bundle independently | Low |
+| 5 | Remove the global app shell and client-side router | High (significant refactor) |
+
+### SSR to RSC
+
+| Step | Action | Risk |
+|---|---|---|
+| 1 | Identify components that do not use hooks or browser APIs | Low |
+| 2 | Mark those as Server Components (remove "use client") | Low |
+| 3 | Move data fetching into Server Components (direct DB/API access) | Medium |
+| 4 | Define clear server/client boundaries | Medium |
+| 5 | Audit bundle size reduction | Low |
+
+## Capacity and Performance Budgets
+
+### Performance Budget by Pattern
+
+| Metric | Budget (Mobile 3G) | Budget (Desktop) |
+|---|---|---|
+| TTFB | < 800ms | < 200ms |
+| FCP | < 1.8s | < 1.0s |
+| LCP | < 2.5s | < 1.5s |
+| TTI | < 3.8s | < 2.0s |
+| TBT | < 200ms | < 100ms |
+| CLS | < 0.1 | < 0.1 |
+| INP | < 200ms | < 100ms |
+
+### JS Budget Guidelines
+
+| Page Type | Max JS (compressed) | Rationale |
+|---|---|---|
+| Static content page | < 50KB | Minimal interactivity needed |
+| Standard web page | < 150KB | Balance of features and performance |
+| Interactive application | < 300KB | Code-split aggressively beyond this |
+| Complex SPA (dashboard) | < 500KB | Accept slower initial load for functionality |
+
+### Server Capacity Planning for SSR
+
+| Factor | Estimation Approach |
+|---|---|
+| Render time per page | Benchmark: measure P50 and P99 render times |
+| Concurrent requests | Server CPUs x (1000ms / render_time_ms) |
+| Cache hit ratio target | 80-95% for ISR, reduces origin load proportionally |
+| Edge compute | Reduces origin load, adds per-request cost at edge |
+| Streaming overhead | Longer-lived connections, plan for higher concurrency |
+
+## Pattern Comparison Summary
+
+| Dimension | CSR | SSR | Streaming | SSG | ISR | Islands | RSC | Resumability |
+|---|---|---|---|---|---|---|---|---|
+| First load speed | Slow | Moderate | Fast | Fastest | Fast | Fastest | Fast | Fast |
+| Interactivity | Instant | Delayed | Delayed | Fast | Fast | Instant (islands) | Fast | Instant |
+| SEO | Poor | Good | Good | Good | Good | Good | Good | Good |
+| Server cost | None | High | High | None | Low | None | Moderate | Low |
+| Complexity | Low | Moderate | High | Low | Moderate | Moderate | High | Moderate |
+| JS shipped | All | All | All | Minimal | Minimal | Islands only | Client only | Per-interaction |
+| Data freshness | Real-time | Real-time | Real-time | Build time | Configurable | Build/server | Real-time | Real-time |
+| Best for | Apps | Dynamic pages | Slow data | Static sites | Hybrid | Content sites | React apps | Perf-critical |
+
+## Common Mistakes by Application Type
+
+### E-Commerce
+
+| Mistake | Why It Hurts | Correct Approach |
+|---|---|---|
+| CSR for product pages | Poor SEO, slow LCP, lost sales | ISR for product pages, SSR for search |
+| SSR for every page including static ones | Unnecessary server cost | SSG/ISR for marketing, SSR for dynamic |
+| No streaming for checkout | Slow payment form load | Stream checkout form, prefetch payment SDK |
+
+### Content/Media Sites
+
+| Mistake | Why It Hurts | Correct Approach |
+|---|---|---|
+| SSR for articles that rarely change | Wasted server compute | SSG or ISR with long revalidation |
+| Full hydration for read-only content | Unnecessary JS for non-interactive pages | Islands for interactive widgets only |
+| No edge caching | High TTFB for global audiences | CDN with aggressive caching, ISR |
+
+### SaaS Dashboards
+
+| Mistake | Why It Hurts | Correct Approach |
+|---|---|---|
+| SSG for personalized dashboards | Cannot use request-time data | SSR with streaming for data-heavy views |
+| No code splitting | Entire app loads on first page | Route-based splitting, lazy load heavy views |
+| Hydrating the entire dashboard shell | Slow TTI on complex layouts | Progressive hydration, RSC for data display |
+
+## Framework Selection by Pattern Priority
+
+| If Primary Pattern Is | Consider These Frameworks |
+|---|---|
+| SSG-first | Astro, Eleventy, Hugo |
+| ISR-first | Next.js, Nuxt 3 |
+| SSR + Streaming | Next.js (App Router), Remix, SolidStart |
+| Islands | Astro, Fresh (Deno), Marko |
+| RSC | Next.js (App Router), Waku |
+| Resumability | Qwik, QwikCity |
+| CSR/SPA | React (Vite), Vue (Vite), Angular, Svelte |
+| MPA with transitions | Astro, any framework + View Transitions API |

--- a/skills/rendering-patterns/references/view-transitions.md
+++ b/skills/rendering-patterns/references/view-transitions.md
@@ -1,0 +1,331 @@
+# View Transitions API
+
+Sources: Google Chrome team (web.dev/view-transitions), MDN Web Docs, Archibald (View Transitions explainer), Astro documentation, CSS Working Group specification, Chrome Platform Status
+
+Covers: same-document transitions, cross-document transitions, animation control, fallback strategies, MPA vs SPA transitions, framework integration, accessibility, and performance considerations.
+
+## Overview
+
+The View Transitions API provides a native browser mechanism for animating between visual states during navigation or DOM updates. It captures a screenshot of the old state, applies the DOM update, and crossfades to the new state with customizable CSS animations.
+
+### Core Mechanism
+
+1. Browser captures a screenshot of the old state (creates "old" pseudo-elements)
+2. DOM update is applied (navigation or state change)
+3. Browser captures the new state (creates "new" pseudo-elements)
+4. A crossfade animation runs between old and new states
+5. On completion, pseudo-elements are removed and the real DOM is shown
+
+### Browser Support
+
+| Browser | Same-Document | Cross-Document |
+|---|---|---|
+| Chrome 111+ | Yes | Yes (Chrome 126+) |
+| Edge 111+ | Yes | Yes (Edge 126+) |
+| Safari 18+ | Yes | Yes |
+| Firefox 135+ | Yes | Partial |
+
+## Same-Document View Transitions (SPA)
+
+Same-document transitions animate between states within a single page. This is the foundation for SPA route transitions.
+
+### Basic API
+
+```javascript
+// Trigger a view transition
+document.startViewTransition(() => {
+  // Update the DOM
+  updateContent(newContent);
+});
+
+// With async updates
+document.startViewTransition(async () => {
+  const data = await fetchPageData(url);
+  renderPage(data);
+});
+```
+
+### Transition Lifecycle
+
+| Phase | What Happens | Controllable |
+|---|---|---|
+| Capture old state | Browser screenshots current rendered content | No (automatic) |
+| DOM update | Callback function runs, modifies the DOM | Yes (your code) |
+| Capture new state | Browser screenshots the updated DOM | No (automatic) |
+| Animation | Crossfade between old and new screenshots | Yes (CSS) |
+| Cleanup | Pseudo-elements removed, real DOM exposed | No (automatic) |
+
+### ViewTransition Object
+
+```javascript
+const transition = document.startViewTransition(updateDOM);
+
+// Promises for lifecycle control
+transition.ready       // Resolves when animation pseudo-elements are created
+transition.updateCallbackDone  // Resolves when DOM update callback completes
+transition.finished    // Resolves when animation completes and cleanup is done
+
+// Skip the animation
+transition.skipTransition();
+```
+
+## Cross-Document View Transitions (MPA)
+
+Cross-document transitions animate between full page navigations. This brings SPA-like visual continuity to multi-page applications without JavaScript routers.
+
+### Enabling Cross-Document Transitions
+
+```css
+/* Opt in via CSS on both the old and new pages */
+@view-transition {
+  navigation: auto;
+}
+```
+
+Both pages must opt in. The browser automatically creates a view transition on same-origin navigations.
+
+### Cross-Document Transition Flow
+
+1. User clicks a link (same-origin navigation)
+2. Browser captures old page screenshot
+3. Navigation occurs (new page loads)
+4. New page's first render is captured
+5. Crossfade animation runs
+6. New page is shown
+
+### Cross-Document Considerations
+
+| Aspect | Detail |
+|---|---|
+| Opt-in required | Both old and new pages must include `@view-transition { navigation: auto; }` |
+| Same-origin only | Cross-origin navigations cannot use view transitions |
+| Navigation types | Works with link clicks, form submissions, back/forward |
+| Render blocking | New page rendering may be slightly delayed to coordinate transition |
+| Fallback | Non-supporting browsers perform standard navigation (no breakage) |
+
+## Naming and Targeting Elements
+
+### `view-transition-name`
+
+Assign names to elements that should animate individually rather than as part of the page-wide crossfade:
+
+```css
+.hero-image {
+  view-transition-name: hero;
+}
+
+.page-title {
+  view-transition-name: title;
+}
+```
+
+Named elements animate independently: the browser tracks the old and new positions of elements with the same `view-transition-name` and creates a smooth morph animation between them.
+
+### Rules for `view-transition-name`
+
+| Rule | Detail |
+|---|---|
+| Must be unique per page | Two elements cannot share the same name in the same document |
+| Applied to the element, not a class | Each named element is tracked independently |
+| `none` is the default | Elements without a name participate in the root transition |
+| Dynamic assignment | Assign names via JS/CSS before starting the transition |
+| The name `auto` | Generates a unique name automatically (useful for list items) |
+
+### The Pseudo-Element Tree
+
+During a transition, the browser creates a pseudo-element tree:
+
+```
+::view-transition
+  ::view-transition-group(name)
+    ::view-transition-image-pair(name)
+      ::view-transition-old(name)     <- screenshot of old state
+      ::view-transition-new(name)     <- screenshot of new state
+```
+
+The `root` group captures everything not explicitly named.
+
+## Custom Animations
+
+### Overriding the Default Crossfade
+
+```css
+/* Custom fade duration */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 0.3s;
+}
+
+/* Slide animation for a named element */
+@keyframes slide-from-right {
+  from { transform: translateX(100%); }
+}
+
+@keyframes slide-to-left {
+  to { transform: translateX(-100%); }
+}
+
+::view-transition-old(content) {
+  animation: slide-to-left 0.3s ease-out both;
+}
+
+::view-transition-new(content) {
+  animation: slide-from-right 0.3s ease-out both;
+}
+```
+
+### Common Animation Patterns
+
+| Pattern | Old State Animation | New State Animation |
+|---|---|---|
+| Crossfade (default) | Fade out | Fade in |
+| Slide left | Slide out to left | Slide in from right |
+| Slide up | Slide out upward | Slide in from bottom |
+| Scale | Scale down + fade out | Scale up + fade in |
+| Morph (named) | Automatic position/size interpolation | Automatic |
+| None (instant) | `animation: none` | `animation: none` |
+
+### Directional Transitions
+
+Apply different animations based on navigation direction:
+
+```css
+/* Forward navigation */
+.transition-forward::view-transition-old(content) {
+  animation: slide-to-left 0.25s ease-out;
+}
+.transition-forward::view-transition-new(content) {
+  animation: slide-from-right 0.25s ease-out;
+}
+
+/* Back navigation */
+.transition-back::view-transition-old(content) {
+  animation: slide-to-right 0.25s ease-out;
+}
+.transition-back::view-transition-new(content) {
+  animation: slide-from-left 0.25s ease-out;
+}
+```
+
+In JavaScript, set the class on `<html>` before starting the transition based on navigation type or history state comparison.
+
+### Shared Element Transitions
+
+Named elements on both the old and new pages automatically receive a morph animation:
+
+```css
+/* Old page: product card image */
+.product-card img { view-transition-name: product-image; }
+
+/* New page: product detail hero image */
+.product-detail .hero { view-transition-name: product-image; }
+```
+
+The browser interpolates position, size, and aspect ratio between the two states.
+
+## Framework Integration
+
+### SPA Frameworks
+
+| Framework | Integration Approach |
+|---|---|
+| React (React Router) | Wrap `navigate()` in `document.startViewTransition()` |
+| Vue (Vue Router) | Use `router.beforeResolve` hook with `startViewTransition` |
+| Svelte (SvelteKit) | Built-in `onNavigate` lifecycle hook supports view transitions |
+| Angular | `withViewTransitions()` in router configuration |
+| Astro | Built-in `<ViewTransitions />` component for MPA transitions |
+
+### Astro Integration
+
+Astro provides first-class cross-document view transition support:
+
+```astro
+---
+import { ViewTransitions } from 'astro:transitions';
+---
+<head>
+  <ViewTransitions />
+</head>
+```
+
+Astro handles the opt-in CSS, transition name management, and client-side script persistence across navigations.
+
+### Integration Pattern for SPAs
+
+```javascript
+// Generic SPA integration
+function navigateWithTransition(url, updateFn) {
+  if (!document.startViewTransition) {
+    updateFn();  // Fallback: instant update
+    return;
+  }
+  document.startViewTransition(() => updateFn());
+}
+```
+
+## Accessibility
+
+### Reduced Motion
+
+Respect the user's motion preference:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation-duration: 0.01s !important;
+  }
+}
+```
+
+This effectively makes the transition instant without disabling the API.
+
+### Screen Readers
+
+| Concern | Mitigation |
+|---|---|
+| Transition animations are visual only | Screen readers are not affected |
+| Focus management | Ensure focus moves to appropriate element after transition |
+| Content announcement | Use `aria-live` regions for dynamic content updates |
+| Navigation feedback | Ensure route changes update the document title |
+
+## Performance Considerations
+
+### Transition Performance
+
+| Factor | Impact | Mitigation |
+|---|---|---|
+| Large page screenshots | Memory for capturing old/new states | Limit transition scope with named elements |
+| Complex CSS animations | GPU compositing, paint cost | Use `transform` and `opacity` only |
+| DOM update during transition | Long task blocks transition start | Keep DOM updates fast, defer heavy work |
+| Concurrent transitions | Multiple transitions queue or conflict | Skip previous transition before starting new one |
+
+### Performance Best Practices
+
+1. Keep animation duration short (200-400ms recommended)
+2. Use `transform` and `opacity` for GPU-accelerated animations
+3. Name only elements that need individual animation (not every element)
+4. Skip transitions on slow connections or low-end devices
+5. Avoid layout-triggering properties in transition animations
+6. Test on mobile devices where GPU memory is limited
+
+## Fallback Strategies
+
+### Progressive Enhancement
+
+```javascript
+function navigate(url) {
+  if (document.startViewTransition) {
+    document.startViewTransition(() => loadPage(url));
+  } else {
+    loadPage(url);  // Works without transitions
+  }
+}
+```
+
+The View Transitions API is designed for progressive enhancement. Non-supporting browsers receive standard navigation or instant DOM updates with no degradation.
+
+### Polyfill Considerations
+
+There is no full polyfill for View Transitions. The API requires browser-level screenshot capabilities. For older browsers, use CSS animations triggered on route change as a visual approximation.

--- a/skills/rendering-patterns/tank.json
+++ b/skills/rendering-patterns/tank.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/rendering-patterns",
+  "version": "1.0.0",
+  "description": "Framework-agnostic web rendering and hydration patterns. CSR, SSR, SSG, ISR, streaming SSR, progressive hydration, islands architecture, React Server Components, selective hydration, resumability, View Transitions API. Covers pattern selection, tradeoff analysis, and Core Web Vitals impact. Triggers: rendering pattern, SSR vs CSR, SSG, ISR, streaming SSR, progressive hydration, islands architecture, RSC, resumability, Qwik, View Transitions, hydration cost, SPA vs MPA.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}

--- a/skills/vite-mastery/SKILL.md
+++ b/skills/vite-mastery/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: "@tank/vite-mastery"
+description: |
+  Comprehensive Vite build tool mastery. Covers vite.config.ts authoring
+  (resolve aliases, define, env variables, conditional config), development
+  server (HMR, proxy, HTTPS, custom middleware), build optimization (Rollup
+  options, manual chunks, code splitting, minification, CSS splitting, asset
+  inlining), plugin development (hooks, virtual modules, transform pipeline,
+  enforce ordering), SSR (entry, externalization, streaming, hydration),
+  library mode (build.lib, externals, multiple formats, CSS extraction),
+  PWA via vite-plugin-pwa (workbox, manifest, offline), environment and
+  mode configuration (.env, import.meta.env), and performance profiling
+  (rollup-plugin-visualizer, optimizeDeps, pre-bundling). Synthesizes
+  Vite official documentation (vitejs.dev), Rollup documentation, esbuild
+  documentation, Evan You (Vite design philosophy), and community
+  optimization guides.
+
+  Trigger phrases: "vite", "vite config", "vite.config.ts", "vite build",
+  "vite dev server", "vite HMR", "vite proxy", "vite plugin", "vite SSR",
+  "vite library mode", "build.lib", "rollup options", "manual chunks",
+  "code splitting vite", "vite optimize", "optimizeDeps", "vite PWA",
+  "vite-plugin-pwa", "import.meta.env", "vite env variables", "vite resolve alias",
+  "vite chunk splitting", "vite bundle size", "bundle too large",
+  "vite performance", "rollup-plugin-visualizer", "vite define",
+  "vite CSS splitting", "vite asset inlining", "virtual module vite",
+  "vite conditional config", "vite HTTPS", "vite middleware"
+---
+
+# Vite Mastery
+
+Configure, optimize, and extend Vite builds for any frontend project.
+
+## Core Philosophy
+
+1. **Unbundled dev, bundled prod.** Dev uses native ESM for speed; prod uses Rollup for optimization. Understand both pipelines.
+2. **Convention over configuration.** Vite works out of the box. Only configure what you measured needs changing.
+3. **Measure before splitting.** Never add manual chunks, change minifiers, or adjust thresholds without profiling first.
+4. **Plugins are Rollup hooks + Vite extras.** Master Rollup's plugin interface and Vite's extensions on top of it.
+5. **Environment isolation is non-negotiable.** Env variables must never leak between modes or between client and server.
+
+## Quick-Start: Common Problems
+
+### "Bundle too large"
+
+1. Run `npx vite-bundle-visualizer` or add `rollup-plugin-visualizer` to see what's in the bundle.
+2. Check for accidentally bundled server-only code or dev dependencies.
+3. Apply manual chunks for large vendor libraries.
+   -> See `references/build-optimization.md` for chunk splitting strategies.
+
+### "HMR not working"
+
+1. Verify the file is within the project root (files outside root bypass HMR).
+2. Check for circular imports — Vite's HMR propagation fails on cycles.
+3. Ensure the framework plugin is loaded (`@vitejs/plugin-react`, `@vitejs/plugin-vue`).
+4. Check `server.hmr` config if behind a reverse proxy.
+   -> See `references/configuration-and-dev-server.md` for proxy and HMR config.
+
+### "Module not found / resolve errors"
+
+1. Check `resolve.alias` paths — use `path.resolve(__dirname, ...)` or `fileURLToPath`.
+2. Verify `optimizeDeps.include` for CJS dependencies that fail pre-bundling.
+3. Check `ssr.noExternal` for SSR builds that need to bundle specific packages.
+   -> See `references/configuration-and-dev-server.md` for resolve configuration.
+
+### "Env variables undefined"
+
+1. Confirm the variable is prefixed with `VITE_` (only `VITE_*` vars are exposed to client).
+2. Use `import.meta.env.VITE_*` — not `process.env`.
+3. Verify the `.env` file matches the current mode (`.env.production`, `.env.staging`).
+   -> See `references/environment-pwa-tooling.md` for env and mode configuration.
+
+## Configuration Decision Trees
+
+| Signal | Recommendation |
+| --- | --- |
+| Need path shortcuts | `resolve.alias` with absolute paths |
+| CJS dependency fails in dev | Add to `optimizeDeps.include` |
+| Need compile-time constants | `define` with `JSON.stringify` |
+| Need different config per mode | Export a function: `export default defineConfig(({ mode }) => ...)` |
+| API calls hit CORS in dev | `server.proxy` with `changeOrigin: true` |
+| Bundle > 500kB gzipped | Profile with visualizer, apply manual chunks |
+| Building a library | Use `build.lib` with external dependencies |
+| Need SSR | Configure `ssr.entry` and `ssr.noExternal` |
+| Need offline support | Add `vite-plugin-pwa` with workbox strategies |
+
+## Build Optimization Decision Tree
+
+| Symptom | Diagnostic | Fix |
+| --- | --- | --- |
+| Large single chunk | No code splitting | Add dynamic imports at route boundaries |
+| Vendor chunk > 250kB | Single vendor bundle | Split with `manualChunks` by domain |
+| Duplicate modules across chunks | Shared deps not extracted | Rollup handles this automatically; verify with visualizer |
+| Slow minification | Using terser | Switch to esbuild (default) unless terser features needed |
+| Large CSS bundle | All CSS in one file | Enable `build.cssCodeSplit` (default true) |
+| Small assets bloating requests | Too many HTTP requests for tiny files | Increase `build.assetsInlineLimit` (default 4096 bytes) |
+
+## Plugin Selection Guide
+
+| Need | Plugin | Notes |
+| --- | --- | --- |
+| React Fast Refresh | `@vitejs/plugin-react` | Uses Babel. Use `@vitejs/plugin-react-swc` for speed. |
+| Vue SFC support | `@vitejs/plugin-vue` | Required for `.vue` files |
+| Svelte support | `@sveltejs/vite-plugin-svelte` | Required for `.svelte` files |
+| Legacy browser support | `@vitejs/plugin-legacy` | Generates polyfilled chunks |
+| PWA / service worker | `vite-plugin-pwa` | Workbox integration |
+| Bundle analysis | `rollup-plugin-visualizer` | Add in build only |
+| SVG as components | `vite-plugin-svgr` (React) | Framework-specific |
+| Environment validation | `@t3-oss/env-core` | Validates env at build time |
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It Fails | Fix |
+| --- | --- | --- |
+| Importing `process.env` in client code | Undefined in browser; Vite uses `import.meta.env` | Replace with `import.meta.env.VITE_*` |
+| Using `__dirname` in vite.config.ts | Fails with ESM config format | Use `fileURLToPath(new URL('.', import.meta.url))` |
+| Splitting every dependency into its own chunk | Creates waterfall of HTTP requests | Group by domain (e.g., `react-vendor`, `ui-vendor`) |
+| Disabling pre-bundling globally | Breaks dev server performance | Only exclude specific packages with `optimizeDeps.exclude` |
+| Putting secrets in `VITE_*` env vars | Exposed in client bundle | Only prefix public values with `VITE_` |
+| Running terser in dev | Destroys dev server speed | Terser is prod-only by default; never change this |
+| Giant `vite.config.ts` with all logic inline | Unmaintainable | Extract plugin factories and helper functions |
+| Ignoring `build.rollupOptions.output.manualChunks` return value | Orphaned modules in wrong chunks | Always return a string or `undefined`, never skip |
+
+## Reference Index
+
+| File | Contents |
+| --- | --- |
+| `references/configuration-and-dev-server.md` | vite.config.ts structure, resolve aliases, define, conditional config, dev server, HMR, proxy, HTTPS, middleware |
+| `references/build-optimization.md` | Rollup options, manual chunks, code splitting strategies, minification, CSS code splitting, asset inlining, tree-shaking |
+| `references/plugin-development.md` | Plugin hooks, virtual modules, transform pipeline, enforce ordering, HMR API, plugin testing |
+| `references/ssr-and-library-mode.md` | SSR entry, externalization, streaming, client hydration, build.lib, external deps, multiple formats, CSS extraction |
+| `references/environment-pwa-tooling.md` | .env files, import.meta.env, mode config, vite-plugin-pwa, workbox strategies, rollup-plugin-visualizer, optimizeDeps |

--- a/skills/vite-mastery/references/build-optimization.md
+++ b/skills/vite-mastery/references/build-optimization.md
@@ -1,0 +1,379 @@
+# Build Optimization
+
+Sources: Vite official documentation (vitejs.dev), Rollup documentation, esbuild documentation, community optimization guides
+
+Covers Vite-specific build configuration: Rollup output options, manual chunks,
+minification (esbuild vs terser), CSS code splitting, asset inlining thresholds,
+and build performance profiling. For framework-agnostic code splitting concepts
+and bundle analysis tools, see `@tank/web-performance` references/bundle-optimization.md.
+
+## Build Defaults
+
+Vite's production build uses Rollup with sensible defaults:
+
+```ts
+export default defineConfig({
+  build: {
+    target: 'modules',          // browsers supporting native ESM
+    outDir: 'dist',             // output directory
+    assetsDir: 'assets',        // nested directory for generated assets
+    sourcemap: false,           // true | 'inline' | 'hidden'
+    minify: 'esbuild',         // 'esbuild' (fast) | 'terser' (smaller) | false
+    cssMinify: 'esbuild',      // separate from JS minify since Vite 5
+    cssCodeSplit: true,         // split CSS per async chunk
+    assetsInlineLimit: 4096,   // bytes; smaller files inlined as base64
+    chunkSizeWarningLimit: 500, // kB; warning threshold
+    emptyOutDir: true,          // clean outDir before build
+  },
+})
+```
+
+## Code Splitting Strategies
+
+Vite automatically code-splits at dynamic import boundaries. Manual intervention
+is needed when automatic splitting produces suboptimal chunks.
+
+### Automatic Splitting via Dynamic Imports
+
+```ts
+// Route-based splitting (most common)
+const Dashboard = lazy(() => import('./pages/Dashboard'))
+const Settings = lazy(() => import('./pages/Settings'))
+
+// Feature-based splitting
+const heavyChart = () => import('./components/HeavyChart')
+```
+
+Every `import()` call creates a new chunk. Shared dependencies between chunks
+are automatically extracted into a common chunk by Rollup.
+
+### Manual Chunks
+
+Override Rollup's automatic chunking when you need control:
+
+```ts
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          // Group by domain
+          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
+          'ui-vendor': ['@radix-ui/react-dialog', '@radix-ui/react-popover'],
+          'chart-vendor': ['recharts', 'd3-scale', 'd3-shape'],
+        },
+      },
+    },
+  },
+})
+```
+
+### Function-Based Manual Chunks
+
+For dynamic logic, use the function form:
+
+```ts
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            // Split node_modules by top-level package
+            const parts = id.split('node_modules/')[1].split('/')
+            const pkg = parts[0].startsWith('@') ? `${parts[0]}/${parts[1]}` : parts[0]
+
+            // Group large frameworks
+            if (['react', 'react-dom', 'react-router-dom'].includes(pkg)) {
+              return 'react-vendor'
+            }
+            if (pkg.startsWith('@radix-ui') || pkg === 'class-variance-authority') {
+              return 'ui-vendor'
+            }
+            // Everything else in a general vendor chunk
+            return 'vendor'
+          }
+          // Return undefined to let Rollup handle non-vendor modules
+        },
+      },
+    },
+  },
+})
+```
+
+Return `undefined` (not a string) to let Rollup apply its default strategy for
+that module. Never return an empty string.
+
+### Manual Chunks Pitfalls
+
+| Pitfall | Consequence | Prevention |
+| --- | --- | --- |
+| Putting everything in one vendor chunk | No cache granularity; any dep update invalidates all | Split by update frequency |
+| One chunk per dependency | HTTP request waterfall | Group by domain (max 5-8 chunks) |
+| Circular chunk dependencies | Runtime errors or duplicate code | Verify with visualizer |
+| Forgetting transitive deps | Module appears in multiple chunks | Include the full dependency subgraph |
+| Not returning `undefined` for unmatched modules | Empty chunk or misplaced code | Always handle the fallback case |
+
+### Recommended Chunk Strategy
+
+| Chunk | Contents | Update Frequency |
+| --- | --- | --- |
+| `framework` | React/Vue/Svelte runtime | Rare (months) |
+| `ui-vendor` | UI library (Radix, Headless UI) | Low (weeks) |
+| `vendor` | All other node_modules | Medium |
+| Route chunks (auto) | Per-route application code | High (every deploy) |
+| `shared` | Shared application utilities | High |
+
+## Minification
+
+### esbuild (default)
+
+Fastest option. Handles most code correctly. Default since Vite 2.
+
+```ts
+export default defineConfig({
+  build: {
+    minify: 'esbuild',
+    target: 'es2020', // controls syntax lowering
+  },
+})
+```
+
+### terser
+
+Slower but produces slightly smaller output. Required for specific transformations.
+
+```ts
+export default defineConfig({
+  build: {
+    minify: 'terser',
+    terserOptions: {
+      compress: {
+        drop_console: true,       // remove console.* calls
+        drop_debugger: true,      // remove debugger statements
+        pure_funcs: ['console.log'], // mark as side-effect-free
+      },
+      mangle: {
+        safari10: true,           // work around Safari 10 bugs
+      },
+      format: {
+        comments: false,          // remove all comments
+      },
+    },
+  },
+})
+```
+
+Install terser separately: `npm i -D terser`
+
+### When to Use Which
+
+| Scenario | Choice |
+| --- | --- |
+| Default / fastest builds | esbuild |
+| Need `drop_console` | terser (or use `define` to replace `console.log` with no-op) |
+| Need property mangling | terser |
+| Class names must be preserved (ORM, serialization) | terser with `keep_classnames: true` |
+| Build time is critical (CI/CD) | esbuild |
+
+### esbuild Alternative for Console Removal
+
+Instead of terser, use `esbuild.drop`:
+
+```ts
+export default defineConfig({
+  esbuild: {
+    drop: ['console', 'debugger'],
+  },
+})
+```
+
+This is faster than terser and achieves the same result for console removal.
+
+## CSS Code Splitting
+
+When `build.cssCodeSplit` is `true` (default), CSS imported by an async chunk
+is extracted into its own file and loaded alongside the chunk.
+
+```ts
+export default defineConfig({
+  build: {
+    cssCodeSplit: true, // default
+  },
+})
+```
+
+Disable only when you need a single CSS file (rare):
+
+```ts
+export default defineConfig({
+  build: {
+    cssCodeSplit: false, // all CSS in one file
+  },
+})
+```
+
+### CSS Processing Pipeline
+
+1. PostCSS (if `postcss.config.js` exists) - autoprefixer, nesting, etc.
+2. CSS Modules (files named `*.module.css`)
+3. Pre-processors (Sass, Less, Stylus) - install the preprocessor, no config needed
+4. Minification (esbuild or Lightning CSS)
+
+```bash
+# Install preprocessors as needed (no plugin required)
+npm i -D sass
+npm i -D less
+npm i -D stylus
+```
+
+### Lightning CSS (experimental)
+
+```ts
+export default defineConfig({
+  css: {
+    transformer: 'lightningcss',
+    lightningcss: {
+      targets: browserslistToTargets(browserslist('>= 0.25%')),
+    },
+  },
+  build: {
+    cssMinify: 'lightningcss',
+  },
+})
+```
+
+## Asset Handling
+
+### Inline Threshold
+
+Files smaller than `assetsInlineLimit` are inlined as base64 data URIs:
+
+```ts
+export default defineConfig({
+  build: {
+    assetsInlineLimit: 4096, // 4kB default
+  },
+})
+```
+
+| Threshold | Trade-off |
+| --- | --- |
+| Lower (1024) | More HTTP requests, smaller HTML/JS, better caching |
+| Default (4096) | Balanced |
+| Higher (8192+) | Fewer requests, larger bundle, no individual caching |
+
+SVG files are never inlined by default (they can be imported as components instead).
+
+### Output File Names
+
+```ts
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      output: {
+        entryFileNames: 'js/[name]-[hash].js',
+        chunkFileNames: 'js/[name]-[hash].js',
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name?.endsWith('.css')) return 'css/[name]-[hash].css'
+          if (/\.(png|jpe?g|gif|svg|webp|avif)$/.test(assetInfo.name ?? '')) {
+            return 'images/[name]-[hash][extname]'
+          }
+          return 'assets/[name]-[hash][extname]'
+        },
+      },
+    },
+  },
+})
+```
+
+## Tree-Shaking
+
+Rollup performs tree-shaking by default. Ensure it works:
+
+1. Use ESM imports/exports exclusively. CJS defeats tree-shaking.
+2. Mark packages as side-effect-free in `package.json`:
+   ```json
+   { "sideEffects": false }
+   ```
+   Or specify files with side effects:
+   ```json
+   { "sideEffects": ["*.css", "./src/polyfills.ts"] }
+   ```
+3. Avoid barrel files that re-export everything (`index.ts` with `export * from`).
+4. Import specific paths when available: `import debounce from 'lodash-es/debounce'`.
+
+### Verifying Tree-Shaking
+
+Use the visualizer to confirm unused exports are eliminated:
+
+```ts
+import { visualizer } from 'rollup-plugin-visualizer'
+
+export default defineConfig({
+  plugins: [
+    visualizer({
+      open: true,
+      gzipSize: true,
+      brotliSize: true,
+      filename: 'stats.html',
+    }),
+  ],
+})
+```
+
+Run `vite build` and inspect the generated `stats.html`.
+
+## Build Performance
+
+### Profiling the Build
+
+```bash
+# Measure build time
+time npx vite build
+
+# Detailed Rollup timing
+VITE_CJS_TRACE=true npx vite build
+
+# Generate bundle stats
+npx vite-bundle-visualizer
+```
+
+### Build Speed Optimizations
+
+| Optimization | Impact | How |
+| --- | --- | --- |
+| Use esbuild minification | High | Default; do not switch to terser unless needed |
+| Reduce source maps | Medium | `sourcemap: false` in prod (or `'hidden'`) |
+| Limit Rollup plugins | Medium | Remove dev-only plugins from prod build |
+| Increase Node memory | Low | `NODE_OPTIONS='--max-old-space-size=8192'` |
+| Use SWC-based React plugin | Medium | `@vitejs/plugin-react-swc` instead of Babel-based |
+
+### Target Configuration
+
+The `build.target` option controls which syntax features are preserved:
+
+```ts
+export default defineConfig({
+  build: {
+    target: 'es2020',     // specific ES version
+    // OR
+    target: 'chrome100',  // specific browser
+    // OR
+    target: ['es2020', 'edge88', 'firefox78', 'chrome87', 'safari14'],
+  },
+})
+```
+
+Higher targets produce smaller output because fewer syntax transformations are needed.
+
+## Chunk Analysis Checklist
+
+After every significant dependency change:
+
+1. Run `npx vite build` and check warnings for oversized chunks.
+2. Generate a visualizer report.
+3. Verify no duplicate modules appear across chunks.
+4. Confirm lazy-loaded routes produce separate chunks.
+5. Check that vendor chunks are stable (same hash when app code changes).
+6. Validate gzipped sizes: aim for < 50kB initial JS, < 200kB total initial load.

--- a/skills/vite-mastery/references/configuration-and-dev-server.md
+++ b/skills/vite-mastery/references/configuration-and-dev-server.md
@@ -1,0 +1,363 @@
+# Configuration and Dev Server
+
+Sources: Vite official documentation (vitejs.dev), Rollup documentation, esbuild documentation
+
+Covers vite.config.ts structure, resolve aliases, define constants, conditional
+configuration, dev server options, HMR, proxy configuration, HTTPS, and custom middleware.
+
+## Config File Basics
+
+Vite reads `vite.config.ts` (or `.js`, `.mjs`) from the project root. Use `defineConfig`
+for type hints.
+
+### Static Config
+
+```ts
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  root: '.', // project root (where index.html lives)
+  base: '/', // public base path for deployment
+  publicDir: 'public', // static assets copied as-is
+  cacheDir: 'node_modules/.vite', // pre-bundling cache
+})
+```
+
+### Conditional Config (by mode)
+
+Export a function to access `mode`, `command`, and `isSsrBuild`:
+
+```ts
+import { defineConfig } from 'vite'
+
+export default defineConfig(({ command, mode, isSsrBuild }) => {
+  const isDev = command === 'serve'
+  const isProd = mode === 'production'
+
+  return {
+    define: {
+      __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+    },
+    build: {
+      sourcemap: isDev ? 'inline' : false,
+      minify: isProd ? 'esbuild' : false,
+    },
+  }
+})
+```
+
+`command` is `'serve'` during dev and `'build'` during production build.
+`mode` defaults to `'development'` for serve, `'production'` for build.
+Override mode with `--mode staging`.
+
+### Async Config
+
+The function can be async for dynamic setup (reading files, network calls):
+
+```ts
+export default defineConfig(async ({ mode }) => {
+  const secrets = await loadSecrets(mode)
+  return {
+    define: {
+      __API_KEY__: JSON.stringify(secrets.apiKey),
+    },
+  }
+})
+```
+
+## Resolve Configuration
+
+### Aliases
+
+Map import paths to filesystem locations:
+
+```ts
+import { resolve } from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+      '@components': resolve(__dirname, 'src/components'),
+      '@utils': resolve(__dirname, 'src/utils'),
+    },
+  },
+})
+```
+
+For ESM config files where `__dirname` is unavailable:
+
+```ts
+import { fileURLToPath, URL } from 'node:url'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+})
+```
+
+Update `tsconfig.json` paths to match aliases for TypeScript resolution:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@components/*": ["src/components/*"]
+    }
+  }
+}
+```
+
+### Resolve Extensions and Conditions
+
+```ts
+export default defineConfig({
+  resolve: {
+    extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json'], // defaults
+    conditions: ['import', 'module', 'browser', 'default'], // package.json conditions
+    mainFields: ['browser', 'module', 'jsnext:main', 'jsnext'], // defaults
+  },
+})
+```
+
+## Define: Compile-Time Constants
+
+Replace expressions at build time. Values are inlined as-is, so wrap strings
+with `JSON.stringify`:
+
+```ts
+export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify('1.2.3'),
+    __DEV__: JSON.stringify(true),
+    'process.env.NODE_ENV': JSON.stringify('production'), // for legacy libs
+    'import.meta.env.CUSTOM': JSON.stringify('value'),
+  },
+})
+```
+
+Access in code: `if (__DEV__) { ... }` -- the expression is replaced at build time,
+and dead code is eliminated by the minifier.
+
+## Dev Server Configuration
+
+### Basic Options
+
+```ts
+export default defineConfig({
+  server: {
+    host: '0.0.0.0',     // expose to network (default: 'localhost')
+    port: 3000,           // default: 5173
+    strictPort: true,     // fail if port taken (default: false, auto-increment)
+    open: true,           // open browser on start
+    cors: true,           // enable CORS
+  },
+})
+```
+
+### Proxy Configuration
+
+Route API requests to a backend server to avoid CORS during development:
+
+```ts
+export default defineConfig({
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+      '/ws': {
+        target: 'ws://localhost:8080',
+        ws: true,
+      },
+      // Regex-based matching
+      '^/api/v[12]/.*': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
+  },
+})
+```
+
+`changeOrigin: true` rewrites the `Host` header to match the target, required
+for virtual-hosted backends.
+
+### HTTPS
+
+```ts
+import basicSsl from '@vitejs/plugin-basic-ssl'
+
+export default defineConfig({
+  plugins: [basicSsl()],
+  server: {
+    https: true,
+  },
+})
+```
+
+For custom certificates:
+
+```ts
+import fs from 'fs'
+
+export default defineConfig({
+  server: {
+    https: {
+      key: fs.readFileSync('certs/localhost-key.pem'),
+      cert: fs.readFileSync('certs/localhost.pem'),
+    },
+  },
+})
+```
+
+Generate local certs with `mkcert`: `mkcert -install && mkcert localhost`.
+
+### HMR Configuration
+
+HMR works automatically with framework plugins. Custom HMR config is needed
+when behind a reverse proxy or in containers:
+
+```ts
+export default defineConfig({
+  server: {
+    hmr: {
+      protocol: 'ws',       // 'ws' or 'wss'
+      host: 'localhost',
+      port: 5173,
+      clientPort: 443,       // when behind reverse proxy
+      overlay: true,         // show error overlay (default: true)
+    },
+  },
+})
+```
+
+### HMR Troubleshooting
+
+| Problem | Cause | Fix |
+| --- | --- | --- |
+| Full page reload instead of HMR | Module not accepting updates | Ensure framework plugin is loaded |
+| HMR timeout | Firewall/proxy blocking WebSocket | Configure `server.hmr.clientPort` and `protocol` |
+| Changes not detected | File outside project root | Move file or configure `server.watch.paths` |
+| Circular dependency breaks HMR | Propagation cannot resolve cycle | Break the circular import |
+| CSS changes cause full reload | CSS module imported conditionally | Import CSS statically at module top level |
+
+### Custom Middleware
+
+Use `configureServer` hook in a plugin to add Express-compatible middleware:
+
+```ts
+function apiMockPlugin(): Plugin {
+  return {
+    name: 'api-mock',
+    configureServer(server) {
+      server.middlewares.use('/api/health', (req, res) => {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ status: 'ok' }))
+      })
+    },
+  }
+}
+```
+
+### File System Watching
+
+```ts
+export default defineConfig({
+  server: {
+    watch: {
+      usePolling: true,    // needed for Docker/WSL
+      interval: 1000,      // polling interval in ms
+      ignored: ['**/node_modules/**', '**/.git/**'],
+    },
+  },
+})
+```
+
+## Dependency Pre-Bundling (optimizeDeps)
+
+Vite pre-bundles dependencies with esbuild during dev for two reasons:
+1. Convert CJS to ESM
+2. Consolidate many small modules into one request
+
+### Configuration
+
+```ts
+export default defineConfig({
+  optimizeDeps: {
+    include: [
+      'lodash-es',           // force pre-bundle ESM deps
+      'react',               // force pre-bundle for faster dev startup
+      'linked-dep > nested', // pre-bundle nested dep of a linked package
+    ],
+    exclude: [
+      'my-local-package',    // skip pre-bundling (must be valid ESM)
+    ],
+    esbuildOptions: {
+      target: 'esnext',
+      plugins: [],           // esbuild plugins for pre-bundling
+    },
+  },
+})
+```
+
+### When to Use
+
+| Symptom | Action |
+| --- | --- |
+| CJS dependency fails in browser | Add to `include` |
+| Linked local package rebuilds slowly | Add to `exclude` |
+| Dependency has many internal modules (lodash-es) | Add to `include` to reduce requests |
+| Pre-bundling keeps re-running on start | Check for non-deterministic imports; pin with `include` |
+
+### Force Re-optimization
+
+Delete `node_modules/.vite` or run `vite --force` to clear the pre-bundle cache.
+
+## Multi-Page Configuration
+
+```ts
+import { resolve } from 'path'
+
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        admin: resolve(__dirname, 'admin/index.html'),
+        login: resolve(__dirname, 'login/index.html'),
+      },
+    },
+  },
+})
+```
+
+Each HTML entry point gets its own chunk tree.
+
+## Project Structure Conventions
+
+```
+project-root/
+  index.html          <- entry point (must be in root)
+  public/             <- static assets (copied as-is, no processing)
+  src/
+    main.ts           <- application entry
+    assets/            <- processed assets (images, fonts imported in code)
+    components/
+  vite.config.ts
+  .env                <- default env
+  .env.local          <- local overrides (gitignored)
+  .env.production     <- production env
+```
+
+`index.html` is the true entry point. Vite resolves `<script type="module" src="/src/main.ts">`
+from it. This is fundamentally different from Webpack where a JS file is the entry.

--- a/skills/vite-mastery/references/environment-pwa-tooling.md
+++ b/skills/vite-mastery/references/environment-pwa-tooling.md
@@ -1,0 +1,426 @@
+# Environment, PWA, and Tooling Integration
+
+Sources: Vite official documentation (vitejs.dev), vite-plugin-pwa documentation, Workbox documentation, rollup-plugin-visualizer documentation
+
+Covers .env files, import.meta.env, mode-based configuration, environment
+validation, vite-plugin-pwa setup, workbox caching strategies, offline support,
+bundle analysis with rollup-plugin-visualizer, and optimizeDeps tuning.
+
+## Environment Variables
+
+### .env File Hierarchy
+
+Vite loads `.env` files in this order (later files override earlier):
+
+```
+.env                  <- always loaded
+.env.local            <- always loaded, gitignored
+.env.[mode]           <- loaded for specific mode
+.env.[mode].local     <- loaded for specific mode, gitignored
+```
+
+Default modes: `development` (vite serve), `production` (vite build).
+Custom modes: `vite build --mode staging` loads `.env.staging`.
+
+### Client-Side Variables
+
+Only variables prefixed with `VITE_` are exposed to client code:
+
+```bash
+# .env
+VITE_API_URL=https://api.example.com
+VITE_APP_TITLE=My App
+SECRET_KEY=never-exposed           # NOT available in client code
+DATABASE_URL=postgres://...        # NOT available in client code
+```
+
+Access in code:
+
+```ts
+const apiUrl = import.meta.env.VITE_API_URL    // "https://api.example.com"
+const mode = import.meta.env.MODE              // "development" | "production"
+const isProd = import.meta.env.PROD            // boolean
+const isDev = import.meta.env.DEV              // boolean
+const baseUrl = import.meta.env.BASE_URL       // from `base` config
+const ssrFlag = import.meta.env.SSR            // boolean (true during SSR)
+```
+
+### TypeScript Support
+
+Augment the `ImportMeta` interface for type safety:
+
+```ts
+// src/vite-env.d.ts
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string
+  readonly VITE_APP_TITLE: string
+  readonly VITE_FEATURE_FLAGS: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+```
+
+### Environment Variable Validation
+
+Validate env vars at build time to catch missing configuration early:
+
+```ts
+// src/env.ts
+function getEnvVar(key: string): string {
+  const value = import.meta.env[key]
+  if (value === undefined) {
+    throw new Error(`Missing required environment variable: ${key}`)
+  }
+  return value
+}
+
+export const env = {
+  apiUrl: getEnvVar('VITE_API_URL'),
+  appTitle: getEnvVar('VITE_APP_TITLE'),
+} as const
+```
+
+For schema-based validation, use `@t3-oss/env-core` or `zod`:
+
+```ts
+import { z } from 'zod'
+
+const envSchema = z.object({
+  VITE_API_URL: z.string().url(),
+  VITE_APP_TITLE: z.string().min(1),
+  VITE_FEATURE_FLAGS: z.string().transform(s => s.split(',')),
+})
+
+export const env = envSchema.parse(import.meta.env)
+```
+
+### Server-Side Environment Variables
+
+In SSR or server routes, access all env vars via `process.env` (no `VITE_` prefix
+required for server-only code):
+
+```ts
+// server.ts (not bundled by Vite client build)
+const dbUrl = process.env.DATABASE_URL
+const secret = process.env.SECRET_KEY
+```
+
+### Custom Env Prefix
+
+Change the prefix from `VITE_` to something else:
+
+```ts
+export default defineConfig({
+  envPrefix: 'APP_', // exposes APP_* variables instead of VITE_*
+})
+```
+
+Multiple prefixes:
+
+```ts
+export default defineConfig({
+  envPrefix: ['VITE_', 'APP_'],
+})
+```
+
+### Mode-Based Configuration Pattern
+
+```ts
+// vite.config.ts
+import { defineConfig, loadEnv } from 'vite'
+
+export default defineConfig(({ mode }) => {
+  // Load env file based on `mode` in the current working directory
+  const env = loadEnv(mode, process.cwd(), '')
+
+  return {
+    define: {
+      __API_URL__: JSON.stringify(env.VITE_API_URL),
+    },
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_API_URL,
+          changeOrigin: true,
+        },
+      },
+    },
+  }
+})
+```
+
+`loadEnv(mode, root, prefix)` loads env files and returns an object.
+Pass `''` as prefix to load ALL variables (not just `VITE_*`).
+
+## PWA with vite-plugin-pwa
+
+### Installation and Basic Setup
+
+```bash
+npm i -D vite-plugin-pwa
+```
+
+```ts
+import { VitePWA } from 'vite-plugin-pwa'
+
+export default defineConfig({
+  plugins: [
+    VitePWA({
+      registerType: 'autoUpdate', // auto-update service worker
+      includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'mask-icon.svg'],
+      manifest: {
+        name: 'My App',
+        short_name: 'App',
+        description: 'My application description',
+        theme_color: '#ffffff',
+        background_color: '#ffffff',
+        display: 'standalone',
+        scope: '/',
+        start_url: '/',
+        icons: [
+          { src: 'pwa-192x192.png', sizes: '192x192', type: 'image/png' },
+          { src: 'pwa-512x512.png', sizes: '512x512', type: 'image/png' },
+          { src: 'pwa-512x512.png', sizes: '512x512', type: 'image/png', purpose: 'any maskable' },
+        ],
+      },
+    }),
+  ],
+})
+```
+
+### Registration Types
+
+| Type | Behavior | Use Case |
+| --- | --- | --- |
+| `'autoUpdate'` | New SW activates immediately, page reloads | Most apps |
+| `'prompt'` | Shows update prompt, user decides | Apps where data loss on reload is a concern |
+
+### Prompt Registration
+
+```ts
+VitePWA({
+  registerType: 'prompt',
+  // In your app, use the virtual module:
+})
+```
+
+```ts
+// In your application code
+import { useRegisterSW } from 'virtual:pwa-register/react'
+
+function App() {
+  const {
+    needRefresh: [needRefresh],
+    updateServiceWorker,
+  } = useRegisterSW()
+
+  return (
+    <>
+      {needRefresh && (
+        <div>
+          <span>New version available!</span>
+          <button onClick={() => updateServiceWorker(true)}>Update</button>
+        </div>
+      )}
+    </>
+  )
+}
+```
+
+### Workbox Caching Strategies
+
+```ts
+VitePWA({
+  workbox: {
+    // Pre-cache app shell
+    globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+
+    // Runtime caching for API calls
+    runtimeCaching: [
+      {
+        urlPattern: /^https:\/\/api\.example\.com\/.*/i,
+        handler: 'NetworkFirst',
+        options: {
+          cacheName: 'api-cache',
+          expiration: {
+            maxEntries: 100,
+            maxAgeSeconds: 60 * 60 * 24, // 24 hours
+          },
+          cacheableResponse: {
+            statuses: [0, 200],
+          },
+        },
+      },
+      {
+        urlPattern: /\.(?:png|jpg|jpeg|svg|gif|webp)$/,
+        handler: 'CacheFirst',
+        options: {
+          cacheName: 'image-cache',
+          expiration: {
+            maxEntries: 50,
+            maxAgeSeconds: 60 * 60 * 24 * 30, // 30 days
+          },
+        },
+      },
+      {
+        urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
+        handler: 'StaleWhileRevalidate',
+        options: {
+          cacheName: 'google-fonts',
+          expiration: {
+            maxEntries: 20,
+          },
+        },
+      },
+    ],
+  },
+})
+```
+
+### Workbox Strategy Selection
+
+| Strategy | Behavior | Best For |
+| --- | --- | --- |
+| `CacheFirst` | Cache, fallback to network | Static assets, images, fonts |
+| `NetworkFirst` | Network, fallback to cache | API calls, dynamic data |
+| `StaleWhileRevalidate` | Cache immediately, update in background | Frequently updated static resources |
+| `NetworkOnly` | Network only, no caching | Auth endpoints, real-time data |
+| `CacheOnly` | Cache only, no network | Pre-cached app shell |
+
+### Offline Fallback Page
+
+```ts
+VitePWA({
+  workbox: {
+    navigateFallback: '/offline.html',
+    navigateFallbackDenylist: [/^\/api/],
+  },
+})
+```
+
+Create `public/offline.html` for the fallback page.
+
+### Development
+
+Enable PWA in dev mode for testing (disabled by default):
+
+```ts
+VitePWA({
+  devOptions: {
+    enabled: true,
+    type: 'module',
+  },
+})
+```
+
+## Bundle Analysis
+
+### rollup-plugin-visualizer
+
+```bash
+npm i -D rollup-plugin-visualizer
+```
+
+```ts
+import { visualizer } from 'rollup-plugin-visualizer'
+
+export default defineConfig({
+  plugins: [
+    visualizer({
+      open: true,             // auto-open in browser
+      filename: 'stats.html', // output file
+      gzipSize: true,         // show gzipped sizes
+      brotliSize: true,       // show brotli sizes
+      template: 'treemap',    // 'treemap' | 'sunburst' | 'network'
+    }),
+  ],
+})
+```
+
+Run `vite build` to generate the report.
+
+### Alternative: vite-bundle-visualizer
+
+Zero-config alternative:
+
+```bash
+npx vite-bundle-visualizer
+```
+
+### Reading the Visualizer Output
+
+| Pattern | Meaning | Action |
+| --- | --- | --- |
+| One huge block | Single large dependency | Consider lazy loading or a lighter alternative |
+| Many small blocks | Over-split chunks | Consolidate with manual chunks |
+| Duplicate blocks | Same module in multiple chunks | Check manual chunks configuration |
+| Unexpected packages | Transitive dependency bloat | Audit with `npm ls <package>` |
+| Large polyfills | Legacy browser support | Review `@vitejs/plugin-legacy` targets |
+
+## Dependency Pre-Bundling Tuning
+
+### Force Include
+
+Pre-bundle dependencies that cause issues during dev:
+
+```ts
+export default defineConfig({
+  optimizeDeps: {
+    include: [
+      'react',
+      'react-dom',
+      'lodash-es',              // many internal modules
+      'my-lib > nested-dep',    // nested dependency
+    ],
+  },
+})
+```
+
+### Force Exclude
+
+Skip pre-bundling for dependencies that must remain as-is:
+
+```ts
+export default defineConfig({
+  optimizeDeps: {
+    exclude: [
+      'my-wasm-package',        // WASM packages
+    ],
+  },
+})
+```
+
+### Troubleshooting Pre-Bundling
+
+| Issue | Cause | Fix |
+| --- | --- | --- |
+| `Pre-bundling re-optimized` on every start | Dynamic imports discovered at runtime | Add discovered deps to `include` |
+| CJS module fails | Not pre-bundled | Add to `include` |
+| WASM module fails | Pre-bundling strips WASM | Add to `exclude` |
+| Linked package not updating | Cached pre-bundle | Run `vite --force` |
+
+### Cache Control
+
+```ts
+export default defineConfig({
+  cacheDir: 'node_modules/.vite', // default location
+  optimizeDeps: {
+    force: true, // always re-bundle (slow, use for debugging only)
+  },
+})
+```
+
+Clear cache: delete `node_modules/.vite` or run `vite --force`.
+
+## Performance Profiling Workflow
+
+1. Measure baseline: `time npx vite build` and record the output size.
+2. Generate report: add `rollup-plugin-visualizer` and rebuild.
+3. Identify targets: look for the largest modules in the treemap.
+4. Apply fixes: dynamic imports, manual chunks, lighter alternatives.
+5. Verify improvement: rebuild, compare sizes and load times.
+6. Monitor ongoing: add size budget checks to CI to prevent regressions.

--- a/skills/vite-mastery/references/plugin-development.md
+++ b/skills/vite-mastery/references/plugin-development.md
@@ -1,0 +1,441 @@
+# Plugin Development
+
+Sources: Vite official documentation (vitejs.dev), Rollup documentation, Vite plugin API reference
+
+Covers Vite plugin anatomy, Rollup-compatible hooks, Vite-specific hooks, virtual
+modules, the transform pipeline, enforce ordering, HMR API, and plugin testing.
+
+## Plugin Anatomy
+
+A Vite plugin is an object with a `name` and one or more hooks. It extends Rollup's
+plugin interface with Vite-specific additions.
+
+```ts
+import type { Plugin } from 'vite'
+
+function myPlugin(options?: { debug?: boolean }): Plugin {
+  return {
+    name: 'vite-plugin-my-plugin', // required, used in warnings and errors
+    enforce: 'pre', // optional: 'pre' | 'post' (default: normal)
+    apply: 'build', // optional: 'build' | 'serve' (default: both)
+
+    // Vite-specific hooks
+    config(config, env) { /* modify config */ },
+    configResolved(config) { /* read final config */ },
+    configureServer(server) { /* add dev middleware */ },
+    transformIndexHtml(html) { /* modify index.html */ },
+    handleHotUpdate(ctx) { /* custom HMR handling */ },
+
+    // Rollup-compatible hooks
+    resolveId(source, importer) { /* resolve imports */ },
+    load(id) { /* provide module content */ },
+    transform(code, id) { /* transform module code */ },
+  }
+}
+
+export default myPlugin
+```
+
+### Plugin Naming Convention
+
+Use the prefix `vite-plugin-` for npm packages. For framework-specific plugins,
+use `vite-plugin-vue-`, `vite-plugin-react-`, etc.
+
+## Hook Execution Order
+
+### Build Pipeline
+
+```
+1. config            (Vite: modify config before resolution)
+2. configResolved    (Vite: read final resolved config)
+3. options           (Rollup: modify Rollup options)
+4. buildStart        (Rollup: build has started)
+5. resolveId         (Rollup: resolve each import)
+6. load              (Rollup: load module content)
+7. transform         (Rollup: transform module code)
+8. buildEnd          (Rollup: build has finished)
+9. closeBundle       (Rollup: bundle is written)
+```
+
+### Dev Server Pipeline
+
+```
+1. config
+2. configResolved
+3. configureServer   (Vite: add dev server middleware)
+4. buildStart
+5. transformIndexHtml (Vite: on each HTML request)
+6. resolveId -> load -> transform (on each module request)
+7. handleHotUpdate   (Vite: on file change)
+```
+
+## Enforce Ordering
+
+Plugins run in this order:
+
+1. Alias resolution (Vite internal)
+2. Plugins with `enforce: 'pre'`
+3. Vite core plugins (resolve, CSS, esbuild transform)
+4. Plugins without `enforce` (normal)
+5. Vite build plugins (minify, manifest, reporting)
+6. Plugins with `enforce: 'post'`
+
+| Use Case | Enforce |
+| --- | --- |
+| Need to run before all transforms (raw source) | `'pre'` |
+| Default behavior, after Vite core | omit (normal) |
+| Need to process final output | `'post'` |
+| Only during dev | `apply: 'serve'` |
+| Only during build | `apply: 'build'` |
+
+```ts
+function myPrePlugin(): Plugin {
+  return {
+    name: 'my-pre-plugin',
+    enforce: 'pre',
+    transform(code, id) {
+      // Runs before Vite's own transforms
+      // `code` is the raw source
+    },
+  }
+}
+```
+
+## Vite-Specific Hooks
+
+### config
+
+Modify the Vite config before it is resolved. Return a partial config to merge:
+
+```ts
+config(config, { command, mode }) {
+  if (command === 'build') {
+    return {
+      build: {
+        sourcemap: true,
+      },
+    }
+  }
+}
+```
+
+### configResolved
+
+Read the final, resolved config. Do not mutate it. Store references for later hooks:
+
+```ts
+let resolvedConfig: ResolvedConfig
+
+configResolved(config) {
+  resolvedConfig = config
+}
+```
+
+### configureServer
+
+Add custom middleware to the dev server. The `server` object exposes the
+Connect middleware stack:
+
+```ts
+configureServer(server) {
+  // Runs before Vite's internal middleware
+  server.middlewares.use((req, res, next) => {
+    if (req.url === '/api/mock') {
+      res.end(JSON.stringify({ data: 'mock' }))
+    } else {
+      next()
+    }
+  })
+}
+```
+
+Return a function to add middleware AFTER Vite's internals (post-middleware):
+
+```ts
+configureServer(server) {
+  return () => {
+    server.middlewares.use((req, res, next) => {
+      // Runs after Vite serves static files
+      // Useful for SPA fallback
+    })
+  }
+}
+```
+
+### transformIndexHtml
+
+Transform the `index.html` file. Receives the HTML string and returns
+modified HTML or an array of tag descriptors:
+
+```ts
+transformIndexHtml(html, ctx) {
+  return html.replace('__TITLE__', 'My App')
+}
+
+// Or inject tags:
+transformIndexHtml() {
+  return [
+    {
+      tag: 'script',
+      attrs: { src: '/analytics.js', defer: true },
+      injectTo: 'head',
+    },
+    {
+      tag: 'meta',
+      attrs: { name: 'version', content: '1.0.0' },
+      injectTo: 'head-prepend',
+    },
+  ]
+}
+```
+
+Injection positions: `'head'`, `'head-prepend'`, `'body'`, `'body-prepend'`.
+
+### handleHotUpdate
+
+Custom HMR logic when files change:
+
+```ts
+handleHotUpdate({ file, server, modules, timestamp }) {
+  if (file.endsWith('.custom')) {
+    // Notify all connected clients
+    server.ws.send({
+      type: 'custom',
+      event: 'custom-update',
+      data: { file, timestamp },
+    })
+    return [] // prevent default HMR for this file
+  }
+  // Return undefined to use default HMR behavior
+}
+```
+
+## Virtual Modules
+
+Virtual modules exist only in memory. Use the `\0` prefix convention to signal
+that a module is virtual (prevents other plugins from resolving it):
+
+```ts
+const VIRTUAL_MODULE_ID = 'virtual:my-config'
+const RESOLVED_VIRTUAL_ID = '\0' + VIRTUAL_MODULE_ID
+
+function virtualConfigPlugin(data: Record<string, unknown>): Plugin {
+  return {
+    name: 'virtual-config',
+    resolveId(id) {
+      if (id === VIRTUAL_MODULE_ID) {
+        return RESOLVED_VIRTUAL_ID
+      }
+    },
+    load(id) {
+      if (id === RESOLVED_VIRTUAL_ID) {
+        return `export default ${JSON.stringify(data)}`
+      }
+    },
+  }
+}
+```
+
+Usage in application code:
+
+```ts
+import config from 'virtual:my-config'
+console.log(config) // the data object
+```
+
+Add type declarations:
+
+```ts
+// src/vite-env.d.ts or env.d.ts
+declare module 'virtual:my-config' {
+  const config: Record<string, unknown>
+  export default config
+}
+```
+
+### Dynamic Virtual Modules
+
+Generate content based on the file system or external data:
+
+```ts
+function routeManifestPlugin(): Plugin {
+  return {
+    name: 'route-manifest',
+    resolveId(id) {
+      if (id === 'virtual:routes') return '\0virtual:routes'
+    },
+    async load(id) {
+      if (id === '\0virtual:routes') {
+        const files = await glob('src/pages/**/*.tsx')
+        const routes = files.map(f => ({
+          path: fileToRoutePath(f),
+          component: f,
+        }))
+        return `export default ${JSON.stringify(routes)}`
+      }
+    },
+  }
+}
+```
+
+## Transform Pipeline
+
+The `transform` hook processes every module. It receives source code and must
+return transformed code (or null to skip):
+
+```ts
+transform(code, id) {
+  // Only process specific files
+  if (!id.endsWith('.md')) return null
+
+  const html = markdownToHtml(code)
+  return {
+    code: `export default ${JSON.stringify(html)}`,
+    map: null, // provide source map if possible
+  }
+}
+```
+
+### Filtering Modules
+
+Use `createFilter` from `@rollup/pluginutils` for efficient include/exclude:
+
+```ts
+import { createFilter } from '@rollup/pluginutils'
+
+function myTransformPlugin(opts?: { include?: string[]; exclude?: string[] }): Plugin {
+  const filter = createFilter(opts?.include ?? ['**/*.custom'], opts?.exclude)
+
+  return {
+    name: 'my-transform',
+    transform(code, id) {
+      if (!filter(id)) return null
+      return transformCustomSyntax(code)
+    },
+  }
+}
+```
+
+### Source Maps
+
+Always provide source maps when transforming code. Use `magic-string` for
+efficient string manipulation with automatic source map generation:
+
+```ts
+import MagicString from 'magic-string'
+
+transform(code, id) {
+  if (!id.endsWith('.ts')) return null
+
+  const s = new MagicString(code)
+  s.replace('__TIMESTAMP__', Date.now().toString())
+
+  return {
+    code: s.toString(),
+    map: s.generateMap({ hires: true }),
+  }
+}
+```
+
+## HMR API (Client-Side)
+
+Modules can accept their own updates using `import.meta.hot`:
+
+```ts
+if (import.meta.hot) {
+  import.meta.hot.accept((newModule) => {
+    // Handle the updated module
+    if (newModule) {
+      updateUI(newModule.default)
+    }
+  })
+
+  // Cleanup before module is replaced
+  import.meta.hot.dispose(() => {
+    clearInterval(timer)
+  })
+
+  // Store state across HMR updates
+  import.meta.hot.data.count = import.meta.hot.data.count ?? 0
+
+  // Listen for custom events from plugins
+  import.meta.hot.on('custom-update', (data) => {
+    console.log('Custom update:', data)
+  })
+}
+```
+
+### HMR Guard Pattern
+
+Wrap HMR code so it is tree-shaken in production:
+
+```ts
+if (import.meta.hot) {
+  // This entire block is removed in production builds
+}
+```
+
+## Plugin Testing
+
+### Unit Testing Hooks
+
+Test individual hooks by calling them directly:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import myPlugin from './my-plugin'
+
+describe('myPlugin', () => {
+  const plugin = myPlugin({ debug: true })
+
+  it('resolves virtual module', () => {
+    const result = (plugin.resolveId as Function)('virtual:my-config', undefined)
+    expect(result).toBe('\0virtual:my-config')
+  })
+
+  it('loads virtual module content', () => {
+    const result = (plugin.load as Function)('\0virtual:my-config')
+    expect(result).toContain('export default')
+  })
+
+  it('ignores non-virtual imports', () => {
+    const result = (plugin.resolveId as Function)('./real-file.ts', undefined)
+    expect(result).toBeUndefined()
+  })
+})
+```
+
+### Integration Testing with Vite
+
+Use `vite.build` programmatically:
+
+```ts
+import { build } from 'vite'
+
+it('produces expected output', async () => {
+  const result = await build({
+    root: fixture('basic'),
+    plugins: [myPlugin()],
+    build: { write: false },
+  })
+
+  const output = (result as any).output[0]
+  expect(output.code).toContain('expected-string')
+})
+```
+
+## Plugin Composition
+
+Plugins can return arrays for logical grouping:
+
+```ts
+function myFrameworkPlugin(): Plugin[] {
+  return [
+    myResolvePlugin(),
+    myTransformPlugin(),
+    myDevServerPlugin(),
+  ]
+}
+```
+
+Vite flattens nested arrays in the plugins config, so this works seamlessly.

--- a/skills/vite-mastery/references/ssr-and-library-mode.md
+++ b/skills/vite-mastery/references/ssr-and-library-mode.md
@@ -1,0 +1,397 @@
+# SSR and Library Mode
+
+Sources: Vite official documentation (vitejs.dev), Rollup documentation, Vite SSR guide
+
+Covers SSR entry points, externalization strategy, streaming SSR, client hydration,
+library mode configuration, external dependencies, multiple output formats, and
+CSS extraction for libraries.
+
+## SSR Overview
+
+Vite provides low-level SSR primitives. Frameworks (Nuxt, SvelteKit, Remix) build
+on these. Use raw Vite SSR when building a custom framework or when existing
+frameworks do not fit.
+
+### SSR Architecture
+
+```
+Browser Request
+     |
+     v
+Node.js Server
+     |
+     +--> vite.ssrLoadModule('./src/entry-server.ts')  [dev]
+     |    OR import('./dist/server/entry-server.js')   [prod]
+     |
+     v
+Render HTML string
+     |
+     v
+Inject into index.html template
+     |
+     v
+Send to browser
+     |
+     v
+Browser loads client bundle -> hydration
+```
+
+### Project Structure for SSR
+
+```
+src/
+  entry-client.ts    <- browser entry (hydration)
+  entry-server.ts    <- server entry (renderToString)
+  App.tsx            <- shared application root
+  pages/
+server.ts            <- Node.js HTTP server
+index.html           <- HTML template with placeholders
+vite.config.ts
+```
+
+## SSR Entry Points
+
+### Server Entry
+
+```ts
+// src/entry-server.ts
+import { renderToString } from 'react-dom/server'
+import { App } from './App'
+
+export async function render(url: string) {
+  const html = renderToString(<App url={url} />)
+  return { html }
+}
+```
+
+### Client Entry
+
+```ts
+// src/entry-client.ts
+import { hydrateRoot } from 'react-dom/client'
+import { App } from './App'
+
+hydrateRoot(document.getElementById('app')!, <App url={window.location.pathname} />)
+```
+
+### HTML Template
+
+```html
+<!DOCTYPE html>
+<html>
+  <head><!--head-tags--></head>
+  <body>
+    <div id="app"><!--app-html--></div>
+    <script type="module" src="/src/entry-client.ts"></script>
+  </body>
+</html>
+```
+
+## Development Server for SSR
+
+Use `vite.createServer` in middleware mode:
+
+```ts
+import express from 'express'
+import { createServer as createViteServer } from 'vite'
+
+async function startServer() {
+  const app = express()
+
+  const vite = await createViteServer({
+    server: { middlewareMode: true },
+    appType: 'custom', // disable Vite's built-in HTML serving
+  })
+
+  // Use Vite's middleware for HMR and module serving
+  app.use(vite.middlewares)
+
+  app.use('*', async (req, res) => {
+    const url = req.originalUrl
+
+    // 1. Read and transform the HTML template
+    let template = await fs.readFile('index.html', 'utf-8')
+    template = await vite.transformIndexHtml(url, template)
+
+    // 2. Load the server entry module (with HMR support)
+    const { render } = await vite.ssrLoadModule('/src/entry-server.ts')
+
+    // 3. Render the app
+    const { html: appHtml } = await render(url)
+
+    // 4. Inject into template
+    const html = template.replace('<!--app-html-->', appHtml)
+
+    res.status(200).set({ 'Content-Type': 'text/html' }).end(html)
+  })
+
+  app.listen(3000)
+}
+
+startServer()
+```
+
+`vite.ssrLoadModule` loads modules through Vite's transform pipeline with HMR
+support. Changes to any module trigger instant updates without server restart.
+
+## SSR Externalization
+
+In SSR mode, Vite externalizes dependencies by default (they are `require`d at
+runtime instead of bundled). Configure exceptions:
+
+```ts
+export default defineConfig({
+  ssr: {
+    // Force-bundle these packages (needed for ESM-only deps)
+    noExternal: [
+      'my-esm-only-package',
+      /^@my-scope\/.*/,  // regex matching
+    ],
+
+    // Force-externalize (override noExternal)
+    external: [
+      'legacy-cjs-package',
+    ],
+
+    // SSR build target
+    target: 'node', // 'node' | 'webworker'
+  },
+})
+```
+
+### When to Use noExternal
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `ERR_REQUIRE_ESM` during SSR | CJS server trying to require ESM package | Add to `ssr.noExternal` |
+| CSS import fails in SSR | External package has CSS imports | Add to `ssr.noExternal` |
+| Package uses `import.meta` | Not supported in CJS context | Add to `ssr.noExternal` |
+| Browser-only APIs in SSR | Package references `window`/`document` | Guard with `typeof window` checks |
+
+## Streaming SSR
+
+Use `renderToPipeableStream` (React) or equivalent for streaming:
+
+```ts
+// src/entry-server.ts (React streaming)
+import { renderToPipeableStream } from 'react-dom/server'
+import { App } from './App'
+
+export function render(url: string, res: ServerResponse) {
+  const { pipe } = renderToPipeableStream(<App url={url} />, {
+    onShellReady() {
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'text/html')
+      pipe(res)
+    },
+    onError(error) {
+      console.error(error)
+      res.statusCode = 500
+      res.end('Internal Server Error')
+    },
+  })
+}
+```
+
+### SSR Production Build
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  build: {
+    ssr: true,
+    rollupOptions: {
+      input: 'src/entry-server.ts',
+    },
+  },
+})
+```
+
+Or use two separate builds:
+
+```bash
+# Build client
+vite build --outDir dist/client
+
+# Build server
+vite build --outDir dist/server --ssr src/entry-server.ts
+```
+
+## Library Mode
+
+Build reusable libraries with `build.lib`:
+
+```ts
+import { resolve } from 'path'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      name: 'MyLib',        // global variable name for UMD/IIFE
+      fileName: 'my-lib',   // output file name (without extension)
+      formats: ['es', 'cjs'], // output formats
+    },
+    rollupOptions: {
+      external: ['react', 'react-dom', 'react/jsx-runtime'],
+      output: {
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM',
+        },
+      },
+    },
+  },
+})
+```
+
+### Output Formats
+
+| Format | Extension | Use Case |
+| --- | --- | --- |
+| `es` | `.mjs` | Modern bundlers, ESM environments |
+| `cjs` | `.cjs` | Node.js, legacy bundlers |
+| `umd` | `.umd.js` | Browser `<script>` tags, AMD loaders |
+| `iife` | `.iife.js` | Direct browser inclusion |
+
+### Multiple Entry Points
+
+```ts
+export default defineConfig({
+  build: {
+    lib: {
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        utils: resolve(__dirname, 'src/utils.ts'),
+        hooks: resolve(__dirname, 'src/hooks/index.ts'),
+      },
+      formats: ['es', 'cjs'],
+    },
+  },
+})
+```
+
+### package.json for Libraries
+
+Configure entry points for consumers:
+
+```json
+{
+  "name": "my-lib",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./dist/my-lib.cjs",
+  "module": "./dist/my-lib.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/my-lib.mjs",
+      "require": "./dist/my-lib.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./utils": {
+      "import": "./dist/utils.mjs",
+      "require": "./dist/utils.cjs",
+      "types": "./dist/utils.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "sideEffects": false
+}
+```
+
+### External Dependencies
+
+Externalize everything that consumers will provide. The library should not bundle
+peer dependencies or framework runtimes:
+
+```ts
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      external: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        /^@radix-ui/,     // regex for scoped packages
+      ],
+    },
+  },
+})
+```
+
+Rule: If it is in `peerDependencies`, it must be in `external`.
+
+### CSS Handling in Libraries
+
+By default, CSS is injected via JS. For libraries, extract CSS to a separate file:
+
+```ts
+export default defineConfig({
+  build: {
+    lib: { /* ... */ },
+    cssCodeSplit: false, // combine all CSS into one file
+  },
+})
+```
+
+Consumers import the CSS separately:
+
+```ts
+import 'my-lib/dist/style.css'
+import { Button } from 'my-lib'
+```
+
+For CSS Modules or CSS-in-JS, the styles are typically bundled with the component
+and no separate import is needed.
+
+### Type Generation
+
+Vite does not generate `.d.ts` files. Use one of:
+
+```bash
+# tsc directly
+tsc --emitDeclarationOnly --outDir dist
+
+# vite-plugin-dts (recommended)
+npm i -D vite-plugin-dts
+```
+
+```ts
+import dts from 'vite-plugin-dts'
+
+export default defineConfig({
+  plugins: [dts({ rollupTypes: true })],
+  build: {
+    lib: { /* ... */ },
+  },
+})
+```
+
+`rollupTypes: true` bundles all declarations into a single `.d.ts` file.
+
+## Library Mode Checklist
+
+Before publishing a library built with Vite:
+
+1. All peer dependencies are listed in `external`.
+2. `package.json` exports map is correct for all formats.
+3. `types` field points to generated `.d.ts` files.
+4. `sideEffects` field is set (usually `false`, or `["*.css"]` if CSS exists).
+5. CSS is extracted (not injected via JS) unless using CSS-in-JS.
+6. Tree-shaking works: verify with a test consumer project.
+7. Bundle does not include React/Vue/framework runtime.
+8. Source maps are generated (`sourcemap: true`).
+
+## SSR vs Library Mode Comparison
+
+| Aspect | SSR Mode | Library Mode |
+| --- | --- | --- |
+| Purpose | Server-rendered application | Reusable npm package |
+| Entry config | `build.ssr` or `--ssr` flag | `build.lib` |
+| Externals | Auto-externalized node_modules | Manual via `rollupOptions.external` |
+| Output | Single server bundle | Multiple formats (ESM, CJS, UMD) |
+| CSS | Injected or collected | Extracted to separate file |
+| Types | Not needed (internal) | Required (public API) |
+| HTML | Template-based injection | Not applicable |

--- a/skills/vite-mastery/tank.json
+++ b/skills/vite-mastery/tank.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/vite-mastery",
+  "version": "1.0.0",
+  "description": "Comprehensive Vite build tool mastery. Covers vite.config.ts, dev server (HMR, proxy), build optimization (Rollup, manual chunks, code splitting, minification), plugin development (hooks, virtual modules), SSR, library mode, PWA, environment config, and performance profiling. Synthesizes Vite docs, Rollup docs, esbuild docs, Evan You. Triggers: vite, vite config, vite build, HMR, vite plugin, SSR, library mode, manual chunks, code splitting, optimizeDeps, import.meta.env, bundle size, vite PWA.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}

--- a/skills/web-performance/SKILL.md
+++ b/skills/web-performance/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: "@tank/web-performance"
+description: |
+  Web performance optimization for modern JavaScript applications. Covers
+  Core Web Vitals measurement and diagnosis (LCP, INP, CLS), loading
+  strategies (static/dynamic import, route-based splitting, import-on-
+  interaction, import-on-visibility), bundle optimization (tree-shaking,
+  code splitting, chunk strategies, bundle analysis), resource hints
+  (preload, prefetch, preconnect, modulepreload), runtime performance
+  (DOM batch reads/writes, requestAnimationFrame, Web Workers, virtual
+  lists, event delegation, debounce/throttle), network optimization
+  (compression, HTTP/2+, caching headers, CDN, service workers), image
+  optimization (modern formats, responsive images, lazy loading, LQIP),
+  and third-party script management. Framework-agnostic.
+
+  Synthesizes Grigorik (High Performance Browser Networking), Wagner
+  (Web Performance in Action), Google Web Vitals documentation, Chromium
+  performance guides, web.dev, MDN Web Docs.
+
+  Trigger phrases: "web performance", "Core Web Vitals", "LCP", "INP",
+  "CLS", "page speed", "slow page", "Lighthouse score", "bundle size",
+  "code splitting", "tree shaking", "lazy loading", "preload", "prefetch",
+  "cache strategy", "service worker", "image optimization", "web worker",
+  "runtime performance", "layout shift", "first contentful paint",
+  "loading performance", "bundle analysis", "performance budget",
+  "third party scripts", "resource hints", "HTTP caching"
+---
+
+# Web Performance
+
+Measure first. Fix the bottleneck. Ship smaller, faster, leaner.
+
+## Core Philosophy
+
+1. **Measure before optimizing.** Lighthouse, CrUX, and DevTools profiling dictate priorities, not hunches.
+2. **Ship less JavaScript.** Every kilobyte costs parse time, compile time, and execution time on every device.
+3. **Critical path is king.** Identify what blocks first paint and first interaction. Eliminate everything else from that path.
+4. **Perceived performance beats raw speed.** Skeleton screens, optimistic updates, and progressive rendering make 3s feel like 1s.
+5. **Performance is a budget, not a task.** Set thresholds, automate enforcement, fail the build when budgets break.
+
+## Quick-Start: Symptom to Fix
+
+### "LCP is slow (>2.5s)"
+
+1. Identify the LCP element (DevTools > Performance > Timings).
+2. If image: add `fetchpriority="high"`, ensure no lazy-loading, use responsive `srcset`.
+3. If text: eliminate render-blocking CSS/fonts. Inline critical CSS. Use `font-display: swap`.
+4. If server-slow: check TTFB. Preconnect to origins. Consider CDN or edge rendering.
+5. -> See `references/core-web-vitals.md`
+
+### "INP is high (>200ms)"
+
+1. Profile with DevTools > Performance. Find long tasks (>50ms).
+2. Break long tasks: `yield()` via `scheduler.yield()` or `setTimeout(0)`.
+3. Move heavy computation to Web Workers.
+4. Debounce rapid-fire input handlers. Use `requestAnimationFrame` for visual updates.
+5. -> See `references/runtime-performance.md`
+
+### "CLS is bad (>0.1)"
+
+1. Set explicit `width`/`height` on images and videos.
+2. Reserve space for dynamic content (ads, embeds, lazy-loaded sections).
+3. Avoid injecting content above the fold after initial render.
+4. Use `contain: layout` on containers with dynamic children.
+5. -> See `references/core-web-vitals.md`
+
+### "Bundle is too large"
+
+1. Run bundle analyzer (`webpack-bundle-analyzer`, `vite-bundle-visualizer`, `source-map-explorer`).
+2. Identify largest chunks. Apply dynamic `import()` for below-fold and interaction-gated features.
+3. Audit dependencies: replace heavy libraries (moment -> date-fns, lodash -> lodash-es or native).
+4. Verify tree-shaking: use ESM imports, check `sideEffects` in package.json.
+5. -> See `references/bundle-optimization.md`
+
+### "Third-party scripts block rendering"
+
+1. Audit all third-party scripts. Move non-critical to `async` or `defer`.
+2. Implement facades for heavy embeds (YouTube, chat widgets, maps).
+3. Delay non-essential scripts until after user interaction or idle.
+4. -> See `references/network-and-caching.md`
+
+## Loading Strategy Decision Tree
+
+| Signal | Strategy |
+| --- | --- |
+| Above-fold, critical path | Static import, inline critical CSS |
+| Below-fold component | `import()` on visibility (IntersectionObserver) |
+| Triggered by user action (modal, dropdown) | `import()` on interaction (click/hover) |
+| Entire route/page | Route-based code splitting |
+| Large library used in one feature | Dynamic import, separate chunk |
+| Third-party embed (YouTube, maps) | Facade pattern with lazy load |
+
+## Resource Hint Decision Tree
+
+| Scenario | Hint | Example |
+| --- | --- | --- |
+| LCP image or critical font | `<link rel="preload">` | `<link rel="preload" as="image" href="hero.webp">` |
+| Next-page navigation likely | `<link rel="prefetch">` | `<link rel="prefetch" href="/dashboard.js">` |
+| Third-party origin needed soon | `<link rel="preconnect">` | `<link rel="preconnect" href="https://cdn.example.com">` |
+| ES module in critical path | `<link rel="modulepreload">` | `<link rel="modulepreload" href="/app.js">` |
+| Many possible next origins | `<link rel="dns-prefetch">` | `<link rel="dns-prefetch" href="https://api.example.com">` |
+
+See `references/loading-strategies.md` for import patterns and splitting techniques.
+
+## Image Format Decision Tree
+
+| Content Type | Format | Fallback |
+| --- | --- | --- |
+| Photographic content | AVIF > WebP > JPEG | `<picture>` with source sets |
+| Graphics, logos, icons | SVG (vector) or WebP | PNG-8 for simple graphics |
+| Animated content | Animated WebP or short video | GIF (last resort) |
+| Thumbnails / placeholders | LQIP (blurred tiny image) or CSS gradient | Solid color placeholder |
+
+See `references/image-optimization.md` for responsive images, lazy loading, and LQIP patterns.
+
+## Performance Budget Template
+
+| Metric | Target | Action |
+| --- | --- | --- |
+| LCP | < 2.5s (p75) | Block deploy if exceeded |
+| INP | < 200ms (p75) | Alert, investigate |
+| CLS | < 0.1 (p75) | Block deploy if exceeded |
+| Total JS (compressed) | < 200 KB | Fail CI build |
+| Total CSS (compressed) | < 50 KB | Warn in CI |
+| Largest single chunk | < 100 KB | Warn, suggest splitting |
+| Hero image | < 200 KB | Warn, suggest compression |
+
+## Anti-Patterns
+
+| Anti-Pattern | Impact | Fix |
+| --- | --- | --- |
+| Importing entire lodash | +70 KB bundle | Cherry-pick or use `lodash-es` |
+| Synchronous `<script>` in `<head>` | Blocks parsing | Move to body end, add `defer` |
+| Unoptimized hero image (5 MB PNG) | LCP > 5s | Compress, serve WebP/AVIF, use `srcset` |
+| Layout reads interleaved with writes | Forced synchronous layout | Batch reads then writes, use `rAF` |
+| No `width`/`height` on images | CLS spikes | Always set intrinsic dimensions |
+| Polling instead of event-driven | Wasted CPU, battery drain | Use MutationObserver, IntersectionObserver, SSE |
+| Bundling unused polyfills | +30-50 KB | Use `browserslist` and differential serving |
+| Inlining everything | Defeats caching | Inline only critical CSS; externalize the rest |
+
+## Reference Index
+
+| File | Contents |
+| --- | --- |
+| `references/core-web-vitals.md` | LCP, INP, CLS measurement, diagnosis workflows, optimization patterns, field vs lab data |
+| `references/loading-strategies.md` | Static/dynamic imports, route splitting, import-on-interaction, import-on-visibility, resource hints |
+| `references/bundle-optimization.md` | Tree-shaking, code splitting, chunk strategies, bundle analysis tools, dependency auditing |
+| `references/runtime-performance.md` | DOM batching, requestAnimationFrame, Web Workers, virtual lists, event delegation, long tasks |
+| `references/network-and-caching.md` | Compression, HTTP/2+, caching headers, CDN strategy, service workers, third-party script management |
+| `references/image-optimization.md` | Modern formats (AVIF, WebP), responsive images, lazy loading, LQIP, video replacement, CDN transforms |

--- a/skills/web-performance/references/bundle-optimization.md
+++ b/skills/web-performance/references/bundle-optimization.md
@@ -1,0 +1,295 @@
+# Bundle Optimization and Tree-Shaking
+
+Sources: Webpack documentation (v5), Vite/Rollup documentation, web.dev bundle optimization guides, Osmani (JavaScript performance patterns), bundlephobia.com methodology
+
+Covers: Tree-shaking mechanics, code splitting strategies, chunk optimization,
+bundle analysis tools, dependency auditing, and performance budgets in CI.
+For Vite-specific build configuration (Rollup options, manual chunks, CSS splitting),
+see `@tank/vite-mastery` references/build-optimization.md.
+
+## Tree-Shaking
+
+Tree-shaking eliminates dead code (unused exports) from the final bundle. It requires ES module syntax (`import`/`export`) and a bundler that performs static analysis.
+
+### Requirements for Effective Tree-Shaking
+
+| Requirement | Why | Common Failure |
+| --- | --- | --- |
+| ES module syntax | Static analysis needs static imports | CommonJS `require()` is dynamic, cannot tree-shake |
+| `sideEffects: false` in package.json | Tells bundler unused files can be dropped | Missing flag causes entire library to be included |
+| No side effects at module level | Top-level code runs on import | `console.log`, DOM manipulation, global mutation at top level |
+| Named exports over default | Default export wraps everything | `export default { a, b, c }` defeats tree-shaking |
+| Granular imports | Import only what you use | `import _ from 'lodash'` pulls everything |
+
+### Configuring sideEffects
+
+In your application's `package.json`:
+
+```json
+{
+  "sideEffects": [
+    "*.css",
+    "*.scss",
+    "./src/polyfills.js"
+  ]
+}
+```
+
+This tells the bundler: "All files except these can be safely dropped if their exports are unused."
+
+For libraries: set `"sideEffects": false` if the library is pure (no global side effects).
+
+### Import Patterns and Their Impact
+
+```javascript
+// BAD: Imports entire library (~70 KB for lodash)
+import _ from 'lodash';
+_.debounce(fn, 300);
+
+// BETTER: Named import from ESM build
+import { debounce } from 'lodash-es';
+
+// BEST: Cherry-pick the specific module
+import debounce from 'lodash-es/debounce';
+```
+
+### Verifying Tree-Shaking
+
+1. Build in production mode with source maps.
+2. Open the bundle in `source-map-explorer` or `webpack-bundle-analyzer`.
+3. Search for known unused exports. If they appear, tree-shaking failed.
+4. Check the bundler output for warnings about CommonJS fallbacks.
+
+## Code Splitting Strategies
+
+### Split by Route
+
+Each page/route gets its own chunk. Users only download code for the page they visit.
+
+```
+entry.js (shared runtime + framework)
+  -> home-chunk.js
+  -> dashboard-chunk.js
+  -> settings-chunk.js
+```
+
+This is the highest-impact split. Implement first.
+
+### Split by Feature
+
+Heavy features that are not always used get their own chunks.
+
+| Feature | Trigger | Chunk |
+| --- | --- | --- |
+| Rich text editor | User clicks "Edit" | `editor-chunk.js` |
+| Chart library | Dashboard page load | `charts-chunk.js` |
+| PDF export | User clicks "Export" | `pdf-chunk.js` |
+| Admin panel | Admin route | `admin-chunk.js` |
+
+### Split by Vendor
+
+Separate third-party code from application code. Vendors change less frequently, enabling long-term caching.
+
+```javascript
+// vite.config.js
+export default {
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            // Group large dependencies into named chunks
+            if (id.includes('recharts') || id.includes('d3')) {
+              return 'charts-vendor';
+            }
+            if (id.includes('react') || id.includes('react-dom')) {
+              return 'react-vendor';
+            }
+            return 'vendor';
+          }
+        },
+      },
+    },
+  },
+};
+```
+
+### Avoiding Over-Splitting
+
+Too many small chunks cause HTTP overhead (even with HTTP/2).
+
+| Guideline | Target |
+| --- | --- |
+| Minimum chunk size | 20 KB (compressed) |
+| Maximum initial chunks | 5-8 parallel requests |
+| Shared code threshold | Extract if used by 2+ routes and > 10 KB |
+
+Webpack: use `optimization.splitChunks.minSize` (default 20 KB).
+Vite: Rollup handles this automatically but `manualChunks` overrides it.
+
+## Bundle Analysis
+
+### Tools
+
+| Tool | Bundler | Output |
+| --- | --- | --- |
+| `webpack-bundle-analyzer` | Webpack | Interactive treemap, searchable |
+| `vite-bundle-visualizer` | Vite | Treemap for Rollup output |
+| `source-map-explorer` | Any | Treemap from source maps |
+| `bundlephobia.com` | N/A (web) | Size/download cost of npm packages |
+| `pkg-size.dev` | N/A (web) | Bundle size with tree-shaking simulation |
+| `size-limit` | Any | Budget enforcement in CI |
+
+### Running Bundle Analysis
+
+```bash
+# Webpack
+npx webpack-bundle-analyzer dist/stats.json
+
+# Generate stats.json
+webpack --profile --json > dist/stats.json
+
+# Vite
+npx vite-bundle-visualizer
+
+# Source map explorer (any bundler)
+npx source-map-explorer dist/assets/*.js
+```
+
+### Reading a Treemap
+
+1. **Largest rectangles** = largest modules. Attack these first.
+2. **node_modules** section: identify heavy dependencies. Question each one.
+3. **Duplicate modules**: same library appearing in multiple chunks. Configure shared chunk extraction.
+4. **Unexpected inclusions**: modules you did not import directly. Trace the import chain.
+
+## Dependency Auditing
+
+### The Replacement Checklist
+
+Before adding a dependency, check:
+
+1. **Size**: What is the minified + gzipped cost? Check bundlephobia.com.
+2. **Tree-shakeable**: Does it export ESM? Does it set `sideEffects: false`?
+3. **Alternatives**: Can a native API replace it?
+4. **Usage scope**: Is it used in one place or throughout the app?
+
+### Common Heavy Dependencies and Alternatives
+
+| Heavy Library | Size (min+gz) | Alternative | Size (min+gz) |
+| --- | --- | --- | --- |
+| `moment` | 72 KB | `date-fns` (tree-shakeable) | 2-8 KB (per function) |
+| `lodash` | 71 KB | `lodash-es` (tree-shakeable) | 1-3 KB (per function) |
+| `lodash` | 71 KB | Native JS (Array methods, structuredClone) | 0 KB |
+| `axios` | 13 KB | Native `fetch` | 0 KB |
+| `classnames` | 1 KB | Template literals or `clsx` | 0.5 KB |
+| `uuid` | 3 KB | `crypto.randomUUID()` | 0 KB |
+| `numeral` | 16 KB | `Intl.NumberFormat` | 0 KB |
+
+### Detecting Duplicates
+
+```bash
+# Webpack: check for duplicate versions of the same package
+npx webpack --stats-modules-space 999 | grep -E "^\s+.*node_modules"
+
+# npm: list duplicate dependencies
+npm ls --all | grep -E "deduped|UNMET"
+
+# pnpm: why is a package included?
+pnpm why <package-name>
+```
+
+## Performance Budgets
+
+### Defining Budgets
+
+| Budget Type | Metric | Recommended |
+| --- | --- | --- |
+| Total JS (compressed) | Transfer size | < 200 KB |
+| Total CSS (compressed) | Transfer size | < 50 KB |
+| Largest single chunk | Transfer size | < 100 KB |
+| Total page weight | Transfer size | < 500 KB |
+| Third-party JS | Transfer size | < 50 KB |
+| Main thread JS execution | Time | < 2s on mid-tier mobile |
+
+### Enforcing in CI with size-limit
+
+```json
+// package.json
+{
+  "size-limit": [
+    { "path": "dist/assets/*.js", "limit": "200 KB", "gzip": true },
+    { "path": "dist/assets/*.css", "limit": "50 KB", "gzip": true },
+    { "path": "dist/assets/index-*.js", "limit": "80 KB", "gzip": true }
+  ]
+}
+```
+
+```bash
+npx size-limit
+```
+
+Integrate into CI: fail the build if any budget is exceeded.
+
+### Enforcing with Bundler Limits
+
+```javascript
+// webpack.config.js
+module.exports = {
+  performance: {
+    maxAssetSize: 200 * 1024,     // 200 KB per asset
+    maxEntrypointSize: 300 * 1024, // 300 KB per entry
+    hints: 'error',                // Fail build on violation
+  },
+};
+```
+
+## Advanced: Differential Serving
+
+Serve modern bundles to modern browsers, legacy bundles to old browsers.
+
+```html
+<!-- Modern browsers: smaller, faster -->
+<script type="module" src="/app.modern.js"></script>
+
+<!-- Legacy browsers: polyfills included -->
+<script nomodule src="/app.legacy.js"></script>
+```
+
+Modern bundles skip transpilation of async/await, optional chaining, nullish coalescing, and other modern syntax. This saves 10-20% bundle size.
+
+### Browserslist Configuration
+
+```
+# .browserslistrc
+# Modern: targets for type="module" browsers
+[modern]
+last 2 Chrome versions
+last 2 Firefox versions
+last 2 Safari versions
+last 2 Edge versions
+
+# Legacy: IE11 and older
+[legacy]
+> 0.5%
+not dead
+IE 11
+```
+
+## Monitoring Bundle Size Over Time
+
+Track bundle sizes across commits. Alert on regressions.
+
+```bash
+# CI step: record size and compare to baseline
+CURRENT=$(stat -f%z dist/assets/index*.js | paste -sd+ | bc)
+BASELINE=$(cat .bundle-baseline 2>/dev/null || echo 0)
+DIFF=$((CURRENT - BASELINE))
+
+if [ $DIFF -gt 10240 ]; then
+  echo "Bundle grew by $((DIFF / 1024)) KB. Investigate."
+  exit 1
+fi
+```
+
+Integrate with GitHub PR comments to surface size changes in code review.

--- a/skills/web-performance/references/core-web-vitals.md
+++ b/skills/web-performance/references/core-web-vitals.md
@@ -1,0 +1,259 @@
+# Core Web Vitals
+
+Sources: Google Web Vitals documentation (2024-2026), Chromium performance team publications, web.dev, CrUX methodology documentation
+
+Covers: LCP, INP, and CLS measurement, diagnosis, and optimization. Field data vs lab data interpretation. Threshold targets and regression prevention.
+
+## The Three Vitals
+
+| Metric | Full Name | Measures | Good | Needs Work | Poor |
+| --- | --- | --- | --- | --- | --- |
+| LCP | Largest Contentful Paint | Loading performance | < 2.5s | 2.5-4.0s | > 4.0s |
+| INP | Interaction to Next Paint | Responsiveness | < 200ms | 200-500ms | > 500ms |
+| CLS | Cumulative Layout Shift | Visual stability | < 0.1 | 0.1-0.25 | > 0.25 |
+
+All thresholds are measured at the 75th percentile of page loads across both mobile and desktop.
+
+## Field Data vs Lab Data
+
+| Aspect | Field (RUM) | Lab (Synthetic) |
+| --- | --- | --- |
+| Source | Real users (CrUX, RUM providers) | Controlled test (Lighthouse, WebPageTest) |
+| Variability | High (devices, networks, geography) | Low (consistent environment) |
+| Use for | Pass/fail ranking decisions | Debugging, development iteration |
+| INP accuracy | Accurate (real interactions) | Simulated only (TBT as proxy) |
+| CLS accuracy | Full session (accurate) | Single page load (partial) |
+
+Always prioritize field data for performance assessment. Use lab data for debugging root causes.
+
+### Measurement Tools
+
+| Tool | Type | Best For |
+| --- | --- | --- |
+| Chrome UX Report (CrUX) | Field | Origin-level real-user data, BigQuery analysis |
+| `web-vitals` JS library | Field | Custom RUM collection, per-page granularity |
+| Lighthouse | Lab | Development auditing, CI integration |
+| Chrome DevTools Performance | Lab | Frame-by-frame debugging, long task identification |
+| WebPageTest | Lab | Waterfall analysis, filmstrip comparison, third-party impact |
+| PageSpeed Insights | Both | Quick field + lab snapshot for any URL |
+
+### Implementing RUM Collection
+
+```javascript
+import { onLCP, onINP, onCLS } from 'web-vitals';
+
+function sendToAnalytics(metric) {
+  const body = JSON.stringify({
+    name: metric.name,
+    value: metric.value,
+    rating: metric.rating,
+    delta: metric.delta,
+    id: metric.id,
+    navigationType: metric.navigationType,
+    url: location.href,
+  });
+  // Use sendBeacon for reliability during page unload
+  navigator.sendBeacon('/analytics', body);
+}
+
+onLCP(sendToAnalytics);
+onINP(sendToAnalytics);
+onCLS(sendToAnalytics);
+```
+
+## Largest Contentful Paint (LCP)
+
+### What Counts as LCP
+
+- `<img>` elements (including inside `<picture>`)
+- `<image>` inside SVG
+- `<video>` poster image or first displayed frame
+- Block-level elements with background images via `url()`
+- Text blocks (`<p>`, `<h1>`, etc.) rendered with web fonts
+
+### LCP Breakdown
+
+Per Google's web.dev decomposition model:
+
+LCP = TTFB + Resource Load Delay + Resource Load Time + Element Render Delay
+
+| Sub-metric | Cause | Optimization |
+| --- | --- | --- |
+| TTFB | Slow server, no CDN, no caching | CDN, edge rendering, server caching, preconnect |
+| Resource Load Delay | Late discovery of LCP resource | `<link rel="preload">`, inline critical CSS, avoid JS-dependent image loading |
+| Resource Load Time | Large image, slow network | Compress images, serve modern formats (AVIF/WebP), use responsive `srcset` |
+| Element Render Delay | Render-blocking JS/CSS | Defer non-critical JS, inline critical CSS, `font-display: swap` |
+
+### LCP Optimization Checklist
+
+1. Identify the LCP element: DevTools > Performance panel > Timings track > LCP marker.
+2. Ensure the LCP resource is discoverable in the HTML source (not injected by JS).
+3. Add `fetchpriority="high"` to the LCP image.
+4. Remove `loading="lazy"` from above-fold images.
+5. Preload the LCP image if it is a CSS background or loaded via JS:
+
+```html
+<link rel="preload" as="image" href="/hero.webp"
+      imagesrcset="/hero-400.webp 400w, /hero-800.webp 800w"
+      imagesizes="100vw">
+```
+
+6. Inline critical CSS (above-fold styles) in `<head>`. Load remaining CSS asynchronously.
+7. Use `font-display: swap` or `font-display: optional` for web fonts.
+8. Preconnect to required origins:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://cdn.example.com" crossorigin>
+```
+
+### Common LCP Mistakes
+
+| Mistake | Impact | Fix |
+| --- | --- | --- |
+| `loading="lazy"` on hero image | Delays LCP by deferring load | Remove lazy, add `fetchpriority="high"` |
+| LCP image set via JS or CSS | Browser cannot discover early | Use `<img>` in HTML, or `<link rel="preload">` |
+| Render-blocking Google Fonts | Blocks text rendering | Use `font-display: swap`, preconnect, or self-host |
+| Full-page client-side rendering | Empty HTML until JS executes | SSR, SSG, or streaming HTML |
+| Massive uncompressed hero image | Slow download | Compress, serve WebP/AVIF, use `srcset` |
+
+## Interaction to Next Paint (INP)
+
+### How INP Works
+
+INP measures the latency from user input (click, tap, keypress) to the next visual update. It tracks all interactions during the page lifecycle and reports the worst (or near-worst) interaction latency.
+
+Per Google's web.dev decomposition model:
+
+INP = Input Delay + Processing Time + Presentation Delay
+
+| Sub-metric | Cause | Optimization |
+| --- | --- | --- |
+| Input Delay | Main thread busy with other work | Break long tasks, yield to main thread |
+| Processing Time | Slow event handler | Optimize handler logic, defer non-visual work |
+| Presentation Delay | Expensive layout/paint after handler | Reduce DOM size, avoid forced reflow, use `content-visibility` |
+
+### INP Optimization Strategies
+
+1. **Identify slow interactions:** DevTools > Performance > record an interaction > inspect "Interactions" track.
+2. **Break long tasks (>50ms):** Use `scheduler.yield()` or manual yielding:
+
+```javascript
+async function processLargeList(items) {
+  for (let i = 0; i < items.length; i++) {
+    processItem(items[i]);
+    if (i % 100 === 0) {
+      // Yield to let browser handle pending input
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+  }
+}
+```
+
+3. **Move computation off main thread:** Use Web Workers for data processing, sorting, filtering.
+4. **Debounce high-frequency handlers:** Especially `input`, `scroll`, `mousemove`.
+5. **Use `requestAnimationFrame` for visual updates:** Never modify DOM in response to events without batching.
+6. **Reduce DOM size:** Target < 1,500 elements. Deep DOM trees increase style recalculation cost.
+7. **Use `content-visibility: auto`** on off-screen sections to skip rendering work.
+
+### Long Task Detection
+
+```javascript
+const observer = new PerformanceObserver((list) => {
+  for (const entry of list.getEntries()) {
+    console.warn('Long task detected:', entry.duration, 'ms', entry);
+  }
+});
+observer.observe({ type: 'longtask', buffered: true });
+```
+
+## Cumulative Layout Shift (CLS)
+
+### What Causes Layout Shifts
+
+| Cause | Frequency | Fix |
+| --- | --- | --- |
+| Images without dimensions | Very common | Always set `width` and `height` attributes |
+| Ads/embeds without reserved space | Common | Use `min-height` or aspect-ratio containers |
+| Dynamically injected content | Common | Reserve space before injection, use `content-visibility` |
+| Web fonts causing text reflow | Common | `font-display: optional`, size-adjust, font metric overrides |
+| Late-loading CSS | Occasional | Inline critical CSS, avoid CSS-in-JS flash |
+| Animations using layout properties | Occasional | Animate `transform`/`opacity` only, never `top`/`left`/`width`/`height` |
+
+### CLS Debugging
+
+1. Open DevTools > Performance panel > enable "Layout Shifts" checkbox.
+2. Record a page load. Examine blue markers in the timeline.
+3. Click a shift to see the affected elements highlighted.
+4. Use the Layout Instability API for production monitoring:
+
+```javascript
+const observer = new PerformanceObserver((list) => {
+  for (const entry of list.getEntries()) {
+    if (!entry.hadRecentInput) {
+      console.log('Layout shift:', entry.value, entry.sources);
+    }
+  }
+});
+observer.observe({ type: 'layout-shift', buffered: true });
+```
+
+### CLS Prevention Patterns
+
+Reserve space for dynamic content:
+
+```css
+/* Aspect ratio container for images */
+.image-container {
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  background: #f0f0f0; /* placeholder color */
+}
+
+/* Fixed-height ad slot */
+.ad-slot {
+  min-height: 250px;
+  contain: layout;
+}
+
+/* Font metric override to prevent reflow */
+@font-face {
+  font-family: 'CustomFont';
+  src: url('/font.woff2') format('woff2');
+  font-display: optional;
+  size-adjust: 105%;
+  ascent-override: 90%;
+  descent-override: 20%;
+}
+```
+
+## Performance Regression Prevention
+
+### CI Integration
+
+Run Lighthouse in CI on every PR. Fail the build when Core Web Vitals budgets are exceeded.
+
+```yaml
+# Example: Lighthouse CI budget
+- url: https://staging.example.com
+  budgets:
+    - metric: largest-contentful-paint
+      budget: 2500
+    - metric: cumulative-layout-shift
+      budget: 0.1
+    - metric: total-blocking-time
+      budget: 200
+    - metric: interactive
+      budget: 3500
+```
+
+### Monitoring Strategy
+
+| Layer | Tool | Frequency |
+| --- | --- | --- |
+| Real User Monitoring | `web-vitals` + analytics pipeline | Every page load |
+| Synthetic monitoring | Lighthouse CI, WebPageTest | Every deploy + hourly |
+| CrUX dashboard | BigQuery or PageSpeed Insights | Weekly review |
+| Alerting | Custom thresholds on RUM p75 | Real-time |
+
+Set alerts at the 75th percentile. Investigate when any vital crosses from "good" to "needs improvement."

--- a/skills/web-performance/references/image-optimization.md
+++ b/skills/web-performance/references/image-optimization.md
@@ -1,0 +1,295 @@
+# Image and Media Optimization
+
+Sources: Google web.dev image optimization guides, MDN Web Docs (responsive images, lazy loading), Squoosh documentation, Chromium image decoding architecture, HTTP Archive annual reports
+
+Covers: Modern image formats (AVIF, WebP, JPEG, PNG), responsive images with srcset and sizes, lazy loading, Low-Quality Image Placeholders (LQIP), video replacement for animated content, and image CDN transforms.
+
+## Format Selection
+
+### Format Comparison
+
+| Format | Best For | Compression | Browser Support | Alpha | Animation |
+| --- | --- | --- | --- | --- | --- |
+| AVIF | Photos, illustrations | Best (50% smaller than JPEG) | Chrome, Firefox, Safari 16.4+ | Yes | Yes |
+| WebP | Photos, illustrations | Good (25-35% smaller than JPEG) | All modern browsers | Yes | Yes |
+| JPEG | Photos (fallback) | Good | Universal | No | No |
+| PNG | Graphics needing transparency | Lossless | Universal | Yes | No |
+| SVG | Icons, logos, illustrations | Vector (scales infinitely) | Universal | Yes | Yes (CSS/SMIL) |
+| GIF | Simple animations (legacy) | Poor | Universal | Binary only | Yes |
+
+### Decision Tree
+
+| Content | Primary Format | Fallback |
+| --- | --- | --- |
+| Hero photograph | AVIF | WebP, then JPEG |
+| Product photo | AVIF or WebP | JPEG |
+| Icon or logo | SVG | PNG (for raster fallback) |
+| Screenshot with text | WebP (lossless) or PNG | PNG |
+| Animated content (short) | Animated WebP or `<video>` | GIF (last resort) |
+| Animated content (long) | `<video>` (MP4/WebM) | Never use GIF |
+| Decorative background | CSS gradient or WebP | JPEG |
+| Thumbnail / placeholder | Tiny AVIF/WebP or CSS blur | Solid color |
+
+### Quality Settings
+
+| Format | Recommended Quality | Notes |
+| --- | --- | --- |
+| AVIF | 50-65 | Excellent quality at low values |
+| WebP | 75-85 | Good balance of size and quality |
+| JPEG | 75-85 | Below 70 shows visible artifacts |
+| PNG | Lossless | Use pngquant for lossy PNG-8 if size matters |
+
+Test quality with A/B comparison. Audience tolerance varies by content type.
+
+## The `<picture>` Element
+
+Serve modern formats with automatic fallback:
+
+```html
+<picture>
+  <!-- AVIF for browsers that support it -->
+  <source type="image/avif"
+          srcset="/img/hero.avif 1x, /img/hero@2x.avif 2x">
+
+  <!-- WebP fallback -->
+  <source type="image/webp"
+          srcset="/img/hero.webp 1x, /img/hero@2x.webp 2x">
+
+  <!-- JPEG for everything else -->
+  <img src="/img/hero.jpg"
+       alt="Hero image description"
+       width="1200" height="600"
+       loading="eager"
+       fetchpriority="high"
+       decoding="async">
+</picture>
+```
+
+The browser selects the first `<source>` it supports. The `<img>` is always required as the final fallback.
+
+## Responsive Images
+
+### srcset with Width Descriptors
+
+Let the browser choose the optimal image size based on viewport and device pixel ratio:
+
+```html
+<img src="/img/product-800.jpg"
+     srcset="/img/product-400.jpg 400w,
+            /img/product-800.jpg 800w,
+            /img/product-1200.jpg 1200w,
+            /img/product-1600.jpg 1600w"
+     sizes="(max-width: 600px) 100vw,
+            (max-width: 1200px) 50vw,
+            33vw"
+     alt="Product name"
+     width="800" height="600"
+     loading="lazy"
+     decoding="async">
+```
+
+### How `sizes` Works
+
+| sizes Value | Meaning |
+| --- | --- |
+| `100vw` | Image fills the full viewport width |
+| `50vw` | Image fills half the viewport |
+| `(max-width: 600px) 100vw, 50vw` | Full width on mobile, half on desktop |
+| `(max-width: 600px) calc(100vw - 32px), 400px` | Accounting for padding, or fixed width |
+
+The browser uses `sizes` to calculate which `srcset` entry to download before layout.
+
+### Breakpoint Strategy
+
+Generate image sizes at common layout breakpoints:
+
+| Breakpoint | Typical Image Width | srcset Entry |
+| --- | --- | --- |
+| Mobile (< 600px) | 400-600px | `400w`, `600w` |
+| Tablet (600-1024px) | 600-800px | `800w` |
+| Desktop (1024-1440px) | 800-1200px | `1200w` |
+| Large desktop (> 1440px) | 1200-1600px | `1600w` |
+| Retina (2x) | 2x of layout width | Already handled by `w` descriptors |
+
+Do not generate more than 4-6 sizes. The marginal benefit of more sizes does not justify the build complexity and CDN storage.
+
+### Art Direction
+
+Use `<picture>` with `media` attributes when the image composition changes at breakpoints:
+
+```html
+<picture>
+  <!-- Cropped vertical for mobile -->
+  <source media="(max-width: 600px)"
+          srcset="/img/hero-mobile.avif" type="image/avif">
+  <source media="(max-width: 600px)"
+          srcset="/img/hero-mobile.webp" type="image/webp">
+
+  <!-- Wide landscape for desktop -->
+  <source srcset="/img/hero-desktop.avif" type="image/avif">
+  <source srcset="/img/hero-desktop.webp" type="image/webp">
+
+  <img src="/img/hero-desktop.jpg" alt="Hero" width="1600" height="600">
+</picture>
+```
+
+## Lazy Loading
+
+### Native Lazy Loading
+
+```html
+<!-- Lazy load below-fold images -->
+<img src="/img/product.webp" loading="lazy" alt="Product"
+     width="400" height="300" decoding="async">
+
+<!-- Do not lazy load above-fold / LCP images — they need eager loading -->
+<img src="/img/hero.webp" loading="eager" alt="Hero"
+     width="1200" height="600" fetchpriority="high">
+```
+
+### Rules
+
+| Position | loading | fetchpriority | decoding |
+| --- | --- | --- | --- |
+| Above fold, LCP candidate | `eager` (or omit) | `high` | `async` |
+| Above fold, not LCP | `eager` (or omit) | `auto` | `async` |
+| Below fold | `lazy` | `auto` | `async` |
+| Far below fold (gallery) | `lazy` | `low` | `async` |
+
+### Intersection Observer (Custom Lazy Loading)
+
+For more control or older browser support:
+
+```javascript
+const imageObserver = new IntersectionObserver(
+  (entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        const img = entry.target;
+        img.src = img.dataset.src;
+        if (img.dataset.srcset) img.srcset = img.dataset.srcset;
+        img.removeAttribute('data-src');
+        imageObserver.unobserve(img);
+      }
+    });
+  },
+  { rootMargin: '300px' } // Start loading 300px before visible
+);
+
+document.querySelectorAll('img[data-src]').forEach(img => {
+  imageObserver.observe(img);
+});
+```
+
+## LQIP (Low-Quality Image Placeholder)
+
+Show a blurred tiny image while the full image loads. Prevents layout shift and improves perceived performance.
+
+### Inline Base64 LQIP
+
+```html
+<div class="lqip-container" style="aspect-ratio: 16/9;">
+  <!-- Tiny blurred placeholder (< 1 KB inline) -->
+  <img class="lqip-placeholder"
+       src="data:image/webp;base64,UklGRlYAAABXRUJQVlA4IEoAAADQAQCdASoQAAkAAkA..."
+       style="filter: blur(20px); width: 100%; height: 100%; object-fit: cover;"
+       alt="" aria-hidden="true">
+
+  <!-- Full image (replaces placeholder on load) -->
+  <img class="lqip-full"
+       src="/img/hero.webp"
+       loading="lazy"
+       onload="this.previousElementSibling.remove(); this.style.opacity=1;"
+       style="opacity: 0; transition: opacity 0.3s;"
+       alt="Hero image" width="1200" height="675">
+</div>
+```
+
+### CSS Gradient Placeholder
+
+Even simpler: extract the dominant color and use it as background:
+
+```html
+<div style="background: #2a4858; aspect-ratio: 16/9;">
+  <img src="/img/landscape.webp"
+       loading="lazy"
+       style="opacity: 0; transition: opacity 0.3s;"
+       onload="this.style.opacity=1"
+       alt="Landscape" width="1200" height="675">
+</div>
+```
+
+### BlurHash
+
+Encode images into a compact string that renders as a blurred preview on the client. Libraries: `blurhash`, `thumbhash`.
+
+```javascript
+// Server: encode during image processing
+import { encode } from 'blurhash';
+const hash = encode(imageData, width, height, 4, 3);
+// Store "LKO2?U%2Tw=w]~RBVZRi};RPxuwH" in database
+
+// Client: decode and render as canvas
+import { decode } from 'blurhash';
+const pixels = decode(hash, 32, 32);
+// Render pixels to a small canvas, display as background
+```
+
+## Replacing GIFs with Video
+
+Animated GIFs are 5-20x larger than equivalent video. Replace them.
+
+```html
+<!-- Replaces an animated GIF -->
+<video autoplay loop muted playsinline
+       width="600" height="400"
+       poster="/img/animation-poster.webp">
+  <source src="/video/animation.webm" type="video/webm">
+  <source src="/video/animation.mp4" type="video/mp4">
+</video>
+```
+
+Conversion:
+
+```bash
+# Convert GIF to WebM (VP9)
+ffmpeg -i animation.gif -c:v libvpx-vp9 -b:v 0 -crf 40 animation.webm
+
+# Convert GIF to MP4 (H.264)
+ffmpeg -i animation.gif -movflags +faststart -pix_fmt yuv420p animation.mp4
+```
+
+Typical size reduction: 80-95%.
+
+## Image CDN Transforms
+
+Use an image CDN (Cloudinary, Imgix, Cloudflare Images, Vercel OG) to transform images on the fly.
+
+```html
+<!-- Cloudinary: auto format, auto quality, resize to 800px -->
+<img src="https://res.cloudinary.com/demo/image/upload/f_auto,q_auto,w_800/sample.jpg"
+     alt="Sample" width="800" height="600" loading="lazy">
+
+<!-- Imgix: WebP auto, quality 75, width 800 -->
+<img src="https://example.imgix.net/photo.jpg?auto=format&q=75&w=800"
+     alt="Photo" width="800" height="600" loading="lazy">
+```
+
+Benefits:
+- No build-time image processing pipeline
+- Automatic format negotiation (AVIF/WebP/JPEG)
+- On-the-fly resize and crop
+- Global CDN delivery
+- Reduces origin storage (one source image, infinite variants)
+
+## Performance Impact Summary
+
+| Optimization | Typical LCP Improvement | Effort |
+| --- | --- | --- |
+| Serve AVIF/WebP instead of JPEG/PNG | 30-50% smaller images | Low (build pipeline change) |
+| Responsive images with srcset | 40-60% savings on mobile | Medium |
+| Lazy load below-fold images | Faster initial load | Low |
+| LQIP placeholders | Better perceived speed, zero CLS | Medium |
+| Replace GIFs with video | 80-95% smaller files | Low |
+| Image CDN | All of the above, automated | Low (service integration) |
+| fetchpriority="high" on LCP image | 100-300ms LCP improvement | Trivial |

--- a/skills/web-performance/references/loading-strategies.md
+++ b/skills/web-performance/references/loading-strategies.md
@@ -1,0 +1,319 @@
+# Loading Strategies and Code Splitting
+
+Sources: Grigorik (High Performance Browser Networking), Osmani (Learning JavaScript Design Patterns), Google web.dev loading documentation, Webpack/Vite/Rollup documentation
+
+Covers: Static and dynamic imports, route-based splitting, import-on-interaction, import-on-visibility, resource hints (preload, prefetch, preconnect, modulepreload), and critical rendering path optimization.
+
+## Import Strategy Decision Tree
+
+| Context | Strategy | Mechanism |
+| --- | --- | --- |
+| Core app logic, always needed | Static import | `import { x } from 'mod'` |
+| Entire route/page | Route-based split | Framework router + dynamic import |
+| Below-fold component | Import on visibility | IntersectionObserver + dynamic import |
+| Triggered by user action | Import on interaction | Event handler + dynamic import |
+| Large library, single feature | Feature-based split | Dynamic import at usage point |
+| Unlikely-needed future page | Prefetch | `<link rel="prefetch">` or router prefetch |
+
+## Static Imports
+
+The default. Bundler includes the module in the initial bundle.
+
+```javascript
+import { formatDate } from './utils/date';
+import { Button } from './components/Button';
+```
+
+Use static imports for:
+- App shell and layout components
+- Routing infrastructure
+- Authentication logic
+- Above-fold UI components
+- Tiny utilities (< 2 KB)
+
+## Dynamic Imports
+
+Create separate chunks loaded on demand. Return a Promise.
+
+```javascript
+// Basic dynamic import
+const module = await import('./heavy-feature');
+module.init();
+
+// With named exports
+const { Chart } = await import('./Chart');
+
+// Error handling
+try {
+  const { editor } = await import('./CodeEditor');
+  editor.mount(container);
+} catch (err) {
+  showFallback('Editor failed to load');
+}
+```
+
+### Chunk Naming (Webpack)
+
+```javascript
+// Named chunks for debugging and caching
+const Chart = await import(/* webpackChunkName: "chart" */ './Chart');
+
+// Prefetch hint (load during idle)
+const Analytics = await import(/* webpackPrefetch: true */ './Analytics');
+
+// Preload hint (load in parallel with current chunk)
+const Modal = await import(/* webpackPreload: true */ './Modal');
+```
+
+### Chunk Naming (Vite/Rollup)
+
+Vite uses `manualChunks` in the Rollup config:
+
+```javascript
+// vite.config.js
+export default {
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['react', 'react-dom'],
+          charts: ['recharts', 'd3-scale'],
+        },
+      },
+    },
+  },
+};
+```
+
+## Route-Based Code Splitting
+
+Every route becomes its own chunk. The router loads the chunk when the user navigates.
+
+### Generic Pattern (Framework-Agnostic)
+
+```javascript
+const routes = {
+  '/': () => import('./pages/Home'),
+  '/dashboard': () => import('./pages/Dashboard'),
+  '/settings': () => import('./pages/Settings'),
+  '/reports': () => import('./pages/Reports'),
+};
+
+async function navigate(path) {
+  const loader = routes[path];
+  if (!loader) return show404();
+  const { default: Page } = await loader();
+  render(Page);
+}
+```
+
+### Prefetching Next Routes
+
+Prefetch likely next pages during idle time:
+
+```javascript
+function prefetchRoute(path) {
+  const loader = routes[path];
+  if (loader) loader(); // Trigger fetch, cache the promise
+}
+
+// Prefetch on link hover
+document.querySelectorAll('a[data-route]').forEach(link => {
+  link.addEventListener('mouseenter', () => {
+    prefetchRoute(link.dataset.route);
+  }, { once: true });
+});
+```
+
+## Import on Interaction
+
+Load code only when the user triggers an action. Ideal for modals, dropdowns, rich editors, and settings panels.
+
+```javascript
+// Load a modal on button click
+document.getElementById('open-editor').addEventListener('click', async () => {
+  const { CodeEditor } = await import('./CodeEditor');
+  const editor = new CodeEditor();
+  editor.mount(document.getElementById('editor-container'));
+}, { once: true });
+```
+
+### Hover-Triggered Preloading
+
+Start loading on hover, mount on click. Reduces perceived latency.
+
+```javascript
+let editorPromise = null;
+
+button.addEventListener('pointerenter', () => {
+  editorPromise = editorPromise || import('./CodeEditor');
+}, { once: true });
+
+button.addEventListener('click', async () => {
+  const { CodeEditor } = await editorPromise || import('./CodeEditor');
+  new CodeEditor().mount(container);
+});
+```
+
+## Import on Visibility
+
+Load components when they scroll into view. Ideal for below-fold content, image galleries, charts, and comment sections.
+
+```javascript
+function loadOnVisible(element, loader) {
+  const observer = new IntersectionObserver(
+    async (entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          observer.unobserve(entry.target);
+          const module = await loader();
+          module.default.mount(entry.target);
+        }
+      }
+    },
+    { rootMargin: '200px' } // Start loading 200px before visible
+  );
+  observer.observe(element);
+}
+
+// Usage
+loadOnVisible(
+  document.getElementById('chart-container'),
+  () => import('./HeavyChart')
+);
+```
+
+### rootMargin Strategy
+
+| Content Type | rootMargin | Rationale |
+| --- | --- | --- |
+| Images | 200-300px | Start decoding before viewport |
+| Heavy components (charts, editors) | 400-600px | Extra time for JS parse + init |
+| Below-fold sections | 100px | Minimal overhead |
+| Infinite scroll items | 500-1000px | Prefetch next batch early |
+
+## Resource Hints
+
+### Preload
+
+Forces immediate high-priority fetch. Use for resources needed in the current page that the browser discovers late.
+
+```html
+<!-- LCP image -->
+<link rel="preload" as="image" href="/hero.webp"
+      imagesrcset="/hero-400.webp 400w, /hero-800.webp 800w"
+      imagesizes="(max-width: 600px) 400px, 800px">
+
+<!-- Critical font -->
+<link rel="preload" as="font" type="font/woff2"
+      href="/fonts/main.woff2" crossorigin>
+
+<!-- Critical CSS loaded async -->
+<link rel="preload" as="style" href="/above-fold.css">
+```
+
+**Warnings:**
+- Preload too many resources and they compete, slowing everything.
+- Chrome warns if a preloaded resource is not used within 3 seconds.
+- Limit preloads to 2-3 critical resources maximum.
+
+### Prefetch
+
+Low-priority fetch for resources likely needed on the next navigation.
+
+```html
+<!-- Next page JS bundle -->
+<link rel="prefetch" href="/dashboard-chunk.js">
+
+<!-- Next page data -->
+<link rel="prefetch" href="/api/dashboard-data" as="fetch" crossorigin>
+```
+
+Prefetch does not execute the resource. It only caches it. Execution happens when the resource is actually requested.
+
+### Preconnect
+
+Establishes connection (DNS + TCP + TLS) to a third-party origin before it is needed.
+
+```html
+<!-- CDN for images -->
+<link rel="preconnect" href="https://images.cdn.com" crossorigin>
+
+<!-- API server -->
+<link rel="preconnect" href="https://api.example.com" crossorigin>
+
+<!-- Analytics (lower priority, use dns-prefetch) -->
+<link rel="dns-prefetch" href="https://analytics.example.com">
+```
+
+**Limit preconnect to 2-4 origins.** Each connection consumes CPU and memory. Use `dns-prefetch` for less critical origins.
+
+### Modulepreload
+
+Like preload, but for ES modules. Fetches, parses, and compiles the module and its dependencies.
+
+```html
+<link rel="modulepreload" href="/app.js">
+<link rel="modulepreload" href="/vendor.js">
+```
+
+Use for critical-path ES modules in applications using native ESM or Vite.
+
+## Critical Rendering Path
+
+The sequence: HTML parse -> DOM construction -> CSS parse -> CSSOM construction -> Render tree -> Layout -> Paint.
+
+### Render-Blocking Resources
+
+| Resource | Default Behavior | Optimization |
+| --- | --- | --- |
+| `<link rel="stylesheet">` | Blocks rendering | Inline critical CSS, load rest async |
+| `<script>` (no attribute) | Blocks parsing + rendering | Add `defer` or `async` |
+| `<script defer>` | Defers execution until DOM ready | Maintains order, does not block parsing |
+| `<script async>` | Executes as soon as downloaded | No order guarantee, does not block parsing |
+| `<script type="module">` | Deferred by default | Same as `defer` behavior |
+
+### Critical CSS Extraction
+
+Inline the CSS needed for above-fold content. Load the rest asynchronously.
+
+```html
+<head>
+  <!-- Inline critical styles -->
+  <style>
+    /* Only above-fold layout and typography */
+    body { margin: 0; font-family: system-ui; }
+    .header { height: 64px; display: flex; }
+    .hero { min-height: 50vh; }
+  </style>
+
+  <!-- Load full stylesheet asynchronously -->
+  <link rel="preload" as="style" href="/styles.css"
+        onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="/styles.css"></noscript>
+</head>
+```
+
+### Script Loading Strategy
+
+| Script Type | Attribute | When to Use |
+| --- | --- | --- |
+| App bootstrap | `<script type="module">` or `defer` | Main application entry point |
+| Non-critical feature | `async` + conditional | Analytics, A/B testing |
+| Third-party (critical) | `async` | Payment SDK, auth provider |
+| Third-party (non-critical) | Manual delayed load | Chat widget, feedback tool |
+| Inline handler | None (must be sync) | Avoid; move to external file with `defer` |
+
+## Waterfall Analysis
+
+When debugging loading performance, read the network waterfall:
+
+1. HTML document arrives (TTFB).
+2. Parser discovers `<link>` and `<script>` tags -> initiates fetches.
+3. CSS blocks rendering until CSSOM is built.
+4. `defer` scripts execute after DOM is ready.
+5. `DOMContentLoaded` fires.
+6. Images, fonts, and async resources load.
+7. `load` event fires.
+
+**Optimization principle:** Push critical resources as close to step 2 as possible. Defer everything else to step 6 or later.

--- a/skills/web-performance/references/network-and-caching.md
+++ b/skills/web-performance/references/network-and-caching.md
@@ -1,0 +1,315 @@
+# Network and Caching Optimization
+
+Sources: Grigorik (High Performance Browser Networking), MDN Web Docs (HTTP caching, Service Worker API), Google web.dev caching guides, Chromium network stack documentation
+
+Covers: HTTP caching headers, compression (gzip, Brotli), HTTP/2 and HTTP/3, CDN strategy, service worker caching patterns, and third-party script management.
+
+## HTTP Caching
+
+### Cache-Control Header
+
+The primary mechanism for controlling browser and CDN caching.
+
+| Directive | Meaning | Use When |
+| --- | --- | --- |
+| `public` | Any cache (browser, CDN, proxy) can store | Static assets, public pages |
+| `private` | Only browser cache, not CDN/proxy | User-specific content, authenticated pages |
+| `max-age=N` | Cache is fresh for N seconds | All cacheable responses |
+| `s-maxage=N` | CDN/proxy cache duration (overrides max-age) | CDN-cached pages with different browser TTL |
+| `no-cache` | Must revalidate with server before using | HTML pages, API responses that change |
+| `no-store` | Never cache | Sensitive data, banking pages |
+| `immutable` | Never revalidate (used with content-hashed URLs) | Hashed static assets |
+| `stale-while-revalidate=N` | Serve stale while fetching fresh in background | API responses, non-critical data |
+
+### Caching Strategy by Resource Type
+
+| Resource | Cache-Control | ETag | Rationale |
+| --- | --- | --- | --- |
+| HTML pages | `no-cache` or `max-age=0, must-revalidate` | Yes | Always check for fresh content |
+| Hashed JS/CSS (`app.a1b2c3.js`) | `public, max-age=31536000, immutable` | No | Content-hash guarantees correctness |
+| Unhashed JS/CSS | `public, max-age=3600` | Yes | Short TTL with revalidation |
+| Images (hashed) | `public, max-age=31536000, immutable` | No | Long cache, bust via URL change |
+| Images (unhashed) | `public, max-age=86400` | Yes | Daily refresh |
+| API responses | `private, max-age=60, stale-while-revalidate=300` | Yes | Fresh data with background refresh |
+| Fonts | `public, max-age=31536000, immutable` | No | Fonts rarely change |
+
+### ETag and Conditional Requests
+
+When `max-age` expires, the browser sends a conditional request:
+
+```
+GET /styles.css
+If-None-Match: "abc123"     <- ETag from previous response
+
+Server response (if unchanged):
+304 Not Modified             <- No body transferred, saves bandwidth
+```
+
+ETags enable efficient revalidation without re-downloading unchanged resources.
+
+### Content-Hashed URLs
+
+The most effective caching pattern: include a content hash in the filename.
+
+```
+/assets/app.a1b2c3d4.js    <- Hash changes when content changes
+/assets/vendor.e5f6g7h8.js
+/assets/styles.i9j0k1l2.css
+```
+
+Set `Cache-Control: public, max-age=31536000, immutable`. The hash guarantees the browser fetches a new URL when content changes. No cache invalidation needed.
+
+All modern bundlers (Webpack, Vite, Rollup) generate content-hashed filenames by default.
+
+## Compression
+
+### Brotli vs Gzip
+
+| Aspect | Brotli | Gzip |
+| --- | --- | --- |
+| Compression ratio | 15-25% smaller than gzip | Baseline |
+| Compression speed | Slower (use static pre-compression) | Fast |
+| Decompression speed | Similar to gzip | Fast |
+| Browser support | All modern browsers | Universal |
+| Requirement | HTTPS only | HTTP or HTTPS |
+
+### Configuration
+
+```nginx
+# nginx: Enable both Brotli and gzip
+brotli on;
+brotli_types text/html text/css application/javascript application/json image/svg+xml;
+brotli_comp_level 6;
+
+gzip on;
+gzip_types text/html text/css application/javascript application/json image/svg+xml;
+gzip_min_length 1024;
+```
+
+### Static Pre-Compression
+
+For static assets, compress at build time for maximum compression ratio:
+
+```bash
+# Brotli (quality 11 for static files)
+brotli --quality=11 dist/assets/*.js dist/assets/*.css
+
+# Gzip
+gzip -k -9 dist/assets/*.js dist/assets/*.css
+```
+
+Configure the server to serve `.br` or `.gz` files when `Accept-Encoding` matches.
+
+### What to Compress
+
+| Type | Compress? | Rationale |
+| --- | --- | --- |
+| JavaScript | Yes | Text-based, high compression ratio |
+| CSS | Yes | Text-based, high compression ratio |
+| HTML | Yes | Text-based |
+| JSON | Yes | Text-based |
+| SVG | Yes | Text-based XML |
+| WOFF2 | No | Already compressed internally |
+| JPEG/PNG/WebP/AVIF | No | Already compressed; re-compression wastes CPU |
+| Video/Audio | No | Already compressed |
+
+## HTTP/2 and HTTP/3
+
+### HTTP/2 Benefits
+
+| Feature | Impact |
+| --- | --- |
+| Multiplexing | Multiple requests over one connection, no head-of-line blocking |
+| Header compression (HPACK) | Reduces header overhead (especially cookies) |
+| Server Push | Server sends resources before browser requests them |
+| Stream prioritization | Critical resources get bandwidth first |
+
+### HTTP/2 Implications for Optimization
+
+| Old Advice (HTTP/1.1) | New Advice (HTTP/2+) |
+| --- | --- |
+| Concatenate all JS into one file | Use smaller, granular chunks |
+| Sprite sheets for icons | Individual SVG or icon font |
+| Domain sharding (multiple CDN domains) | Single connection is better |
+| Inline all CSS | Inline only critical CSS; external is fine |
+
+With HTTP/2, many small files are often better than few large files because multiplexing eliminates the per-request overhead.
+
+### HTTP/3 (QUIC)
+
+Built on UDP instead of TCP. Benefits:
+- Zero round-trip connection establishment (0-RTT)
+- No head-of-line blocking at transport layer
+- Better performance on lossy networks (mobile)
+- Faster connection migration (switching from Wi-Fi to cellular)
+
+Enable by setting the `Alt-Svc` header:
+
+```
+Alt-Svc: h3=":443"; ma=86400
+```
+
+## CDN Strategy
+
+### What to CDN-Cache
+
+| Content | CDN? | TTL | Rationale |
+| --- | --- | --- | --- |
+| Static assets (JS, CSS, images) | Yes | Long (1 year with hash) | Immutable, serve from edge |
+| HTML pages (static/SSG) | Yes | Short (60s) with revalidation | Serve from edge, revalidate frequently |
+| API responses (public) | Yes | Short (10-60s) with stale-while-revalidate | Reduce origin load |
+| API responses (private) | No | N/A | User-specific data must not be shared |
+| Dynamic HTML (SSR) | Depends | Short or stale-while-revalidate | Edge caching reduces TTFB |
+
+### CDN Cache Invalidation
+
+```bash
+# Purge specific URL
+curl -X POST https://cdn.example.com/purge \
+  -d '{"url": "https://example.com/index.html"}'
+
+# Purge by cache tag
+curl -X POST https://cdn.example.com/purge \
+  -d '{"tags": ["product-123"]}'
+```
+
+Use cache tags (Surrogate-Key / Cache-Tag headers) for granular invalidation without purging everything.
+
+## Service Workers
+
+### Caching Strategies
+
+| Strategy | Behavior | Use For |
+| --- | --- | --- |
+| Cache First | Serve from cache, fallback to network | Static assets, fonts, images |
+| Network First | Try network, fallback to cache | HTML pages, API data |
+| Stale While Revalidate | Serve from cache, update in background | Non-critical API data, feeds |
+| Network Only | Always network, no caching | Authentication, real-time data |
+| Cache Only | Only cache, never network | Offline-first static content |
+
+### Cache First Implementation
+
+```javascript
+// service-worker.js
+const CACHE_NAME = 'static-v1';
+const STATIC_ASSETS = [
+  '/app.js',
+  '/styles.css',
+  '/offline.html',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.destination === 'image' ||
+      event.request.url.includes('/assets/')) {
+    event.respondWith(
+      caches.match(event.request).then(cached => {
+        return cached || fetch(event.request).then(response => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          return response;
+        });
+      })
+    );
+  }
+});
+```
+
+### Stale While Revalidate Implementation
+
+```javascript
+self.addEventListener('fetch', (event) => {
+  if (event.request.url.includes('/api/')) {
+    event.respondWith(
+      caches.match(event.request).then(cached => {
+        const fetchPromise = fetch(event.request).then(response => {
+          const clone = response.clone();
+          caches.open('api-cache').then(cache =>
+            cache.put(event.request, clone)
+          );
+          return response;
+        });
+        return cached || fetchPromise;
+      })
+    );
+  }
+});
+```
+
+## Third-Party Script Management
+
+### Audit Framework
+
+For every third-party script, answer:
+
+1. **Is it necessary?** Can the feature be removed or built in-house?
+2. **What is the cost?** Size, main-thread time, network requests it spawns.
+3. **Can it be deferred?** Load after critical content.
+4. **Can it use a facade?** Show a static placeholder until user interaction.
+
+### Loading Strategies by Priority
+
+| Priority | Strategy | Example |
+| --- | --- | --- |
+| Critical (blocks revenue) | `async` in `<head>` | Payment SDK, A/B testing |
+| Important (enhances UX) | `defer` in `<head>` | Analytics, error tracking |
+| Non-essential (nice to have) | Load on interaction or idle | Chat widget, feedback tool |
+| Below-fold embed | Facade + lazy load | YouTube, Google Maps |
+
+### Facade Pattern
+
+Replace heavy third-party embeds with a lightweight placeholder. Load the real embed on interaction.
+
+```html
+<!-- Facade: static thumbnail, loads real player on click -->
+<div class="youtube-facade" data-video-id="dQw4w9WgXcQ">
+  <img src="/thumbs/dQw4w9WgXcQ.webp" alt="Video title"
+       width="560" height="315" loading="lazy">
+  <button aria-label="Play video">Play</button>
+</div>
+
+<script>
+document.querySelectorAll('.youtube-facade').forEach(facade => {
+  facade.addEventListener('click', () => {
+    const iframe = document.createElement('iframe');
+    iframe.src = `https://www.youtube.com/embed/${facade.dataset.videoId}?autoplay=1`;
+    iframe.width = 560;
+    iframe.height = 315;
+    iframe.allow = 'autoplay; encrypted-media';
+    facade.replaceWith(iframe);
+  }, { once: true });
+});
+</script>
+```
+
+A YouTube facade saves ~500 KB of JavaScript per embed.
+
+### Delayed Loading
+
+Load non-critical scripts after user interaction or during idle time:
+
+```javascript
+function loadScript(src) {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.onload = resolve;
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+}
+
+// Load on first user interaction
+['click', 'scroll', 'keydown', 'touchstart'].forEach(event => {
+  window.addEventListener(event, () => {
+    loadScript('https://chat-widget.com/sdk.js');
+    loadScript('https://feedback.com/widget.js');
+  }, { once: true });
+});
+```

--- a/skills/web-performance/references/runtime-performance.md
+++ b/skills/web-performance/references/runtime-performance.md
@@ -1,0 +1,403 @@
+# Runtime Performance
+
+Sources: Grigorik (High Performance Browser Networking), Google Chromium rendering documentation, web.dev runtime performance guides, MDN Web Docs (Performance API, Web Workers), Wagner (Web Performance in Action)
+
+Covers: DOM batch reads/writes, requestAnimationFrame, forced reflow avoidance, Web Workers, virtual lists, event delegation, debounce/throttle, long task management, and memory optimization.
+
+## The Rendering Pipeline
+
+Every frame the browser executes:
+
+```
+JavaScript -> Style -> Layout -> Paint -> Composite
+```
+
+| Phase | Cost | Triggered By |
+| --- | --- | --- |
+| JavaScript | Variable | Event handlers, timers, rAF callbacks |
+| Style | Moderate | Class changes, inline style changes |
+| Layout (reflow) | Expensive | Width/height/position changes, DOM mutations |
+| Paint | Expensive | Color/background changes, text changes |
+| Composite | Cheap | Transform/opacity changes only |
+
+**Target: 16.6ms per frame** for 60fps. If any phase exceeds this, frames drop.
+
+### Composite-Only Animations
+
+The cheapest visual changes only trigger compositing:
+
+```css
+/* GOOD: Only triggers composite */
+.animate {
+  transform: translateX(100px);
+  opacity: 0.5;
+  will-change: transform;
+}
+
+/* BAD: Triggers layout + paint + composite */
+.animate-bad {
+  left: 100px;     /* Layout */
+  width: 200px;    /* Layout */
+  background: red; /* Paint */
+}
+```
+
+Always animate `transform` and `opacity`. Never animate `top`, `left`, `width`, `height`, `margin`, or `padding`.
+
+## DOM Batching: Reads and Writes
+
+Interleaving DOM reads and writes causes forced synchronous layout (layout thrashing).
+
+### The Problem
+
+```javascript
+// BAD: Read-write-read-write forces layout recalculation each cycle
+for (const el of elements) {
+  const height = el.offsetHeight;    // READ -> forces layout
+  el.style.height = height * 2 + 'px'; // WRITE -> invalidates layout
+}
+// Each READ after a WRITE forces the browser to recalculate layout
+```
+
+### The Fix: Batch Reads, Then Batch Writes
+
+```javascript
+// GOOD: All reads first, then all writes
+const heights = [];
+for (const el of elements) {
+  heights.push(el.offsetHeight); // READ (only one layout calculation)
+}
+for (let i = 0; i < elements.length; i++) {
+  elements[i].style.height = heights[i] * 2 + 'px'; // WRITE
+}
+```
+
+### Properties That Trigger Layout
+
+Reading any of these forces a synchronous layout if the DOM is dirty:
+
+| Category | Properties |
+| --- | --- |
+| Box dimensions | `offsetWidth`, `offsetHeight`, `offsetTop`, `offsetLeft` |
+| Scroll | `scrollTop`, `scrollLeft`, `scrollWidth`, `scrollHeight` |
+| Client | `clientWidth`, `clientHeight`, `clientTop`, `clientLeft` |
+| Window | `innerWidth`, `innerHeight`, `getComputedStyle()` |
+| Element | `getBoundingClientRect()`, `focus()` |
+
+### Using requestAnimationFrame for Writes
+
+```javascript
+function updateLayout(elements, newPositions) {
+  // Schedule writes for the next frame
+  requestAnimationFrame(() => {
+    for (let i = 0; i < elements.length; i++) {
+      elements[i].style.transform = `translateY(${newPositions[i]}px)`;
+    }
+  });
+}
+```
+
+### fastdom Pattern
+
+For complex interleaved operations, use the read/write scheduling pattern:
+
+```javascript
+// Read phase
+const measurements = [];
+requestAnimationFrame(() => {
+  // Batch all reads
+  for (const el of elements) {
+    measurements.push(el.getBoundingClientRect());
+  }
+
+  // Then schedule writes in the next microtask
+  requestAnimationFrame(() => {
+    for (let i = 0; i < elements.length; i++) {
+      elements[i].style.transform =
+        `translate(${measurements[i].left}px, ${measurements[i].top}px)`;
+    }
+  });
+});
+```
+
+## Long Tasks and Main Thread Management
+
+A long task is any JavaScript execution that takes > 50ms, blocking user input.
+
+### Yielding to the Main Thread
+
+```javascript
+// Modern: scheduler.yield() (Chrome 129+)
+async function processItems(items) {
+  for (const item of items) {
+    processItem(item);
+    await scheduler.yield(); // Yield after each item
+  }
+}
+
+// Fallback: setTimeout yielding
+function yieldToMain() {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function processItemsCompat(items) {
+  for (let i = 0; i < items.length; i++) {
+    processItem(items[i]);
+    if (i % 50 === 0) await yieldToMain();
+  }
+}
+```
+
+### Time-Slicing Pattern
+
+Process work in fixed time slices, yielding between slices:
+
+```javascript
+async function timeSlice(tasks, sliceMs = 5) {
+  let deadline = performance.now() + sliceMs;
+  let i = 0;
+
+  while (i < tasks.length) {
+    tasks[i]();
+    i++;
+
+    if (performance.now() >= deadline) {
+      await yieldToMain();
+      // Reset deadline for next slice
+      deadline = performance.now() + sliceMs;
+    }
+  }
+}
+```
+
+## Web Workers
+
+Move CPU-intensive work off the main thread entirely.
+
+### When to Use Workers
+
+| Use Case | Main Thread? | Worker? |
+| --- | --- | --- |
+| DOM manipulation | Yes | No (no DOM access) |
+| Event handling | Yes | No |
+| Data parsing (large JSON) | No | Yes |
+| Sorting/filtering large datasets | No | Yes |
+| Image processing | No | Yes |
+| Cryptographic operations | No | Yes |
+| Text search/regex on large text | No | Yes |
+| WebSocket message processing | Either | Recommended |
+
+### Basic Worker Pattern
+
+```javascript
+// main.js
+const worker = new Worker('/worker.js');
+
+worker.postMessage({ type: 'sort', data: largeArray });
+
+worker.addEventListener('message', (event) => {
+  const { sorted } = event.data;
+  renderList(sorted);
+});
+```
+
+```javascript
+// worker.js
+self.addEventListener('message', (event) => {
+  const { type, data } = event.data;
+
+  if (type === 'sort') {
+    const sorted = data.sort((a, b) => a.value - b.value);
+    self.postMessage({ sorted });
+  }
+});
+```
+
+### Transferable Objects
+
+For large ArrayBuffers, use transfer instead of copy:
+
+```javascript
+// Main thread: transfer the buffer (zero-copy)
+const buffer = new ArrayBuffer(1024 * 1024); // 1 MB
+worker.postMessage({ buffer }, [buffer]);
+// buffer is now unusable in main thread (transferred)
+
+// Worker: receive and process
+self.addEventListener('message', (event) => {
+  const { buffer } = event.data;
+  const view = new Float32Array(buffer);
+  // Process the data...
+  self.postMessage({ buffer }, [buffer]); // Transfer back
+});
+```
+
+### Comlink (Simplified Worker API)
+
+```javascript
+// worker.js
+import { expose } from 'comlink';
+
+const api = {
+  async processData(data) {
+    return heavyComputation(data);
+  },
+};
+
+expose(api);
+
+// main.js
+import { wrap } from 'comlink';
+
+const worker = new Worker('/worker.js');
+const api = wrap(worker);
+
+const result = await api.processData(largeDataset);
+```
+
+## Virtual Lists (Windowed Rendering)
+
+Render only visible items. Critical for lists with 1,000+ items.
+
+### Core Concept
+
+Instead of rendering 10,000 DOM nodes, render only the 20-30 visible in the viewport. As the user scrolls, recycle DOM nodes with new data.
+
+### Minimal Implementation
+
+```javascript
+class VirtualList {
+  constructor(container, items, itemHeight) {
+    this.container = container;
+    this.items = items;
+    this.itemHeight = itemHeight;
+    this.visibleCount = Math.ceil(container.clientHeight / itemHeight) + 2;
+
+    this.container.style.overflow = 'auto';
+    this.container.style.position = 'relative';
+
+    // Spacer for total scroll height
+    this.spacer = document.createElement('div');
+    this.spacer.style.height = `${items.length * itemHeight}px`;
+    this.container.appendChild(this.spacer);
+
+    this.container.addEventListener('scroll', () => this.render());
+    this.render();
+  }
+
+  render() {
+    const scrollTop = this.container.scrollTop;
+    const startIndex = Math.floor(scrollTop / this.itemHeight);
+    const endIndex = Math.min(startIndex + this.visibleCount, this.items.length);
+
+    // Clear and re-render visible items
+    const fragment = document.createDocumentFragment();
+    for (let i = startIndex; i < endIndex; i++) {
+      const el = document.createElement('div');
+      el.style.position = 'absolute';
+      el.style.top = `${i * this.itemHeight}px`;
+      el.style.height = `${this.itemHeight}px`;
+      el.textContent = this.items[i];
+      fragment.appendChild(el);
+    }
+
+    // Remove old rendered items, add new
+    this.spacer.innerHTML = '';
+    this.spacer.style.height = `${this.items.length * this.itemHeight}px`;
+    this.spacer.appendChild(fragment);
+  }
+}
+```
+
+For production, use established libraries: `@tanstack/virtual`, `react-window`, `react-virtuoso`.
+
+## Event Delegation
+
+Attach one handler to a parent instead of N handlers to N children.
+
+```javascript
+// BAD: 1000 event listeners
+document.querySelectorAll('.item').forEach(item => {
+  item.addEventListener('click', handleClick);
+});
+
+// GOOD: 1 event listener
+document.getElementById('list').addEventListener('click', (event) => {
+  const item = event.target.closest('.item');
+  if (item) handleClick(item);
+});
+```
+
+Benefits:
+- Lower memory usage (1 listener vs N)
+- Works with dynamically added elements
+- Faster setup (no loop over elements)
+
+## Debounce and Throttle
+
+### Debounce
+
+Execute after the user stops firing events. Use for search input, resize, form validation.
+
+```javascript
+function debounce(fn, ms) {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), ms);
+  };
+}
+
+searchInput.addEventListener('input', debounce((e) => {
+  fetchResults(e.target.value);
+}, 300));
+```
+
+### Throttle
+
+Execute at most once per interval. Use for scroll handlers, mousemove, game loops.
+
+```javascript
+function throttle(fn, ms) {
+  let last = 0;
+  return (...args) => {
+    const now = Date.now();
+    if (now - last >= ms) {
+      last = now;
+      fn(...args);
+    }
+  };
+}
+
+window.addEventListener('scroll', throttle(updateScrollIndicator, 100));
+```
+
+## content-visibility
+
+Skip rendering of off-screen content entirely:
+
+```css
+.section {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 500px; /* Estimated height */
+}
+```
+
+The browser skips layout and paint for off-screen sections, dramatically reducing initial rendering cost for long pages. The `contain-intrinsic-size` prevents scrollbar jumping by providing an estimated height.
+
+## Memory Optimization
+
+| Pattern | Problem | Fix |
+| --- | --- | --- |
+| Event listeners not removed | Memory leak on SPA navigation | Remove in cleanup/destroy lifecycle |
+| Closures holding large objects | Prevents garbage collection | Nullify references when done |
+| Unbounded caches/arrays | Memory grows indefinitely | Use LRU cache, set max size |
+| Detached DOM nodes | Elements removed but still referenced | Clear references after removal |
+| Large object creation in loops | GC pressure, jank | Reuse objects, use object pools |
+
+### Detecting Memory Leaks
+
+1. DevTools > Memory > Heap Snapshot.
+2. Take snapshot before action, perform action, take snapshot after.
+3. Compare snapshots. Look for unexpected retained objects.
+4. Use "Allocation timeline" to see where objects are allocated.

--- a/skills/web-performance/tank.json
+++ b/skills/web-performance/tank.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/web-performance",
+  "version": "1.0.0",
+  "description": "Web performance optimization for modern JS apps. Core Web Vitals (LCP, INP, CLS), loading strategies, bundle optimization (tree-shaking, code splitting), resource hints, runtime performance (DOM batching, Web Workers, virtual lists), network optimization (caching, CDN, service workers), image optimization (AVIF, WebP, responsive), and third-party script management. Framework-agnostic. Synthesizes Grigorik, Wagner, web.dev, Chromium guides.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

- **5 new skills** covering gaps in clean-code/architecture/engineering domains
- **1 updated skill** (@tank/react v2.2.0 → v2.3.0)

### New Skills

| Skill | Version | Size | Refs | Published |
|---|---|---|---|---|
| `@tank/design-patterns` | 1.0.0 | 65.4 KB (7 files) | 5 refs | ✅ |
| `@tank/web-performance` | 1.0.0 | 66.6 KB (8 files) | 6 refs | ✅ |
| `@tank/rendering-patterns` | 1.0.0 | 63.7 KB (7 files) | 5 refs | ✅ |
| `@tank/app-architecture` | 1.0.0 | 82.0 KB (8 files) | 6 refs | ✅ |
| `@tank/vite-mastery` | 1.0.0 | 56.8 KB (7 files) | 5 refs | ✅ |

### Updated Skill

- `@tank/react` v2.3.0: Trimmed SKILL.md (240→179 lines), added compound/polymorphic patterns, React Compiler, Vite-era stack, React 19 full API, new `modern-react-2026.md` reference

### Quality

- All skills reviewed by code-reviewer agents (structure, content, overlap, triggers)
- Copyright audit passed — 4 near-verbatim paraphrases rephrased, Google CWV formulas attributed
- No content overlap between skills (cross-references added where topics border)
- Trigger phrase conflicts resolved
- All 6 already published to Tank registry