### PR TITLE
feat: add @tank/ux-writing skill

### DIFF
--- a/skills/ux-writing/SKILL.md
+++ b/skills/ux-writing/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: "@tank/ux-writing"
+description: |
+  Write clear, effective interface copy — microcopy, error messages, onboarding
+  flows, form labels, empty states, notifications, and every word users read
+  inside an app. Covers voice and tone design, component-level microcopy
+  patterns, error message formulas, content design process, form copy,
+  inclusive/accessible writing, and localization readiness.
+  Synthesizes Yifrah (Microcopy), Podmajersky (Strategic Writing for UX),
+  Winters (Content Design), Metts/Welfle (Writing Is Designing), Hall
+  (Conversational Design), Fenton/Lee (Nicely Said), Ben-David (The Business
+  of UX Writing), plus Google Material Design, Apple HIG, Microsoft,
+  Shopify Polaris, Atlassian, and NN/g research.
+
+  Trigger phrases: "UX writing", "microcopy", "UI copy", "interface copy",
+  "error message", "empty state", "onboarding copy", "button label",
+  "form copy", "placeholder text", "validation message", "toast message",
+  "notification copy", "voice and tone", "content design", "UX text",
+  "confirmation dialog", "call to action", "CTA copy", "helper text",
+  "loading message", "success message", "permission request copy",
+  "write the copy for", "what should this button say",
+  "how to word this error", "write microcopy for"
+---
+
+# UX Writing
+
+## Core Philosophy
+
+1. **Clarity is non-negotiable.** Users scan, they don't read. Every word
+   must earn its place — if removing it changes nothing, remove it.
+2. **Write the conversation, not the interface.** Imagine explaining the
+   action to someone sitting next to you. That's the copy.
+3. **Microcopy is UX.** A confusing error message is a broken feature.
+   Copy is as functional as code — it directly impacts task completion,
+   conversion rates, and support ticket volume.
+4. **Voice is stable, tone adapts.** The product sounds like itself
+   everywhere, but dials warmth up for onboarding and seriousness up for
+   errors. Define voice once, map tone per context.
+5. **Every component has a pattern.** Buttons, errors, empty states,
+   tooltips, forms — each has proven formulas. Use them instead of
+   reinventing from scratch.
+
+## Quick-Start: Common Problems
+
+### "Write error message copy"
+
+1. Apply the three-part formula: [What happened] + [Why] + [How to fix]
+2. Match severity tier to tone (critical = direct, warning = advisory)
+3. Avoid "invalid", "oops", error codes, blame language
+   -> See `references/error-messages.md`
+
+### "Write copy for an empty state"
+
+1. Apply the four-part formula: [What's missing] + [Why empty] + [Next step] + [Action button]
+2. Match empty state type (first-use, no results, cleared, error-caused)
+3. Frame as opportunity, not absence
+   -> See `references/empty-states-onboarding.md`
+
+### "What should this button say?"
+
+1. Start with a verb — describe the action, not the noun
+2. Be specific: "Save changes" not "Submit", "Delete project" not "OK"
+3. For destructive actions, name what's being destroyed
+   -> See `references/component-microcopy.md`
+
+### "Write form labels and helper text"
+
+1. Labels above inputs, sentence case, no colons
+2. Mark the minority (optional fields if most are required, or vice versa)
+3. Use helper text for format hints — never rely on placeholder text alone
+   -> See `references/forms-and-inputs.md`
+
+### "Define voice and tone for our product"
+
+1. Run the voice discovery workshop (3-5 voice attributes)
+2. Map tone per context using the dial model
+3. Document with Do/Don't examples per attribute
+   -> See `references/voice-and-tone.md`
+
+### "Make this copy accessible / localization-ready"
+
+1. Target 7th-8th grade reading level, max 25 words per sentence
+2. Avoid idioms, metaphors, cultural references, humor that won't translate
+3. Budget 30-40% word expansion for translated strings
+   -> See `references/inclusive-writing.md`
+
+## Decision Trees
+
+### What to Write First
+
+| Signal | Start With |
+|--------|------------|
+| New product / no voice defined | Voice and tone framework |
+| Specific screen needs copy | Component-level patterns for that element |
+| High error/support volume | Error messages and form validation |
+| Low activation / high churn | Empty states and onboarding |
+| Redesign / content audit | Content design process |
+| International audience | Inclusive writing + localization |
+
+### Tone by Context
+
+| UI Context | Tone Setting | Reasoning |
+|------------|-------------|-----------|
+| Onboarding / welcome | Warm, encouraging | User is uncertain — build confidence |
+| Success / completion | Brief, satisfied | Don't over-celebrate routine tasks |
+| Error / failure | Direct, helpful | Frustration is high — solve fast |
+| Destructive action | Serious, precise | Consequences are real — no ambiguity |
+| Empty state | Inviting, optimistic | Motivate the first action |
+| Loading / waiting | Calm, transparent | Reduce anxiety about progress |
+| Settings / admin | Neutral, informative | Task-focused, no personality needed |
+| Payment / financial | Careful, reassuring | Money triggers anxiety — build trust |
+
+### Copy Length by Component
+
+| Component | Target Length | Hard Limit |
+|-----------|-------------|------------|
+| Button label | 1-3 words | 5 words |
+| Toast / snackbar | 1-2 lines | 2 lines mobile |
+| Tooltip | 1-2 sentences | 150 characters |
+| Dialog title | 3-8 words | 1 line |
+| Error inline | 1 sentence | 2 sentences |
+| Empty state body | 1-3 sentences | 4 sentences |
+| Helper text | 1 sentence | 80 characters |
+
+## Reference Index
+
+| File | Contents |
+|------|----------|
+| `references/voice-and-tone.md` | Voice discovery workshop, tone mapping (Apple dials, Google axes, NN/g dimensions), voice documentation, antipatterns |
+| `references/component-microcopy.md` | Element-by-element patterns: buttons, headings, labels, tooltips, notifications, dialogs, loading, navigation |
+| `references/error-messages.md` | Error anatomy formula, severity tiers, inline/form/system/payment/404 patterns, antipattern catalog |
+| `references/empty-states-onboarding.md` | Empty state types, first-run experience, permission requests, feature discovery, success states, upgrade copy |
+| `references/content-design-process.md` | Content-first design, discovery, workflow, pair writing, crits, testing, measuring impact, style guides |
+| `references/forms-and-inputs.md` | Labels, placeholders, helper text, validation, selects, checkboxes, file uploads, multi-step, submit/confirm |
+| `references/inclusive-writing.md` | Plain language, screen readers, inclusive language, localization, RTL, sensitivity, cognitive load |

--- a/skills/ux-writing/references/component-microcopy.md
+++ b/skills/ux-writing/references/component-microcopy.md
@@ -1,0 +1,341 @@
+# Component Microcopy Patterns
+
+Sources: Yifrah (Microcopy), Podmajersky (Strategic Writing for UX), Google Material Design 3, Microsoft Writing Style Guide, Shopify Polaris
+
+Covers: Element-by-element microcopy patterns for every standard UI component — buttons, headings, labels, tooltips, notifications, dialogs, loading states, and navigation. Do/Don't pairs and character constraints for each.
+
+## Universal Rules
+
+Apply these to every piece of UI text before component-specific rules.
+
+| Rule | Rationale |
+|---|---|
+| Sentence case | Universal across Google, Microsoft, Apple, Shopify. Title Case feels dated and creates ambiguity with proper nouns. |
+| Active voice | "File was deleted" → "You deleted the file." Reduces cognitive load. |
+| Present tense | "Your message has been sent" → "Message sent." Present is shorter and more direct. |
+| Second person | Address users as "you." Never "the user" or passive constructions. |
+| Contractions | Use "don't," "can't," "you'll." Reads as human, not robotic. Exception: legal or compliance text. |
+| Lead with the outcome | Front-load the word that matters most. Users scan — the first 2-3 words decide if they read on. |
+
+### Writing Checklist (Per Element)
+
+1. Can the user act on this information right now?
+2. Is every word earning its place? (Shopify: "Approach content like Jenga — what's the most you can take away?")
+3. Does it match the voice? (Stable qualities.) Does it match the tone? (Context-appropriate modulation.)
+4. Would a user understand this without reading anything else on the page?
+
+## Button Labels
+
+Buttons are commitments. The label must tell the user exactly what happens when they click.
+
+### Core Rules
+
+- Start with a verb. The verb is the action; the noun is the object.
+- Be specific. Name the outcome, not the gesture.
+- Match the button label to the preceding context. If the heading says "Delete project," the button says "Delete project," not "OK."
+- Limit to 1-4 words. If a button needs more, the surrounding context is failing.
+
+### Do / Don't
+
+| Do | Don't | Why |
+|---|---|---|
+| Save changes | Submit | "Submit" is a form mechanic, not a user goal. |
+| Create account | OK | "OK" forces users to re-read the dialog to understand what they're agreeing to. |
+| Delete 3 items | Yes | "Yes/No" pairs are ambiguous — users must parse the question. |
+| Export as PDF | Click here | "Click here" describes the input device, not the outcome. |
+| Add to cart | Continue | "Continue" is acceptable only in linear flows where the next step is obvious. |
+
+### Destructive Action Buttons
+
+Destructive actions demand friction. Pair a descriptive red button with a safe escape.
+
+| Pattern | Primary (destructive) | Secondary (safe) |
+|---|---|---|
+| Delete | Delete project | Keep project |
+| Cancel subscription | Cancel subscription | Keep subscription |
+| Remove member | Remove [Name] | Go back |
+| Discard draft | Discard | Keep editing |
+
+Rules for destructive buttons:
+- Name the thing being destroyed in the label.
+- Make the safe option visually dominant (outlined or secondary style).
+- Never use "Cancel" as a button label in a cancellation dialog — it creates a double negative ("Cancel the cancel?").
+
+### Primary vs Secondary Wording
+
+| Primary | Secondary |
+|---|---|
+| Specific action verb: "Publish post" | Escape route: "Save as draft" |
+| Affirmative commitment | Neutral retreat: "Not now," "Go back," "Keep editing" |
+| Matches the page title or dialog heading | Provides the alternative path |
+
+## Headings and Titles
+
+Headings orient. They answer "Where am I?" and "What can I do here?" in under a second.
+
+### Hierarchy Rules
+
+| Level | Purpose | Pattern | Example |
+|---|---|---|---|
+| Page title | Name the place or task | Noun phrase or verb phrase | "Account settings," "Create a new project" |
+| Section heading | Group related content | Short noun phrase | "Billing," "Notifications," "Team members" |
+| Dialog title | State what's happening | Brief statement or question | "Delete this file?" or "Unsaved changes" |
+| Card title | Identify the object | Noun or noun + qualifier | "Monthly revenue," "Recent activity" |
+
+### Do / Don't
+
+| Do | Don't | Why |
+|---|---|---|
+| Account settings | Your Account Settings Page | Redundant. The user knows it's a page; drop "Your" and "Page." |
+| Delete this file? | Warning! | "Warning" is a category, not content. Name the action. |
+| Create project | Create a New Project | Drop articles and adjectives that add no information. |
+| Billing | Billing Information and Payment Methods | Scan cost is too high. Shorten; let the page content explain. |
+
+### Rules
+
+- No periods at the end of headings.
+- Sentence case (not Title Case).
+- Headings are not sentences — omit articles ("a," "the") when possible.
+- Dialog titles: if the dialog asks a question, phrase the title as a question. If it states a consequence, phrase it as a statement.
+
+## Labels and Placeholder Text
+
+Three distinct text types serve fields. Each has a job — conflating them creates confusion.
+
+### Role Definitions
+
+| Element | Persists? | Purpose | Example |
+|---|---|---|---|
+| Field label | Always visible | Identify what to enter | "Email address" |
+| Placeholder text | Disappears on focus | Show format or example | "name@company.com" |
+| Helper text | Always visible (below field) | Clarify requirements | "Use your work email for SSO" |
+
+### Field Labels
+
+- Use nouns or short noun phrases: "Full name," "Phone number."
+- Never end with a colon in modern UI (the field border implies the relationship).
+- Keep to 1-3 words. If a label needs more, the field may need redesign.
+- Required fields: mark optional fields with "(optional)" rather than marking required fields with an asterisk. Most fields are required — label the exception.
+
+### Placeholder Text
+
+- Format examples only: "MM/DD/YYYY," "name@company.com."
+- Never use placeholders as labels. When the user types, the label disappears and they lose context.
+- Never put instructions in placeholders. "Enter your email" vanishes on focus — the user loses the instruction mid-task.
+- Use lighter text color (not just gray — ensure 4.5:1 contrast ratio for accessibility when visible).
+
+### Helper Text
+
+- Explain constraints before the user hits them: "Password must be at least 8 characters."
+- Provide context: "This name appears on your public profile."
+- Keep to one sentence. Two sentences means the interface needs simplification.
+
+### Do / Don't
+
+| Do | Don't | Why |
+|---|---|---|
+| Label: "Email address" / Placeholder: "name@company.com" | Placeholder only: "Enter your email address" | Placeholder disappears. User loses context mid-typing. |
+| Helper: "Must be at least 8 characters" | Placeholder: "Must be at least 8 characters" | Requirements must stay visible. |
+| Label: "Phone number (optional)" | Label: "Phone number*" with legend "* = optional" | Asterisks are ambiguous. "(optional)" is explicit. |
+
+## Tooltips and Hints
+
+Tooltips are last-resort explanations. If the UI needs a tooltip, consider whether the primary text can be clearer first.
+
+### When to Use
+
+| Use a tooltip | Don't use a tooltip |
+|---|---|
+| Icon-only buttons that need text equivalents | To explain a core workflow (redesign the UI instead) |
+| Jargon the user may not know | To repeat the label with more words |
+| Feature behind a toggle that has consequences | For information the user needs before acting (use helper text) |
+| Truncated text that needs full display | For required reading (users skip hover states) |
+
+### Writing Rules
+
+- Maximum 150 characters. Beyond that, use an inline hint or a help panel.
+- One idea per tooltip. If it needs "and," split into two elements.
+- No title in the tooltip unless the trigger element is ambiguous.
+- Plain text only — no links, no formatting. (Links are inaccessible in hover states; keyboard users cannot reach them.)
+- Start with a verb or a definition — not "This is..."
+
+### Do / Don't
+
+| Do | Don't | Why |
+|---|---|---|
+| "Pin this item to your sidebar" | "Click this to pin" | Don't describe the interaction mechanic. |
+| "API key for authenticating requests" | "This is your API key that you use to authenticate your API requests" | Remove filler. One pass of information. |
+| "Available after trial ends" | "This feature is currently locked because you are on a trial plan" | Front-load the timing; omit the obvious. |
+
+## Notifications and Toasts
+
+Notifications interrupt. Earn the interruption with density and immediate relevance.
+
+### Anatomy
+
+```
+[Icon] [Title — 3-5 words] [optional body — 1 sentence] [optional action]
+```
+
+### Patterns by Type
+
+| Type | Icon | Title pattern | Body pattern | Duration |
+|---|---|---|---|---|
+| Success | Checkmark | Past tense outcome: "Changes saved" | Omit unless next step exists | 4-6 seconds auto-dismiss |
+| Info | Info circle | Neutral statement: "New version available" | One sentence of context | Persistent or 8 seconds |
+| Warning | Triangle | Present tense risk: "Storage almost full" | Consequence + threshold | Persistent until resolved |
+| Error | X circle | See `references/error-messages.md` | See `references/error-messages.md` | Persistent until action taken |
+
+### Constraints
+
+- Snackbar/toast: maximum 2 lines on mobile (Material Design 3 spec).
+- One action button maximum on toasts. Two actions belong in a banner or dialog.
+- Action button label: verb, not "Dismiss." Give the user a forward path: "Upgrade," "Undo," "View."
+- No exclamation marks in success messages (Atlassian). Celebration inflation devalues real wins.
+- No periods in toast titles. Period in body text only if it is a complete sentence.
+
+### Do / Don't
+
+| Do | Don't | Why |
+|---|---|---|
+| "Changes saved" | "Your changes have been successfully saved!" | Strip filler. No "successfully" — success is implied by the checkmark. |
+| "3 files uploaded" | "Upload complete" | Specificity builds confidence. Name the count. |
+| "Connection lost. Retrying..." | "Something went wrong" | Name the problem. Vague messages erode trust. |
+| Action: "Undo" | Action: "OK" | "OK" acknowledges. "Undo" gives control. |
+
+## Confirmation Dialogs
+
+Confirmation dialogs exist to prevent irreversible mistakes. If the action is reversible, skip the dialog.
+
+### When to Confirm
+
+| Confirm | Skip confirmation |
+|---|---|
+| Permanent deletion | Archiving (reversible) |
+| Payment or billing change | Saving a draft |
+| Removing another user's access | Toggling a non-critical setting |
+| Exiting with unsaved changes | Navigation within the app |
+
+### Anatomy
+
+```
+[Title: Name the action or consequence]
+[Body: 1-2 sentences — what happens and whether it's reversible]
+[Secondary button: safe exit]  [Primary button: confirm action]
+```
+
+### Title Patterns
+
+| Scenario | Title | Why |
+|---|---|---|
+| Deleting data | "Delete [object name]?" | Question format signals a decision point. |
+| Losing unsaved work | "Unsaved changes" | Statement format signals a status. |
+| Removing a person | "Remove [Name] from [Team]?" | Include the person's name — specificity prevents mistakes. |
+| Irreversible action | "This can't be undone" | When the consequence is more important than the action. |
+
+### Body Text Rules
+
+- State the consequence explicitly: "This will permanently delete all 12 files in this folder."
+- Include counts and names: "Remove Alex from the Design team? They'll lose access to 4 shared projects."
+- If reversible, say so: "You can restore this from Trash within 30 days."
+- If irreversible, say so: "This action can't be undone."
+- Never use "Are you sure?" — it adds a question without adding information.
+
+### Button Pairing
+
+| Context | Destructive button | Safe button |
+|---|---|---|
+| Delete | "Delete [object]" | "Keep [object]" |
+| Discard | "Discard changes" | "Keep editing" |
+| Remove user | "Remove [Name]" | "Cancel" |
+| Leave page | "Leave without saving" | "Stay on page" |
+
+### Do / Don't
+
+| Do | Don't | Why |
+|---|---|---|
+| Title: "Delete 'Q3 Report'?" / Body: "This file will be permanently deleted." / Buttons: "Delete file" / "Keep file" | Title: "Are you sure?" / Body: "Do you want to delete this?" / Buttons: "Yes" / "No" | Every element must carry specific information. Generic text forces re-reading. |
+| "Remove Alex from Design? They'll lose access to 4 shared projects." | "Remove this member from the team?" | Names and numbers eliminate ambiguity. |
+
+## Loading States
+
+Loading is dead time. Use it to set expectations and maintain the user's sense of progress.
+
+### Patterns by Wait Duration
+
+| Duration | Pattern | Copy guidance |
+|---|---|---|
+| < 1 second | No indicator needed | Instant feedback via state change (button → disabled). |
+| 1-3 seconds | Spinner with label | Short verb phrase: "Saving..." "Loading dashboard..." |
+| 3-10 seconds | Progress bar or skeleton | Describe what's loading: "Loading your projects..." |
+| 10-30 seconds | Progress bar + percentage or step | Name the stage: "Processing images (3 of 12)..." |
+| > 30 seconds | Background task with notification | "We'll notify you when the export is ready." |
+
+### Spinner and Progress Labels
+
+- Use the gerund (verb + "-ing"): "Uploading," "Generating report."
+- Include the object when context is ambiguous: "Loading dashboard" not just "Loading."
+- End with ellipsis (...) to signal ongoing activity. No period.
+- Never say "Please wait" — it shifts the cognitive burden to patience instead of progress.
+
+### Skeleton Screens
+
+Skeleton screens replace content with placeholder shapes. No text is needed on the skeleton itself. The value is spatial continuity — the user sees the layout before the data.
+
+### Do / Don't
+
+| Do | Don't | Why |
+|---|---|---|
+| "Uploading 3 files..." | "Please wait while we upload your files" | Remove "please wait." Name the count. |
+| "Generating report (2 of 5)..." | "Loading..." | Progress steps reduce perceived wait time. |
+| "This may take a few minutes. We'll email you when it's done." | "Processing. Do not close this window." | Give the user freedom; don't trap them. |
+
+## Navigation and Menus
+
+Navigation text is wayfinding. Users scan it to build a mental model of the product.
+
+### Menu Items
+
+- Use nouns for destinations: "Dashboard," "Settings," "Team."
+- Use verbs for actions: "Create project," "Import data," "Invite member."
+- Never mix nouns and verbs at the same level — pick one pattern per menu section.
+- 1-2 words maximum for top-level navigation. Save longer labels for submenus.
+
+### Breadcrumbs
+
+- Mirror the page titles exactly. "Settings > Notifications" not "Settings > Notification preferences" if the page title is "Notifications."
+- Truncate the middle, not the ends: "Home > ... > Project settings > Integrations."
+- The current page in the breadcrumb is not a link.
+
+### Tab Labels
+
+- Nouns only: "Overview," "Activity," "Members," "Settings."
+- Parallel structure: if one tab is a plural noun, all tabs should be plural nouns.
+- Include counts when useful: "Comments (12)," "Issues (3)."
+- Maximum 1-2 words per tab. Tabs with 3+ word labels signal an information architecture problem.
+
+### Do / Don't
+
+| Do | Don't | Why |
+|---|---|---|
+| Dashboard · Projects · Team · Settings | Home · View Projects · Manage Your Team · System Settings | Inconsistent patterns and unnecessary verbs inflate scan cost. |
+| Overview · Activity · Members | General · What's Happening · People on This Project | Parallel structure, minimal words. |
+| Comments (12) | Comments | Counts set expectations and surface activity. |
+
+## Character Constraint Quick Reference
+
+| Component | Recommended limit | Source |
+|---|---|---|
+| Button label | 1-4 words | Cross-system consensus |
+| Toast title | 3-5 words | Atlassian, Material Design 3 |
+| Toast body | 1 sentence, ≤ 60 characters | Material Design 3 (2-line mobile max) |
+| Tooltip | ≤ 150 characters | Shopify Polaris |
+| Dialog title | 3-8 words | Material Design 3 |
+| Dialog body | 1-2 sentences | Cross-system consensus |
+| Field label | 1-3 words | Shopify Polaris |
+| Helper text | 1 sentence | Podmajersky |
+| Tab label | 1-2 words | Cross-system consensus |
+| Top-level nav item | 1-2 words | Cross-system consensus |
+| Breadcrumb segment | Match page title | Material Design 3 |
+| Loading label | Verb + object, ≤ 30 characters | Microsoft Style Guide |
+| Section heading | 1-3 words | Shopify Polaris |

--- a/skills/ux-writing/references/content-design-process.md
+++ b/skills/ux-writing/references/content-design-process.md
@@ -1,0 +1,343 @@
+# Content Design Process
+
+Sources: Winters/Edwards (Content Design), Ben-David (The Business of UX Writing), Metts/Welfle (Writing Is Designing), Podmajersky (Strategic Writing for UX)
+
+Covers: The end-to-end content design workflow — from research and discovery through drafting, testing, and measurement — plus collaboration models, style guide creation, and organizational maturity.
+
+## Content-First Design
+
+Design the conversation before designing the screen. Visual layout follows content structure, not the other way around.
+
+### The Conversation-First Approach
+
+Podmajersky frames every interface as a dialogue between the product and the user. Before opening a design tool, write out the exchange:
+
+1. What does the user need to accomplish?
+2. What does the product need to communicate?
+3. What is the minimum exchange that satisfies both?
+
+Write this exchange as a script — literal back-and-forth dialogue — then extract the content model from it.
+
+### Why Content Precedes Layout
+
+| Content-first advantage | What it prevents |
+|---|---|
+| Reveals actual information hierarchy | Designers guessing at content length with lorem ipsum |
+| Exposes missing states early | "We forgot what happens when..." discovered in dev |
+| Forces scope decisions | Feature creep hidden behind placeholder copy |
+| Aligns stakeholders on messaging | Late-stage rewrites that break layouts |
+| Surfaces terminology conflicts | Engineering naming leaking into user-facing text |
+
+Metts and Welfle reinforce this: writing IS a design activity. Treat words as a design material with the same weight as color, type, and layout. Content and visual design happen in parallel, not sequentially.
+
+### Content-First in Practice
+
+- Write real content into wireframes from the first iteration
+- Use content to drive component selection, not the reverse
+- Prototype with words before pixels — a text-only flow test catches logic gaps faster than a clickable mockup
+- Maintain a content model (structured inventory of what text appears where) alongside the design system
+
+## Content Discovery
+
+Research what users need to read before deciding what to write.
+
+### User Stories for Content
+
+Winters and Edwards adapt user stories specifically for content decisions:
+
+```
+As a [user type],
+I need to know [information],
+So that I can [action/decision].
+```
+
+Examples:
+- "As a first-time buyer, I need to know shipping costs before checkout, so that I can decide whether to purchase."
+- "As a returning user, I need to know what changed since my last visit, so that I can act on new information."
+
+These stories map directly to content requirements — each one generates specific microcopy needs.
+
+### Job Stories for Content
+
+Job stories add situational context that user stories miss:
+
+```
+When [situation],
+I want to [motivation],
+So I can [expected outcome].
+```
+
+Example: "When I see an error after submitting a form, I want to understand what went wrong, so I can fix it without starting over."
+
+### Content Audit
+
+Inventory existing content before creating new content:
+
+| Audit dimension | What to evaluate |
+|---|---|
+| Accuracy | Is the information correct and current? |
+| Completeness | Are any user questions unanswered? |
+| Consistency | Does terminology match across surfaces? |
+| Clarity | Can users understand this on first read? |
+| Tone alignment | Does it match the intended voice? |
+| Redundancy | Is the same information repeated unnecessarily? |
+| Accessibility | Does it work for screen readers and low literacy? |
+
+Tag each content item with a disposition: keep, revise, remove, or create.
+
+### Competitive Content Analysis
+
+Study how competitors and adjacent products communicate:
+
+1. Screenshot the same flow (signup, checkout, error handling) across 3-5 competitors
+2. Catalog word choices, tone, information density, and help patterns
+3. Identify gaps — what do competitors fail to explain?
+4. Note conventions users expect from the category (do not break established patterns without cause)
+
+## Content Design Workflow
+
+A six-stage loop. Each stage produces an artifact that feeds the next.
+
+| Stage | Activity | Output |
+|---|---|---|
+| 1. Research | User interviews, analytics review, support ticket analysis, content audit | Content brief: user needs, business goals, constraints |
+| 2. Content model | Map information architecture, define content types, identify reuse | Structured content inventory with hierarchy and relationships |
+| 3. Draft | Write real copy in context (wireframes, prototypes, spreadsheets) | First-pass content in situ, flagged questions for design/eng |
+| 4. Review | Content crit, stakeholder review, legal/compliance check | Revised draft with resolved feedback |
+| 5. Test | Comprehension testing, A/B tests, tree testing, usability sessions | Test results with confidence levels and recommendations |
+| 6. Iterate | Revise based on test data, update content model, document decisions | Final copy, updated style guide entries, measurement baseline |
+
+### Stage Details
+
+**Research:** Pull from three sources simultaneously — qualitative (interviews, usability sessions), quantitative (analytics, funnel data), and support (ticket themes, chat logs, FAQ traffic). Prioritize by frequency and severity.
+
+**Content model:** Define each content type: what fields it has, where it appears, what triggers it, what variations exist. This prevents one-off copy that cannot scale.
+
+**Draft:** Write in the actual interface, not in a document. Use the real constraints — character limits, layout boundaries, responsive breakpoints. Flag every assumption explicitly.
+
+**Review:** Use the content crit format described below. Separate review rounds: first for content accuracy and strategy, then for voice/tone polish.
+
+**Test:** Match the test method to the question. Comprehension testing for clarity, A/B testing for conversion impact, tree testing for navigation labels.
+
+**Iterate:** Treat published content as a hypothesis. Schedule post-launch reviews at 2 weeks and 6 weeks.
+
+## Pair Writing
+
+Winters and Edwards formalize collaborative writing as a core practice, not an occasional activity.
+
+### What Pair Writing Is
+
+Two people write together in real time — one drives (types), one navigates (challenges, suggests, checks). Rotate roles every 15-20 minutes.
+
+### Pair Combinations and Their Value
+
+| Pair | What the combination produces |
+|---|---|
+| Writer + Designer | Content and layout evolve together; prevents "make the copy fit" problems |
+| Writer + Engineer | Surfaces technical constraints early; aligns variable names with user-facing terms |
+| Writer + PM | Ensures copy reflects product strategy; resolves scope questions in real time |
+| Writer + Researcher | Grounds every word choice in evidence; prevents assumption-driven writing |
+| Writer + Writer | Catches blind spots; produces more consistent voice across flows |
+
+### Running a Pair Writing Session
+
+1. Define the scope: one flow, one screen, or one component — never "the whole feature"
+2. Share context: user research, business requirements, technical constraints
+3. Write together for 45-60 minutes maximum
+4. The navigator reads every draft aloud — spoken text reveals rhythm problems that silent reading misses
+5. Document decisions and rationale, not just the final copy
+
+## Content Crits
+
+Structured review sessions modeled on design critiques. Replace ad-hoc Slack feedback with disciplined evaluation.
+
+### Crit Format
+
+| Element | Detail |
+|---|---|
+| Duration | 30 minutes maximum |
+| Group size | 3-6 people (writer, designer, PM minimum) |
+| Presenter | The content designer — frames the context and specific questions |
+| Materials | Content in context (mockup, prototype, or annotated wireframe) |
+| Ground rules | Feedback on the work, not the person; questions before suggestions |
+
+### What to Evaluate
+
+Use Podmajersky's heuristics scorecard as a framework:
+
+1. **Purposeful** — Does every word earn its place?
+2. **Concise** — Is this the minimum effective copy?
+3. **Conversational** — Does it sound like a helpful human?
+4. **Clear** — Can the target user understand this immediately?
+5. **Consistent** — Does it match the voice chart and existing patterns?
+6. **Accessible** — Does it work across reading levels and assistive technology?
+7. **Actionable** — Does the user know exactly what to do next?
+8. **Appropriate** — Does the tone match the emotional context?
+9. **On-brand** — Does it reinforce the product's personality?
+
+### Feedback Framework
+
+Structure feedback as observations, not directives:
+
+- "I notice [observation]" — state what you see
+- "I wonder [question]" — probe the intent
+- "What if [suggestion]" — offer an alternative without prescribing
+
+Avoid: "Change this to..." or "This is wrong." The writer retains final decision authority.
+
+## UX Copy Testing
+
+Treat copy as a design hypothesis. Test it with the same rigor applied to visual design.
+
+### Testing Methods
+
+| Method | Best for | Sample size | Effort |
+|---|---|---|---|
+| A/B testing | Conversion impact of copy variants | 1000+ per variant | Medium (needs traffic) |
+| Comprehension testing | Whether users understand the message | 5-8 users | Low |
+| Cloze testing | Whether users can predict content | 15-20 users | Low |
+| Tree testing | Navigation label effectiveness | 50+ users | Medium |
+| Preference testing | Which variant users prefer (and why) | 20-30 users | Low |
+| Highlighter testing | Which parts users find confusing or helpful | 8-12 users | Low |
+| First-click testing | Whether labels guide users to correct targets | 30+ users | Medium |
+
+### A/B Testing Microcopy
+
+Test one variable at a time. Common high-impact tests:
+
+- CTA button labels (specific verb vs. generic)
+- Error message wording (technical vs. plain language)
+- Onboarding headline framing (benefit vs. feature)
+- Form field labels (noun vs. question format)
+- Confirmation message detail level
+
+Run tests for a minimum of 2 full business cycles. Do not call results early on partial data.
+
+### Comprehension Testing
+
+Ask users to read the copy, then:
+
+1. Explain what they just read in their own words
+2. Describe what action they would take next
+3. Identify anything confusing or unclear
+4. Rate their confidence in understanding (1-5 scale)
+
+If more than 1 in 5 users misinterpret the message, revise and retest.
+
+## Measuring UX Writing Impact
+
+Ben-David's core argument: writing must prove its value in business terms, not subjective quality assessments.
+
+### Primary Metrics
+
+| Metric | What it measures | How to capture |
+|---|---|---|
+| Task completion rate | Can users finish the flow? | Analytics funnel tracking |
+| Error rate | How often users make mistakes | Form validation logs, analytics events |
+| Time-on-task | How long the flow takes | Session recording tools, analytics |
+| Support ticket deflection | Did clearer copy reduce support load? | Ticket volume before/after, topic tagging |
+| Comprehension score | Do users understand the content? | Comprehension testing sessions |
+| Drop-off rate | Where do users abandon? | Funnel analytics per step |
+| Satisfaction (CSAT/SUS) | How do users feel about the experience? | Post-task surveys |
+
+### Building a Measurement Baseline
+
+1. Capture current metrics before any copy changes
+2. Document what copy exists at each measurement point
+3. Make one change at a time (isolate variables)
+4. Measure at the same points after the change
+5. Allow sufficient time for statistical significance
+6. Report results as deltas: "Error rate dropped from 12% to 4% after revising the password requirements copy"
+
+### Communicating Results to Stakeholders
+
+Frame every result in business impact:
+
+- Not: "We improved the error message clarity score by 40%"
+- Instead: "Revised error messages reduced password reset support tickets by 30%, saving approximately 15 support hours per week"
+
+Pair qualitative evidence (user quotes, session clips) with quantitative data. Numbers persuade executives; user stories persuade designers and engineers.
+
+## Content Style Guide Creation
+
+A living reference that scales content quality beyond individual writers.
+
+### Style Guide Structure
+
+| Section | Contents |
+|---|---|
+| Voice principles | 3-5 attributes with definitions and examples (see `references/voice-and-tone.md`) |
+| Word list | Approved/rejected terms with rationale |
+| Grammar conventions | Sentence case, contractions, serial comma, abbreviations |
+| Component patterns | Standard copy for buttons, labels, errors, confirmations, empty states |
+| Glossary | Product-specific terms with definitions |
+| Examples | Before/after rewrites showing principles in action |
+| Anti-patterns | Common mistakes with corrections |
+
+### Building the Guide
+
+1. Audit existing content for patterns (both good and bad)
+2. Document decisions already made — do not invent rules that contradict shipped product
+3. Start with the 10 most common content decisions writers face
+4. Write each entry as a rule + rationale + example — never a rule alone
+5. Publish where people already work (design system docs, not a PDF)
+6. Assign an owner who reviews and updates quarterly
+
+### Maintaining the Guide
+
+- Review every new component type for style guide implications
+- Add entries when the same question gets asked twice
+- Remove entries that no one references (measure page views)
+- Version the guide — teams need to know what changed and when
+- Run a quarterly "style guide health check" with the content team
+
+## Content Design Maturity Model
+
+Ben-David maps organizational maturity across five levels.
+
+| Level | Description | Content design role | Typical signals |
+|---|---|---|---|
+| 1. Ad-hoc | No dedicated writing role; engineers or PMs write copy | None — copy is an afterthought | Inconsistent terminology, no style guide, copy bugs filed as "low priority" |
+| 2. Reactive | Writer exists but is consulted late in the process | Copy editor — polishes after design is final | Writer reviews mockups, limited to word-level changes |
+| 3. Integrated | Writer joins the product team as a peer | Content designer — contributes from discovery | Writer participates in research, writes content briefs, runs content crits |
+| 4. Strategic | Content design influences product decisions | Content strategist — shapes product direction | Content model drives feature scoping, writing metrics in product KPIs |
+| 5. Embedded | Content design is indistinguishable from product design | Design partner — equal to visual design lead | Content-first workflow is default, voice is a competitive advantage |
+
+### Moving Up the Maturity Curve
+
+- **1 to 2:** Hire or designate a writer. Create a basic style guide. Start measuring one content metric.
+- **2 to 3:** Move the writer into the product squad. Include writing in sprint planning. Establish content crits.
+- **3 to 4:** Build a content model. Tie writing work to business metrics. Give writing a seat in product roadmap discussions.
+- **4 to 5:** Content-first design is the default workflow. Writing quality is a product differentiator. Content design has a career ladder.
+
+## Working with Stakeholders
+
+Content design sits at the intersection of product, design, engineering, marketing, and legal. Navigating competing feedback is a core skill.
+
+### Handling Feedback
+
+| Feedback type | Response strategy |
+|---|---|
+| Subjective preference ("I don't like this word") | Ask what outcome they want — redirect from opinion to objective |
+| Scope expansion ("Can we also mention...") | Refer to the content brief — if it was not in scope, it requires a new decision |
+| Legal/compliance requirement | Accept the constraint, then find the clearest expression within it |
+| Executive override | Document the decision and rationale; revisit with data after launch |
+| Contradictory feedback from multiple reviewers | Escalate to the decision-maker with both positions and a recommendation |
+
+### Managing Review Cycles
+
+1. Set expectations early: define who reviews, when, and how many rounds
+2. Consolidate feedback — never iterate on conflicting comments from separate threads
+3. Distinguish between "must change" (factual errors, legal issues) and "nice to have" (style preferences)
+4. Time-box reviews: 48 hours maximum per round
+5. Final approval comes from the content designer, not the loudest stakeholder
+
+### Proving Writing Value
+
+Build a portfolio of evidence over time:
+
+- Track every copy change alongside its metric impact
+- Collect user quotes that reference content quality
+- Document time saved by having a style guide (fewer review cycles, less back-and-forth)
+- Calculate support ticket deflection savings in hours and dollars
+- Present quarterly impact reports to leadership — small, consistent proof beats annual grand presentations

--- a/skills/ux-writing/references/empty-states-onboarding.md
+++ b/skills/ux-writing/references/empty-states-onboarding.md
@@ -1,0 +1,357 @@
+# Empty States and Onboarding Copy
+
+Sources: Yifrah (Microcopy), Podmajersky (Strategic Writing for UX), Metts/Welfle (Writing Is Designing), NN/g empty state guidelines, Atlassian Design System
+
+Covers: Copy patterns for empty screens, first-run experiences, onboarding flows, permission requests, feature discovery, zero-data dashboards, success celebrations, and upgrade gates.
+
+## Empty State Anatomy
+
+Every empty state follows a four-part formula:
+
+```
+[What's missing] + [Why it's empty] + [What to do next] + [Action button]
+```
+
+**What's missing** names the absent content in the user's language. Say "No projects yet" not "0 items found." Frame the absence around the user's goal, not the system's data model.
+
+**Why it's empty** gives a one-sentence explanation calibrated to the empty state type. First-use states explain the feature. No-results states explain the filter. Error-caused states explain the failure. Skip this element when the reason is self-evident.
+
+**What to do next** provides a concrete instruction. Use imperative form: "Create your first project" not "You can create a project." One action path. If multiple paths exist, pick the most common and link the rest.
+
+**Action button** uses a verb-noun label matching the instruction. "Create project" not "Get started." The button is the bridge from empty to populated — make it specific.
+
+### Do/Don't: First-Use Empty State
+
+| Do | Don't |
+|---|---|
+| **No invoices yet.** Create your first invoice to start tracking payments. [Create invoice] | **It's empty in here!** There are currently no items to display in this section. [Get started] |
+| **Your dashboard is ready.** Add a widget to see your metrics at a glance. [Add widget] | **Nothing to show.** You haven't added anything yet. Please add some content to see it here. [OK] |
+
+## Empty State Types
+
+| Type | When it appears | Tone | Pattern |
+|---|---|---|---|
+| First-use | User has never created content here | Welcoming, instructive | Explain the value of the feature + single clear CTA |
+| No results | Search or filter returns nothing | Helpful, neutral | Restate the query + suggest broadening + offer reset |
+| Cleared/completed | User finished all tasks or cleared items | Celebratory or calm | Acknowledge completion + suggest what's next |
+| Error-caused | Content failed to load | Reassuring, direct | State the problem + offer retry or workaround |
+| No permission | User lacks access rights | Respectful, informative | Explain what's here + who to contact for access |
+
+### First-Use Empty States
+
+Frame around the value the user will unlock, not the mechanics of the feature.
+
+```
+Your reports will appear here.
+Track revenue, usage, and growth — all in one place.
+[Create your first report]
+```
+
+Avoid "Welcome to the Reports section!" — the page heading already communicates where they are. Use the body copy to sell the outcome.
+
+### No-Results Empty States
+
+Mirror the user's search intent back to them, then offer escape routes.
+
+```
+No results for "quarterly review"
+Try different keywords, check for typos, or clear your filters.
+[Clear filters]
+```
+
+Never blame the user. "Your search didn't match anything" implies the user failed. "No results for [query]" keeps it neutral.
+
+### Cleared/Completed Empty States
+
+Match the emotional weight of the accomplishment. Inbox-zero deserves acknowledgment. Clearing a notification list does not.
+
+| Context | Copy |
+|---|---|
+| All tasks complete | **All caught up.** Completed tasks move to your archive. |
+| Inbox cleared | **Nothing new.** You've handled everything. |
+| Cart emptied | **Your cart is empty.** Browse products to find something you like. |
+
+### Error-Caused Empty States
+
+See `references/error-messages.md` for full error writing patterns. In empty state context, keep the error explanation brief and pair it with a retry action.
+
+```
+Couldn't load your projects.
+Check your connection and try again.
+[Retry]
+```
+
+### No-Permission Empty States
+
+Respect the user's position. Avoid making them feel locked out or lesser.
+
+```
+Projects is available on the Team plan.
+Talk to your admin to upgrade, or explore other features.
+[Contact admin]  [Explore features]
+```
+
+Never say "You don't have permission." Say what the content is and how to get access.
+
+## First-Run Experience
+
+### Welcome Screens
+
+A welcome screen earns exactly one interaction before the user's patience expires. Spend it on orientation, not celebration.
+
+**Structure:**
+
+1. Headline: State the core value in 6 words or fewer
+2. Subhead: One sentence expanding on the benefit
+3. Primary CTA: The most important first action
+4. Secondary link: Skip or explore on their own
+
+| Do | Don't |
+|---|---|
+| **Ship faster with automated deploys.** Connect your repo to deploy on every push. [Connect repository] | **Welcome to DeployPro!** We're so excited you've joined us. There's so much to explore. Let's get started on your journey! [Let's go!] |
+
+Avoid "Welcome to [Product]" as a headline — it wastes the most prominent real estate on information the user already knows.
+
+### Feature Tours
+
+Write tour steps as micro-tasks, not feature descriptions.
+
+| Step pattern | Example |
+|---|---|
+| **Bad:** "This is the sidebar. It contains navigation." | Describes furniture. |
+| **Good:** "Pin your most-used projects here for quick access." | Teaches a behavior. |
+
+Each tooltip in a tour should answer: "What can I do here that I couldn't figure out alone?" If the answer is nothing, cut the step.
+
+**Tour copy rules:**
+
+- 3-5 steps maximum per tour
+- Lead each step with a verb: "Drag," "Click," "Pin," "Filter"
+- End the tour with a productive action, not "You're all set!"
+- Offer "Skip tour" on every step, not just the first
+
+### Progressive Onboarding
+
+Reveal complexity gradually. Teach features at the moment they become relevant, not in a front-loaded tutorial.
+
+| Stage | Writing approach |
+|---|---|
+| First session | Explain only what's needed for the first task |
+| After first success | Introduce one adjacent feature ("Now that you've created a project, invite your team") |
+| Power-user threshold | Surface shortcuts and advanced features via contextual tips |
+
+## Permission Requests
+
+### Why Before What
+
+Users grant permissions at higher rates when they understand the benefit before seeing the system dialog. Use a pre-permission screen.
+
+**Pre-permission pattern:**
+
+```
+[Benefit headline]
+[1-sentence explanation of why the permission helps them]
+[Allow] [Not now]
+```
+
+**Example:**
+
+```
+Get notified when tasks are assigned to you.
+We'll send a push notification so you never miss a deadline.
+[Turn on notifications]  [Not now]
+```
+
+### Benefit-Led Framing
+
+| Do | Don't |
+|---|---|
+| **Find nearby stores** — Location access shows stores within walking distance. | **Allow location access?** This app wants to use your location. |
+| **Import contacts to find your team** — We'll check if anyone you know is already here. | **Access your contacts?** We need your contact list to function properly. |
+
+Frame the permission as a feature the user is activating, not a resource the app is demanding.
+
+### Declining Gracefully
+
+When a user declines, acknowledge it without guilt. Explain what they'll miss and how to re-enable later.
+
+```
+No problem. You can turn on notifications anytime in Settings.
+```
+
+Never re-prompt immediately after a decline. Wait until the user encounters a moment where the permission would have helped.
+
+## Onboarding Flows
+
+### Signup Copy
+
+Reduce friction at every field. Each piece of signup text should either reduce anxiety or accelerate completion.
+
+| Element | Pattern |
+|---|---|
+| Headline | State the benefit of signing up, not "Create an account" |
+| Social auth buttons | "[Logo] Continue with Google" — verb + provider name |
+| Email field label | "Work email" or "Email" — never "Enter your email address" |
+| Password requirements | Show requirements upfront, validate inline, never reveal only on error |
+| Submit button | "Create account" or "Start free trial" — never "Submit" |
+| Terms | "By creating an account, you agree to our [Terms] and [Privacy Policy]." — one line, links only |
+
+### Email Verification
+
+The verification screen is a dead zone where users abandon. Keep them engaged.
+
+```
+Check your email
+We sent a verification link to ada@example.com.
+Didn't get it? [Resend email]  [Change email address]
+```
+
+Provide both "Resend" and "Change email" — users mistype addresses more often than they think. Display the address they entered so they can spot typos.
+
+### Profile Completion
+
+Use progress indicators with copy that frames completion as a benefit, not an obligation.
+
+| Do | Don't |
+|---|---|
+| **3 steps to a complete profile** — Complete profiles get 40% more responses. | **Your profile is incomplete!** Please fill out all required fields. |
+| **Add a photo** — Teams with photos collaborate 2x faster. | **Upload profile picture** (required) |
+
+Defer non-essential fields. Ask for the minimum at signup and request details when they become relevant.
+
+## Feature Discovery
+
+### Tooltips and Spotlights
+
+Contextual tips appear when the user first encounters a feature. Write them as quick wins.
+
+**Tooltip formula:** [What you can do] + [How to do it] — in 15 words or fewer.
+
+```
+Filter by date range — click the calendar icon to narrow results.
+```
+
+### Coachmarks
+
+Numbered coachmarks walk through a complex interface. Limit to 3-4 per sequence.
+
+| Step | Copy pattern |
+|---|---|
+| 1 | **Start here.** [Verb] + [object] to [outcome]. |
+| 2 | **Then try this.** [Verb] + [object] for [benefit]. |
+| 3 | **One more thing.** [Verb] + [object] when you need [advanced use]. |
+| Finish | [Productive CTA] — not "Got it!" |
+
+### Walkthrough Copy Rules
+
+- Anchor each step to a visible UI element
+- Use present tense: "Click here to filter" not "You will be able to filter"
+- Dismiss options: "Got it" for single tips, "Skip" + step count for sequences
+- Never block the primary workflow — coachmarks overlay, never prevent action
+- Trigger by behavior, not by calendar ("first time visiting this page" not "3 days after signup")
+
+## Success States and Celebrations
+
+### When to Celebrate
+
+| Situation | Response |
+|---|---|
+| First-ever completed action (first deploy, first invoice) | Celebrate: short congratulation + next step |
+| Routine completed action (100th commit) | Quiet: confirmation only |
+| Milestone achievement (10 projects, 1-year anniversary) | Celebrate if user opted into gamification |
+| Cleared inbox or task list | Acknowledge calmly: "All caught up." |
+| Upgrade or purchase | Confirm + reassure: "Your plan is now active." |
+
+### Celebration Copy
+
+Keep celebrations proportional to effort. Over-celebrating trivial actions feels patronizing.
+
+| Do | Don't |
+|---|---|
+| **First deploy complete.** Your site is live at example.com. [View site] | **AMAZING! You did it! Your first deploy is done! We're so proud of you!** |
+| **Invoice sent.** You'll get a notification when Alex views it. | **Woohoo! Invoice successfully sent! Great job!** |
+
+One exclamation mark per screen, maximum. Atlassian's guideline: no exclamation marks in success messages at all. Calibrate to your product's voice.
+
+### Streak and Reward Copy
+
+If the product uses streaks, badges, or gamification:
+
+- State the achievement factually: "7-day streak" not "OMG 7 days!"
+- Connect it to real value: "7-day streak — you've reviewed 23 PRs this week"
+- Let the visual (animation, badge, confetti) carry the emotional weight; the copy stays grounded
+
+## Zero-Data Dashboards
+
+Dashboards with charts and tables are the hardest empty states because the page structure implies data should exist.
+
+### Charts With No Data
+
+Replace the chart area with a contextual message, not a broken or blank chart.
+
+```
+Revenue will appear here after your first sale.
+Connect a payment provider to start tracking.
+[Connect Stripe]
+```
+
+Never render empty axes and gridlines with "No data" floating in the center. Replace the entire chart region.
+
+### Tables With No Data
+
+| Approach | When to use |
+|---|---|
+| Single-row message inside the table | User expects a table and may add rows (e.g., team members) |
+| Replace table with centered empty state | Table is not the primary UI metaphor (e.g., dashboard widget) |
+
+Table-row message pattern:
+
+```
+| Name | Role | Status |
+| --- | --- | --- |
+| No team members yet. [Invite your team] to start collaborating. | | |
+```
+
+### System Status Communication
+
+When data will arrive automatically (analytics, logs, monitoring), communicate the system state:
+
+```
+Waiting for data...
+Events will appear here within a few minutes of connecting your app.
+[View setup guide]
+```
+
+Use "Waiting for data" (the system is working) not "No data yet" (the user failed to provide something).
+
+## Upgrade and Paywall Copy
+
+### Feature Gates
+
+When a free user encounters a paid feature, frame the gate as a value proposition, not a restriction.
+
+| Do | Don't |
+|---|---|
+| **Unlock advanced analytics** — See conversion funnels, retention curves, and custom reports. [See plans] | **This feature is not available on your plan.** Upgrade to access it. [Upgrade] |
+| **Custom domains are available on Pro.** Use your own domain to match your brand. [Compare plans] | **Error: Feature restricted.** You must upgrade. |
+
+### Value Framing Rules
+
+- Name the specific features they'll unlock, not "premium features"
+- Lead with the benefit ("See conversion funnels") before the mechanism ("available on Pro")
+- Use "See plans" or "Compare plans" over "Upgrade now" — let users evaluate before committing
+- Never use "Error" or "Restricted" language for intentional feature gates
+- Provide a way to dismiss or go back — gates should inform, not trap
+
+### Trial Expiry Copy
+
+Progressive urgency, not sudden panic:
+
+| Days remaining | Tone | Example |
+|---|---|---|
+| 7+ | Informational | "Your trial ends in 10 days. [See plans]" |
+| 3-6 | Gentle nudge | "3 days left in your trial. Keep your data by choosing a plan. [Choose plan]" |
+| 1 | Urgent, not alarming | "Your trial ends tomorrow. [Upgrade to keep access]" |
+| Expired | Matter-of-fact | "Your trial has ended. Your data is saved for 30 days. [Choose a plan] [Export data]" |
+
+Never threaten data loss without providing an export option. State the retention period explicitly.

--- a/skills/ux-writing/references/error-messages.md
+++ b/skills/ux-writing/references/error-messages.md
@@ -1,0 +1,333 @@
+# Error Message Patterns
+
+Sources: Yifrah (Microcopy), Podmajersky (Strategic Writing for UX), Shopify Polaris, Microsoft Writing Style Guide, NN/g error message guidelines
+
+Covers: Error message anatomy, severity-driven tone, inline validation, form submission errors, system/network failures, payment-specific copy, 404 recovery, and antipattern catalog.
+
+## Error Message Anatomy
+
+Every error message answers three questions in order:
+
+1. **What happened** — State the effect on the user, not the system.
+2. **Why it happened** — Include only when the cause is actionable or non-obvious.
+3. **How to fix it** — Give a concrete next step. Link to help if the fix is complex.
+
+The universal formula:
+
+```
+[What happened] + [Why, if helpful] + [How to fix]
+```
+
+### Applying the Formula
+
+| Situation | Bad | Good |
+|---|---|---|
+| File too large | "Upload failed" | "This file is over 25 MB. Compress it or choose a smaller file." |
+| Duplicate email | "Invalid entry" | "This email is already registered. Log in instead or use a different email." |
+| Session expired | "Error 401" | "Your session expired. Log in again to continue." |
+| Unsupported format | "Cannot process file" | "PDFs and DOCs are supported. Convert your file and try again." |
+
+### Structural Rules
+
+- Lead with the user impact, not the technical cause.
+- Use sentence case. Never all-caps for error headings.
+- End with a path forward — a button, a link, or explicit instructions.
+- One idea per sentence. Keep sentences under 25 words.
+- Use present tense: "Your password doesn't match" not "Your password didn't match."
+
+## Severity Levels
+
+Match visual treatment, placement, and tone to the severity of the problem.
+
+| Severity | Visual Treatment | Placement | Tone | Example |
+|---|---|---|---|---|
+| Critical/Blocker | Red border, error icon, prominent banner | Top of page or blocking modal | Direct, serious, no humor | "Payment failed. Your card was not charged. Try again or use a different payment method." |
+| Warning | Yellow/amber border, warning icon | Inline or banner | Calm, advisory | "Your subscription renews tomorrow. Update your payment method if needed." |
+| Info/Suggestion | Blue or neutral, info icon | Inline or toast | Neutral, helpful | "Passwords with 12+ characters are stronger." |
+
+### Tone by Severity
+
+- **Critical:** Strip all personality. No jokes, no "oops," no exclamation marks. Be precise and empathetic.
+- **Warning:** Moderate personality. State the risk and the remedy without alarm.
+- **Info:** Light personality is acceptable. Frame as guidance, not correction.
+
+## Inline Validation Errors
+
+Inline errors appear beside individual form fields. Timing and phrasing determine whether users feel helped or harassed.
+
+### Timing
+
+| Event | Show Error? | Rationale |
+|---|---|---|
+| User focuses empty required field, then leaves | No | Punishes exploration. User may intend to return. |
+| User types, content is invalid, then leaves field | Yes | User attempted input; feedback is useful. |
+| User submits form with empty required fields | Yes | Explicit action taken; surface all issues. |
+| User corrects an error mid-typing | Remove error as soon as input becomes valid | Immediate positive feedback reduces frustration. |
+
+Do not validate on blur for empty required fields. This is the most common inline validation mistake — it scolds users before they've tried.
+
+### Placement
+
+- Display the error message directly below the field.
+- Use `aria-describedby` to associate the message with the input.
+- Pair with a red border on the field — color alone is insufficient (colorblind users).
+- Never replace the field label with the error. Both must be visible simultaneously.
+
+### Phrasing Patterns
+
+| Pattern | Don't | Do |
+|---|---|---|
+| Required field | "This field is required" | "Enter your email address" |
+| Format mismatch | "Invalid email" | "Enter an email like name@example.com" |
+| Too short | "Too short" | "Use at least 8 characters" |
+| Too long | "Maximum length exceeded" | "Use 100 characters or fewer (you've used 142)" |
+| Number out of range | "Invalid value" | "Enter a number between 1 and 100" |
+| Pattern mismatch | "Invalid format" | "Use only letters, numbers, and hyphens" |
+
+### Password Field Specifics
+
+- Show requirements upfront as a checklist, not after failure.
+- Check off each requirement in real time as the user types.
+- If showing requirements on error, list all unmet rules — not just the first one.
+
+```
+Do:  "Your password needs:
+      [x] 8+ characters
+      [ ] One uppercase letter
+      [ ] One number"
+
+Don't: "Password invalid"
+Don't: "Password must contain an uppercase letter" (then, after fixing: "Password must contain a number")
+```
+
+## Form Submission Errors
+
+When a form submission fails, the user has already committed effort. Respect that investment.
+
+### Page-Level Error Summary
+
+Display a summary banner at the top of the form:
+
+```
+Do:  "2 fields need your attention"
+     - Email address: Enter a valid email like name@example.com
+     - Phone number: Enter a 10-digit phone number
+
+Don't: "There were errors in your submission"
+Don't: "Please fix the following errors and resubmit"
+```
+
+Scroll the user to the summary banner after submission. Each item in the summary links to its corresponding field.
+
+### Batch Error Rules
+
+- Count and state how many fields need attention: "3 fields need your attention."
+- Anchor-link each error to its field. Clicking an error in the summary focuses that field.
+- Keep inline errors visible simultaneously — the summary is a navigation aid, not a replacement.
+- Preserve all valid input. Never clear the form on error.
+- Disable the submit button only while a request is in flight, not as validation feedback.
+
+### Server-Side Validation Errors
+
+When the server rejects input the client didn't catch:
+
+- Map server error codes to human-readable inline messages.
+- Place each message at its corresponding field, identical to client-side errors.
+- If a server error doesn't map to a specific field, show it in the page-level summary.
+
+```
+Do:  "This username is taken. Try another one."
+Don't: "Error: DUPLICATE_KEY_VIOLATION on field 'username'"
+```
+
+## System and Network Errors
+
+Users don't know or care about HTTP status codes, DNS resolution, or server architecture. Translate system failures into outcomes and actions.
+
+### Connection and Timeout Errors
+
+```
+Do:  "Couldn't connect. Check your internet connection and try again."
+Do:  "This is taking longer than usual. Wait a moment or try again."
+
+Don't: "ERR_CONNECTION_TIMED_OUT"
+Don't: "Request failed with status code 504"
+```
+
+### Server Unavailable
+
+```
+Do:  "Something went wrong on our end. Try again in a few minutes."
+Do:  "We're fixing a problem right now. Check status.example.com for updates."
+
+Don't: "500 Internal Server Error"
+Don't: "The server encountered an unexpected condition"
+```
+
+### Permission Denied
+
+```
+Do:  "You don't have access to this page. Contact your admin to request access."
+Don't: "403 Forbidden"
+Don't: "Access denied"
+```
+
+### Rate Limiting
+
+```
+Do:  "You've made too many requests. Wait 30 seconds and try again."
+Don't: "429 Too Many Requests"
+```
+
+### Offline States
+
+- Detect offline status and show a persistent, non-dismissable banner.
+- State what still works: "You're offline. You can still view saved items."
+- Auto-dismiss the banner when connectivity returns.
+
+### General Principles for System Errors
+
+- Never expose stack traces, error codes, or internal identifiers to users.
+- Log technical details to the console or error reporting service — not the UI.
+- Offer a retry action where applicable. Auto-retry silently for transient failures; show the error only after retries exhaust.
+- Include a status page link for extended outages.
+
+## Payment and Financial Errors
+
+Payment errors carry emotional weight. Users feel vulnerability around money. Every word must convey security and competence.
+
+### Core Rules
+
+- Never blame the user. "Your card was declined" is better than "You entered an invalid card."
+- Never expose specific decline reasons from the payment processor — they can be misleading or reveal fraud signals.
+- Always confirm what didn't happen: "Your card was not charged."
+- Offer alternatives immediately.
+
+### Common Payment Errors
+
+| Situation | Message |
+|---|---|
+| Card declined (generic) | "This card was declined. Try a different card or contact your bank." |
+| Insufficient funds | "This card was declined. Try a different payment method." (Never state "insufficient funds" — it's private.) |
+| Expired card | "This card has expired. Update the expiration date or use a different card." |
+| Incorrect CVV | "Check your security code and try again." |
+| Billing address mismatch | "Check your billing address matches your card statement and try again." |
+| Duplicate transaction | "It looks like this was already submitted. Check your order history before trying again." |
+| Currency not supported | "This card doesn't support [currency]. Try a different card." |
+| 3D Secure failure | "Verification wasn't completed. Try again and complete the verification step." |
+
+### Fraud and Security
+
+- Never tell users their transaction was flagged for fraud.
+- Use the same "card was declined" language for fraud rejections as for legitimate declines.
+- If manual review is needed: "Your order is being reviewed. We'll email you within 24 hours."
+
+## 404 and Not Found Patterns
+
+"Not found" is an error, but it's also a navigation opportunity. The goal is recovery, not a dead end.
+
+### Page Not Found (404)
+
+```
+Do:  Heading: "Page not found"
+     Body: "This page doesn't exist or may have moved."
+     Actions: [Go to homepage] [Search]
+
+Don't: "404 Not Found"
+Don't: "Oops! Looks like you're lost! :("
+```
+
+- Show the URL that failed — helps users spot typos.
+- Suggest likely destinations based on URL patterns.
+- Include search if the site has one.
+- Keep the main navigation intact. Never hide the nav on a 404.
+
+### Search With No Results
+
+```
+Do:  "No results for 'foobar'"
+     "Check your spelling or try a broader search term."
+     [Show popular searches or categories]
+
+Don't: "0 results"
+Don't: "Your search did not match any documents"
+```
+
+- Offer spelling correction suggestions automatically.
+- Show related or popular items to keep the user in a browsing flow.
+- If filters are active, suggest removing filters.
+
+### Deleted or Archived Content
+
+```
+Do:  "This item was deleted"
+     "It was removed on March 15, 2026."
+     [Go to your items]
+
+Do:  "This project was archived"
+     "Contact the project owner to restore it."
+
+Don't: "Resource not found"
+```
+
+- Distinguish between "never existed," "was deleted," and "was archived."
+- Each case requires a different recovery path.
+
+## Error Message Antipatterns
+
+| Antipattern | Why It Fails | Fix |
+|---|---|---|
+| "Invalid" (e.g., "Invalid email") | No guidance on what's wrong or how to fix it | State the expected format: "Enter an email like name@example.com" |
+| "An error has occurred" | Says nothing the user can act on | State the specific error and the fix |
+| Raw error codes ("ERR_422", "NullPointerException") | Meaningless to users, signals broken product | Map every code to a human sentence |
+| Blame language ("You entered the wrong password") | Creates adversarial relationship | Neutral framing: "That password doesn't match our records" |
+| Over-apologizing ("We're so sorry!") | Erodes confidence, reads as insincere at scale | One "sorry" max per flow, only for genuine disruption |
+| "Oops!" / "Uh oh!" / "Whoopsie!" | Trivializes the user's problem, especially for critical errors | Remove. Use direct, calm language |
+| Exclamation marks in errors | Reads as shouting or panic | Use periods. Reserve exclamation marks for celebrations |
+| "Please try again later" (with no context) | User doesn't know when "later" is or what went wrong | State the cause and a specific timeframe if possible |
+| Jargon ("SMTP relay failure") | Only meaningful to engineers | Translate to outcomes: "Your email couldn't be sent" |
+| Double negatives ("Not invalid") | Increases cognitive load | Positive framing: "This entry is valid" |
+| Hiding errors (silent failure) | User thinks action succeeded when it didn't | Always surface feedback for user-initiated actions |
+| Generic "Something went wrong" for all errors | Prevents self-service resolution | Differentiate errors so users can resolve what's within their control |
+
+## Writing Error Messages Checklist
+
+Use this when reviewing error copy before shipping.
+
+### Content
+
+- [ ] States what happened in terms the user understands
+- [ ] Explains why only if the reason is actionable
+- [ ] Provides a concrete next step or action
+- [ ] Uses the user's language, not system language
+- [ ] Avoids "invalid," "error," "failed," and "please try again" as standalone messages
+
+### Tone
+
+- [ ] Does not blame the user
+- [ ] Does not over-apologize
+- [ ] Does not use humor for critical errors
+- [ ] Matches severity level (serious for critical, calm for warnings)
+- [ ] Uses no exclamation marks
+
+### Formatting
+
+- [ ] Sentence case
+- [ ] One idea per sentence
+- [ ] Under 25 words per sentence
+- [ ] Action button uses a specific verb (not "OK" or "Dismiss")
+
+### Accessibility
+
+- [ ] Error is associated with its field via `aria-describedby`
+- [ ] Color is not the only indicator (icon or text accompanies red border)
+- [ ] Error is announced to screen readers via `aria-live="polite"` or `role="alert"`
+- [ ] Focus moves to the first error or the error summary on submission
+
+### Placement and Timing
+
+- [ ] Inline errors appear below their field, not in a tooltip or modal
+- [ ] Page-level summary appears at the top and links to each field
+- [ ] Errors don't appear on blur for empty required fields
+- [ ] Errors clear immediately when the user corrects the input
+- [ ] Valid input is preserved on form resubmission

--- a/skills/ux-writing/references/forms-and-inputs.md
+++ b/skills/ux-writing/references/forms-and-inputs.md
@@ -1,0 +1,360 @@
+# Form and Input Copy
+
+Sources: Yifrah (Microcopy), Podmajersky (Strategic Writing for UX), Shopify Polaris, Google Material Design 3, Microsoft Writing Style Guide
+
+Covers: Copy patterns for every form element — labels, placeholders, helper text, validation, buttons, multi-step flows, and confirmation states. Forms are the highest-friction touchpoint in most apps; precise copy directly impacts conversion and completion rates.
+
+## Field Labels
+
+Place labels above the input. Inline labels (inside the field) vanish on focus and break accessibility. Left-aligned labels work for dense admin forms but slow scan speed on consumer-facing flows.
+
+### Phrasing Rules
+
+- Use sentence case: "Email address" not "Email Address"
+- State what the field collects, not what the user should do: "Company name" not "Enter your company name"
+- Keep to 1-3 words when possible
+- Match the label to the data: "Phone number" not "Phone" when the format matters
+
+| Do | Don't |
+|---|---|
+| Full name | Please enter your full name |
+| Email address | Your Email Address |
+| Date of birth | DOB |
+| Billing address | Address for Billing Purposes |
+
+### Required vs Optional Marking in Labels
+
+Mark the minority. If most fields are required, mark only optional fields with "(optional)" appended to the label. If most are optional, mark required fields with "(required)" or an asterisk.
+
+| Form composition | Mark strategy | Example |
+|---|---|---|
+| Mostly required fields | Append "(optional)" to the few optional ones | "Middle name (optional)" |
+| Mostly optional fields | Append "(required)" or use asterisk | "Email address *" |
+| All required | No marking needed — add a single note above the form | "All fields are required." |
+
+When using asterisks, always include a legend at the top of the form: "* Required". Never rely on color alone.
+
+## Placeholder Text
+
+### When to Use
+
+Use placeholders only to show expected format — never as a replacement for labels. Placeholder text disappears on focus, creating a memory burden. Screen readers may skip it entirely.
+
+| Do | Don't |
+|---|---|
+| Label: "Phone number" / Placeholder: "(555) 123-4567" | Placeholder only: "Enter your phone number" |
+| Label: "Website" / Placeholder: "https://example.com" | Placeholder as instruction: "Type your URL here" |
+| No placeholder when the label is self-explanatory | Repeating the label as placeholder: "Email" / "Email" |
+
+### When NOT to Use
+
+- When the label already communicates the expected input clearly
+- For critical information the user needs to reference while typing
+- On fields where example data could be confused with pre-filled data (use helper text instead)
+
+## Helper Text
+
+Persistent text below a field that provides context the label alone cannot convey. Unlike placeholders, helper text remains visible during and after input.
+
+### When to Add
+
+- The field has specific format or length requirements
+- The data request may confuse users ("This appears on your receipt")
+- Privacy or usage context matters ("We will only use this to verify your identity")
+
+### Phrasing
+
+- Lead with the benefit or reason, not the constraint
+- Keep to one sentence, under 80 characters
+- Use sentence case, no period unless multiple sentences
+
+| Field | Helper text |
+|---|---|
+| Password | At least 8 characters with one number |
+| Username | This will be your public display name |
+| SSN | Used only for identity verification — encrypted and never stored |
+| Promo code | Find this on your invitation email |
+
+| Do | Don't |
+|---|---|
+| Appears on your public profile | Warning: this will be visible to other users!!! |
+| At least 8 characters | Must contain minimum 8 characters, including upper case, lower case, number and symbol |
+
+## Input Masks and Formatting Hints
+
+Show the expected format explicitly so users do not have to guess. Use input masks (auto-formatting as the user types) or format hints in helper text.
+
+| Input type | Mask / hint approach | Example display |
+|---|---|---|
+| Phone number | Input mask with auto-grouping | (555) 123-4567 |
+| Credit card | Input mask with spaces every 4 digits | 4242 4242 4242 4242 |
+| Date | Placeholder showing format | MM/DD/YYYY |
+| Currency | Prefix symbol, auto-decimal | $0.00 |
+| ZIP / Postal code | Helper text for format | "5 digits or ZIP+4 (12345-6789)" |
+
+When the input auto-formats, tell the user: "We will format this as you type." Avoid surprising transformations without explanation.
+
+## Select and Dropdown Options
+
+### Default Option Text
+
+Use an instructional default that cannot be confused with a real selection.
+
+| Do | Don't |
+|---|---|
+| "Select a country" | "Country" (repeats the label) |
+| "Choose a role" | "-- Select --" (generic, unhelpful) |
+| "None" (when no-selection is valid) | "" (empty default — ambiguous) |
+
+### Option Labeling
+
+- Use parallel phrasing across all options
+- Front-load the distinguishing word: "Monthly billing" / "Annual billing" not "Billing — monthly"
+- Sort logically: alphabetical for long lists, frequency-based for short lists, chronological for dates
+
+### Sorting Order
+
+| List type | Sort by |
+|---|---|
+| Countries / states | Alphabetical, with user's detected country first |
+| Frequency options (Daily, Weekly) | Logical sequence, not alphabetical |
+| Plan tiers | Low to high (or high to low if upselling) |
+
+## Checkbox and Radio Copy
+
+### Statement Phrasing
+
+Write checkboxes as affirmative statements the user agrees to by checking. Write radio buttons as noun phrases or short declarative options the user selects between.
+
+| Type | Do | Don't |
+|---|---|---|
+| Checkbox | "Send me weekly updates" | "Do you want weekly updates?" |
+| Checkbox | "I agree to the Terms of Service" | "Terms of Service agreement" |
+| Radio | "Standard shipping (5-7 days)" | "Click here for standard" |
+| Radio | "Pay monthly" / "Pay annually" | "Monthly?" / "Annual?" |
+
+### Group Labels
+
+Every checkbox or radio group needs a visible group label (the `<legend>` in a `<fieldset>`). Phrase it as a question or instruction:
+
+- "How would you like to be contacted?"
+- "Select your plan"
+- "Notification preferences"
+
+### Positive Framing
+
+Frame options positively. Let users opt in to what they want, not opt out of what they do not want.
+
+| Do | Don't |
+|---|---|
+| "Send me product updates" | "Uncheck to stop receiving emails" |
+| "Keep me signed in" | "Don't sign me out" |
+
+## File Upload Instructions
+
+Communicate accepted formats, size limits, and quantity constraints before the user attempts an upload.
+
+### Pre-Upload Messaging
+
+Place format and size constraints as helper text beneath the upload area:
+
+- "Accepted formats: JPG, PNG, or PDF. Max 10 MB."
+- "Upload up to 5 files. Each file must be under 25 MB."
+
+### Drag-and-Drop Messaging
+
+| State | Copy |
+|---|---|
+| Default | "Drag files here or browse" |
+| Hover / dragover | "Drop files to upload" |
+| Uploading | "Uploading 3 files..." with progress indicator |
+| Success | "3 files uploaded" with file names listed |
+| Failure | "invoice.pdf could not be uploaded — file exceeds 10 MB" |
+
+| Do | Don't |
+|---|---|
+| "Drag files here or browse" | "Click or drag and drop files into this area to upload" |
+| "PNG or JPG, up to 5 MB" | "Supported file types: .png, .jpg, .jpeg, .gif, .bmp, .tiff" |
+
+## Inline Validation Copy
+
+Validate as the user completes each field — not on submit only. Show feedback adjacent to the field, not in a banner at the top of the form.
+
+### Timing
+
+| Validation type | When to trigger |
+|---|---|
+| Format errors (email, phone) | On blur (after the user leaves the field) |
+| Character/length limits | Real-time as the user types |
+| Availability checks (username) | After a debounce (300-500ms after last keystroke) |
+| Required field empty | On blur or on submit — never while the user is still in the field |
+
+### Tone by Severity
+
+| Severity | Tone | Example |
+|---|---|---|
+| Success | Neutral confirmation | "Username is available" |
+| Warning | Helpful, non-blocking | "This password is weak — consider adding numbers or symbols" |
+| Error | Direct, solution-first | "Enter an email address — for example, name@company.com" |
+
+### Phrasing Rules
+
+- State what to do, not what went wrong: "Enter a valid phone number" not "Invalid phone number"
+- Never use "invalid" — it is jargon and feels accusatory (Shopify Polaris, Google Material Design 3)
+- Include an example when the correct format is not obvious
+- Keep to one line — under 60 characters
+
+| Do | Don't |
+|---|---|
+| Enter a 10-digit phone number | Error: Invalid phone format |
+| Passwords must be at least 8 characters | Too short |
+| Enter a date in MM/DD/YYYY format | Bad date |
+| This field is required | Required! |
+
+Cross-reference: see `error-messages.md` for error message patterns beyond inline validation.
+
+## Form Progress and Multi-Step
+
+### Step Labels
+
+Label each step with what the user accomplishes in it, not a generic number.
+
+| Do | Don't |
+|---|---|
+| "1. Shipping / 2. Payment / 3. Review" | "Step 1 / Step 2 / Step 3" |
+| "Account details" | "Page 1 of 3" |
+
+### Progress Indicators
+
+Show both position and total: "Step 2 of 4" or a segmented progress bar with labels. Communicate time expectation when possible: "About 2 minutes left."
+
+### Save and Resume
+
+When forms can be saved mid-flow, tell the user:
+
+- Auto-save: "Your progress is saved automatically"
+- Manual save: "Save and continue later" (button label)
+- Returning: "Welcome back — pick up where you left off"
+
+| Do | Don't |
+|---|---|
+| "Your progress is saved automatically" | (silently auto-saving with no indication) |
+| "Save and continue later" | "Save draft" (ambiguous — draft of what?) |
+
+## Submit Button Copy
+
+### Action-Specific Labels
+
+Name the button after the action it performs. Generic labels ("Submit", "OK", "Continue") create uncertainty about what will happen.
+
+| Context | Do | Don't |
+|---|---|---|
+| Account creation | "Create account" | "Submit" |
+| Payment | "Place order" / "Pay $49.00" | "Continue" |
+| Newsletter | "Subscribe" | "Submit" |
+| Search filters | "Apply filters" | "Go" |
+| Settings | "Save changes" | "OK" |
+| Destructive | "Delete project" | "Yes" / "Confirm" |
+
+### Loading State
+
+Replace button text with a present-participle verb matching the action:
+
+- "Create account" becomes "Creating account..."
+- "Place order" becomes "Placing order..."
+- "Save changes" becomes "Saving..."
+
+Disable the button during loading to prevent duplicate submissions.
+
+### Disabled State
+
+When a submit button is disabled because the form is incomplete, do not rely on the disabled state alone. Provide a visible explanation:
+
+- Tooltip on hover: "Complete all required fields to continue"
+- Inline note beneath the button: "Fill in the highlighted fields above"
+
+| Do | Don't |
+|---|---|
+| Disabled button + note explaining why | Grayed-out button with no explanation |
+| "Complete all required fields to continue" | (nothing — user clicks repeatedly, confused) |
+
+## Success and Confirmation
+
+### Immediate Feedback
+
+After submission, confirm the action and tell the user what happens next.
+
+| Action | Confirmation copy |
+|---|---|
+| Account created | "Account created. Check your email to verify." |
+| Order placed | "Order confirmed. You will receive a confirmation email at alex@example.com." |
+| Settings saved | "Changes saved." (inline, near the save button — no page redirect) |
+| File uploaded | "Resume uploaded successfully." |
+
+### Confirmation Details
+
+For transactional forms (orders, bookings, registrations), display a summary:
+
+- Order number or reference ID
+- Key details (items, dates, amounts)
+- Next step: "You will receive a confirmation email within 5 minutes"
+- Escape hatch: "Something wrong? Contact support" or "Edit order"
+
+### Receipt and Summary Patterns
+
+- Lead with the most important confirmation: "Your order is confirmed"
+- Follow with specifics in a structured summary (table or key-value list)
+- Close with the next expected event and a timeline: "Ships within 2 business days"
+
+| Do | Don't |
+|---|---|
+| "Order confirmed. Shipping in 2-3 days." | "Success!" (what succeeded? what now?) |
+| "Check your email to verify your account" | "Thank you for registering" (no next step) |
+
+## Password and Security Fields
+
+### Strength Indicators
+
+Show password strength as the user types. Use a visual meter paired with a text label.
+
+| Strength | Label | Color |
+|---|---|---|
+| Weak | "Weak" | Red |
+| Fair | "Fair" | Orange |
+| Strong | "Strong" | Green |
+
+Avoid numeric scores ("3/5") — they are meaningless without context.
+
+### Requirements Display
+
+List password requirements upfront, and check them off in real time as the user meets each one:
+
+- "At least 8 characters" (checked/unchecked)
+- "One uppercase letter" (checked/unchecked)
+- "One number or symbol" (checked/unchecked)
+
+| Do | Don't |
+|---|---|
+| List requirements visibly before input | Reveal requirements only after a failed attempt |
+| Check off each requirement as met | "Password does not meet requirements" (which ones?) |
+
+### Show/Hide Toggle
+
+Label the toggle with the action it will perform:
+
+- "Show password" (when hidden)
+- "Hide password" (when visible)
+
+Place the toggle inside or adjacent to the password field. Use an eye icon paired with the text label for both visual and accessible clarity.
+
+### Security Context
+
+For sensitive fields (SSN, tax ID, bank account), add helper text explaining why the data is needed and how it is protected:
+
+- "Required for tax reporting. Encrypted and stored securely."
+- "We never share your financial information with third parties."
+
+| Do | Don't |
+|---|---|
+| "Encrypted and stored securely" | "Don't worry, it's safe" (vague, patronizing) |
+| "Required for identity verification" | "We need this" (no reason given) |

--- a/skills/ux-writing/references/inclusive-writing.md
+++ b/skills/ux-writing/references/inclusive-writing.md
@@ -1,0 +1,310 @@
+# Inclusive and Accessible Writing
+
+Sources: Microsoft Writing Style Guide, Apple HIG, So (Voice Content and Usability), Metts/Welfle (Writing Is Designing), WCAG 2.2, Atlassian Design System
+
+Covers: Making interface text work for all users — plain language, screen reader compatibility, inclusive defaults, localization readiness, RTL support, sensitive contexts, and cognitive load reduction.
+
+## Plain Language Principles
+
+Write for the widest possible audience. Every extra syllable is a barrier.
+
+### Reading Level Targets
+
+| Audience | Target Grade Level | Flesch-Kincaid Score | Example Domain |
+|---|---|---|---|
+| Consumer products | 7th-8th grade | 60-70 | Banking apps, e-commerce |
+| Developer tools | 9th-10th grade | 50-60 | API docs, CLIs |
+| Enterprise B2B | 8th-9th grade | 55-65 | SaaS dashboards |
+| Accessibility-critical | 6th grade or lower | 70+ | Government, healthcare |
+
+### Sentence and Word Rules
+
+- Cap sentences at 25 words. Break longer sentences into two.
+- Use one idea per sentence. Compound clauses increase parse time by 40%.
+- Prefer common words over formal synonyms: "use" not "utilize", "start" not "initiate", "end" not "terminate".
+- Avoid nominalizations: "decide" not "make a decision", "configure" not "perform configuration".
+- Remove filler phrases: "in order to" → "to", "at this point in time" → "now", "due to the fact that" → "because".
+- Spell out abbreviations on first use. After that, use the abbreviation only if it appears three or more times.
+
+### Jargon Policy
+
+| Context | Acceptable | Replace With |
+|---|---|---|
+| Error messages | Never use jargon | Plain description of what happened |
+| Developer tools | Domain terms OK | Define on first use or link to glossary |
+| Settings labels | Avoid unless standard | Descriptive phrase + help text |
+| Legal/compliance | Required terms only | Pair legal term with plain summary |
+
+Test readability with Hemingway Editor, Flesch-Kincaid scoring, or Microsoft Editor. Run checks before every release.
+
+## Writing for Screen Readers
+
+Screen readers linearize content. Write as if every user reads top-to-bottom, one element at a time.
+
+### Alt Text for Images
+
+- Functional images (icons, buttons): describe the action. "Search", "Close dialog", "Download report".
+- Informational images (charts, photos): describe the content. "Bar chart showing revenue growth from $2M to $5M over Q1-Q4".
+- Decorative images: use empty `alt=""`. Never omit the `alt` attribute entirely — that forces screen readers to read the file name.
+- Complex images (infographics, diagrams): provide a short `alt` plus a longer description via `aria-describedby` or a linked text alternative.
+
+### Meaningful Link Text
+
+| Bad | Good | Why |
+|---|---|---|
+| "Click here" | "View your billing history" | Identifies destination |
+| "Learn more" | "Learn more about two-factor authentication" | Distinguishes from other "Learn more" links |
+| "Read more" | "Read the full changelog for v3.2" | Scannable in link lists |
+| "Here" | "Download the accessibility report" | Understandable out of context |
+
+Screen reader users navigate by tabbing through links. Each link must be understandable in isolation, without surrounding text.
+
+### ARIA Labels and Live Regions
+
+- Add `aria-label` when visible text is insufficient: icon-only buttons, abbreviated labels, ambiguous controls.
+- Write ARIA labels as full phrases: `aria-label="Remove item from cart"` not `aria-label="Remove"`.
+- For dynamic content updates (toasts, counters, status changes), pair the UI text with `aria-live="polite"` or `aria-live="assertive"` regions.
+- Avoid redundant ARIA. If a button says "Save changes", do not add `aria-label="Save changes"` — the visible text is already the accessible name.
+
+### Heading Hierarchy
+
+- Use heading levels (H1-H6) in strict order. Never skip levels for visual styling.
+- Write headings as concise labels: "Payment method" not "Please select your preferred payment method".
+- Each page needs exactly one H1. It should match the page title or primary task.
+- Screen reader users scan by heading. Every distinct section needs a heading — even sections that are visually obvious require a heading for non-visual navigation.
+
+## Inclusive Language
+
+Default to language that includes everyone. Exclusion is never a style choice.
+
+### Gender-Neutral Defaults
+
+- Use "they/them/their" as the default singular pronoun. It has been standard in English since the 14th century.
+- Address users directly with "you/your" — this avoids gendered pronouns entirely and is the preferred UI writing pattern.
+- Replace gendered terms with neutral alternatives:
+
+| Replace | With |
+|---|---|
+| Guys, ladies | Everyone, team, folks |
+| Mankind | Humanity, people |
+| Man-hours | Person-hours, labor hours |
+| Manpower | Workforce, staffing |
+| Chairman | Chair, chairperson |
+| Master/slave | Primary/replica, leader/follower, main/secondary |
+| Whitelist/blacklist | Allowlist/blocklist |
+| Grandfathered | Legacy, exempt |
+| Sanity check | Confidence check, coherence check |
+
+### Ability and Disability
+
+- Use person-first language by default: "person with a disability" not "disabled person". Follow the preference of the specific community when known — some Deaf and autistic communities prefer identity-first language.
+- Never use disability as metaphor: "blind to the issue", "lame excuse", "crazy prices", "falling on deaf ears".
+- Describe interface actions without assuming physical ability:
+
+| Assumes Ability | Inclusive Alternative |
+|---|---|
+| "See the results below" | "The results appear below" |
+| "Watch the tutorial" | "View the tutorial" or "Follow the tutorial" |
+| "Click the button" | "Select the button" |
+| "Tap and hold" | "Select and hold" or "Long press" |
+
+### Age, Culture, and Family
+
+- Do not assume family structure. Use "parent or guardian" not "mom or dad". Use "household" not "family" when referring to shared accounts.
+- Avoid age-based assumptions. "Even your grandmother could use it" is patronizing. Describe simplicity without referencing age groups.
+- Do not assume cultural context. Holidays, seasons, food references, sports metaphors, and humor conventions vary globally.
+- Avoid referencing skin color or ethnicity in examples unless directly relevant.
+
+## Localization-Ready Writing
+
+Write English that translates well. Localization problems start in the source language.
+
+### What Breaks in Translation
+
+| Pattern | Problem | Fix |
+|---|---|---|
+| Idioms and metaphors | "It's a piece of cake" has no equivalent in most languages | Use literal, direct language |
+| Humor and wordplay | Puns and cultural jokes fail silently | Remove or replace with neutral phrasing |
+| String concatenation | `"You have " + count + " items"` breaks grammar in languages with different word order | Use ICU MessageFormat: `{count, plural, one {# item} other {# items}}` |
+| Hardcoded plurals | `item + (count > 1 ? "s" : "")` fails in languages with 3+ plural forms (Arabic has 6) | Use CLDR plural rules via i18n library |
+| Embedded variables mid-sentence | "Welcome back, {name}!" works in English but {name} placement varies by language | Allow translators to reorder variables |
+| Sentence fragments as UI | "Settings > Advanced > Network" may need restructuring | Provide full translatable strings, not fragments |
+
+### Date, Time, and Number Awareness
+
+- Never hardcode date formats. "03/04/2025" means March 4 (US) or April 3 (most of the world).
+- Use relative time for recent events: "2 minutes ago", "Yesterday". Let the i18n library handle formatting.
+- Do not assume decimal points. Many European locales use commas: 1.234,56 not 1,234.56.
+- Currency placement varies: $100 (US), 100€ (France), ¥100 (Japan). Always use locale-aware formatting.
+
+### Word Expansion Budgets
+
+UI layouts must accommodate text expansion when translated from English.
+
+| Target Language | Expansion Factor | Notes |
+|---|---|---|
+| German | 30-40% longer | Compound words are common |
+| French | 15-20% longer | Articles and prepositions add length |
+| Finnish | 30-40% longer | Agglutinative — words accumulate suffixes |
+| Japanese | 10-20% shorter | Kanji compress meaning |
+| Arabic | 20-25% longer | Right-to-left, different numeral widths |
+| Chinese (Simplified) | 10-30% shorter | Dense logographic script |
+
+Design UI with expansion in mind:
+- Avoid fixed-width containers for text. Use flexible layouts.
+- Buttons need 30-40% extra width headroom.
+- Navigation labels: keep English under 15 characters to give translators room.
+- Never truncate translated text — it may cut mid-word or mid-meaning.
+
+### Translatable String Rules
+
+- Write complete sentences, not fragments that get assembled at runtime.
+- Isolate UI strings into resource files. Never embed user-facing text in code logic.
+- Provide translator context: comments explaining where the string appears, what it refers to, and any character limits.
+- Avoid reusing identical English strings for different contexts. "Post" (noun) and "Post" (verb) need separate translation keys.
+
+## Right-to-Left Considerations
+
+Arabic, Hebrew, Farsi, and Urdu require mirrored layouts. Text direction affects more than alignment.
+
+### RTL Layout Impact on Copy
+
+- UI mirrors horizontally. Back arrows point right. Progress bars fill right-to-left. Navigation flows right-to-left.
+- Icons with directional meaning (arrows, send, reply) must flip. Icons without direction (home, settings, search) stay the same.
+- Bidirectional text (mixing RTL and LTR in one string) needs explicit Unicode direction marks. Example: a Hebrew sentence containing an English brand name.
+- Numbers in RTL languages still read left-to-right. Phone numbers, dates, and numeric IDs do not mirror.
+
+### Writing Guidelines for RTL
+
+- Test every string in RTL context. Text that reads naturally in English may break visual flow when mirrored.
+- Avoid left/right directional references in copy. "The menu on the left" fails in RTL. Use "the navigation menu" or positional labels that adapt.
+- Ensure text alignment responds to `dir="rtl"`. Use logical CSS properties (`margin-inline-start`) rather than physical ones (`margin-left`).
+- Punctuation placement follows the language direction. Parentheses, quotation marks, and brackets must adapt.
+
+## Sensitivity and Emotional Context
+
+Some interface moments carry emotional weight. Write with extra care when users face stress, fear, or vulnerability.
+
+### Money and Financial Difficulty
+
+- State amounts clearly. No hidden fees revealed in small print.
+- Use neutral language around financial status. "Your account balance is $0" not "You have no money".
+- Avoid celebratory language for charges: "Payment of $500 processed successfully!" reads differently to someone struggling financially. Prefer: "Payment of $500 confirmed."
+- Provide clear next steps for failed payments without shame: "We couldn't process your payment. Update your payment method to continue."
+
+### Health and Medical
+
+- Use precise, non-alarmist language. "Your results are ready for review" not "Important health alert!"
+- Never diagnose or imply diagnosis in UI copy. Present data; let professionals interpret.
+- Allow users to skip or dismiss health-related prompts without judgment.
+- Respect that health information is deeply personal. Minimize data collection language to what is strictly necessary.
+
+### Legal and Compliance
+
+- Pair legal language with plain-language summaries. Show the legal text for compliance; show the summary for comprehension.
+- Do not hide consent in walls of text. Surface the key commitment clearly: "You agree to a 12-month subscription at $10/month."
+- Label required disclosures explicitly. "Required by law" helps users understand why they are reading dense text.
+
+### Personal Data and Privacy
+
+- Explain why data is collected before asking for it. "We use your location to show nearby stores" preceding the permission request.
+- Use precise language about data handling: "stored on your device", "sent to our servers", "shared with partners". Avoid vague terms like "processed" without explanation.
+- Give clear confirmation when data is deleted: "Your account data has been permanently deleted. This cannot be undone."
+
+### Account Deletion and Destructive Actions
+
+- Use direct, unambiguous language: "Delete your account and all data permanently" not "Deactivate".
+- State consequences explicitly before the action: "You will lose: 47 projects, 3 team memberships, and all billing history."
+- Require explicit confirmation with clear, non-tricky phrasing. The cancel button should say "Keep my account" not "Cancel".
+- Avoid guilt-tripping retention copy: "Are you sure? We'll miss you!" manipulates users during a vulnerable moment.
+
+## Color and Visual References in Text
+
+Never rely on color alone to convey meaning. WCAG 1.4.1 requires information conveyed by color to also be available without it.
+
+### Problematic Patterns
+
+| Fails Accessibility | Accessible Alternative |
+|---|---|
+| "Fields marked in red are required" | "Required fields are marked with an asterisk (*)" |
+| "Click the green button to continue" | "Select Continue to proceed" |
+| "See the highlighted items" | "See the items marked with a star icon" |
+| "Errors are shown in red below" | "2 errors found. See details below each field." |
+
+### Guidelines
+
+- Reference elements by label, position, or icon — never by color alone.
+- Pair color indicators with text labels, icons, or patterns. A red error badge also needs the word "Error" or an error icon.
+- Status indicators need text equivalents: green dot + "Online", yellow dot + "Away", red dot + "Offline".
+- Charts and graphs need patterns, labels, or textures in addition to color differentiation.
+
+## Cognitive Load Reduction
+
+Reduce the mental effort required to parse interface text. Every unnecessary word is a tax on attention.
+
+### Chunking Information
+
+- Group related information under clear headings.
+- Use bullet lists for 3+ items. Inline lists ("A, B, and C") work for 2-3 short items only.
+- Limit choices presented at once. Show 3-5 options; hide the rest behind progressive disclosure.
+- Separate instructions from context. Lead with what to do, then explain why.
+
+### Progressive Disclosure in Copy
+
+- Show essential information first. Move details behind expandable sections, tooltips, or "Learn more" links.
+- Label progressive disclosure clearly. "Show advanced options" tells users what is hidden. "More" does not.
+- Default to the simplest path. Advanced users will find settings; beginners need guidance.
+
+### One Idea Per Sentence
+
+| Overloaded | Split |
+|---|---|
+| "Enter your email address, which we'll use to send you a verification code that expires in 10 minutes." | "Enter your email address. We'll send a verification code. The code expires in 10 minutes." |
+| "Your subscription renews automatically on the 1st of each month unless you cancel before the renewal date in your account settings." | "Your subscription renews on the 1st of each month. Cancel anytime in Account Settings." |
+
+### Scannable Structure
+
+- Front-load keywords. Put the most important word first in headings, labels, and list items.
+- Use consistent patterns. If one list item starts with a verb, all items start with a verb.
+- Keep parallel structure. Inconsistent formatting forces users to re-parse each item.
+- Use whitespace intentionally. Dense blocks of text signal "skip this" to most users.
+
+## Writing for Diverse Literacy Levels
+
+Design for the full spectrum — multilingual users, non-native speakers, varying technical comfort.
+
+### Multilingual Audiences
+
+- Use short, simple sentences. They translate more accurately and are easier for non-native readers.
+- Avoid phrasal verbs when possible: "submit" not "send in", "cancel" not "call off", "continue" not "go on".
+- Provide visual context alongside text. Icons, illustrations, and layout reinforce meaning when language is a barrier.
+- Consider offering language switching prominently — not buried in a footer link.
+
+### Technical vs Non-Technical Paths
+
+- Offer layered explanations. A simple label for everyone, a technical detail for power users.
+- Example: "Two-factor authentication" as the label, "Requires a 6-digit code from your authenticator app (TOTP)" as help text.
+- Never assume everyone knows acronyms. Expand on first use, even common ones like "URL" or "API" in consumer-facing products.
+
+### Readability Across Education Levels
+
+- Write for the lowest common denominator without being condescending. Short sentences and common words are not "dumbed down" — they are clear.
+- Use examples to clarify abstract concepts. "Enter a strong password (example: Sunset-Tiger-42!)" is clearer than "Enter a strong password."
+- Test with real users across literacy levels. Readability scores are proxies, not guarantees.
+
+## Localization Testing Checklist
+
+Run these checks before shipping any localized release.
+
+| Test | Method | Pass Criteria |
+|---|---|---|
+| Pseudo-localization | Replace strings with accented characters (ëñüß) and padding | UI renders without clipping, overflow, or layout breaks |
+| String length stress | Inject German-length strings (140% of English) into all UI elements | No truncation, no overlapping, no broken layouts |
+| Plural forms | Test 0, 1, 2, 5, 11, 21 in each locale | Correct plural form for every count in every language |
+| RTL mirror | Switch to Arabic or Hebrew locale | Layout mirrors correctly, bidirectional text renders properly |
+| Concatenation audit | Search codebase for string concatenation with variables | All dynamic strings use ICU MessageFormat or equivalent |
+| Date/time/number | Display dates, times, currencies in each locale | Locale-appropriate formatting throughout |
+| Cultural review | Native speaker reviews all strings in context | No offensive, confusing, or culturally inappropriate content |
+| Context screenshots | Provide translators with screenshots of every string in situ | Translations match the UI context, not just the isolated string |
+| Character encoding | Verify UTF-8 handling for CJK, Arabic, Thai, Devanagari | No mojibake, no missing characters, no rendering artifacts |
+| Truncation audit | Check all fixed-width elements across locales | No meaningful content cut off; ellipsis used appropriately |

--- a/skills/ux-writing/references/voice-and-tone.md
+++ b/skills/ux-writing/references/voice-and-tone.md
@@ -1,0 +1,282 @@
+# Voice and Tone Frameworks
+
+Sources: Yifrah (Microcopy), Podmajersky (Strategic Writing for UX), Fenton/Lee (Nicely Said), Hall (Conversational Design), So (Voice Content and Usability), Apple HIG (WWDC24/25), Google Material Design 3, Microsoft Writing Style Guide, NN/g research
+
+Covers: Voice discovery, tone mapping systems, brand personality for interfaces, voice documentation standards, and antipattern detection. The foundational strategy layer that governs all interface writing decisions.
+
+## Voice vs. Tone Distinction
+
+Voice is the stable personality of a product. It does not change between screens, states, or user moods. Tone is the situational modulation of that voice — the same person speaks differently at a funeral than at a party.
+
+This distinction is the single most important concept in UX writing strategy. Every platform style guide converges on it:
+
+| Concept | Definition | Changes? | Analogy |
+|---------|-----------|----------|---------|
+| Voice | The product's consistent character traits | No — stable across all contexts | Who you are |
+| Tone | How voice qualities dial up or down per situation | Yes — adapts to context and emotion | How you speak right now |
+| Register | The formality level within a tone choice | Yes — formal to casual | The clothes you wear |
+
+Apple's HIG frames this as a set of dials: voice defines the dial labels (Clarity, Simplicity, Friendliness, Helpfulness), while tone sets where each dial points in a given moment. A deletion confirmation dials Clarity to maximum and Friendliness down. A first-run welcome dials Friendliness up and keeps Clarity moderate.
+
+Microsoft collapses voice into three stable commitments: "warm and relaxed, crisp and clear, ready to lend a hand." These never change — but their intensity does.
+
+### Why This Matters for Teams
+
+Without a defined voice, every writer invents their own. The product sounds like five different people wrote it — because five different people did. Without tone guidance, writers default to one register everywhere: either relentlessly cheerful (errors included) or uniformly robotic.
+
+Define voice once. Map tone per context. Revisit quarterly.
+
+## Voice Discovery Workshop
+
+Use this process to define a product's voice from scratch. Synthesized from Yifrah's voice questionnaire, Podmajersky's voice chart, Fenton/Lee's spectrum method, and Hall's conversational personality framework.
+
+### Step 1: Stakeholder Alignment (60 min)
+
+Gather product, design, engineering, and marketing leads. Run the **personality card sort**:
+
+1. Spread 40-60 personality adjectives on cards (confident, playful, authoritative, warm, minimal, bold, gentle, precise, witty, earnest, etc.)
+2. Each participant selects 5 that describe the product as it should be
+3. Each participant selects 3 the product should never be
+4. Cluster overlapping selections on a wall
+5. Negotiate to a final set of 3-5 positive traits and 3 anti-traits
+
+### Step 2: Voice Attribute Definition
+
+For each selected trait, build a **voice attribute row**:
+
+| Attribute | Description | Do | Don't | This, not that |
+|-----------|-------------|-----|-------|----------------|
+| Confident | We know our domain and state things directly | "Your file is saved." | "Your file has been saved successfully!" | Direct, not boastful |
+| Warm | We acknowledge the human, not just the task | "Welcome back, Alex." | "User session resumed." | Friendly, not saccharine |
+| Precise | Every word earns its place | "2 items removed." | "The selected items have been successfully removed from your list." | Concise, not cold |
+
+This table format comes from Podmajersky's voice chart, extended with Fenton/Lee's "this, not that" column to prevent misinterpretation.
+
+### Step 3: Persona Stress Test (Yifrah)
+
+Yifrah's voice questionnaire validates voice attributes against edge cases:
+
+1. If the product were a person, how would it deliver bad news?
+2. How would it celebrate a user's achievement?
+3. How would it ask for sensitive information (payment, health data)?
+4. How would it respond if the user made a mistake?
+5. How would it handle an outage or service degradation?
+6. How would it greet a first-time user vs. a power user?
+
+Write sample responses for each scenario using the voice attributes. If any answer feels wrong, the attributes need adjustment.
+
+### Step 4: Anti-Voice Boundary
+
+Document 3-5 explicit anti-traits with concrete examples:
+
+| Anti-trait | Why it fails | Example to avoid |
+|-----------|-------------|-----------------|
+| Robotic | Destroys trust and empathy | "Error 403: Forbidden. Contact administrator." |
+| Sarcastic | Alienates users in vulnerable moments | "Oops! Looks like you forgot your password. Again." |
+| Patronizing | Undermines user competence | "Great job! You clicked the button!" |
+
+### Step 5: Validation Across Contexts
+
+Write 8-10 sample strings across different UI states (welcome, error, empty state, confirmation, loading, success, warning, destructive action). Read them aloud in sequence. They should sound like the same person adapting to different situations — not like different people.
+
+## Tone Mapping
+
+Three major frameworks exist for mapping tone to context. Use them together — they address different dimensions.
+
+### Apple's Dial Model
+
+Four tone qualities, each a spectrum:
+
+| Dial | Low end | High end | Adjust based on |
+|------|---------|----------|----------------|
+| Clarity | Ambient, suggestive | Explicit, unambiguous | Consequence severity |
+| Simplicity | Rich detail, full explanation | Stripped to essentials | User expertise and urgency |
+| Friendliness | Formal, neutral | Warm, conversational | Emotional context |
+| Helpfulness | Hands-off, informational | Guided, prescriptive | User confidence level |
+
+Apply by asking: "For this screen, where does each dial sit?" A critical error: Clarity=max, Simplicity=high, Friendliness=low-mid, Helpfulness=max. A feature tour: Clarity=mid, Simplicity=mid, Friendliness=high, Helpfulness=high.
+
+### Google's Two-Axis Tone Map
+
+Plot every UI context on two axes:
+
+```
+                   Serious
+                     |
+                     |
+        Errors ------|------ Legal/Compliance
+                     |
+   Concise ----------+---------- Detailed
+                     |
+     Tooltips -------|------ Onboarding
+                     |
+                     |
+                   Playful
+```
+
+- **Serious + Concise** (top-left): Error messages, destructive confirmations
+- **Serious + Detailed** (top-right): Legal text, security explanations, compliance
+- **Playful + Concise** (bottom-left): Success toasts, badges, micro-celebrations
+- **Playful + Detailed** (bottom-right): Onboarding flows, feature discovery, tutorials
+
+### NN/g's Four Dimensions
+
+Nielsen Norman Group identifies four independent tone dimensions. Rate each on a 1-7 scale per context:
+
+| Dimension | Pole A | Pole B |
+|-----------|--------|--------|
+| Humor | Funny | Serious |
+| Formality | Casual | Formal |
+| Respect | Irreverent | Respectful |
+| Enthusiasm | Enthusiastic | Matter-of-fact |
+
+NN/g research shows users consistently prefer interfaces rated high on **Respectful** and moderate on **Casual**. Humor is the riskiest dimension — it polarizes users and fails across cultures.
+
+### Unified Mapping Method
+
+Combine all three frameworks into a single scoring exercise:
+
+1. List every UI context the product contains (see Tone by Context below)
+2. For each context, set Apple's four dials
+3. Plot position on Google's two-axis map
+4. Rate NN/g's four dimensions
+5. Write 2-3 sample strings at those settings
+6. Review for internal consistency
+
+## Tone by Context
+
+Map tone settings to specific UI contexts. Adapt this table to the product's voice attributes.
+
+| UI Context | Emotional State | Clarity | Friendliness | Recommended Register |
+|-----------|----------------|---------|-------------|---------------------|
+| First-run welcome | Curious, uncertain | Mid | High | Warm, inviting, brief |
+| Onboarding steps | Engaged, learning | Mid-High | High | Encouraging, guided |
+| Empty states | Potentially confused | High | Mid-High | Helpful, motivating |
+| Feature discovery | Interested | Mid | Mid-High | Enthusiastic but not pushy |
+| Form labels | Task-focused | Max | Low-Mid | Neutral, precise |
+| Inline validation | Mildly frustrated | Max | Mid | Constructive, immediate |
+| Success confirmation | Satisfied, relieved | Mid | Mid-High | Brief, affirming |
+| Warning (recoverable) | Concerned | High | Mid | Calm, clear on consequence |
+| Error (blocking) | Frustrated, anxious | Max | Mid | Serious, solution-first |
+| Destructive confirmation | Hesitant, cautious | Max | Low | Direct, consequence-explicit |
+| Loading/progress | Waiting, impatient | Mid | Mid | Informative, time-aware |
+| Permission requests | Suspicious, protective | Max | Mid | Transparent, benefit-first |
+| Upgrade/paywall | Evaluating, skeptical | High | Mid | Value-focused, no pressure |
+| Account/security | Vigilant | Max | Low-Mid | Precise, trustworthy |
+| Celebratory moments | Happy, accomplished | Mid | High | Genuine, not excessive |
+| Offboarding/cancellation | Disappointed, resolved | High | Mid | Respectful, no guilt |
+
+### Context Escalation Pattern
+
+IBM Carbon and Atlassian both use a **conversational gradient**: tone becomes progressively less conversational as severity increases.
+
+```
+Most conversational                     Least conversational
+|                                                         |
+Welcome → Tips → Empty → Success → Warning → Error → Legal
+```
+
+Match this gradient to the product's voice range. A playful product still gets serious at errors — it just starts from a higher friendliness baseline.
+
+## Voice Documentation
+
+A voice guide is useless if nobody reads it. Structure it for scanability and practical application.
+
+### Recommended Structure
+
+1. **Voice summary** — 1-2 sentences capturing the overall personality
+2. **Voice attributes table** — 3-5 traits with Do/Don't/This-not-that columns (see Step 2 above)
+3. **Anti-traits** — What the product never sounds like, with examples
+4. **Tone map** — Table or diagram showing tone shifts per context
+5. **Sample strings** — 10-15 real UI strings demonstrating voice in action, covering success, error, empty, onboarding, and neutral states
+6. **Word list** — Approved and banned terminology (Apple and Google both emphasize this)
+7. **Decision tree** — For ambiguous situations: "When in doubt, optimize for clarity over personality"
+
+### Voice Attribute Spectrum Visualization
+
+Podmajersky and Fenton/Lee both recommend visualizing voice as a position on spectrums rather than a binary:
+
+```
+Formal  |----[X]--------------------| Casual
+Serious |--------[X]----------------| Playful
+Minimal |--[X]----------------------| Verbose
+Guiding |--------------[X]----------| Hands-off
+Technical |----------[X]------------| Plain language
+```
+
+Place an X on each spectrum. This immediately communicates more than a list of adjectives. Include this in the voice guide.
+
+### Maintenance Cadence
+
+| Activity | Frequency | Owner |
+|----------|-----------|-------|
+| Voice audit — sample 20 strings across product | Quarterly | Content design lead |
+| Tone calibration — review tone map against new features | Per major release | Content + product |
+| Word list update — add new terms, deprecate old ones | Monthly | Any content designer |
+| Full voice review — reassess attributes against brand evolution | Annually | Content + brand |
+
+## Common Voice Antipatterns
+
+### Robot Voice
+
+**Signal:** Every string sounds like a system log. No acknowledgment of the human reading it.
+
+**Example:** "Operation completed. 3 records modified. Transaction ID: 4f2a."
+
+**Fix:** Add minimal human context without over-personalizing. "3 contacts updated." conveys the same information with human framing.
+
+**Root cause:** Engineers wrote the copy. No content review step exists.
+
+### The Over-Friendly Assistant
+
+**Signal:** Exclamation marks everywhere. Every action is "awesome" or "great." Errors apologize profusely.
+
+**Example:** "Oops! Something went wrong. We're so sorry about that! Don't worry though, our amazing team is on it!"
+
+**Fix:** Reserve enthusiasm for genuinely celebratory moments. Errors need solutions, not cheerfulness. Apply Shopify's rule: exclamation marks only for genuinely celebratory moments. IBM goes further: avoid "please" and "thank you" in UI — it can read as condescending.
+
+**Root cause:** Overcorrection from robot voice. No tone map defining where warmth is appropriate.
+
+### Inconsistent Personality
+
+**Signal:** The product sounds different in every section. Settings are formal, onboarding is playful, errors are robotic, modals are verbose.
+
+**Example:** Welcome: "Hey there! Ready to get started?" → Settings: "Configure notification preferences for system-level alerts." → Error: "Error code 5012."
+
+**Fix:** Conduct a voice audit. Pull 30 strings from across the product, read them in sequence, flag any that break character. Create a voice attribute table and measure every string against it.
+
+**Root cause:** Multiple writers without a shared voice guide. Or a voice guide that nobody references.
+
+### Corporate Jargon Creep
+
+**Signal:** Marketing language leaks into the product UI. Buzzwords replace clear instructions.
+
+**Example:** "Leverage our cutting-edge AI-powered solution to streamline your workflow and drive engagement."
+
+**Fix:** Apply the conversation test (Hall): would a helpful colleague say this to someone standing next to them? If not, rewrite in plain language. Enforce a maximum reading level — Shopify targets 7th grade.
+
+**Root cause:** Marketing and product share a CMS or content process without role-specific guidelines.
+
+### Tone-Deaf Severity Mismatch
+
+**Signal:** The product uses the same register for trivial and critical moments. A deleted account gets the same treatment as a dismissed tooltip.
+
+**Example:** "All done! Your account has been permanently deleted." (cheerful tone for an irreversible action)
+
+**Fix:** Map the tone by context table above. Destructive actions demand maximum clarity and minimum friendliness. Apply the context escalation gradient.
+
+**Root cause:** No tone map exists. Writers default to the product's dominant tone regardless of context.
+
+## Cross-Framework Quick Reference
+
+| Framework | Origin | Best for | Core mechanism |
+|-----------|--------|---------|---------------|
+| Voice chart | Podmajersky | Defining voice attributes | Trait + Do/Don't table |
+| Voice questionnaire | Yifrah | Stress-testing voice under pressure | Scenario-based Q&A |
+| Tone spectrum | Fenton/Lee | Visualizing voice range | Spectrum positioning |
+| Dial model | Apple HIG | Per-context tone calibration | 4 independent dials |
+| Two-axis tone map | Google MD3 | Plotting UI contexts spatially | Playful-Serious x Concise-Detailed |
+| 4 dimensions | NN/g | Measuring tone objectively | Independent 1-7 scales |
+| Conversational gradient | IBM Carbon | Severity-based tone scaling | Linear formality escalation |
+| Personality as material | Hall | Grounding voice in design process | Conversational design principles |
+| 3 C's hierarchy | NN/g | Prioritizing competing goals | Clarity > Concision > Character |

--- a/skills/ux-writing/tank.json
+++ b/skills/ux-writing/tank.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tank/ux-writing",
+  "version": "1.0.0",
+  "description": "Write clear, effective interface copy — microcopy, error messages, onboarding flows, form labels, empty states, notifications. Covers voice/tone design, component-level patterns, error formulas, content design process, form copy, inclusive writing, and localization readiness.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

- Adds `@tank/ux-writing` skill for writing clear, effective interface copy (microcopy, error messages, onboarding, forms, empty states, notifications)
- 7 reference files (282-360 lines each) synthesizing 10 books + 7 platform style guides + NN/g research
- Sources: Yifrah, Podmajersky, Winters, Metts/Welfle, Ben-David, Hall, So, Fenton/Lee, Google Material, Apple HIG, Microsoft, Shopify Polaris, Atlassian

## Files

| File | Lines | Covers |
|------|-------|--------|
| `SKILL.md` | 135 | Entry point, quick-start problems, decision trees |
| `references/voice-and-tone.md` | 282 | Voice discovery, tone mapping, documentation |
| `references/component-microcopy.md` | 341 | Buttons, headings, tooltips, notifications, dialogs |
| `references/error-messages.md` | 333 | Error anatomy, severity tiers, antipatterns |
| `references/empty-states-onboarding.md` | 357 | Empty states, first-run, permissions, success states |
| `references/content-design-process.md` | 343 | Workflow, pair writing, crits, testing, metrics |
| `references/forms-and-inputs.md` | 360 | Labels, placeholders, validation, multi-step |
| `references/inclusive-writing.md` | 310 | Plain language, a11y, localization, RTL |
| `tank.json` | — | Minimal permissions, v1.0.0 |