### PR TITLE
feat: add 7 atom-creator skills + @tank/package-creator meta bundle

### DIFF
--- a/bundles/package-creator/SKILL.md
+++ b/bundles/package-creator/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: "@tank/package-creator"
+description: |
+  Master routing guide for creating ANY Tank package. Given a user request
+  ("I want to create a hook", "I need a tool bundle", "write a new skill"),
+  identifies the correct package type and routes to the specialized creator
+  skill. Covers all 8 package primitives (instruction, bundle, hook, tool,
+  rule, agent, prompt, resource) plus composite patterns. Contains decision
+  trees for package type identification, format selection (instruction-only
+  vs multi-atom), and a universal pre-publish quality checklist.
+  Synthesizes Tank Contributing Standard (AGENTS.md) and the 8 creator
+  skills (@tank/skill-creator, @tank/bundle-creator, @tank/hook-creator,
+  @tank/tool-creator, @tank/rule-creator, @tank/agent-creator,
+  @tank/prompt-creator, @tank/resource-creator).
+
+  Trigger phrases: "create a package", "new tank package", "create a skill",
+  "create a bundle", "create a hook", "create a tool", "create a rule",
+  "create an agent", "create a prompt", "create a resource", "tank package",
+  "what kind of package", "which creator", "package type", "build a package",
+  "new package", "start a package", "package decision tree", "pre-publish check"
+---
+
+# Tank Package Creator
+
+Route any "I want to create..." request to the correct specialized creator.
+
+## Core Philosophy
+
+1. **Route, do not duplicate.** This skill identifies the right creator and
+   hands off. The 8 creator skills contain the deep knowledge. Loading all
+   of them wastes context; loading the right one is the job.
+
+2. **Format follows need.** Instruction-only skills are simpler to author,
+   review, and maintain. Reach for multi-atom bundles only when the problem
+   demands machine enforcement, delegation, or external integration.
+
+3. **Composition over complexity.** Most packages need 1-3 atom kinds. A
+   bundle with all 7 atom kinds is almost certainly over-engineered. Start
+   with the minimum atoms that solve the problem.
+
+4. **Quality is non-negotiable.** Every package passes the same checklist
+   before publishing. No exceptions for "simple" packages.
+
+## What Do You Want to Create?
+
+### "I want to teach the agent domain knowledge"
+
+1. This is an **instruction-only skill** (the simplest package type).
+2. Load `@tank/skill-creator` for the full workflow.
+3. Create under `skills/{name}/` with `SKILL.md` + `tank.json`.
+
+### "I want to intercept agent behavior at lifecycle events"
+
+1. This requires a **hook atom** inside a multi-atom bundle.
+2. Load `@tank/hook-creator` for event catalog and handler patterns.
+3. Load `@tank/bundle-creator` for the bundle scaffold.
+
+### "I want to wire an MCP server into the agent"
+
+1. This requires a **tool atom** inside a multi-atom bundle.
+2. Load `@tank/tool-creator` for transport wiring and extension bags.
+3. Load `@tank/bundle-creator` for the bundle scaffold.
+
+### "I want to enforce a policy without writing code"
+
+1. This requires a **rule atom** inside a multi-atom bundle.
+2. Load `@tank/rule-creator` for policy design and event targeting.
+3. Load `@tank/bundle-creator` for the bundle scaffold.
+
+### "I want to define a sub-agent with specific tools"
+
+1. This requires an **agent atom** inside a multi-atom bundle.
+2. Load `@tank/agent-creator` for role design and tool scoping.
+3. Load `@tank/bundle-creator` for the bundle scaffold.
+
+### "I want a reusable template or slash command"
+
+1. This requires a **prompt atom** inside a multi-atom bundle.
+2. Load `@tank/prompt-creator` for template design and variable syntax.
+3. Load `@tank/bundle-creator` for the bundle scaffold.
+
+### "I want to expose data the agent can read on demand"
+
+1. This requires a **resource atom** inside a multi-atom bundle.
+2. Load `@tank/resource-creator` for URI design and pull-model patterns.
+3. Load `@tank/bundle-creator` for the bundle scaffold.
+
+### "I want a composite package with multiple atom types"
+
+1. Start with `@tank/bundle-creator` for the scaffold and atoms array.
+2. Load the specific creator for each atom kind you need.
+3. Refer to `references/decision-guide.md` for common combinations.
+
+## Decision Trees
+
+### Format Selection
+
+| Signal                                   | Format           | Creator              |
+| ---------------------------------------- | ---------------- | -------------------- |
+| Pure knowledge, no enforcement needed    | Instruction-only | `@tank/skill-creator`  |
+| Need lifecycle hooks                     | Multi-atom       | `@tank/bundle-creator` |
+| Need a sub-agent with scoped tools       | Multi-atom       | `@tank/bundle-creator` |
+| Need declarative policy enforcement      | Multi-atom       | `@tank/bundle-creator` |
+| Need MCP tool or resource registration   | Multi-atom       | `@tank/bundle-creator` |
+| Need on-demand prompt templates          | Multi-atom       | `@tank/bundle-creator` |
+
+### Atom Kind Selection
+
+| Need                                     | Atom Kind     | Specialized Creator       |
+| ---------------------------------------- | ------------- | ------------------------- |
+| Behavioral context injected every session| `instruction` | `@tank/skill-creator`     |
+| Code at lifecycle events (gate, format)  | `hook`        | `@tank/hook-creator`      |
+| Delegatable sub-agent with scoped tools  | `agent`       | `@tank/agent-creator`     |
+| Declarative block/warn/allow policy      | `rule`        | `@tank/rule-creator`      |
+| MCP server registration                 | `tool`        | `@tank/tool-creator`      |
+| On-demand readable data or context       | `resource`    | `@tank/resource-creator`  |
+| Reusable invocable template              | `prompt`      | `@tank/prompt-creator`    |
+
+### Common Bundle Patterns
+
+| Pattern                    | Atoms Involved                    | Example                |
+| -------------------------- | --------------------------------- | ---------------------- |
+| Quality gate               | hook + agent + instruction        | `@tank/quality-gate`   |
+| Safety policy              | rule + instruction                | Command blocklist      |
+| Tool integration           | tool + instruction                | MCP server wrapper     |
+| Automated workflow         | prompt + agent + hook             | PR description bot     |
+| Context provider           | resource + instruction            | Project architecture   |
+| Full enforcement pipeline  | hook + agent + rule + instruction | Review + block + fix   |
+
+## Pre-Publish Checklist (Quick)
+
+Run through `references/quality-checklist.md` before every `tank publish`.
+Summary of critical gates:
+
+1. `name` field matches between `SKILL.md` and `tank.json`
+2. `name` starts with `@tank/`
+3. SKILL.md body under 200 lines
+4. SKILL.md description has 10-15 trigger phrases
+5. tank.json permissions are minimal
+6. tank.json repository is `https://github.com/tankpkg/packages`
+7. Reference files: 250-450 lines, no frontmatter, no overlap
+8. Multi-atom: every atom has required fields, files exist
+
+-> See `references/quality-checklist.md` for the full checklist.
+
+## Creator Skills Index
+
+| Creator                  | Scope                                          |
+| ------------------------ | ---------------------------------------------- |
+| `@tank/skill-creator`    | Instruction-only skills (SKILL.md + references)|
+| `@tank/bundle-creator`   | Multi-atom bundle scaffold and atoms array     |
+| `@tank/hook-creator`     | Hook atoms, DSL/JS handlers, lifecycle events  |
+| `@tank/tool-creator`     | Tool atoms, MCP wiring, extension bags         |
+| `@tank/rule-creator`     | Rule atoms, policy design, declarative guards  |
+| `@tank/agent-creator`    | Agent atoms, role design, tool scoping         |
+| `@tank/prompt-creator`   | Prompt atoms, templates, variable design       |
+| `@tank/resource-creator` | Resource atoms, URI design, pull-model context |
+
+## Reference Index
+
+| File                             | Contents                                       |
+| -------------------------------- | ---------------------------------------------- |
+| `references/decision-guide.md`   | Complete package type identification guide      |
+| `references/quality-checklist.md`| Universal pre-publish validation checklist      |

--- a/bundles/package-creator/references/decision-guide.md
+++ b/bundles/package-creator/references/decision-guide.md
@@ -1,0 +1,336 @@
+# Package Type Decision Guide
+
+Sources: Tank Contributing Standard (AGENTS.md), Tank atom specification, production bundle analysis
+
+Covers: identifying the correct package type for any use case, choosing between
+instruction-only and multi-atom formats, common atom combinations, and
+anti-patterns in package design.
+
+## The Two Formats
+
+Tank supports exactly two package formats. Every package is one or the other.
+
+### Instruction-Only Skill
+
+A single `SKILL.md` instruction blob with optional reference files. No build
+step, no atoms array. Tank auto-generates a single instruction atom at install.
+
+```
+skills/{kebab-name}/
+  SKILL.md              # Required -- frontmatter + body (<200 lines)
+  tank.json             # Required -- metadata + permissions (no atoms field)
+  references/           # Optional -- deep docs (250-450 lines each)
+  scripts/              # Optional -- executable code
+  assets/               # Optional -- templates, images
+```
+
+Best for: domain knowledge, best practices, methodology guides, coding
+standards, framework expertise, workflow documentation.
+
+### Multi-Atom Bundle
+
+A package with an `atoms` array in `tank.json` containing typed primitives.
+Each atom is a discrete unit of agent capability.
+
+```
+bundles/{kebab-name}/
+  tank.json             # Required -- metadata + permissions + atoms array
+  SKILL.md              # Optional -- instruction content (referenced by atom)
+  hooks/                # Optional -- JS/TS hook handlers
+  references/           # Optional -- deep docs (250-450 lines each)
+  scripts/              # Optional -- executable code
+  assets/               # Optional -- templates, images
+```
+
+Best for: lifecycle hooks, sub-agents, policy enforcement, MCP tool wiring,
+prompt templates, data resources, or any combination of the above.
+
+## The Eight Atom Kinds
+
+Every atom in Tank's system is one of these eight kinds. Each has a
+specialized creator skill.
+
+### 1. Instruction
+
+| Field     | Value                              |
+| --------- | ---------------------------------- |
+| Kind      | `instruction`                      |
+| Purpose   | Behavioral context injected into the agent |
+| Required  | `content` (file path to markdown)  |
+| Creator   | `@tank/skill-creator`              |
+
+When to use: the agent needs domain knowledge, coding standards, workflow
+steps, or decision frameworks loaded into its system prompt.
+
+Signals:
+- "The agent needs to know about X"
+- "Follow these coding standards"
+- "Use this methodology"
+- Pure text, no enforcement needed
+
+### 2. Hook
+
+| Field     | Value                              |
+| --------- | ---------------------------------- |
+| Kind      | `hook`                             |
+| Purpose   | Code that runs at lifecycle events |
+| Required  | `event`, `handler`                 |
+| Creator   | `@tank/hook-creator`               |
+
+When to use: intercept agent behavior at a specific lifecycle point. Hooks
+can block, allow, rewrite, or inject context.
+
+Signals:
+- "Before the agent stops, check if..."
+- "After the agent writes a file, run..."
+- "When a session starts, inject..."
+- "Block the agent from doing X"
+- Need to run code (shell commands, API calls, delegation)
+
+### 3. Agent
+
+| Field     | Value                              |
+| --------- | ---------------------------------- |
+| Kind      | `agent`                            |
+| Purpose   | Named role with tools and permissions |
+| Required  | `name`, `role`                     |
+| Creator   | `@tank/agent-creator`              |
+
+When to use: delegate a specific task to a sub-agent with constrained tools
+and an explicit role identity.
+
+Signals:
+- "Review the code changes"
+- "Audit for security issues"
+- "Update the documentation"
+- Need a specialist with a narrower tool set than the main agent
+- Need readonly access for analysis tasks
+
+### 4. Rule
+
+| Field     | Value                              |
+| --------- | ---------------------------------- |
+| Kind      | `rule`                             |
+| Purpose   | Declarative validation constraint  |
+| Required  | `event`, `policy`                  |
+| Creator   | `@tank/rule-creator`               |
+
+When to use: enforce a static policy without writing code. Rules are
+data, not logic -- the runtime evaluates them.
+
+Signals:
+- "Block command X"
+- "Warn when pattern Y appears"
+- "Only allow tools A, B, C"
+- Simple match-and-act pair, no conditional logic needed
+- Policy can be expressed as a single sentence
+
+### 5. Tool
+
+| Field     | Value                              |
+| --------- | ---------------------------------- |
+| Kind      | `tool`                             |
+| Purpose   | MCP server registration            |
+| Required  | `name`                             |
+| Creator   | `@tank/tool-creator`               |
+
+When to use: wire an existing MCP server into the agent's harness so
+its tools become available.
+
+Signals:
+- "Connect to this MCP server"
+- "Make this tool available to the agent"
+- "Register a database/API/service tool"
+- MCP server already exists; need a thin wiring layer
+- Never for building the MCP server itself
+
+### 6. Resource
+
+| Field     | Value                              |
+| --------- | ---------------------------------- |
+| Kind      | `resource`                         |
+| Purpose   | URI-addressable data the agent can read |
+| Required  | `uri`                              |
+| Creator   | `@tank/resource-creator`           |
+
+When to use: expose data the agent can pull on demand rather than having
+it injected every session.
+
+Signals:
+- "The agent sometimes needs to reference X"
+- "Expose the project architecture map"
+- "Make the style guide available"
+- Content is large, situational, or task-specific
+- Content changes per environment or run
+
+### 7. Prompt
+
+| Field     | Value                              |
+| --------- | ---------------------------------- |
+| Kind      | `prompt`                           |
+| Purpose   | Reusable invocable template        |
+| Required  | `name`, `template`                 |
+| Creator   | `@tank/prompt-creator`             |
+
+When to use: create a parameterized template the user invokes by name
+or slash command.
+
+Signals:
+- "Generate a commit message with this format"
+- "Create a PR description template"
+- "Slash command for incident reports"
+- User triggers it on demand, not every session
+- Output has a consistent structure with variable slots
+
+### 8. Composite (Bundle of Atoms)
+
+Not a distinct atom kind but a design pattern: combining multiple atom
+kinds in a single bundle to create a cohesive capability.
+
+Creator: `@tank/bundle-creator` (the scaffold) + specific creators for
+each atom kind used.
+
+Signals:
+- Need more than one atom kind
+- Atoms interact (hook delegates to agent, rule gates a tool)
+- Single installable package delivers a complete workflow
+
+## Format Decision Flowchart
+
+Follow this sequence to determine which format to use:
+
+```
+START
+  |
+  v
+Does the package need ONLY to teach the agent knowledge?
+  |
+  +-- YES --> Instruction-only skill
+  |           Use @tank/skill-creator
+  |
+  +-- NO
+      |
+      v
+      Does it need any of these?
+        - Lifecycle hooks (intercept behavior)
+        - Sub-agents (delegated specialists)
+        - Rules (declarative enforcement)
+        - Tools (MCP server wiring)
+        - Resources (on-demand data)
+        - Prompts (invocable templates)
+      |
+      +-- YES --> Multi-atom bundle
+      |           Use @tank/bundle-creator + specific creators
+      |
+      +-- NO --> Instruction-only skill (default)
+```
+
+## Common Bundle Compositions
+
+### Quality Gate (hook + agent + instruction)
+
+Intercepts `pre-stop`, delegates review to a readonly agent, blocks
+the agent from stopping if critical issues exist.
+
+Atoms: 1 hook (pre-stop), 1 agent (reviewer), 1 instruction (context).
+
+### Safety Policy (rules + instruction)
+
+Declares a set of block/warn rules for dangerous operations. The
+instruction explains the rationale so the agent self-corrects.
+
+Atoms: N rules (one per concern), 1 instruction (rationale).
+
+### Tool Integration (tool + instruction)
+
+Wires an MCP server and provides usage guidance so the agent knows
+when and why to use the tool.
+
+Atoms: 1 tool (wiring), 1 instruction (guidance).
+
+### Workflow Automation (prompt + agent + hook)
+
+A prompt template generates structured output, an agent processes it,
+and a hook triggers the workflow at the right lifecycle point.
+
+Atoms: 1 prompt (template), 1 agent (processor), 1 hook (trigger).
+
+### Context Provider (resource + instruction)
+
+Exposes on-demand data with behavioral guidance for when to read it.
+
+Atoms: 1 resource (data), 1 instruction (guidance).
+
+### Full Enforcement Pipeline (hook + agent + rule + instruction)
+
+The most complex pattern. A hook intercepts an event, delegates to an
+agent for analysis, rules enforce policies on the findings, and the
+instruction ties everything together.
+
+Atoms: 1 hook (interceptor), 1 agent (analyzer), N rules (policies),
+1 instruction (context).
+
+## Anti-Patterns
+
+| Pattern | Problem | Fix |
+|---------|---------|-----|
+| Using a bundle when a skill suffices | Unnecessary complexity | If all atoms would be instruction, use a skill |
+| Every atom kind in one bundle | Over-engineered, hard to maintain | Compose only what the capability requires |
+| Duplicating instruction content in hook code | Drift, double maintenance | Single source of truth in SKILL.md |
+| Building MCP server code inside a tool atom | Stale, wrong abstraction | Tool atoms are wiring, not implementation |
+| One agent with all tools | Diluted expertise | Least-privilege, one responsibility per agent |
+| Rules for complex conditional logic | Rules are data, not code | Use hooks for conditional logic |
+| Prompt atoms for always-needed context | Prompts are on-demand | Use instruction atoms for ambient context |
+| Resources for small, always-relevant data | Resources are pull-model | Use instruction atoms for small ambient data |
+
+## Package Naming Conventions
+
+- Directory: `skills/{kebab-name}/` for instruction-only, `bundles/{kebab-name}/` for multi-atom
+- Package name: `@tank/{kebab-name}` -- must match between SKILL.md and tank.json
+- Name the package for the CAPABILITY, not the implementation
+- Max 64 characters for the `{kebab-name}` portion
+- Lowercase, digits, hyphens only
+
+Good names: `@tank/quality-gate`, `@tank/react`, `@tank/security-review`
+Bad names: `@tank/hook-agent-rule-combo`, `@tank/my-bundle`, `@tank/v2`
+
+## Deciding Between Similar Atom Kinds
+
+### Instruction vs Resource
+
+| Signal | Instruction | Resource |
+|--------|-------------|----------|
+| Always relevant | Yes | Overkill |
+| Under 50 lines | Yes | Overkill |
+| Large data (>50 lines) | Bloats context | Yes |
+| Situational or task-specific | Wasteful | Yes |
+| Changes per environment | Cannot | Yes |
+
+### Instruction vs Prompt
+
+| Signal | Instruction | Prompt |
+|--------|-------------|--------|
+| Agent needs this every session | Yes | No |
+| User invokes by name/command | No | Yes |
+| Has variable slots | No | Yes |
+| Produces structured output on demand | No | Yes |
+
+### Rule vs Hook
+
+| Signal | Rule | Hook |
+|--------|------|------|
+| Simple match-and-act pair | Yes | Overkill |
+| Static policy | Yes | Overkill |
+| Conditional logic needed | Cannot | Yes |
+| External API calls needed | Cannot | Yes |
+| Agent delegation needed | Cannot | Yes |
+| Dynamic rewriting | Cannot | Yes |
+
+### Tool vs Resource
+
+| Signal | Tool | Resource |
+|--------|------|----------|
+| Agent invokes operations (create, update, delete) | Yes | No |
+| Agent reads data on demand | No | Yes |
+| Backed by an MCP server with callable tools | Yes | No |
+| Backed by a static or dynamic data source | No | Yes |

--- a/bundles/package-creator/references/quality-checklist.md
+++ b/bundles/package-creator/references/quality-checklist.md
@@ -1,0 +1,351 @@
+# Universal Pre-Publish Quality Checklist
+
+Sources: Tank Contributing Standard (AGENTS.md), production publishing workflow, Tank registry conventions
+
+Covers: every validation check for Tank packages before running `tank publish`.
+Applicable to both instruction-only skills and multi-atom bundles. Organized
+by file, then by concern. Run this checklist top-to-bottom before every publish.
+
+## How to Use This Checklist
+
+Run through each section sequentially. A single failure in a Critical gate
+blocks publishing. Warnings indicate quality issues that degrade the package
+but do not prevent publishing.
+
+Severity levels:
+
+| Level    | Meaning                                      |
+| -------- | -------------------------------------------- |
+| Critical | Blocks publishing. Must fix before `tank publish`. |
+| High     | Causes user confusion or activation failure. Fix strongly recommended. |
+| Medium   | Quality degradation. Fix when practical.     |
+| Low      | Polish item. Fix if time allows.             |
+
+## 1. Package Structure
+
+### Critical
+
+- [ ] Directory follows naming convention:
+  - Instruction-only: `skills/{kebab-name}/`
+  - Multi-atom: `bundles/{kebab-name}/`
+- [ ] `{kebab-name}` uses only lowercase letters, digits, and hyphens
+- [ ] `{kebab-name}` is 64 characters or fewer
+- [ ] `SKILL.md` exists (required for instruction-only; optional for bundles but strongly recommended)
+- [ ] `tank.json` exists at the package root
+
+### High
+
+- [ ] Reference files live in `references/` directory
+- [ ] Scripts live in `scripts/` directory
+- [ ] Assets live in `assets/` directory
+- [ ] No unexpected files at the package root
+
+### Medium
+
+- [ ] No empty directories
+- [ ] No backup files (.bak, .swp, .orig, ~files)
+- [ ] No OS artifacts (.DS_Store, Thumbs.db)
+
+## 2. SKILL.md Frontmatter
+
+### Critical
+
+- [ ] Frontmatter exists (YAML between `---` delimiters)
+- [ ] `name` field is present
+- [ ] `name` starts with `@tank/`
+- [ ] `name` matches the directory: `@tank/{directory-name}`
+- [ ] `name` matches `tank.json` `name` field exactly
+- [ ] `description` field is present
+
+### High
+
+- [ ] `description` includes 10-15 trigger phrases
+- [ ] `description` covers scope and capabilities (what the skill does)
+- [ ] `description` includes source attribution (books, specs, docs synthesized)
+- [ ] Trigger phrases cover how users actually phrase requests, not just formal names
+
+### Medium
+
+- [ ] Trigger phrases are comma-separated in quotes
+- [ ] Description is 2-8 lines (not a single line, not a wall of text)
+- [ ] No markdown formatting in frontmatter (no bold, no links, no code blocks)
+
+## 3. SKILL.md Body
+
+### Critical
+
+- [ ] Body is under 200 lines (strict limit)
+- [ ] First line of body is a level-1 heading (`# Title`)
+
+### High
+
+- [ ] Contains a Core Philosophy section with 3-5 numbered principles
+- [ ] Each principle uses bold key phrase + explanation format
+- [ ] Contains a Quick-Start or problem-solution section
+- [ ] Decision trees rendered as tables, not prose
+- [ ] Reference Index table is the LAST section of the body
+- [ ] Every reference file is listed in the Reference Index
+
+### Medium
+
+- [ ] Uses imperative form ("Run the script" not "You should run")
+- [ ] No "When to Use This Skill" section (belongs in description)
+- [ ] No vendor-specific naming (claude-*, cc-*)
+- [ ] No emoji anywhere in the body
+
+### Low
+
+- [ ] Consistent heading hierarchy (no skipped levels)
+- [ ] Code blocks include language annotation
+- [ ] Tables are properly aligned
+- [ ] No trailing whitespace on lines
+
+## 4. tank.json Manifest
+
+### Critical
+
+- [ ] Valid JSON (parseable without errors)
+- [ ] `name` field is present and starts with `@tank/`
+- [ ] `name` matches SKILL.md `name` exactly
+- [ ] `version` field is present and valid semver (e.g., `1.0.0`)
+- [ ] `permissions` object is present
+
+### High
+
+- [ ] `description` field is present and concise (1 paragraph max)
+- [ ] `repository` field is `"https://github.com/tankpkg/packages"`
+- [ ] `permissions.network.outbound` is an empty array unless the package makes HTTP calls
+- [ ] `permissions.filesystem.read` is `["**/*"]` (standard default)
+- [ ] `permissions.filesystem.write` is an empty array unless the package writes files
+- [ ] `permissions.subprocess` is `false` unless the package runs shell commands
+
+### Medium
+
+- [ ] `description` includes key trigger terms (shorter than SKILL.md description)
+- [ ] No unnecessary fields beyond the standard schema
+- [ ] JSON is formatted with 2-space indentation
+
+### Permission Audit
+
+For each declared permission beyond the defaults, verify:
+
+- [ ] `network.outbound` entries: each hostname is actually called by the package
+- [ ] `filesystem.write` entries: each path is actually written to
+- [ ] `subprocess: true`: the package actually executes shell commands
+- [ ] No wildcard patterns in write paths (specific paths only)
+- [ ] No unnecessary `subprocess: true` (instruction-only skills never need it)
+
+## 5. Multi-Atom Bundle Validation
+
+Skip this section entirely for instruction-only skills.
+
+### Critical
+
+- [ ] `atoms` array exists in `tank.json`
+- [ ] Every atom has a valid `kind` field (one of: instruction, hook, agent, rule, tool, resource, prompt)
+- [ ] Every `instruction` atom has a `content` field pointing to an existing file
+- [ ] Every `hook` atom has an `event` field and a `handler` field
+- [ ] Every `agent` atom has a `name` field and a `role` field
+- [ ] Every `rule` atom has an `event` field and a `policy` field
+- [ ] Every `tool` atom has a `name` field
+- [ ] Every `resource` atom has a `uri` field
+- [ ] Every `prompt` atom has a `name` field and a `template` field
+
+### High
+
+- [ ] Hook atoms: `handler.type` is either `"dsl"` or `"js"`
+- [ ] Hook atoms with JS handlers: the entry file exists at the declared path
+- [ ] Hook atoms: `event` is a canonical event name from the Tank specification
+- [ ] Agent atoms: `tools` array uses canonical tool names (bash, read, write, edit, grep, glob, lsp, mcp, browser, fetch, git, task, notebook)
+- [ ] Agent atoms: `model` is a valid tier (fast, balanced, powerful, custom) or a specific model ID string
+- [ ] Rule atoms: `policy` is one of `block`, `warn`, `allow`
+- [ ] Rule atoms: `reason` field is present (strongly recommended)
+- [ ] Permissions cover what ALL atoms need combined
+
+### Medium
+
+- [ ] Extension bags use platform names as keys (claude-code, opencode, cursor, windsurf, default)
+- [ ] Agent atoms with `readonly: true` do not have `write`, `edit`, or `bash` in their tools array
+- [ ] No duplicate atom names within the same bundle
+- [ ] Hook handler files use TypeScript (.ts) extension
+
+## 6. Reference Files
+
+### Critical
+
+- [ ] Each reference file starts with a level-1 heading (`# Title`)
+- [ ] Each reference file has a `Sources:` line (third line or immediately after title)
+
+### High
+
+- [ ] Each file is 250-450 lines (target range)
+- [ ] No YAML frontmatter in any reference file
+- [ ] No emoji in any reference file
+- [ ] No content overlap between reference files
+- [ ] Professional tone, imperative form throughout
+
+### Medium
+
+- [ ] Tables used for frameworks, comparisons, and decision trees
+- [ ] Code blocks include language annotation
+- [ ] Cross-references to other reference files where related
+- [ ] Each file covers a distinct subtopic
+
+### Low
+
+- [ ] Consistent formatting across all reference files
+- [ ] No broken internal references (e.g., "See section X" where X does not exist)
+- [ ] Headers follow a logical hierarchy
+
+## 7. Scripts and Assets
+
+### High
+
+- [ ] Scripts in `scripts/` are executable (correct shebang, permissions)
+- [ ] Scripts have inline documentation explaining purpose and usage
+- [ ] Assets in `assets/` are referenced somewhere in the package
+
+### Medium
+
+- [ ] Scripts do not hardcode paths or credentials
+- [ ] Scripts use environment variables for configuration
+- [ ] Asset file sizes are reasonable (no multi-MB files in context)
+
+## 8. Content Quality
+
+### High
+
+- [ ] Package provides actionable value (decision trees, procedures, worked examples)
+- [ ] Content synthesizes knowledge rather than summarizing or copying sources
+- [ ] No placeholder content ("TODO", "TBD", "add later")
+- [ ] No duplicate information between SKILL.md body and reference files
+
+### Medium
+
+- [ ] Consistent terminology throughout the package
+- [ ] Acronyms defined on first use
+- [ ] Examples use realistic, non-trivial scenarios
+- [ ] Anti-patterns section included where appropriate
+
+### Low
+
+- [ ] Cross-references between reference files are bidirectional
+- [ ] Examples are tested and functional
+- [ ] Code snippets follow current best practices for their language
+
+## 9. Pre-Publish Commands
+
+Run these commands before publishing:
+
+### Validate JSON
+
+```bash
+# Verify tank.json is valid JSON
+python3 -c "import json; json.load(open('tank.json'))"
+```
+
+### Check Line Counts
+
+```bash
+# SKILL.md body should be under 200 lines (excluding frontmatter)
+awk '/^---$/{n++; next} n>=2{print}' SKILL.md | wc -l
+
+# Reference files should be 250-450 lines
+wc -l references/*.md
+```
+
+### Dry Run
+
+```bash
+# Always dry-run first
+tank publish --dry-run --org tank
+```
+
+### Verify Name Consistency
+
+```bash
+# Extract names and compare
+grep '^name:' SKILL.md
+python3 -c "import json; print(json.load(open('tank.json'))['name'])"
+# These must match exactly
+```
+
+### Check for Secrets
+
+```bash
+# Scan for common secret patterns
+grep -rn 'sk-\|api_key\|password\|secret\|token' . --include='*.md' --include='*.json' --include='*.ts'
+# Should return nothing
+```
+
+## 10. Publishing Workflow
+
+After all checks pass:
+
+1. Create a feature branch for the new or updated package.
+2. Commit all package files to the branch.
+3. Open a PR and merge to `main`.
+4. Only after the merge is complete, publish from `main`:
+
+```bash
+tank publish --org tank
+```
+
+Rules:
+- Never publish from a feature branch.
+- Always publish under the `tank` organization.
+- Verify the `name` field starts with `@tank/` before publishing.
+- Use `tank publish --dry-run` first to catch issues.
+
+## Quick Reference: Minimum Viable Package
+
+### Instruction-Only Skill
+
+```
+skills/{name}/
+  SKILL.md       # Frontmatter (name, description) + body (<200 lines)
+  tank.json      # name, version, description, permissions, repository
+```
+
+Minimum tank.json:
+
+```json
+{
+  "name": "@tank/{name}",
+  "version": "1.0.0",
+  "description": "...",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}
+```
+
+### Multi-Atom Bundle
+
+```
+bundles/{name}/
+  tank.json      # name, version, description, permissions, repository, atoms
+  SKILL.md       # Optional but recommended for instruction atom
+```
+
+Minimum tank.json with one atom:
+
+```json
+{
+  "name": "@tank/{name}",
+  "version": "1.0.0",
+  "description": "...",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    { "kind": "instruction", "content": "./SKILL.md" }
+  ]
+}
+```

--- a/bundles/package-creator/tank.json
+++ b/bundles/package-creator/tank.json
@@ -1,0 +1,22 @@
+{
+  "name": "@tank/package-creator",
+  "version": "1.0.0",
+  "description": "Master routing guide for creating any Tank package. Identifies the correct package type (instruction-only skill, bundle, hook, tool, rule, agent, prompt, resource) from a user request and routes to the specialized creator skill. Includes decision trees for format selection and a universal pre-publish quality checklist. Triggers: create a package, new tank package, which creator, package type, pre-publish check.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": ["**/*"],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    }
+  ]
+}

--- a/skills/agent-creator/SKILL.md
+++ b/skills/agent-creator/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: "@tank/agent-creator"
+description: |
+  Author Tank agent atoms — named roles with tools, permissions, and model
+  tiers that embed in multi-atom bundles. Covers the agent atom schema
+  (required and optional fields), role design (identity-first definition,
+  tool scoping, least-privilege, readonly vs read-write), model tier
+  selection (fast/balanced/powerful/custom), composing multi-agent bundles,
+  and platform portability via extension bags. Harness-agnostic — agents
+  are defined once in tank.json and translated by platform adapters.
+  Synthesizes Tank Contributing Standard (AGENTS.md), quality-gate bundle
+  patterns, and multi-agent system design principles.
+
+  Trigger phrases: "create agent", "agent atom", "tank agent",
+  "agent role", "agent bundle", "readonly agent", "agent tools",
+  "define agent", "new agent atom", "multi-agent bundle",
+  "agent model tier", "compose agents", "code reviewer agent",
+  "security auditor agent", "agent permissions"
+---
+
+# Tank Agent Creator
+
+## Core Philosophy
+
+1. **Identity before instructions** — Define WHO the agent is (name + role)
+   before configuring WHAT it can do (tools + model). A clear role drives
+   behavior more than verbose prompts.
+
+2. **Least-privilege tooling** — Grant only the tools the agent needs.
+   A reviewer needs `read` and `grep`, not `write` and `bash`. Excess
+   tools invite excess behavior.
+
+3. **Readonly by default** — Mark agents `readonly: true` unless they must
+   modify files. Most analysis, review, and audit agents never need write
+   access. This prevents accidental mutations.
+
+4. **One responsibility per agent** — Each agent atom solves one problem.
+   Compose multiple single-purpose agents in a bundle rather than building
+   one omniscient agent that does everything poorly.
+
+5. **Portable, not vendor-locked** — Agent atoms are harness-agnostic.
+   Platform-specific behavior goes in `extensions`, not in the core schema.
+   The same agent definition works across any Tank-compatible harness.
+
+## Quick-Start: Common Tasks
+
+### "I need an agent that reviews code"
+
+1. Define the atom in `tank.json`:
+   ```json
+   {
+     "kind": "agent",
+     "name": "code-reviewer",
+     "role": "Senior code reviewer. Review modified files only. Categorize issues as critical/high/medium/low. Focus on bugs, security, correctness.",
+     "tools": ["read", "grep", "glob", "lsp"],
+     "model": "fast",
+     "readonly": true
+   }
+   ```
+2. Pair with a hook or rule atom to trigger the review automatically.
+   -> See `references/worked-examples.md` for the full pattern.
+
+### "I need an agent that modifies files"
+
+1. Omit `readonly` (defaults to false) and add write tools:
+   ```json
+   {
+     "kind": "agent",
+     "name": "doc-updater",
+     "role": "Documentation maintainer. Update docs to match code changes.",
+     "tools": ["read", "write", "grep", "glob"],
+     "model": "balanced"
+   }
+   ```
+2. Grant `write` and/or `edit` only when the agent must produce file output.
+   -> See `references/role-design.md` for the readonly decision framework.
+
+### "I need multiple agents working together"
+
+1. Define each agent as a separate atom in the same `tank.json`.
+2. Give them different tool sets and model tiers.
+3. Coordinate via hook or rule atoms.
+   -> See `references/worked-examples.md` for the reviewer+fixer pattern.
+
+### "Agent exists but isn't effective"
+
+| Problem | Likely Cause | Fix |
+|---------|-------------|-----|
+| Too generic output | Role is vague | Write a specific, opinionated role string |
+| Does things it shouldn't | Too many tools granted | Remove unnecessary tools |
+| Slow on simple tasks | Wrong model tier | Switch to `fast` for analysis tasks |
+| Modifies files unexpectedly | Missing `readonly: true` | Add readonly for non-mutating agents |
+| Works in one harness only | Platform logic in role | Move platform specifics to `extensions` |
+
+## Decision Trees
+
+### Tool Selection
+
+| Agent Purpose | Recommended Tools | Readonly |
+|--------------|-------------------|----------|
+| Code review / audit | `read`, `grep`, `glob`, `lsp` | Yes |
+| Security scanning | `read`, `grep`, `glob` | Yes |
+| Documentation update | `read`, `write`, `grep`, `glob` | No |
+| Code generation / fix | `read`, `write`, `edit`, `grep`, `glob`, `lsp` | No |
+| Research / exploration | `read`, `grep`, `glob`, `fetch` | Yes |
+| Test writing | `read`, `write`, `edit`, `grep`, `glob`, `bash` | No |
+| Orchestration | `read`, `grep`, `task` | Yes |
+
+### Model Tier Selection
+
+| Task Complexity | Tier | Use When |
+|----------------|------|----------|
+| Pattern matching, formatting, triage | `fast` | Speed matters more than depth |
+| Code generation, editing, analysis | `balanced` | Default for most agents |
+| Architecture, security, complex reasoning | `powerful` | Accuracy is critical |
+| Specific model required | `custom` | Vendor model ID as string |
+
+### Canonical Tool Names
+
+| Name | Capability |
+|------|-----------|
+| `bash` | Shell command execution |
+| `read` | Read file contents |
+| `write` | Create or overwrite files |
+| `edit` | Modify existing files |
+| `grep` | Search file contents |
+| `glob` | Find files by pattern |
+| `lsp` | Language server protocol |
+| `mcp` | MCP server invocation |
+| `browser` | Web browser automation |
+| `fetch` | HTTP requests |
+| `git` | Git operations |
+| `task` | Subagent delegation |
+| `notebook` | Notebook operations |
+
+## Anti-Patterns
+
+| Pattern | Problem | Fix |
+|---------|---------|-----|
+| One agent that does everything | Diluted expertise, tool sprawl | Split into focused agents |
+| All tools granted to every agent | Unintended side effects | Least-privilege per role |
+| Role string is a full essay | Models lose focus | Keep role under 3 sentences |
+| Platform-specific logic in role | Breaks portability | Use `extensions` bag |
+| No `readonly` on analysis agents | Accidental file mutations | Default to `readonly: true` |
+| Duplicating role across bundles | Drift between copies | Extract to shared bundle |
+
+## Reference Index
+
+| File | Contents |
+|------|----------|
+| `references/agent-atom-anatomy.md` | Tank agent atom schema — required fields, optional fields, canonical tools, model tiers, extension bags, how agents differ from standalone platform agents |
+| `references/role-design.md` | Designing effective agent roles — identity-first definition, tool scoping, readonly vs read-write, single-responsibility, composing multi-agent bundles |
+| `references/worked-examples.md` | Four worked agent examples — code-reviewer, security-auditor, doc-updater, and a multi-agent reviewer+fixer bundle |

--- a/skills/agent-creator/references/agent-atom-anatomy.md
+++ b/skills/agent-creator/references/agent-atom-anatomy.md
@@ -1,0 +1,287 @@
+# Agent Atom Anatomy
+
+Sources: Tank Contributing Standard (AGENTS.md), quality-gate bundle (canonical example), Tank atom specification
+
+Covers: the complete schema for `kind: "agent"` atoms in Tank bundles — required fields, optional fields, canonical tool names, model tiers, extension bags, and how agent atoms differ from standalone platform-specific agents.
+
+## What Is an Agent Atom
+
+An agent atom is a typed primitive inside a Tank bundle's `tank.json`. It
+declares a named role that platform adapters translate into whatever agent
+format the target harness expects. The atom itself is portable — it contains
+no platform-specific logic.
+
+Agent atoms live in the `atoms` array of a multi-atom package:
+
+```json
+{
+  "name": "@tank/my-bundle",
+  "version": "1.0.0",
+  "atoms": [
+    {
+      "kind": "agent",
+      "name": "code-reviewer",
+      "role": "Senior code reviewer. Review modified files only.",
+      "tools": ["read", "grep", "glob", "lsp"],
+      "model": "fast",
+      "readonly": true
+    }
+  ]
+}
+```
+
+The `kind` field must be `"agent"`. This distinguishes it from the six other
+atom kinds: `instruction`, `hook`, `rule`, `tool`, `resource`, and `prompt`.
+
+## Required Fields
+
+Every agent atom must include these two fields. Omitting either causes a
+validation error.
+
+### `name` (string, required)
+
+The agent's identifier within the bundle. Used by hooks, rules, and other
+atoms to reference this agent. Must be kebab-case.
+
+```json
+"name": "code-reviewer"
+```
+
+Rules for naming:
+- Lowercase, digits, hyphens only
+- Descriptive of the agent's function
+- Unique within the bundle (no two agent atoms share a name)
+- Short — prefer `reviewer` over `comprehensive-code-quality-reviewer`
+
+### `role` (string, required)
+
+A concise description of the agent's identity, expertise, and behavioral
+constraints. This is the agent's system prompt in compressed form. Platform
+adapters expand it into whatever format the harness requires.
+
+```json
+"role": "Senior code reviewer. Review ONLY the modified files/hunks provided. Categorize every issue as critical, high, medium, or low. Focus on bugs, security, correctness, and maintainability. Do NOT review style/formatting — linters handle that. Be concise: one line per issue with file, line, severity, and what's wrong."
+```
+
+Guidelines for writing effective roles:
+- Lead with WHO the agent is: "Senior code reviewer", "Security auditor",
+  "Documentation maintainer"
+- Follow with WHAT it does: specific task scope
+- Include CONSTRAINTS: what it must not do
+- Keep it under three sentences for `fast` model agents
+- Allow up to five sentences for `powerful` model agents that need nuance
+- Use imperative form: "Review", "Categorize", "Focus on"
+- Include output format expectations when relevant
+
+## Optional Fields
+
+These fields refine agent behavior. Omitting them applies sensible defaults.
+
+### `tools` (string array, optional)
+
+The set of canonical tool names the agent can access. Omitting grants no
+tools — the agent can only reason and respond, not take actions.
+
+```json
+"tools": ["read", "grep", "glob", "lsp"]
+```
+
+Apply least-privilege: grant only tools the agent needs for its stated role.
+
+### Canonical Tool Reference
+
+| Name | Capability | Typical Use |
+|------|-----------|-------------|
+| `bash` | Execute shell commands | Build, test, install, run scripts |
+| `read` | Read file contents | Inspect code, config, docs |
+| `write` | Create or overwrite files | Generate new files |
+| `edit` | Modify existing files | Patch, refactor, fix code |
+| `grep` | Search file contents by pattern | Find usages, patterns, strings |
+| `glob` | Find files by name pattern | Discover file structure |
+| `lsp` | Language server operations | Go-to-definition, references, diagnostics |
+| `mcp` | Invoke MCP server tools | External service integration |
+| `browser` | Web browser automation | Scraping, testing, visual verification |
+| `fetch` | HTTP requests | API calls, download resources |
+| `git` | Git operations | Diff, log, blame, branch |
+| `task` | Delegate to subagents | Orchestration, parallel work |
+| `notebook` | Notebook operations | Jupyter, observable notebooks |
+
+Custom tool names are also accepted. Platform adapters map them to their
+local equivalents or ignore unknown names gracefully.
+
+### `model` (string, optional)
+
+The computational tier for this agent. Determines the trade-off between
+speed, cost, and reasoning depth.
+
+```json
+"model": "fast"
+```
+
+| Tier | When to Use | Trade-off |
+|------|------------|-----------|
+| `fast` | Pattern matching, triage, formatting, simple review | Fastest, cheapest, least depth |
+| `balanced` | Code generation, editing, moderate analysis | Default for most agents |
+| `powerful` | Architecture decisions, security audit, complex reasoning | Slowest, most expensive, deepest |
+| `custom` | Specific model required by use case | Set value to vendor model ID string |
+
+When `model` is omitted, the platform adapter chooses its own default
+(typically `balanced`).
+
+For `custom`, provide the vendor model identifier directly:
+
+```json
+"model": "anthropic/claude-sonnet-4-20250514"
+```
+
+### `readonly` (boolean, optional)
+
+When `true`, the agent must not modify files or execute destructive commands.
+Platform adapters enforce this by stripping write-capable tools or adding
+permission restrictions.
+
+```json
+"readonly": true
+```
+
+Default: `false` (the agent can use all granted tools without restriction).
+
+Set `readonly: true` for:
+- Code reviewers
+- Security auditors
+- Architecture analyzers
+- Dependency scanners
+- Any agent whose role is observation, not mutation
+
+### `extensions` (object, optional)
+
+Platform-specific overrides. Each key is a platform adapter name, and the
+value is an opaque object passed through without validation. The core Tank
+spec does not interpret extensions — adapters own their shape.
+
+```json
+{
+  "kind": "agent",
+  "name": "reviewer",
+  "role": "Code reviewer.",
+  "tools": ["read", "grep"],
+  "readonly": true,
+  "extensions": {
+    "opencode": {
+      "mode": "subagent",
+      "temperature": 0.1,
+      "color": "#4CAF50"
+    },
+    "cursor": {
+      "when": "code-review"
+    }
+  }
+}
+```
+
+Use extensions to configure:
+- Agent visibility mode (e.g., subagent-only vs user-facing)
+- Temperature and sampling parameters
+- UI presentation (color, icon, category)
+- Platform-specific permissions beyond the canonical set
+- Routing and delegation hints
+
+## Agent Atoms vs Standalone Platform Agents
+
+Tank agent atoms are not the same as platform-native agent files. The key
+differences:
+
+| Aspect | Tank Agent Atom | Platform Agent |
+|--------|----------------|----------------|
+| Location | `tank.json` `atoms` array | Platform-specific directory |
+| Format | JSON object with typed fields | Markdown, YAML, or platform format |
+| Portability | Works across any Tank-compatible harness | Locked to one platform |
+| Role definition | `role` field (compact) | Full system prompt (verbose) |
+| Tool permissions | Canonical names in `tools` array | Platform-specific permission syntax |
+| Model selection | Tier names (`fast`, `balanced`, etc.) | Vendor model IDs |
+| Composition | Multiple atoms in one bundle | Separate files per agent |
+| Distribution | Installed via `tank install` | Manual copy or platform package manager |
+
+### When to Use Agent Atoms
+
+- Building reusable, distributable agent bundles
+- Composing multi-agent workflows (reviewer + fixer + gate)
+- Sharing agents across teams and projects
+- Ensuring portability across harnesses
+
+### When to Use Platform Agents Instead
+
+- One-off personal agents for a specific workflow
+- Agents that depend heavily on platform-specific features
+- Prototyping before packaging as a Tank bundle
+
+## Composition with Other Atom Kinds
+
+Agent atoms gain power when combined with other atom kinds in the same
+bundle.
+
+### Agent + Hook
+
+A hook triggers the agent at a lifecycle point. The quality-gate bundle
+pairs a `pre-stop` hook with a `code-reviewer` agent — the hook detects
+modified code files and delegates review to the agent.
+
+### Agent + Rule
+
+A rule enforces a constraint based on the agent's output. If the agent
+reports critical issues, a rule can block the session from stopping.
+
+### Agent + Instruction
+
+An instruction atom injects behavioral context. The agent handles the
+role; the instruction provides domain knowledge, checklists, or review
+criteria.
+
+### Agent + Tool
+
+A tool atom registers an MCP server. The agent references the tool by
+name in its `tools` array to gain custom capabilities beyond the
+canonical set.
+
+## Validation Rules
+
+Platform adapters validate agent atoms at install time. Expect errors for:
+
+| Violation | Error |
+|-----------|-------|
+| Missing `name` | "Agent atom requires 'name' field" |
+| Missing `role` | "Agent atom requires 'role' field" |
+| Duplicate `name` in bundle | "Duplicate agent name in atoms array" |
+| Empty `tools` array | Warning only — agent can reason without tools |
+| Unknown tool name | Warning only — adapter may not support it |
+| `readonly: true` with `write`/`edit`/`bash` tools | Warning — adapter may strip those tools |
+
+## Complete Agent Atom Template
+
+Minimal:
+
+```json
+{
+  "kind": "agent",
+  "name": "my-agent",
+  "role": "Description of who this agent is and what it does."
+}
+```
+
+Full:
+
+```json
+{
+  "kind": "agent",
+  "name": "my-agent",
+  "role": "Description of who this agent is and what it does. Include constraints and output format expectations.",
+  "tools": ["read", "grep", "glob"],
+  "model": "balanced",
+  "readonly": true,
+  "extensions": {
+    "platform-name": {
+      "key": "value"
+    }
+  }
+}
+```

--- a/skills/agent-creator/references/role-design.md
+++ b/skills/agent-creator/references/role-design.md
@@ -1,0 +1,282 @@
+# Role Design for Tank Agent Atoms
+
+Sources: Tank Contributing Standard (AGENTS.md), quality-gate bundle patterns, multi-agent system design principles, production agent analysis
+
+Covers: designing effective agent roles — identity-first definition, tool scoping with least-privilege, readonly vs read-write decisions, single-responsibility per agent, composing multiple agents in one bundle, and common role design mistakes.
+
+## Identity-First Role Definition
+
+The `role` field is the most important field in an agent atom. It determines
+how the agent behaves, what it prioritizes, and how it communicates.
+
+### The Three-Part Role Pattern
+
+Effective roles follow a three-part structure:
+
+1. **Identity declaration** — WHO the agent is
+2. **Task scope** — WHAT it does (and does not do)
+3. **Output contract** — HOW it reports results
+
+```
+"role": "[IDENTITY]. [TASK SCOPE]. [OUTPUT CONTRACT]."
+```
+
+Example from the quality-gate bundle:
+
+```
+"Senior code reviewer. Review ONLY the modified files/hunks provided.
+Categorize every issue as critical, high, medium, or low. Focus on bugs,
+security, correctness, and maintainability. Do NOT review
+style/formatting — linters handle that. Be concise: one line per issue
+with file, line, severity, and what's wrong."
+```
+
+Breaking this down:
+- Identity: "Senior code reviewer"
+- Task scope: "Review ONLY the modified files/hunks provided" + focus areas + exclusions
+- Output contract: "one line per issue with file, line, severity, and what's wrong"
+
+### Identity Archetypes
+
+Choose an identity that signals expertise level and behavioral expectations:
+
+| Archetype | Role Prefix | Behavioral Signal |
+|-----------|------------|-------------------|
+| Reviewer | "Senior code reviewer" | Opinionated, flags issues, does not fix |
+| Auditor | "Security auditor" | Thorough, risk-focused, conservative |
+| Maintainer | "Documentation maintainer" | Keeps artifacts in sync with code |
+| Specialist | "Performance specialist" | Deep expertise in one domain |
+| Generator | "Test generator" | Produces new artifacts from specifications |
+| Fixer | "Bug fixer" | Receives issue reports, produces patches |
+| Orchestrator | "Task coordinator" | Delegates to other agents, tracks progress |
+| Scout | "Dependency scout" | Explores, reports findings, never modifies |
+
+### Role Length Guidelines
+
+| Model Tier | Max Role Length | Reasoning |
+|-----------|----------------|-----------|
+| `fast` | 2-3 sentences | Fast models lose focus on long prompts |
+| `balanced` | 3-5 sentences | Room for nuance without overload |
+| `powerful` | 5-8 sentences | Complex roles need more context |
+
+Exceeding these limits does not cause errors but degrades agent quality.
+Move detailed instructions to a companion `instruction` atom instead.
+
+## Tool Scoping: Least-Privilege
+
+Every tool granted to an agent is a capability and a risk. Apply
+least-privilege rigorously.
+
+### The Tool Audit Process
+
+For each tool in the `tools` array, answer:
+
+1. Does the agent's role REQUIRE this tool to function?
+2. Can the agent achieve the same result with a less powerful tool?
+3. What is the worst outcome if the agent misuses this tool?
+
+If any answer raises concern, remove the tool.
+
+### Tool Privilege Levels
+
+Tools are not equal in risk. Order from least to most privilege:
+
+| Level | Tools | Risk Profile |
+|-------|-------|-------------|
+| Observe | `read`, `grep`, `glob` | Read-only file access, zero mutation risk |
+| Analyze | `lsp`, `fetch` | Read-only with external dependencies |
+| Mutate | `write`, `edit` | Creates or modifies files |
+| Execute | `bash` | Arbitrary command execution |
+| Delegate | `task` | Can spawn other agents |
+| External | `mcp`, `browser` | Interacts with external systems |
+
+### Common Tool Sets by Role
+
+| Agent Role | Tool Set | Rationale |
+|-----------|----------|-----------|
+| Code reviewer | `read`, `grep`, `glob`, `lsp` | Needs to navigate and understand code |
+| Security auditor | `read`, `grep`, `glob` | Must not execute or modify anything |
+| Doc updater | `read`, `write`, `grep`, `glob` | Reads code, writes documentation |
+| Code fixer | `read`, `write`, `edit`, `grep`, `glob`, `lsp` | Full code modification capabilities |
+| Test writer | `read`, `write`, `edit`, `grep`, `glob`, `bash` | Writes tests, runs them to verify |
+| Dependency scout | `read`, `grep`, `glob`, `fetch` | Reads lockfiles, checks registries |
+| Orchestrator | `read`, `grep`, `task` | Reads context, delegates work |
+
+### Tools to Avoid Granting
+
+| Tool | Avoid For | Reason |
+|------|----------|--------|
+| `bash` | Reviewers, auditors, scouts | Execution risk, not needed for analysis |
+| `write` | Reviewers, auditors | Reviewers observe, they do not modify |
+| `browser` | Most agents | Slow, expensive, rarely necessary |
+| `mcp` | Agents without specific MCP needs | Broad capability, hard to constrain |
+| `task` | Leaf agents | Only orchestrators need delegation |
+
+## Readonly vs Read-Write
+
+The `readonly` field is a coarse-grained safety control. When `true`,
+platform adapters strip or block write-capable tools regardless of the
+`tools` array.
+
+### Decision Framework
+
+```
+Does the agent's role produce FILE OUTPUT?
+  ├── No  → readonly: true
+  │         (reviewers, auditors, scouts, analyzers)
+  └── Yes → Does it CREATE new files or MODIFY existing ones?
+            ├── Creates new → readonly: false, tools: ["write", ...]
+            └── Modifies existing → readonly: false, tools: ["edit", ...]
+```
+
+### Readonly Agents (readonly: true)
+
+These agents observe, analyze, and report. They never modify the
+filesystem.
+
+Characteristics:
+- Output is text (reports, issue lists, recommendations)
+- Tools are limited to `read`, `grep`, `glob`, `lsp`, `fetch`
+- Safe to run on any codebase without risk
+- Can be composed as pre-checks before mutating agents
+
+### Read-Write Agents (readonly: false or omitted)
+
+These agents produce file artifacts. They modify the codebase as part
+of their role.
+
+Characteristics:
+- Output includes file changes (new files, patches, rewrites)
+- Tools include `write`, `edit`, or `bash`
+- Require review after execution (pair with a reviewer agent)
+- Higher risk — test thoroughly before deployment
+
+### The Readonly Paradox
+
+Granting `readonly: true` while including `write` or `edit` in tools
+creates a contradiction. Platform adapters handle this by:
+
+1. Stripping the conflicting tools from the granted set
+2. Logging a warning at install time
+3. The `readonly` flag always wins
+
+Avoid this contradiction by aligning `tools` with `readonly`.
+
+## Single-Responsibility Principle
+
+Each agent atom solves ONE problem. This is the most violated principle
+in agent design.
+
+### Signs of a Multi-Responsibility Agent
+
+| Signal | Example | Fix |
+|--------|---------|-----|
+| Role has "and" connecting unrelated tasks | "Review code and update docs" | Split into reviewer + doc-updater |
+| Tools span observe and mutate categories | `["read", "grep", "write", "bash"]` on a "reviewer" | Remove mutation tools from reviewer |
+| Role describes multiple output formats | "Produce a review report and then fix the issues" | Reviewer reports, fixer fixes |
+| Agent name contains "and" or "multi" | `"review-and-fix"` | Two agents: `reviewer`, `fixer` |
+
+### The Composition Alternative
+
+Instead of one complex agent, compose focused agents:
+
+```json
+{
+  "atoms": [
+    {
+      "kind": "agent",
+      "name": "reviewer",
+      "role": "Review code. Report issues by severity.",
+      "tools": ["read", "grep", "glob", "lsp"],
+      "model": "fast",
+      "readonly": true
+    },
+    {
+      "kind": "agent",
+      "name": "fixer",
+      "role": "Fix critical and high issues reported by the reviewer.",
+      "tools": ["read", "write", "edit", "grep", "glob", "lsp"],
+      "model": "balanced"
+    }
+  ]
+}
+```
+
+Benefits:
+- Each agent is simpler and more predictable
+- Reviewer can be `fast` model, fixer needs `balanced`
+- Reviewer is `readonly`, fixer is read-write
+- Failures are isolated — reviewer failure does not corrupt files
+- Agents can be reused independently in other bundles
+
+## Composing Multi-Agent Bundles
+
+Bundles that contain multiple agent atoms are the most powerful Tank
+pattern. They enable workflows where agents hand off to each other.
+
+### Composition Patterns
+
+#### Sequential: Agent A then Agent B
+
+Agent A runs first, produces output. Agent B consumes it.
+
+Use case: reviewer identifies issues, fixer resolves them.
+
+Coordination: a hook atom triggers Agent A, reads its output, then
+triggers Agent B if needed.
+
+#### Parallel: Agent A and Agent B simultaneously
+
+Both agents run on the same input independently.
+
+Use case: security auditor and performance reviewer both analyze the
+same changeset.
+
+Coordination: a hook atom triggers both, aggregates results.
+
+#### Gated: Agent A decides if Agent B runs
+
+Agent A acts as a filter. Agent B only runs if Agent A's output meets
+a condition.
+
+Use case: triage agent classifies the task, specialist agent handles
+it if relevant.
+
+Coordination: a rule atom evaluates Agent A's output, triggers Agent B
+conditionally.
+
+### Bundle Structure for Multi-Agent Packages
+
+```json
+{
+  "name": "@tank/my-workflow",
+  "version": "1.0.0",
+  "atoms": [
+    { "kind": "instruction", "content": "./SKILL.md" },
+    { "kind": "hook", "event": "pre-stop", "handler": { "type": "js", "entry": "./hooks/orchestrate.ts" } },
+    { "kind": "agent", "name": "agent-a", "role": "...", "tools": [...], "readonly": true },
+    { "kind": "agent", "name": "agent-b", "role": "...", "tools": [...] },
+    { "kind": "rule", "event": "pre-stop", "policy": "block", "reason": "Unresolved issues" }
+  ]
+}
+```
+
+### Agent Naming in Multi-Agent Bundles
+
+| Principle | Example | Anti-Example |
+|-----------|---------|-------------|
+| Names describe function | `reviewer`, `fixer`, `scanner` | `agent-1`, `agent-2` |
+| Names are unique per bundle | `security-auditor`, `perf-reviewer` | `reviewer`, `reviewer` |
+| Names use kebab-case | `doc-updater` | `docUpdater`, `DocUpdater` |
+| Names are short | `scanner` | `comprehensive-security-vulnerability-scanner` |
+
+## Common Role Design Mistakes
+
+| Mistake | Why It Fails | Fix |
+|---------|-------------|-----|
+| "Be helpful and thorough" | Vacuous — every agent is "helpful" | State specific expertise and constraints |
+| Role describes tools, not behavior | "Uses grep to find patterns" | "Identify security patterns in code" |
+| No negative constraints | Agent does everything, poorly | Add "Do NOT" clauses for adjacent tasks |
+| Copying skill text as role | Passive knowledge, not active behavior | Transform knowledge into directives |
+| Role references specific files | Breaks when used in different repos | Use generic patterns |
+| Role contains platform-specific logic | Breaks portability | Move to `extensions` |

--- a/skills/agent-creator/references/worked-examples.md
+++ b/skills/agent-creator/references/worked-examples.md
@@ -1,0 +1,401 @@
+# Worked Agent Examples
+
+Sources: Tank Contributing Standard (AGENTS.md), quality-gate bundle (canonical example), multi-agent composition patterns
+
+Covers: four complete agent atom examples with rationale — code-reviewer, security-auditor, doc-updater, and a multi-agent reviewer+fixer bundle. Each example includes the full JSON, field-by-field justification, and guidance on when to use the pattern.
+
+## Example 1: Code Reviewer (Readonly, Fast)
+
+This is the canonical agent atom from the quality-gate bundle. It
+demonstrates the most common pattern — a readonly analysis agent paired
+with a hook.
+
+### The Atom
+
+```json
+{
+  "kind": "agent",
+  "name": "code-reviewer",
+  "role": "Senior code reviewer. Review ONLY the modified files/hunks provided. Categorize every issue as critical, high, medium, or low. Focus on bugs, security, correctness, and maintainability. Do NOT review style/formatting — linters handle that. Be concise: one line per issue with file, line, severity, and what's wrong.",
+  "tools": ["read", "grep", "glob", "lsp"],
+  "model": "fast",
+  "readonly": true
+}
+```
+
+### Field-by-Field Rationale
+
+| Field | Value | Why |
+|-------|-------|-----|
+| `name` | `code-reviewer` | Descriptive, kebab-case, clear function |
+| `role` | (see above) | Identity-first, scoped to modified files, explicit exclusion of style checks, defined output format |
+| `tools` | `read`, `grep`, `glob`, `lsp` | Minimum set to navigate and understand code. No `write`, `edit`, or `bash` — reviewer does not fix |
+| `model` | `fast` | Code review is pattern matching, not deep reasoning. Fast model reduces latency and cost |
+| `readonly` | `true` | Reviewer observes and reports. Must never modify files |
+
+### Bundle Context
+
+In the quality-gate bundle, this agent is triggered by a `pre-stop` hook.
+The hook detects modified code files, delegates to the agent, and blocks
+the session from stopping if critical or high issues are found.
+
+```json
+{
+  "atoms": [
+    {
+      "kind": "hook",
+      "name": "quality-gate",
+      "event": "pre-stop",
+      "handler": { "type": "js", "entry": "./hooks/quality-gate.ts" }
+    },
+    {
+      "kind": "agent",
+      "name": "code-reviewer",
+      "role": "...",
+      "tools": ["read", "grep", "glob", "lsp"],
+      "model": "fast",
+      "readonly": true
+    },
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    }
+  ]
+}
+```
+
+### When to Use This Pattern
+
+- Automatic code review on every agent stop
+- CI-style quality gates within agent workflows
+- Any scenario where analysis must happen before work is considered done
+
+### Variations
+
+| Variation | Change | Rationale |
+|-----------|--------|-----------|
+| Stricter review | Add `lsp` diagnostics focus to role | Catch type errors, unused imports |
+| Language-specific | Narrow role to "Python reviewer" | Deeper expertise in one language |
+| Severity threshold | Pair with rule that blocks on medium+ | Higher quality bar |
+
+## Example 2: Security Auditor (Readonly, Powerful)
+
+A security-focused agent that needs deeper reasoning than a code reviewer.
+Scans for vulnerability patterns, insecure configurations, and supply chain
+risks.
+
+### The Atom
+
+```json
+{
+  "kind": "agent",
+  "name": "security-auditor",
+  "role": "Application security auditor. Analyze code for OWASP Top 10 vulnerabilities, insecure cryptographic usage, hardcoded secrets, SQL injection, XSS, SSRF, path traversal, and insecure deserialization. Check dependency manifests for known CVEs. Report each finding with file, line, CWE ID, severity (critical/high/medium/low), and remediation suggestion. Do NOT fix issues — report only.",
+  "tools": ["read", "grep", "glob"],
+  "model": "powerful",
+  "readonly": true
+}
+```
+
+### Field-by-Field Rationale
+
+| Field | Value | Why |
+|-------|-------|-----|
+| `name` | `security-auditor` | Clear security focus, distinct from generic reviewer |
+| `role` | (see above) | Enumerates specific vulnerability classes to check. Includes CWE ID in output format. Explicit "report only" constraint |
+| `tools` | `read`, `grep`, `glob` | No `lsp` needed — security patterns are string/regex based. No `fetch` — auditor works offline |
+| `model` | `powerful` | Security analysis requires nuanced reasoning about data flow, trust boundaries, and attack vectors. Fast models miss subtle vulnerabilities |
+| `readonly` | `true` | Auditor must never modify code. Modifications could mask findings |
+
+### Bundle Context
+
+Pair with an instruction atom containing security checklists:
+
+```json
+{
+  "atoms": [
+    {
+      "kind": "agent",
+      "name": "security-auditor",
+      "role": "...",
+      "tools": ["read", "grep", "glob"],
+      "model": "powerful",
+      "readonly": true
+    },
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    }
+  ]
+}
+```
+
+The instruction atom can provide OWASP checklists, language-specific
+vulnerability patterns, and severity classification criteria.
+
+### When to Use This Pattern
+
+- Pre-merge security review of pull requests
+- Periodic security audit of entire codebases
+- Compliance scanning for regulated industries
+- Supply chain security checks on dependency updates
+
+### Variations
+
+| Variation | Change | Rationale |
+|-----------|--------|-----------|
+| Dependency-focused | Add `fetch` tool, narrow role to dependencies | Check CVE databases online |
+| Infrastructure | Expand role to include IaC patterns | Terraform, CloudFormation security |
+| Secrets-only | Narrow role to hardcoded secrets and API keys | Fast, focused scan |
+
+## Example 3: Documentation Updater (Read-Write, Balanced)
+
+A read-write agent that keeps documentation in sync with code changes.
+This demonstrates the mutable agent pattern.
+
+### The Atom
+
+```json
+{
+  "kind": "agent",
+  "name": "doc-updater",
+  "role": "Documentation maintainer. When code changes are detected, update corresponding documentation files (README, API docs, inline comments, changelogs). Match the existing documentation style and tone. Update code examples to reflect the new API. Add entries to CHANGELOG.md for user-facing changes. Do NOT modify source code — only documentation files.",
+  "tools": ["read", "write", "grep", "glob"],
+  "model": "balanced"
+}
+```
+
+### Field-by-Field Rationale
+
+| Field | Value | Why |
+|-------|-------|-----|
+| `name` | `doc-updater` | Action-oriented name — this agent updates, not just reads |
+| `role` | (see above) | Scoped to documentation files only. Explicit constraint against modifying source code. Specifies output artifacts (README, API docs, CHANGELOG) |
+| `tools` | `read`, `write`, `grep`, `glob` | Needs `write` to create/update doc files. `read` and `grep` to understand code changes. No `edit` — prefers full file writes for docs. No `lsp` — documentation is prose, not code |
+| `model` | `balanced` | Documentation writing needs decent language ability but not deep reasoning. Balanced is the right trade-off |
+| `readonly` | (omitted) | Defaults to `false`. This agent must write files — readonly would break its purpose |
+
+### Bundle Context
+
+Pair with a hook that triggers after code files are modified:
+
+```json
+{
+  "atoms": [
+    {
+      "kind": "hook",
+      "name": "doc-sync",
+      "event": "post-tool-use",
+      "handler": { "type": "js", "entry": "./hooks/doc-sync.ts" }
+    },
+    {
+      "kind": "agent",
+      "name": "doc-updater",
+      "role": "...",
+      "tools": ["read", "write", "grep", "glob"],
+      "model": "balanced"
+    }
+  ]
+}
+```
+
+The hook detects when `write` or `edit` tools modify source code files
+and triggers the doc-updater to check if documentation needs updating.
+
+### When to Use This Pattern
+
+- Keeping README and API docs in sync with code
+- Automated changelog maintenance
+- Updating code examples in documentation after API changes
+- Maintaining inline documentation comments
+
+### Variations
+
+| Variation | Change | Rationale |
+|-----------|--------|-----------|
+| With `edit` | Add `edit` to tools | When docs need surgical updates, not rewrites |
+| API-doc specialist | Narrow role to OpenAPI/JSDoc | Focused on structured API documentation |
+| Changelog-only | Remove README scope from role | Minimal, focused on release notes |
+
+## Example 4: Multi-Agent Bundle (Reviewer + Fixer)
+
+The most powerful pattern — two agents with different capabilities
+coordinated by a hook. The reviewer finds problems, the fixer resolves
+them.
+
+### The Full Bundle
+
+```json
+{
+  "name": "@tank/review-and-fix",
+  "version": "1.0.0",
+  "description": "Automatic code review with self-healing. Reviewer finds issues, fixer resolves critical and high severity problems, reviewer re-checks until clean.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    },
+    {
+      "kind": "hook",
+      "name": "review-gate",
+      "event": "pre-stop",
+      "handler": {
+        "type": "js",
+        "entry": "./hooks/review-gate.ts"
+      }
+    },
+    {
+      "kind": "agent",
+      "name": "reviewer",
+      "role": "Code reviewer. Analyze modified files for bugs, security issues, logic errors, and missing error handling. Categorize each issue as critical, high, medium, or low. Output one line per issue: file path, line number, severity, description. Do NOT suggest fixes — only identify problems.",
+      "tools": ["read", "grep", "glob", "lsp"],
+      "model": "fast",
+      "readonly": true
+    },
+    {
+      "kind": "agent",
+      "name": "fixer",
+      "role": "Code fixer. Receive a list of issues from the reviewer. Fix ONLY critical and high severity issues. Make minimal, targeted changes. Do NOT refactor unrelated code. After fixing, report what was changed and why.",
+      "tools": ["read", "write", "edit", "grep", "glob", "lsp"],
+      "model": "balanced"
+    },
+    {
+      "kind": "rule",
+      "event": "pre-stop",
+      "policy": "block",
+      "reason": "Unresolved critical or high severity issues remain"
+    }
+  ]
+}
+```
+
+### Architecture Breakdown
+
+```
+Agent finishes work
+        |
+        v
+  [pre-stop hook fires]
+        |
+        v
+  Delegate to "reviewer" agent
+        |
+        v
+  Reviewer reports issues
+        |
+        v
+  Any critical/high issues?
+   +-- No  -> agent stops (medium/low reported)
+   +-- Yes -> delegate to "fixer" agent
+                    |
+                    v
+              Fixer patches critical/high issues
+                    |
+                    v
+              [pre-stop hook fires again]
+              Reviewer re-checks
+                    |
+                    v
+              (loop until clean)
+```
+
+### Agent Comparison
+
+| Aspect | Reviewer | Fixer |
+|--------|----------|-------|
+| Purpose | Identify problems | Resolve problems |
+| Tools | `read`, `grep`, `glob`, `lsp` | `read`, `write`, `edit`, `grep`, `glob`, `lsp` |
+| Model | `fast` | `balanced` |
+| Readonly | Yes | No |
+| Output | Issue list (text) | File modifications |
+| Scope | All issues | Critical and high only |
+
+### Design Decisions
+
+**Why two agents instead of one?**
+A single agent that reviews and fixes conflates observation with action.
+The reviewer might unconsciously ignore issues it cannot fix. Separation
+ensures honest assessment.
+
+**Why `fast` for reviewer and `balanced` for fixer?**
+Review is pattern matching — fast models excel. Fixing requires
+understanding context, generating correct code, and reasoning about side
+effects — balanced models handle this better.
+
+**Why the reviewer explicitly says "Do NOT suggest fixes"?**
+Prevents the reviewer from spending tokens on fix suggestions that the
+fixer will independently generate. Keeps reviewer output concise and
+structured for machine parsing.
+
+**Why a rule atom in addition to the hook?**
+Defense in depth. The hook orchestrates the workflow. The rule provides
+a hard constraint that the session cannot stop with unresolved issues,
+even if the hook has a bug.
+
+### When to Use This Pattern
+
+- Self-healing code quality pipelines
+- Automated bug fix workflows
+- Any scenario requiring review-then-act cycles
+- CI/CD quality gates with automatic remediation
+
+### Platform Extensions Example
+
+Add platform-specific configuration without changing the core atoms:
+
+```json
+{
+  "kind": "agent",
+  "name": "reviewer",
+  "role": "...",
+  "tools": ["read", "grep", "glob", "lsp"],
+  "model": "fast",
+  "readonly": true,
+  "extensions": {
+    "opencode": {
+      "mode": "subagent",
+      "temperature": 0.0,
+      "color": "#FF9800"
+    },
+    "cursor": {
+      "when": "always",
+      "category": "quality"
+    }
+  }
+}
+```
+
+The core atom remains portable. Each platform reads only the extensions
+it understands.
+
+## Choosing the Right Pattern
+
+| Scenario | Pattern | Key Agent(s) |
+|----------|---------|-------------|
+| Passive quality check | Single readonly agent | Reviewer or auditor |
+| Active maintenance | Single read-write agent | Updater or generator |
+| Review then fix | Two-agent sequential | Reviewer + fixer |
+| Multi-perspective analysis | Two-agent parallel | Auditor + reviewer |
+| Conditional specialist dispatch | Two-agent gated | Triage + specialist |
+| Full pipeline | Three+ agent orchestrated | Triage + specialist + reviewer |
+
+## Checklist for New Agent Atoms
+
+Before publishing an agent atom, verify:
+
+- [ ] `name` is kebab-case, descriptive, unique within the bundle
+- [ ] `role` follows the three-part pattern (identity, scope, output)
+- [ ] `tools` grant only what the role requires (least-privilege)
+- [ ] `model` matches the task complexity (see tier table)
+- [ ] `readonly` is `true` for all non-mutating agents
+- [ ] No platform-specific logic in `role` (use `extensions`)
+- [ ] Role does not reference specific files or paths
+- [ ] Role includes at least one "Do NOT" constraint
+- [ ] Agent solves exactly one problem (single-responsibility)
+- [ ] If multi-agent, each agent has distinct tools and model tier

--- a/skills/agent-creator/tank.json
+++ b/skills/agent-creator/tank.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tank/agent-creator",
+  "version": "1.0.0",
+  "description": "Author Tank agent atoms — named roles with tools, permissions, and model tiers for multi-atom bundles. Covers agent atom schema, role design, tool scoping, model tier selection, multi-agent composition, and platform portability. Triggers: create agent, agent atom, tank agent, agent role, agent bundle, readonly agent.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/skills/bundle-creator/SKILL.md
+++ b/skills/bundle-creator/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: "@tank/bundle-creator"
+description: |
+  Author multi-atom Tank bundles that combine instruction, hook, agent, rule,
+  tool, resource, and prompt atoms into composite packages. Covers the atoms
+  array schema, atom kind selection, handler wiring (JS and DSL), agent
+  definition, rule policies, extension bags, permission scoping, and
+  bundle directory layout. Synthesizes the Tank Contributing Standard
+  (AGENTS.md), the @tank/quality-gate canonical bundle, and Tank registry
+  conventions.
+
+  Trigger phrases: "create a bundle", "new bundle", "multi-atom package",
+  "tank bundle", "build a bundle", "atoms array", "hook atom", "agent atom",
+  "rule atom", "tool atom", "resource atom", "prompt atom", "composite package",
+  "bundle tank.json", "write a bundle"
+---
+
+# Bundle Creator
+
+Compose multiple atom primitives into a single deployable package that
+extends agent behavior beyond what instructions alone can achieve.
+
+## Core Philosophy
+
+1. **Atoms are the unit of composition.** Each atom does one thing: inject
+   context, intercept lifecycle events, define a sub-agent, enforce a rule,
+   register a tool, expose a resource, or template a prompt. A bundle wires
+   atoms together into a cohesive capability.
+
+2. **Start with the lightest atom.** If pure instructions solve the problem,
+   use an instruction-only skill. Add atoms only when you need machine
+   enforcement (hooks, rules), delegation (agents), or external integration
+   (tools, resources). Every atom adds complexity.
+
+3. **Permission budget is real.** Each atom widens the package's attack
+   surface. Scope permissions to the minimum each atom actually needs.
+   A readonly reviewer agent does not need `write` or `bash`.
+
+4. **Hooks and rules are different tools.** Hooks run arbitrary code at
+   lifecycle events. Rules declare static policies the runtime enforces.
+   Prefer rules for simple allow/block decisions; use hooks when you need
+   conditional logic, delegation, or side effects.
+
+5. **Name the bundle for the capability, not the atoms.** `@tank/quality-gate`
+   names the outcome. `@tank/hook-agent-rule-combo` names the plumbing.
+   Users install capabilities, not implementation details.
+
+## Quick-Start: Common Problems
+
+### "I need a bundle that reviews code before the agent stops"
+
+1. Create `bundles/{name}/tank.json` with atoms array
+2. Add a `hook` atom on `pre-stop` pointing to `./hooks/{name}.ts`
+3. Add an `agent` atom for the reviewer with `readonly: true`
+4. Add an `instruction` atom referencing `./SKILL.md` for context
+5. Write the hook handler that delegates to the agent
+   -> See `references/worked-examples.md` (quality-gate walkthrough)
+
+### "I need to enforce a rule without writing code"
+
+1. Add a `rule` atom with `event`, `policy`, and `reason`
+2. Pair with an `instruction` atom explaining the rationale
+3. No hook handler needed — the runtime enforces declaratively
+   -> See `references/bundle-composition.md` (rule patterns)
+
+### "I need to register an MCP tool or expose data"
+
+1. Add a `tool` atom with `name` and connection config
+2. Or add a `resource` atom with `uri` for readable data
+3. Add an `instruction` atom so the agent knows when to use them
+   -> See `references/tank-json-anatomy.md` (tool and resource atoms)
+
+### "I am not sure if I need a bundle or a skill"
+
+1. Check the decision tree below
+2. If every atom would be `instruction`, use a skill instead
+   -> See `references/bundle-composition.md` (skill vs bundle)
+
+## Decision Trees
+
+### Skill vs Bundle
+
+| Signal                                  | Format           |
+| --------------------------------------- | ---------------- |
+| Pure instructions/knowledge             | Instruction-only |
+| Need lifecycle hooks (pre-stop, etc.)   | Bundle           |
+| Need a sub-agent with specific tools    | Bundle           |
+| Need machine-enforced rules             | Bundle           |
+| Need MCP tool or resource registration  | Bundle           |
+| Need prompt templates or slash commands | Bundle           |
+
+### Which Atom Kind
+
+| Need                              | Atom Kind     | Required Fields         |
+| --------------------------------- | ------------- | ----------------------- |
+| Behavioral context for the agent  | `instruction` | `content` (file path)   |
+| Code at lifecycle events          | `hook`        | `event`, `handler`      |
+| Delegatable sub-agent             | `agent`       | `name`, `role`          |
+| Declarative policy enforcement    | `rule`        | `event`, `policy`       |
+| MCP server registration           | `tool`        | `name`                  |
+| Readable data/context source      | `resource`    | `uri`                   |
+| Reusable invocable template       | `prompt`      | `name`, `template`      |
+
+### Hook Handler Type
+
+| Signal                                    | Handler Type |
+| ----------------------------------------- | ------------ |
+| Simple block/allow/rewrite on match       | DSL          |
+| Conditional logic, delegation, side fx    | JS           |
+| Needs access to git diff, file content    | JS           |
+| Portable across all runtimes              | DSL          |
+
+### Agent Model Tier
+
+| Workload                            | Model Tier  |
+| ----------------------------------- | ----------- |
+| Fast classification, triage         | `fast`      |
+| Code review, analysis               | `balanced`  |
+| Architecture decisions, complex     | `powerful`  |
+
+## Bundle Directory Layout
+
+```
+bundles/{kebab-name}/
+  tank.json             # Required — metadata + permissions + atoms array
+  SKILL.md              # Optional — instruction content (referenced by atom)
+  hooks/                # Optional — JS/TS hook handlers
+  references/           # Optional — deep docs (250-450 lines each)
+  scripts/              # Optional — executable code
+  assets/               # Optional — templates, images
+```
+
+## Atom Wiring Checklist
+
+1. Every `hook` atom references an existing file in `hooks/`
+2. Every `instruction` atom references an existing `.md` file
+3. Every `agent` atom has `name`, `role`, and a `tools` array
+4. Every `rule` atom has `event`, `policy`, and `reason`
+5. Permissions in `tank.json` cover what all atoms need combined
+6. `repository` points to `https://github.com/tankpkg/packages`
+
+## Reference Index
+
+| File                              | Contents                                                          |
+| --------------------------------- | ----------------------------------------------------------------- |
+| `references/tank-json-anatomy.md` | Full tank.json schema: fields, atoms array, each atom kind        |
+| `references/bundle-composition.md`| When to compose which atoms, sizing signals, permission scoping   |
+| `references/worked-examples.md`   | Three real bundle walkthroughs showing atom interplay             |

--- a/skills/bundle-creator/references/bundle-composition.md
+++ b/skills/bundle-creator/references/bundle-composition.md
@@ -1,0 +1,262 @@
+# Bundle Composition Patterns
+
+Sources: Tank Contributing Standard (AGENTS.md), @tank/quality-gate bundle,
+Tank registry conventions (2025-2026).
+
+Covers: when to compose which atoms together, what makes a good bundle vs a
+bad one, sizing signals, skill-vs-bundle decision, permission scoping, and
+anti-patterns to avoid.
+
+## Skill vs Bundle Decision
+
+The fundamental question: does the package need machine enforcement or just
+context injection?
+
+| Need                                         | Answer              |
+| -------------------------------------------- | ------------------- |
+| Domain knowledge, best practices, workflows  | Instruction-only    |
+| Lifecycle interception (pre-stop, pre-write)  | Bundle with hook    |
+| Delegatable sub-agent with tool constraints  | Bundle with agent   |
+| Declarative policy enforcement               | Bundle with rule    |
+| MCP server integration                       | Bundle with tool    |
+| External data source                         | Bundle with resource|
+| Slash command or prompt template             | Bundle with prompt  |
+
+If every atom in your planned bundle would be `instruction`, stop and
+create an instruction-only skill instead. Bundles exist for atoms that
+need the runtime, not for organizing prose.
+
+## Atom Composition Patterns
+
+### Pattern 1: Hook + Agent + Instruction
+
+The most common bundle pattern. A hook intercepts a lifecycle event,
+delegates to a sub-agent for analysis, and uses the agent's response
+to decide whether to block, continue, or inject context.
+
+**When to use:** Automated quality gates, pre-commit checks, code review,
+security scanning, documentation validation.
+
+**Atom roles:**
+- `hook`: Intercepts the event, orchestrates the flow
+- `agent`: Performs the analysis (readonly, constrained tools)
+- `instruction`: Gives the agent and the hook behavioral context
+
+**Example:** @tank/quality-gate uses `pre-stop` hook -> `code-reviewer`
+agent -> instruction with severity definitions.
+
+**Wiring:** The hook handler calls `delegateToAgent(agentName, prompt)`.
+The agent name in the delegation call must match the agent atom's `name`.
+
+### Pattern 2: Rule + Instruction
+
+Lightweight enforcement without custom code. The runtime enforces the
+rule declaratively. The instruction explains the rationale so the agent
+understands why it was blocked.
+
+**When to use:** Simple allow/block policies, guardrails, safety nets
+that do not need conditional logic.
+
+**Atom roles:**
+- `rule`: Declares the policy (block/warn/allow on event)
+- `instruction`: Explains the "why" so the agent can self-correct
+
+**Example:** A "no-force-push" bundle:
+
+```json
+"atoms": [
+  {
+    "kind": "rule",
+    "event": "pre-command",
+    "policy": "block",
+    "reason": "Force push to main is prohibited"
+  },
+  {
+    "kind": "instruction",
+    "content": "./SKILL.md"
+  }
+]
+```
+
+### Pattern 3: Tool + Instruction
+
+Registers an external MCP tool and provides instructions on when and how
+to use it.
+
+**When to use:** Integrating external services (linters, APIs, databases)
+that the agent should call during its work.
+
+**Atom roles:**
+- `tool`: Registers the MCP server
+- `instruction`: Teaches the agent when to invoke the tool and how to
+  interpret its output
+
+### Pattern 4: Resource + Prompt + Instruction
+
+Exposes data and provides a templated way to query it.
+
+**When to use:** Knowledge bases, schema references, configuration
+lookups where the agent needs both the data and a structured way to
+query it.
+
+**Atom roles:**
+- `resource`: Makes data available
+- `prompt`: Provides a structured query template
+- `instruction`: Explains the data model and query patterns
+
+### Pattern 5: Hook + Rule (Layered Enforcement)
+
+Combines declarative rules with programmatic hooks for defense in depth.
+The rule provides a fast, unconditional check. The hook adds conditional
+logic for nuanced cases.
+
+**When to use:** Security-critical workflows where you want both a hard
+stop (rule) and a smart analysis (hook).
+
+## Sizing Signals
+
+### When a bundle is too small
+
+| Signal                               | Action                      |
+| ------------------------------------ | --------------------------- |
+| Single instruction atom only         | Convert to skill            |
+| Hook does nothing but log            | Remove the hook             |
+| Agent has no tools                   | Merge role into instruction |
+| Rule never triggers in practice      | Remove or soften to warn    |
+
+### When a bundle is too large
+
+| Signal                               | Action                      |
+| ------------------------------------ | --------------------------- |
+| 7+ atoms                            | Split into focused bundles  |
+| Multiple unrelated hook events       | Split by event domain       |
+| Agent has 8+ tools                   | Reduce tool scope           |
+| Permissions cover everything         | Audit and restrict          |
+| SKILL.md exceeds 200 lines          | Move detail to references/  |
+
+### Right-sizing guidance
+
+Most bundles have 2-4 atoms. The canonical @tank/quality-gate has 3 atoms
+(hook + agent + instruction). Resist the urge to add atoms "just in case."
+Each atom should have a clear, testable purpose.
+
+## Permission Scoping
+
+Permissions in tank.json are the union of what all atoms need. Follow
+the principle of least privilege:
+
+### Network
+
+| Atom needs                           | Permission                    |
+| ------------------------------------ | ----------------------------- |
+| No external calls                    | `"outbound": []`              |
+| Calls specific API                   | `"outbound": ["api.host.com"]`|
+| Calls multiple APIs                  | List each hostname explicitly |
+
+Never use wildcard network access. List each hostname.
+
+### Filesystem
+
+| Atom needs                           | Permission                    |
+| ------------------------------------ | ----------------------------- |
+| Read project files (most bundles)    | `"read": ["**/*"]`            |
+| Write reports                        | `"write": ["reports/**"]`     |
+| Write to specific dir                | `"write": ["output/*.json"]`  |
+
+Never grant write to `["**/*"]` unless the bundle genuinely needs to
+write anywhere in the project.
+
+### Subprocess
+
+| Atom needs                           | Permission                    |
+| ------------------------------------ | ----------------------------- |
+| No child processes                   | `"subprocess": false`         |
+| Hook runs git commands               | `"subprocess": true`          |
+| Hook runs test suite                 | `"subprocess": true`          |
+
+The @tank/quality-gate sets `subprocess: false` in its tank.json but its
+hook actually uses `git diff`. This works because the hook runs through
+the agent's existing shell capabilities. Set `subprocess: true` only when
+the hook handler itself spawns processes outside the agent's tool chain.
+
+## Agent Design Within Bundles
+
+### Role String
+
+The agent's `role` field is its system prompt. Write it as a direct
+instruction to the agent:
+
+**Good:** "Senior code reviewer. Flag bugs and security issues by
+severity. Output one line per issue: [SEVERITY] file:line - description."
+
+**Bad:** "This agent is a code reviewer that helps find bugs."
+
+### Tool Selection
+
+Grant the minimum tools the agent needs:
+
+| Agent purpose              | Typical tools                    |
+| -------------------------- | -------------------------------- |
+| Code review (readonly)     | `read`, `grep`, `glob`, `lsp`   |
+| Documentation writer       | `read`, `write`, `grep`         |
+| Test runner                | `read`, `bash`, `grep`          |
+| Security scanner           | `read`, `grep`, `glob`, `fetch` |
+
+### Readonly Flag
+
+Set `readonly: true` for agents that should never modify files. This is
+a safety net — even if the role prompt says "do not write," the readonly
+flag enforces it mechanically.
+
+## Anti-Patterns
+
+### The Kitchen Sink Bundle
+
+**Symptom:** 8+ atoms, broad permissions, does "everything."
+**Fix:** Split into focused bundles. One capability per bundle.
+
+### The Instruction-Only "Bundle"
+
+**Symptom:** All atoms are `instruction` kind. No hooks, agents, or rules.
+**Fix:** Convert to an instruction-only skill. Remove the atoms array.
+
+### The Overprivileged Agent
+
+**Symptom:** Agent has `tools: ["bash", "write", "edit", "mcp"]` but only
+reads files.
+**Fix:** Reduce to `["read", "grep"]` and add `readonly: true`.
+
+### The Silent Hook
+
+**Symptom:** Hook intercepts an event but only logs — never blocks,
+rewrites, or delegates.
+**Fix:** Either add meaningful logic or remove the hook.
+
+### The Orphan Atom
+
+**Symptom:** Agent atom defined but never delegated to by any hook.
+Rule atom on event no hook handles.
+**Fix:** Wire the atom or remove it. Every atom must participate.
+
+### The Missing Instruction
+
+**Symptom:** Bundle has hooks and agents but no instruction atom. The
+agent lacks context about what the bundle does and why.
+**Fix:** Add an instruction atom with a SKILL.md explaining the bundle's
+purpose, severity definitions, and expected behavior.
+
+## Composition Checklist
+
+Before publishing a bundle, verify:
+
+1. Every atom has a clear, testable purpose
+2. No atom is orphaned (unreferenced by any flow)
+3. Permissions are the minimum union of all atom needs
+4. Agent tools are scoped to actual requirements
+5. Hook handlers reference existing files
+6. Instruction content is under 200 lines
+7. The bundle name describes the capability, not the plumbing
+8. The bundle has fewer than 7 atoms (ideally 2-4)
+
+See `references/tank-json-anatomy.md` for the full schema of each field.
+See `references/worked-examples.md` for concrete bundle walkthroughs.

--- a/skills/bundle-creator/references/tank-json-anatomy.md
+++ b/skills/bundle-creator/references/tank-json-anatomy.md
@@ -1,0 +1,341 @@
+# Tank.json Anatomy for Multi-Atom Bundles
+
+Sources: Tank Contributing Standard (AGENTS.md), @tank/quality-gate bundle,
+Tank registry conventions (2025-2026).
+
+Covers: every field in tank.json for multi-atom packages, the atoms array
+structure, each atom kind with required and optional fields, handler types,
+extension bags, and validation rules.
+
+## Top-Level Fields
+
+Every tank.json (instruction-only or multi-atom) requires these fields:
+
+| Field         | Type   | Required | Description                                    |
+| ------------- | ------ | -------- | ---------------------------------------------- |
+| `name`        | string | Yes      | `@tank/{kebab-name}`, matches directory name   |
+| `version`     | string | Yes      | Semver, start at `1.0.0`                       |
+| `description` | string | Yes      | One paragraph, shorter than SKILL.md desc      |
+| `permissions` | object | Yes      | Network, filesystem, subprocess declarations   |
+| `repository`  | string | Yes      | `https://github.com/tankpkg/packages`          |
+| `atoms`       | array  | Bundle   | Array of atom objects (absent for skills)      |
+
+### Name
+
+Must exactly match `@tank/{directory-name}`. The directory portion uses
+lowercase letters, digits, and hyphens only. Maximum 64 characters for
+the kebab-name portion.
+
+```json
+"name": "@tank/quality-gate"
+```
+
+The name in tank.json must match the `name` field in SKILL.md frontmatter
+if the package includes a SKILL.md.
+
+### Version
+
+Standard semver. Start at `1.0.0` for new packages. Bump according to
+semver rules:
+
+| Change                     | Bump  |
+| -------------------------- | ----- |
+| Breaking atom removal/rename | Major |
+| New atom added             | Minor |
+| Bug fix, doc update        | Patch |
+
+### Description
+
+One paragraph. Shorter than the SKILL.md description. Include key trigger
+words so the registry search can find the package.
+
+### Repository
+
+Always `https://github.com/tankpkg/packages` for packages in the Tank
+registry repository.
+
+## Permissions Object
+
+Declares the maximum capabilities any atom in the bundle can exercise.
+Follow the principle of least privilege.
+
+```json
+"permissions": {
+  "network": { "outbound": [] },
+  "filesystem": { "read": ["**/*"], "write": [] },
+  "subprocess": false
+}
+```
+
+### Network
+
+| Field      | Type     | Description                              |
+| ---------- | -------- | ---------------------------------------- |
+| `outbound` | string[] | Hostnames the package may contact        |
+
+Empty array means no network access. Add specific hostnames only when
+an atom needs to call an external API.
+
+```json
+"network": { "outbound": ["api.github.com", "registry.npmjs.org"] }
+```
+
+### Filesystem
+
+| Field   | Type     | Description                              |
+| ------- | -------- | ---------------------------------------- |
+| `read`  | string[] | Glob patterns for readable paths         |
+| `write` | string[] | Glob patterns for writable paths         |
+
+`["**/*"]` for read means "read anything in the project." Write is empty
+by default. Add specific paths only when a hook or script writes files.
+
+```json
+"filesystem": { "read": ["**/*"], "write": ["reports/*.json"] }
+```
+
+### Subprocess
+
+Boolean. `false` by default. Set to `true` only when a hook handler or
+script spawns child processes (e.g., running `git diff`, `npm test`).
+
+## The Atoms Array
+
+The `atoms` field is an array of atom objects. Each object must have a
+`kind` field that determines its type and required fields. Order in the
+array is declaration order, not execution order — the runtime resolves
+execution based on events and triggers.
+
+```json
+"atoms": [
+  { "kind": "instruction", "content": "./SKILL.md" },
+  { "kind": "hook", "event": "pre-stop", "handler": { "type": "js", "entry": "./hooks/gate.ts" } },
+  { "kind": "agent", "name": "reviewer", "role": "Code reviewer", "tools": ["read", "grep"] }
+]
+```
+
+### Validation Rules
+
+- Every atom must have a valid `kind` from the canonical set
+- File paths in `content` and `handler.entry` must reference existing files
+- Agent `tools` must use canonical tool names or custom strings
+- No two agents in the same bundle should share a `name`
+- Hook events must come from the canonical event list
+
+## Atom Kind: instruction
+
+Injects behavioral context into the agent's system prompt.
+
+| Field     | Type   | Required | Description                        |
+| --------- | ------ | -------- | ---------------------------------- |
+| `kind`    | string | Yes      | `"instruction"`                    |
+| `content` | string | Yes      | Relative path to markdown file     |
+
+```json
+{ "kind": "instruction", "content": "./SKILL.md" }
+```
+
+The referenced file is loaded into agent context when the package is
+active. Keep instruction files under 200 lines. Use `references/` for
+deep content that loads on demand.
+
+## Atom Kind: hook
+
+Runs code at specific lifecycle events. Hooks can block, rewrite, inject
+context, or delegate to agents.
+
+| Field     | Type   | Required | Description                        |
+| --------- | ------ | -------- | ---------------------------------- |
+| `kind`    | string | Yes      | `"hook"`                           |
+| `event`   | string | Yes      | Canonical event name               |
+| `handler` | object | Yes      | Handler definition (DSL or JS)     |
+| `name`    | string | No       | Human-readable hook name           |
+
+### Handler Types
+
+**DSL handler** — declarative, portable, no code files needed:
+
+```json
+{
+  "type": "dsl",
+  "actions": [
+    { "action": "block", "match": "rm -rf /", "reason": "Destructive command" },
+    { "action": "rewrite", "match": "sudo ", "replace": "" }
+  ]
+}
+```
+
+DSL actions: `block`, `allow`, `rewrite`, `injectContext`.
+
+**JS handler** — full code, can delegate to agents, access git, etc:
+
+```json
+{
+  "type": "js",
+  "entry": "./hooks/quality-gate.ts"
+}
+```
+
+The entry file exports a default async function that receives an event
+object and a context object. See @tank/quality-gate for the canonical
+implementation.
+
+### Canonical Hook Events
+
+| Category      | Events                                                    |
+| ------------- | --------------------------------------------------------- |
+| Tool          | `pre-tool-use`, `post-tool-use`                           |
+| File          | `pre-file-write`, `post-file-write`, `file-edited`        |
+| Shell         | `pre-command`, `post-command`                              |
+| MCP           | `pre-mcp-tool-use`, `post-mcp-tool-use`                   |
+| Session       | `session-created`, `session-idle`, `session-error`         |
+| Stop          | `pre-stop` (blocking — can force agent to continue)       |
+| Task          | `task-start`, `task-complete`, `task-cancel`               |
+| Conversation  | `pre-user-prompt`, `post-response`                        |
+| System prompt | `system-prompt-transform`                                 |
+| Context       | `pre-context-compact`, `post-context-compact`              |
+| Subagent      | `subagent-start`, `subagent-complete`                     |
+
+## Atom Kind: agent
+
+Defines a named sub-agent with constrained tools and permissions.
+
+| Field      | Type     | Required | Description                         |
+| ---------- | -------- | -------- | ----------------------------------- |
+| `kind`     | string   | Yes      | `"agent"`                           |
+| `name`     | string   | Yes      | Unique name within the bundle       |
+| `role`     | string   | Yes      | System prompt for the agent         |
+| `tools`    | string[] | No       | Canonical tool names allowed        |
+| `model`    | string   | No       | Model tier: fast/balanced/powerful   |
+| `readonly` | boolean  | No       | If true, agent cannot write files   |
+
+```json
+{
+  "kind": "agent",
+  "name": "code-reviewer",
+  "role": "Senior code reviewer. Flag bugs and security issues by severity.",
+  "tools": ["read", "grep", "glob", "lsp"],
+  "model": "fast",
+  "readonly": true
+}
+```
+
+Canonical tool names: `bash`, `read`, `write`, `edit`, `grep`, `glob`,
+`lsp`, `mcp`, `browser`, `fetch`, `git`, `task`, `notebook`.
+
+Model tiers: `fast`, `balanced`, `powerful`, `custom`.
+
+## Atom Kind: rule
+
+Declares a machine-enforced validation constraint. No code needed — the
+runtime enforces the policy.
+
+| Field    | Type   | Required | Description                          |
+| -------- | ------ | -------- | ------------------------------------ |
+| `kind`   | string | Yes      | `"rule"`                             |
+| `event`  | string | Yes      | Canonical event name                 |
+| `policy` | string | Yes      | `"block"`, `"warn"`, or `"allow"`    |
+| `reason` | string | No       | Human-readable explanation           |
+
+```json
+{
+  "kind": "rule",
+  "event": "pre-stop",
+  "policy": "block",
+  "reason": "Unresolved issues found"
+}
+```
+
+## Atom Kind: tool
+
+Registers an MCP server the agent can invoke.
+
+| Field  | Type   | Required | Description                          |
+| ------ | ------ | -------- | ------------------------------------ |
+| `kind` | string | Yes      | `"tool"`                             |
+| `name` | string | Yes      | Tool identifier                      |
+
+```json
+{ "kind": "tool", "name": "custom-linter" }
+```
+
+Requires `network.outbound` or `subprocess: true` in permissions if the
+tool communicates externally or spawns processes.
+
+## Atom Kind: resource
+
+Exposes data or context the agent can read.
+
+| Field  | Type   | Required | Description                          |
+| ------ | ------ | -------- | ------------------------------------ |
+| `kind` | string | Yes      | `"resource"`                         |
+| `uri`  | string | Yes      | URI to the resource                  |
+
+```json
+{ "kind": "resource", "uri": "file://./data/schema.json" }
+```
+
+## Atom Kind: prompt
+
+Defines a reusable invocable template (slash command or callable prompt).
+
+| Field      | Type   | Required | Description                        |
+| ---------- | ------ | -------- | ---------------------------------- |
+| `kind`     | string | Yes      | `"prompt"`                         |
+| `name`     | string | Yes      | Command or template name           |
+| `template` | string | Yes      | Template content or file path      |
+
+```json
+{ "kind": "prompt", "name": "review", "template": "Review {{files}} for {{criteria}}" }
+```
+
+## Extension Bags
+
+Any atom can include an `extensions` object with platform-specific
+overrides. Extensions are passed through without validation — adapters
+own their shape.
+
+```json
+{
+  "kind": "instruction",
+  "content": "./SKILL.md",
+  "extensions": {
+    "cursor": { "alwaysApply": true },
+    "opencode": { "scope": "global" }
+  }
+}
+```
+
+Use extension bags to customize behavior per platform without forking the
+package. Platform names as keys, arbitrary objects as values.
+
+## Complete Minimal Bundle Example
+
+```json
+{
+  "name": "@tank/example-bundle",
+  "version": "1.0.0",
+  "description": "Example multi-atom bundle.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    { "kind": "instruction", "content": "./SKILL.md" },
+    {
+      "kind": "hook",
+      "event": "pre-stop",
+      "handler": { "type": "js", "entry": "./hooks/gate.ts" }
+    },
+    {
+      "kind": "agent",
+      "name": "checker",
+      "role": "Validate output quality.",
+      "tools": ["read", "grep"],
+      "readonly": true
+    }
+  ]
+}
+```

--- a/skills/bundle-creator/references/worked-examples.md
+++ b/skills/bundle-creator/references/worked-examples.md
@@ -1,0 +1,349 @@
+# Worked Bundle Examples
+
+Sources: Tank Contributing Standard (AGENTS.md), @tank/quality-gate bundle
+(canonical reference), Tank registry conventions (2025-2026).
+
+Covers: three complete bundle walkthroughs that demonstrate atom interplay,
+handler wiring, permission scoping, and directory layout. Each example
+includes the full tank.json, rationale for atom choices, and the data
+flow between atoms.
+
+## Example 1: Quality Gate (Hook + Agent + Instruction)
+
+This is the canonical Tank bundle at `bundles/quality-gate/`. It
+automatically reviews code before the agent stops and blocks on critical
+or high severity issues.
+
+### Directory Layout
+
+```
+bundles/quality-gate/
+  tank.json
+  SKILL.md
+  hooks/quality-gate.ts
+  references/review-criteria.md
+```
+
+### tank.json
+
+```json
+{
+  "name": "@tank/quality-gate",
+  "version": "1.0.0",
+  "description": "Automatic code review before the agent stops...",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "hook",
+      "name": "quality-gate",
+      "event": "pre-stop",
+      "handler": { "type": "js", "entry": "./hooks/quality-gate.ts" }
+    },
+    {
+      "kind": "agent",
+      "name": "code-reviewer",
+      "role": "Senior code reviewer. Review ONLY the modified files/hunks provided. Categorize every issue as critical, high, medium, or low. Focus on bugs, security, correctness, and maintainability. Do NOT review style/formatting. Be concise: one line per issue with file, line, severity, and what's wrong.",
+      "tools": ["read", "grep", "glob", "lsp"],
+      "model": "fast",
+      "readonly": true
+    },
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    }
+  ]
+}
+```
+
+### Why These Atoms
+
+**Hook (pre-stop):** The agent is about to finish. The hook intercepts
+this moment to check if code files were modified. If yes, it delegates
+to the reviewer. If the reviewer finds blocking issues, the hook calls
+`continueWithMessage()` to force the agent to keep working.
+
+**Agent (code-reviewer):** A constrained sub-agent with readonly access.
+It receives the file list and diff from the hook, reviews changes, and
+outputs one line per issue in a structured format. The `fast` model tier
+keeps review time low. The `readonly: true` flag prevents the reviewer
+from modifying files — it only observes.
+
+**Instruction (SKILL.md):** Provides severity definitions (what counts
+as critical vs high vs medium vs low), the list of code file extensions
+that trigger review, and the flow diagram. Without this, the agent
+would not know the severity taxonomy.
+
+### Data Flow
+
+```
+1. Agent finishes work
+2. pre-stop event fires
+3. Hook handler executes:
+   a. Runs `git diff --name-only` to get changed files
+   b. Filters for code extensions (.ts, .py, .go, etc.)
+   c. If no code files changed -> allow stop
+   d. If code files changed -> build review prompt with diff
+   e. Delegate to "code-reviewer" agent with the prompt
+4. code-reviewer agent:
+   a. Reads modified files using its tools (read, grep, glob, lsp)
+   b. Outputs structured issues: [SEVERITY] file:line - description
+5. Hook parses the output:
+   a. If critical/high found -> block stop, inject fix instructions
+   b. If only medium/low -> allow stop, report for awareness
+6. If blocked, agent fixes issues, then pre-stop fires again (loop)
+```
+
+### Permission Rationale
+
+- **Network:** No external calls needed. Review is local.
+- **Filesystem read:** `["**/*"]` because the reviewer needs to read any
+  project file.
+- **Filesystem write:** `[]` because the reviewer is readonly. Fixes are
+  done by the main agent, not by the bundle.
+- **Subprocess:** `false` because git commands run through the agent's
+  existing shell capabilities, not through the hook spawning processes.
+
+## Example 2: Guardrails (Rule + Instruction)
+
+A lightweight safety bundle that blocks dangerous shell commands without
+any custom code.
+
+### Directory Layout
+
+```
+bundles/guardrails/
+  tank.json
+  SKILL.md
+```
+
+No hooks directory needed — rules are declarative.
+
+### tank.json
+
+```json
+{
+  "name": "@tank/guardrails",
+  "version": "1.0.0",
+  "description": "Block dangerous shell commands and file operations.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "rule",
+      "event": "pre-command",
+      "policy": "block",
+      "reason": "Destructive commands are prohibited in this workspace"
+    },
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    }
+  ]
+}
+```
+
+### Why These Atoms
+
+**Rule (pre-command, block):** Declaratively blocks dangerous commands
+before they execute. No code to write, test, or maintain. The runtime
+evaluates the rule whenever a shell command is about to run.
+
+**Instruction (SKILL.md):** Explains to the agent which commands are
+considered dangerous and why, so it can self-correct before hitting the
+rule. The instruction includes the rationale (e.g., "force push to main
+destroys shared history") so the agent understands the constraint instead
+of just being blocked.
+
+### Why Not a Hook
+
+A hook could achieve the same result but requires:
+- A TypeScript file in `hooks/`
+- Pattern matching logic
+- Error handling
+- Testing
+
+The rule achieves the same outcome declaratively. Prefer rules when the
+logic is a simple match-and-block without conditional branching.
+
+### When Rules Are Not Enough
+
+Rules become insufficient when you need:
+- Conditional blocking (block only on main branch, allow on feature branches)
+- Analysis before blocking (run a linter, check test coverage)
+- Delegation to a sub-agent for nuanced judgment
+
+In those cases, upgrade to a hook or the hook + agent + instruction
+pattern.
+
+### Data Flow
+
+```
+1. Agent is about to run a shell command
+2. pre-command event fires
+3. Runtime evaluates the rule:
+   a. Does the command match the rule's criteria? -> block
+   b. Otherwise -> allow
+4. If blocked, agent receives the reason string
+5. Agent reads the instruction to understand why and adjusts
+```
+
+## Example 3: Docs Enforcer (Hook + Agent + Prompt + Instruction)
+
+A bundle that ensures documentation stays in sync with code changes.
+When code files are modified, a sub-agent checks if related documentation
+needs updating. A prompt atom provides a structured template for the
+documentation review.
+
+### Directory Layout
+
+```
+bundles/docs-enforcer/
+  tank.json
+  SKILL.md
+  hooks/docs-check.ts
+```
+
+### tank.json
+
+```json
+{
+  "name": "@tank/docs-enforcer",
+  "version": "1.0.0",
+  "description": "Ensure documentation stays in sync with code changes.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "hook",
+      "name": "docs-check",
+      "event": "pre-stop",
+      "handler": { "type": "js", "entry": "./hooks/docs-check.ts" }
+    },
+    {
+      "kind": "agent",
+      "name": "docs-reviewer",
+      "role": "Documentation reviewer. Given a list of modified code files, identify which documentation files (README, API docs, inline comments, JSDoc) need updating. Output one line per stale doc: [STALE] doc-file - reason.",
+      "tools": ["read", "grep", "glob"],
+      "model": "fast",
+      "readonly": true
+    },
+    {
+      "kind": "prompt",
+      "name": "docs-review",
+      "template": "Review documentation for {{files}}. Check: API signatures match, examples compile, links resolve, changelog updated."
+    },
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    }
+  ]
+}
+```
+
+### Why These Atoms
+
+**Hook (pre-stop):** Same interception pattern as quality-gate. When the
+agent finishes, the hook checks if code files were modified and whether
+corresponding documentation exists.
+
+**Agent (docs-reviewer):** A readonly sub-agent that analyzes code changes
+against existing documentation. It uses `read` and `grep` to cross-
+reference function signatures with JSDoc/README content.
+
+**Prompt (docs-review):** A structured template the hook can use when
+delegating to the agent. The template standardizes what the reviewer
+checks: API signatures, examples, links, and changelog. This is reusable
+— the same prompt works regardless of which files changed.
+
+**Instruction (SKILL.md):** Defines what counts as "stale documentation,"
+which file pairings to check (e.g., `src/api.ts` -> `docs/api.md`), and
+the severity of different staleness types.
+
+### How the Prompt Atom Helps
+
+Without the prompt atom, the hook handler would embed the review criteria
+as a string literal. This has problems:
+- Changing the criteria requires editing TypeScript code
+- The template is not discoverable or reusable
+- Users cannot invoke the review manually
+
+With the prompt atom, the template is declared in the manifest. The hook
+references it, but users can also invoke it directly as a slash command.
+
+### Data Flow
+
+```
+1. Agent finishes work
+2. pre-stop event fires
+3. Hook handler executes:
+   a. Gets list of modified code files
+   b. Renders the "docs-review" prompt template with file list
+   c. Delegates rendered prompt to "docs-reviewer" agent
+4. docs-reviewer agent:
+   a. Reads each modified code file
+   b. Greps for corresponding doc files (README, API docs, JSDoc)
+   c. Compares signatures, examples, and links
+   d. Outputs stale docs: [STALE] file - reason
+5. Hook evaluates output:
+   a. If stale docs found -> block stop, inject update instructions
+   b. If all docs current -> allow stop
+```
+
+### Permission Rationale
+
+- **Network:** No external calls. All analysis is local.
+- **Filesystem read:** `["**/*"]` because the agent needs to cross-
+  reference code with docs anywhere in the project.
+- **Filesystem write:** `[]` because the docs-reviewer is readonly.
+  The main agent handles the actual doc updates.
+- **Subprocess:** `false` for the same reason as quality-gate.
+
+## Pattern Comparison
+
+| Aspect              | Quality Gate       | Guardrails      | Docs Enforcer      |
+| ------------------- | ------------------ | --------------- | ------------------ |
+| Atom count          | 3                  | 2               | 4                  |
+| Has hook            | Yes (JS)           | No              | Yes (JS)           |
+| Has agent           | Yes (code-reviewer)| No              | Yes (docs-reviewer)|
+| Has rule            | No                 | Yes (block)     | No                 |
+| Has prompt          | No                 | No              | Yes (template)     |
+| Has instruction     | Yes                | Yes             | Yes                |
+| Complexity          | Medium             | Low             | Medium-High        |
+| Custom code         | ~150 lines TS      | 0               | ~80 lines TS       |
+| Permission scope    | Read-only          | Read-only       | Read-only          |
+
+## Key Takeaways
+
+1. **Start with the simplest pattern that works.** If a rule suffices,
+   do not write a hook. If instruction-only works, do not create a bundle.
+
+2. **The hook is the orchestrator.** In hook+agent patterns, the hook
+   decides when to delegate, parses the agent's output, and decides the
+   outcome (block/continue/inject).
+
+3. **Agents are specialists, not generalists.** Constrain tools, set
+   readonly when possible, use the fastest model tier that works.
+
+4. **Prompts are reusable templates.** Extract review criteria into
+   prompt atoms when the same check applies across different contexts.
+
+5. **Instructions are the glue.** Every bundle needs behavioral context.
+   Without an instruction atom, the agent does not know the bundle's
+   purpose or severity taxonomy.
+
+See `references/tank-json-anatomy.md` for the full schema of each atom.
+See `references/bundle-composition.md` for composition patterns and
+anti-patterns.

--- a/skills/bundle-creator/tank.json
+++ b/skills/bundle-creator/tank.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tank/bundle-creator",
+  "version": "1.0.0",
+  "description": "Author multi-atom Tank bundles that combine instruction, hook, agent, rule, tool, resource, and prompt atoms. Covers atoms array schema, atom kind selection, handler wiring, agent definition, rule policies, extension bags, permission scoping, and bundle directory layout. Triggers: create bundle, new bundle, multi-atom package, tank bundle, atoms array, hook atom, agent atom, rule atom, composite package.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/skills/hook-creator/SKILL.md
+++ b/skills/hook-creator/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: "@tank/hook-creator"
+description: |
+  Author Tank hook atoms that intercept agent lifecycle events. Covers
+  every canonical hook event (pre-tool-use, post-file-write, pre-stop,
+  session-created, etc.), DSL handlers for portable logic (block, allow,
+  rewrite, injectContext), JS/TS handlers for complex behavior, manifest
+  wiring in tank.json, and production patterns from the quality-gate bundle.
+  Synthesizes Tank specification (AGENTS.md), quality-gate reference
+  implementation, and adapter translation patterns for Claude Code,
+  OpenCode, Cursor, and Windsurf.
+
+  Trigger phrases: "create hook", "write a hook", "hook atom", "tank hook",
+  "pre-stop hook", "pre-tool-use hook", "post-file-write hook",
+  "lifecycle hook", "block agent", "DSL handler", "JS handler",
+  "hook handler", "agent gate", "safety gate", "intercept agent",
+  "hook event"
+---
+
+# Tank Hook Creator
+
+## Core Philosophy
+
+1. **Hooks are guardrails, not gods.** A hook intercepts a single lifecycle
+   event, makes a binary decision (block/allow/rewrite/inject), and exits.
+   Keep them narrow and deterministic.
+
+2. **DSL first, JS when forced.** DSL handlers are portable across every
+   adapter. Reach for JS/TS only when you need stateful logic, external
+   delegation, or complex parsing.
+   -> See `references/handler-types.md`
+
+3. **Pre-events block, post-events observe.** Pre-events (pre-stop,
+   pre-tool-use, pre-command) can halt execution. Post-events (post-tool-use,
+   post-file-write) can only inject context or trigger follow-up work.
+
+4. **One hook, one concern.** Separate safety gates, formatting hooks, and
+   context injectors into distinct atoms. Composability beats monoliths.
+
+5. **Canonical events only.** Never invent event names. Use the 30+ events
+   from the Tank specification. Adapters translate these to platform
+   equivalents.
+   -> See `references/hook-events-catalog.md`
+
+## Quick-Start: Common Problems
+
+### "Block the agent from stopping until tests pass"
+
+1. Choose event: `pre-stop` (blocking).
+2. Choose handler: JS (needs to run tests and parse output).
+3. Wire the atom in `tank.json` with `"event": "pre-stop"`.
+4. In the handler, call `ctx.continueWithMessage(...)` to block, or return
+   to allow.
+   -> See `references/worked-examples.md` (Pre-Stop Blocker)
+
+### "Prevent dangerous shell commands"
+
+1. Choose event: `pre-command`.
+2. Choose handler: DSL with `block` action and `match` pattern.
+3. Add the atom: `{ "kind": "hook", "event": "pre-command", "handler": { "type": "dsl", "actions": [{ "action": "block", "match": "rm -rf /", "reason": "Destructive command" }] } }`
+   -> See `references/worked-examples.md` (Pre-Command Safety Gate)
+
+### "Auto-format files after the agent writes them"
+
+1. Choose event: `post-file-write`.
+2. Choose handler: JS (needs to detect file type and run formatter).
+3. In the handler, inspect the written file path, run the appropriate
+   formatter, report results via context injection.
+   -> See `references/worked-examples.md` (Post-File-Write Auto-Formatter)
+
+### "Inject project context when a session starts"
+
+1. Choose event: `session-created`.
+2. Choose handler: DSL with `injectContext` action, or JS for dynamic context.
+3. Provide the context string or file path in the action payload.
+   -> See `references/worked-examples.md` (Session-Start Context Injector)
+
+## Decision Trees
+
+### Handler Type Selection
+
+| Signal                                     | Use DSL          | Use JS/TS        |
+| ------------------------------------------ | ---------------- | ---------------- |
+| Simple string match (block/allow)          | Yes              | Overkill         |
+| Static context injection                   | Yes              | Overkill         |
+| Need to run shell commands                 | No               | Yes              |
+| Need to parse structured output            | No               | Yes              |
+| Need to delegate to another agent          | No               | Yes              |
+| Need state across multiple invocations     | No               | Yes              |
+| Portability across all adapters is critical | Yes              | Risky            |
+
+### Event Category Selection
+
+| Goal                                       | Event Category   | Key Events                        |
+| ------------------------------------------ | ---------------- | --------------------------------- |
+| Gate agent actions                         | Tool / Shell     | `pre-tool-use`, `pre-command`     |
+| Quality checks before completion           | Stop             | `pre-stop`                        |
+| React to file changes                      | File             | `post-file-write`, `file-edited`  |
+| Inject context at start                    | Session          | `session-created`                 |
+| Transform system prompts                   | System prompt    | `system-prompt-transform`         |
+| Monitor subagent behavior                  | Subagent         | `subagent-tool-use`               |
+| Enforce permissions                        | Permissions      | `permission-asked`                |
+
+### Manifest Wiring
+
+| Component       | Location in tank.json                  |
+| --------------- | -------------------------------------- |
+| Hook atom       | `atoms[]` with `kind: "hook"`          |
+| Event binding   | `event` field on the hook atom         |
+| DSL handler     | `handler: { type: "dsl", actions: [] }`|
+| JS handler      | `handler: { type: "js", entry: "..." }`|
+| Companion agent | Separate atom with `kind: "agent"`     |
+
+## Reference Index
+
+| File                              | Contents                                          |
+| --------------------------------- | ------------------------------------------------- |
+| `references/hook-events-catalog.md` | All 30+ canonical events with when-to-use guidance |
+| `references/handler-types.md`       | DSL vs JS handlers, actions, canonical tool names  |
+| `references/worked-examples.md`     | 4+ production hook patterns with full code         |

--- a/skills/hook-creator/references/handler-types.md
+++ b/skills/hook-creator/references/handler-types.md
@@ -1,0 +1,342 @@
+# Handler Types: DSL vs JS/TS
+
+Sources: Tank specification (AGENTS.md), quality-gate reference implementation (bundles/quality-gate/hooks/quality-gate.ts), adapter translation patterns
+
+Covers: DSL handler actions and syntax, JS/TS handler architecture and API, canonical tool names for match patterns, migration path from DSL to JS, and platform adapter considerations.
+
+## Two Handler Types
+
+Tank hooks support exactly two handler types. Every hook atom must declare
+one of them in its `handler` field.
+
+| Property        | DSL Handler                          | JS/TS Handler                         |
+| --------------- | ------------------------------------ | ------------------------------------- |
+| Declaration     | `{ "type": "dsl", "actions": [...] }`| `{ "type": "js", "entry": "./path" }` |
+| Portability     | All adapters                         | Adapter-dependent                     |
+| Statefulness    | Stateless                            | Can maintain state                    |
+| External calls  | None                                 | Shell, agents, APIs                   |
+| Complexity      | Simple match-and-act                 | Arbitrary logic                       |
+| Testing         | Declarative validation               | Unit/integration tests                |
+| Recommended for | 80% of hooks                         | Complex gates and orchestration       |
+
+## DSL Handlers
+
+### Syntax
+
+```json
+{
+  "kind": "hook",
+  "event": "pre-command",
+  "handler": {
+    "type": "dsl",
+    "actions": [
+      { "action": "block", "match": "rm -rf", "reason": "Destructive command blocked" },
+      { "action": "allow", "match": "npm test" },
+      { "action": "rewrite", "match": "npm run dev", "to": "npm run dev -- --port 3001" }
+    ]
+  }
+}
+```
+
+Actions are evaluated top-to-bottom. First match wins. If no action matches,
+the default behavior is to allow the operation.
+
+### DSL Actions
+
+#### block
+
+Prevent the operation from executing.
+
+| Field    | Required | Description                                     |
+| -------- | -------- | ----------------------------------------------- |
+| `action` | Yes      | `"block"`                                       |
+| `match`  | Yes      | String or pattern to match against               |
+| `reason` | Yes      | Human-readable reason shown to the agent          |
+
+```json
+{ "action": "block", "match": "sudo", "reason": "Elevated privileges not allowed" }
+```
+
+The agent receives the reason and can adapt its approach. Use clear,
+actionable reasons so the agent understands what to do instead.
+
+#### allow
+
+Explicitly permit the operation. Use to create allowlists when combined with
+a catch-all block at the end.
+
+| Field    | Required | Description                                     |
+| -------- | -------- | ----------------------------------------------- |
+| `action` | Yes      | `"allow"`                                       |
+| `match`  | Yes      | String or pattern to match against               |
+
+```json
+{ "action": "allow", "match": "npm test" }
+```
+
+#### rewrite
+
+Transform the operation before it executes. Only valid on pre-events.
+
+| Field    | Required | Description                                     |
+| -------- | -------- | ----------------------------------------------- |
+| `action` | Yes      | `"rewrite"`                                     |
+| `match`  | Yes      | String or pattern to match against               |
+| `to`     | Yes      | Replacement string                               |
+
+```json
+{ "action": "rewrite", "match": "python", "to": "python3" }
+```
+
+#### injectContext
+
+Add information to the agent's context. Valid on any event.
+
+| Field     | Required | Description                                    |
+| --------- | -------- | ---------------------------------------------- |
+| `action`  | Yes      | `"injectContext"`                               |
+| `content` | Yes      | String to inject, or file path to read          |
+
+```json
+{ "action": "injectContext", "content": "Always run tests before committing." }
+```
+
+### Match Patterns
+
+The `match` field supports:
+
+| Pattern Type  | Example                | Behavior                          |
+| ------------- | ---------------------- | --------------------------------- |
+| Exact string  | `"rm -rf /"`           | Exact substring match             |
+| Glob          | `"*.test.ts"`          | File-path style matching          |
+| Regex         | `"/^sudo\\s/"`         | Regex when wrapped in `/.../"     |
+
+### Allowlist Pattern
+
+Combine `allow` and `block` to create a restrictive allowlist:
+
+```json
+{
+  "actions": [
+    { "action": "allow", "match": "npm test" },
+    { "action": "allow", "match": "npm run lint" },
+    { "action": "allow", "match": "npm run build" },
+    { "action": "block", "match": "*", "reason": "Only npm test/lint/build allowed" }
+  ]
+}
+```
+
+## JS/TS Handlers
+
+### File Structure
+
+Place handler files in a `hooks/` directory within the package:
+
+```
+bundles/{package-name}/
+  hooks/
+    my-hook.ts      # Handler source
+  tank.json         # References ./hooks/my-hook.ts
+```
+
+### Handler Signature
+
+Export a default async function that receives an event object and a context
+object:
+
+```typescript
+export default async function handler(
+  event: {
+    type: string;
+    properties?: Record<string, unknown>;
+  },
+  ctx: {
+    client: {
+      session: {
+        prompt: (opts: unknown) => Promise<unknown>;
+      };
+    };
+    $: (
+      strings: TemplateStringsArray,
+      ...args: unknown[]
+    ) => { text: () => Promise<string> };
+  },
+): Promise<void> {
+  // Hook logic here
+}
+```
+
+### Context API
+
+The `ctx` object provides:
+
+| Method / Property         | Purpose                                          |
+| ------------------------- | ------------------------------------------------ |
+| `ctx.$\`command\``         | Execute a shell command, returns `{ text() }`    |
+| `ctx.client.session.prompt`| Send a message back to the agent session         |
+
+For `pre-stop` hooks, the context additionally supports:
+
+| Method                    | Purpose                                          |
+| ------------------------- | ------------------------------------------------ |
+| `ctx.continueWithMessage` | Block the stop and send agent back to work       |
+| `ctx.delegateToAgent`     | Spawn a subagent for review/analysis              |
+| `ctx.modifiedFiles`       | Array of `{ path, hunks? }` changed in session   |
+
+### Blocking vs Non-Blocking in JS
+
+For pre-events (pre-stop, pre-tool-use, pre-command):
+
+- **Return normally** to allow the action.
+- **Call `ctx.continueWithMessage(msg)`** to block and redirect the agent.
+- **Throw an error** to block with a generic error message.
+
+For post-events, the return value is ignored. Use `ctx.client.session.prompt`
+to inject follow-up context.
+
+### State Management
+
+JS handlers can maintain state across invocations using module-level
+variables:
+
+```typescript
+const runCount = new Map<string, number>();
+
+export default async function handler(event, ctx) {
+  const sessionId = event.properties?.sessionID as string;
+  const count = (runCount.get(sessionId) ?? 0) + 1;
+  runCount.set(sessionId, count);
+  // Use count to vary behavior on re-runs
+}
+```
+
+See `bundles/quality-gate/hooks/quality-gate.ts` for a production example of
+this pattern (re-run counter for iterative review).
+
+### Delegating to Subagents
+
+JS handlers can delegate work to named agents defined as companion atoms:
+
+```typescript
+const reviewOutput = await ctx.delegateToAgent("code-reviewer", prompt);
+```
+
+The subagent must be declared as a separate `kind: "agent"` atom in the same
+package's `tank.json`. See `bundles/quality-gate/tank.json` for wiring.
+
+## Canonical Tool Names
+
+Use these names in DSL `match` fields and agent `tools` arrays:
+
+| Tool Name  | Purpose                              | Example Match                      |
+| ---------- | ------------------------------------ | ---------------------------------- |
+| `bash`     | Shell command execution              | Block `rm -rf`, allow `npm test`   |
+| `read`     | File reading                         | Block reading `.env` files         |
+| `write`    | File creation/overwrite              | Block writing to `dist/`           |
+| `edit`     | Partial file editing                 | Block edits to `package-lock.json` |
+| `grep`     | Content search                       | Allow searching any file           |
+| `glob`     | File pattern matching                | Allow globbing any directory       |
+| `lsp`      | Language server operations           | Allow symbol lookup                |
+| `mcp`      | MCP server tool invocation           | Block external API calls           |
+| `browser`  | Browser automation                   | Block navigation to external sites |
+| `fetch`    | HTTP requests                        | Block outbound network calls       |
+| `git`      | Git operations                       | Block force push                   |
+| `task`     | Task/todo management                 | Allow task updates                 |
+| `notebook` | Notebook operations                  | Allow read, block execute          |
+
+Custom tool names are also accepted. Adapters translate canonical names to
+platform-specific equivalents.
+
+## Migration Path: DSL to JS
+
+Start with DSL. Migrate to JS when you hit a limitation.
+
+### Step 1: Identify the trigger
+
+The DSL handler works but you need one of:
+- Conditional logic beyond simple matching
+- Shell command execution
+- Subagent delegation
+- State across invocations
+- Structured output parsing
+
+### Step 2: Create the JS handler
+
+1. Create `hooks/` directory in the package.
+2. Write the handler file exporting a default async function.
+3. Move the DSL match logic into the handler's body.
+
+### Step 3: Update tank.json
+
+Replace the DSL handler declaration:
+
+```json
+// Before (DSL)
+{
+  "kind": "hook",
+  "event": "pre-command",
+  "handler": {
+    "type": "dsl",
+    "actions": [{ "action": "block", "match": "rm -rf", "reason": "Destructive" }]
+  }
+}
+
+// After (JS)
+{
+  "kind": "hook",
+  "event": "pre-command",
+  "handler": {
+    "type": "js",
+    "entry": "./hooks/command-gate.ts"
+  }
+}
+```
+
+### Step 4: Add companion atoms if needed
+
+If the JS handler delegates to a subagent, add a `kind: "agent"` atom.
+If the handler needs custom instructions, add a `kind: "instruction"` atom.
+
+## Platform Adapter Considerations
+
+Tank canonical events are translated by platform adapters:
+
+| Tank Event        | Claude Code Equivalent    | OpenCode Equivalent      |
+| ----------------- | ------------------------- | ------------------------ |
+| `pre-stop`        | `PreToolUse` (stop check) | `pre-stop` hook          |
+| `pre-command`     | `PreToolUse` (bash)       | `pre-command` hook       |
+| `post-file-write` | `PostToolUse` (write)     | `post-file-write` hook   |
+| `session-created` | Session init              | `session-created` hook   |
+
+Write hooks against canonical event names. Adapters handle the translation.
+Do not reference platform-specific event names in hook atoms.
+
+## Testing Hooks
+
+### DSL handlers
+
+Validate the actions array declaratively:
+- Confirm each action has required fields.
+- Test match patterns against expected inputs.
+- Verify first-match-wins ordering.
+
+### JS handlers
+
+Write standard unit tests:
+
+```typescript
+import handler from "./hooks/my-hook";
+
+test("blocks destructive commands", async () => {
+  const event = { type: "pre-command", properties: { command: "rm -rf /" } };
+  const ctx = { /* mock context */ };
+  await expect(handler(event, ctx)).rejects.toThrow();
+});
+```
+
+For hooks that use `ctx.$` (shell commands), mock the template literal
+function to return controlled output. For hooks that delegate to agents,
+mock `ctx.delegateToAgent` to return expected review output.
+
+See `bundles/quality-gate/hooks/quality-gate.ts` for patterns on parsing
+structured agent output and managing re-run state.

--- a/skills/hook-creator/references/hook-events-catalog.md
+++ b/skills/hook-creator/references/hook-events-catalog.md
@@ -1,0 +1,304 @@
+# Hook Events Catalog
+
+Sources: Tank specification (AGENTS.md), adapter translation patterns, quality-gate reference implementation
+
+Covers: every canonical Tank hook event organized by category, with timing semantics, blocking behavior, and when-to-use guidance.
+
+## Event Timing Model
+
+Every hook event fires at a specific point in the agent lifecycle. The naming
+convention signals timing:
+
+| Prefix/Suffix  | Timing                        | Can Block? |
+| -------------- | ----------------------------- | ---------- |
+| `pre-*`        | Before the action executes    | Yes        |
+| `post-*`       | After the action completes    | No         |
+| No prefix      | At the moment the event fires | Varies     |
+
+Pre-events receive the proposed action and can block, rewrite, or allow it.
+Post-events receive the completed result and can only observe or inject
+follow-up context.
+
+## Complete Event Reference
+
+### Tool Events
+
+| Event           | Blocks? | Context                            | Use When                                         |
+| --------------- | ------- | ---------------------------------- | ------------------------------------------------ |
+| `pre-tool-use`  | Yes     | Tool name, arguments, target paths | Restricting tool access, blocking dangerous tools |
+| `post-tool-use` | No      | Tool name, arguments, result       | Auditing usage, triggering follow-up actions      |
+
+`pre-tool-use` is the broadest gate — it fires for every tool invocation
+(read, write, edit, grep, glob, lsp, etc.). Use canonical tool names in match
+patterns. Block the agent from using `write` on production configs, or
+restrict `bash` to a safe allowlist.
+
+`post-tool-use` cannot block. Use it to log results, inject summaries of
+findings into context, or update state for later hooks.
+
+### File Events
+
+| Event                  | Blocks? | Context                                | Use When                                   |
+| ---------------------- | ------- | -------------------------------------- | ------------------------------------------ |
+| `pre-file-read`        | Yes     | File path, read options                | Preventing access to sensitive files       |
+| `post-file-read`       | No      | File path, file contents               | Redacting secrets, logging access          |
+| `pre-file-write`       | Yes     | File path, proposed content            | Protecting files/directories from writes   |
+| `post-file-write`      | No      | File path, written content             | Auto-formatting, triggering builds         |
+| `file-edited`          | No      | File path, edit diff/hunks             | Tracking incremental changes, running lint |
+| `file-watcher-updated` | No      | Changed paths, change type (add/mod/del)| Reacting to external changes (user edits) |
+
+`pre-file-read` and `pre-file-write` are security boundaries. Block reads of
+`.env`, secrets, or credentials. Block writes to `package-lock.json`,
+`generated/`, or `dist/`.
+
+`post-file-write` is the auto-formatter hook point. Detect file extension,
+run the appropriate formatter. See `references/worked-examples.md`.
+
+`file-watcher-updated` fires for changes made outside the agent (user saves
+in their editor, another process modifies files). Use it to refresh context
+or re-run validation.
+
+### Shell Events
+
+| Event          | Blocks? | Context                              | Use When                                      |
+| -------------- | ------- | ------------------------------------ | --------------------------------------------- |
+| `pre-command`  | Yes     | Command string, working directory    | Blocking dangerous commands, enforcing lists   |
+| `post-command` | No      | Command, exit code, stdout, stderr   | Capturing test results, detecting failures     |
+
+`pre-command` is the primary safety gate for shell execution. Use DSL
+handlers for simple blocklists/allowlists. See `references/worked-examples.md`
+for the Pre-Command Safety Gate pattern.
+
+`post-command` captures output. Parse test results, detect failures, inject
+error context for the agent's next decision.
+
+### MCP Events
+
+| Event              | Blocks? | Context                            | Use When                                    |
+| ------------------ | ------- | ---------------------------------- | ------------------------------------------- |
+| `pre-mcp-tool-use` | Yes     | MCP server name, tool, arguments   | Restricting MCP tool access, auditing calls |
+| `post-mcp-tool-use`| No      | MCP server name, tool, result      | Processing responses, caching results       |
+
+MCP events mirror tool events but apply specifically to MCP server
+invocations. Use `pre-mcp-tool-use` to block external API calls or restrict
+which MCP tools the agent can invoke.
+
+### Session Events
+
+| Event             | Blocks? | Context                        | Use When                                     |
+| ----------------- | ------- | ------------------------------ | -------------------------------------------- |
+| `session-created` | No      | Session ID, initial config     | Injecting startup context, initializing state |
+| `session-updated` | No      | Session ID, updated properties | Tracking session evolution, syncing state     |
+| `session-idle`    | No      | Session ID, idle duration      | Cleanup, auto-save, resource management      |
+| `session-error`   | No      | Session ID, error details      | Error recovery, alerting, retry logic        |
+| `session-deleted` | No      | Session ID                     | Final cleanup, persisting state              |
+
+`session-created` is the bootstrap hook. Inject project rules, persona
+context, or environment-specific configuration at session start. See
+`references/worked-examples.md` for the Session-Start Context Injector.
+
+`session-idle` fires after a platform-defined idle threshold. Use for
+auto-saving progress or releasing resources.
+
+### Stop Events
+
+| Event      | Blocks? | Context                                     | Use When                                     |
+| ---------- | ------- | ------------------------------------------- | -------------------------------------------- |
+| `pre-stop` | Yes     | Session ID, modified files, session history  | Quality gates, completion checklists, reviews |
+
+`pre-stop` is the most powerful blocking event. It fires when the agent
+attempts to finish. Call `ctx.continueWithMessage(...)` to block the stop and
+send the agent back to work with instructions on what to fix.
+
+The canonical implementation is `bundles/quality-gate/hooks/quality-gate.ts`:
+it delegates to a code-reviewer subagent, parses review output by severity,
+and blocks if critical or high issues exist. The hook re-runs automatically
+after fixes. See `references/worked-examples.md`.
+
+### Task Events
+
+| Event           | Blocks? | Context                          | Use When                                        |
+| --------------- | ------- | -------------------------------- | ----------------------------------------------- |
+| `task-start`    | No      | Task ID, description             | Initializing task state, logging                |
+| `task-resume`   | No      | Task ID, previous state          | Restoring context after interruption            |
+| `task-complete` | No      | Task ID, status, artifacts       | Aggregating results, triggering downstream tasks |
+| `task-cancel`   | No      | Task ID, cancellation reason     | Cleanup, rollback, logging                      |
+
+Task events track the lifecycle of individual tasks within a session. Use
+`task-start` to set up task-specific state. Use `task-complete` to trigger
+CI, update project boards, or aggregate results.
+
+### Conversation Events
+
+| Event             | Blocks? | Context                      | Use When                                       |
+| ----------------- | ------- | ---------------------------- | ---------------------------------------------- |
+| `pre-user-prompt` | Yes     | User message text            | Input validation, prompt rewriting              |
+| `post-response`   | No      | Agent response text          | Response auditing, logging, analytics           |
+| `message-updated` | No      | Message ID, old/new content  | Tracking edits, maintaining conversation state  |
+| `message-removed` | No      | Message ID, removed content  | Cleanup, redaction tracking                     |
+
+`pre-user-prompt` can rewrite user input before the agent processes it.
+Sanitize input, expand abbreviations, or inject additional hints.
+
+`post-response` is the audit point. Log responses, check for sensitive output
+leakage, or trigger analytics.
+
+### System Prompt Events
+
+| Event                    | Blocks? | Context                  | Use When                                 |
+| ------------------------ | ------- | ------------------------ | ---------------------------------------- |
+| `system-prompt-transform`| No*     | Current system prompt    | Injecting dynamic rules, persona switches |
+
+*Cannot block, but can rewrite the system prompt content.
+
+Use to append project-specific rules, modify agent tone, or inject dynamic
+constraints based on branch, framework, or session state.
+
+### Context Events
+
+| Event                  | Blocks? | Context                           | Use When                                      |
+| ---------------------- | ------- | --------------------------------- | --------------------------------------------- |
+| `pre-context-compact`  | Yes     | Context size, compaction strategy  | Preserving critical context from being removed |
+| `post-context-compact` | No      | New size, what was removed        | Re-injecting key facts that were lost          |
+
+Context compaction happens when the context window fills up. Use
+`pre-context-compact` to mark sections as non-compactable. Use
+`post-context-compact` to re-inject critical information.
+
+### Permission Events
+
+| Event               | Blocks? | Context                           | Use When                                 |
+| ------------------- | ------- | --------------------------------- | ---------------------------------------- |
+| `permission-asked`  | Yes     | Permission type, resource, reason | Auto-approving known-safe permissions    |
+| `permission-replied`| No      | Permission type, user decision    | Logging decisions, adapting behavior     |
+
+Use `permission-asked` to auto-allow safe patterns (e.g., always allow
+reading test files) or auto-block risky requests without bothering the user.
+
+### IDE/LSP Events
+
+| Event             | Blocks? | Context                             | Use When                                   |
+| ----------------- | ------- | ----------------------------------- | ------------------------------------------ |
+| `lsp-diagnostics` | No      | File path, diagnostics, severity    | Auto-fixing lint errors, injecting context |
+| `lsp-updated`     | No      | Updated scope, indexing status      | Waiting for LSP readiness before checks    |
+
+`lsp-diagnostics` fires when the language server reports new errors or
+warnings. Use it to inject error context or trigger auto-fix passes.
+
+### Subagent Events
+
+| Event              | Blocks? | Context                            | Use When                                   |
+| ------------------ | ------- | ---------------------------------- | ------------------------------------------ |
+| `subagent-start`   | No      | Subagent name, role, prompt        | Auditing delegation, logging usage         |
+| `subagent-complete` | No     | Subagent name, output, duration    | Aggregating results, quality checks        |
+| `subagent-tool-use` | Yes    | Subagent name, tool, arguments     | Restricting subagent tool access           |
+
+`subagent-tool-use` is a security boundary. Block write tools for read-only
+subagents. Ensure reviewer agents cannot modify code.
+
+### Environment Events
+
+| Event       | Blocks? | Context                                  | Use When                                    |
+| ----------- | ------- | ---------------------------------------- | ------------------------------------------- |
+| `shell-env` | No      | Environment variables, shell, working dir | Detecting project context, setting up env   |
+
+Fires when the shell environment initializes or changes. Use to detect the
+project framework, inject framework-specific rules, or configure the agent's
+working environment.
+
+### Workflow Events
+
+| Event                  | Blocks? | Context                             | Use When                                    |
+| ---------------------- | ------- | ----------------------------------- | ------------------------------------------- |
+| `todo-updated`         | No      | Updated todo items, changes         | Tracking progress, syncing external tools   |
+| `installation-updated` | No      | Package changes, install operations | Auditing deps, running security scans       |
+
+`installation-updated` fires when dependencies change. Use it to run
+`npm audit`, check for known vulnerabilities, or log dependency changes.
+
+## Quick-Reference: All Events by Blocking Capability
+
+### Blocking Events (can halt execution)
+
+| Event                  | Category     | Primary Use Case                        |
+| ---------------------- | ------------ | --------------------------------------- |
+| `pre-tool-use`         | Tool         | Restrict which tools the agent can use  |
+| `pre-file-read`        | File         | Prevent access to sensitive files       |
+| `pre-file-write`       | File         | Protect directories from modification   |
+| `pre-command`          | Shell        | Block dangerous shell commands          |
+| `pre-mcp-tool-use`     | MCP          | Restrict external MCP tool access       |
+| `pre-stop`             | Stop         | Quality gates before completion         |
+| `pre-user-prompt`      | Conversation | Input validation and rewriting          |
+| `pre-context-compact`  | Context      | Preserve critical context from removal  |
+| `permission-asked`     | Permissions  | Auto-approve or auto-deny permissions   |
+| `subagent-tool-use`    | Subagent     | Restrict subagent tool access           |
+
+### Non-Blocking Events (observe and react only)
+
+| Event                  | Category      | Primary Use Case                        |
+| ---------------------- | ------------- | --------------------------------------- |
+| `post-tool-use`        | Tool          | Audit tool usage, inject follow-up      |
+| `post-file-read`       | File          | Redact secrets, log file access         |
+| `post-file-write`      | File          | Auto-format, trigger builds             |
+| `file-edited`          | File          | Track incremental changes               |
+| `file-watcher-updated` | File          | React to external file changes          |
+| `post-command`         | Shell         | Parse test results, detect failures     |
+| `post-mcp-tool-use`    | MCP           | Process MCP responses, cache results    |
+| `session-created`      | Session       | Inject startup context                  |
+| `session-updated`      | Session       | Track session state changes             |
+| `session-idle`         | Session       | Auto-save, resource cleanup             |
+| `session-error`        | Session       | Error recovery, alerting                |
+| `session-deleted`      | Session       | Final cleanup, persist state            |
+| `task-start`           | Task          | Initialize task state                   |
+| `task-resume`          | Task          | Restore context after interruption      |
+| `task-complete`        | Task          | Aggregate results, trigger downstream   |
+| `task-cancel`          | Task          | Cleanup, rollback                       |
+| `post-response`        | Conversation  | Audit responses, analytics              |
+| `message-updated`      | Conversation  | Track edits, maintain state             |
+| `message-removed`      | Conversation  | Cleanup, redaction tracking             |
+| `system-prompt-transform`| System prompt| Dynamic rules, persona switches        |
+| `post-context-compact` | Context       | Re-inject lost critical context         |
+| `permission-replied`   | Permissions   | Log decisions, adapt behavior           |
+| `lsp-diagnostics`      | IDE/LSP       | Auto-fix errors, inject context         |
+| `lsp-updated`          | IDE/LSP       | Wait for LSP readiness                  |
+| `subagent-start`       | Subagent      | Audit delegation, log usage             |
+| `subagent-complete`    | Subagent      | Aggregate subagent results              |
+| `shell-env`            | Environment   | Detect project type, configure env      |
+| `todo-updated`         | Workflow      | Track progress, sync tools              |
+| `installation-updated` | Workflow      | Audit dependencies, security scans      |
+
+## Event Composition Patterns
+
+### Layered Security
+
+Combine multiple blocking events to create defense in depth:
+
+1. `pre-command` — block dangerous shell commands at the command level.
+2. `pre-file-write` — block writes to protected directories as a backup.
+3. `pre-stop` — run a final review to catch anything that slipped through.
+
+### Observe-Then-Act
+
+Chain a post-event with state that a pre-event reads later:
+
+1. `post-file-write` — record which files were written.
+2. `pre-stop` — use the recorded file list to scope the quality review.
+
+This is the pattern used by `bundles/quality-gate/hooks/quality-gate.ts`.
+
+### Bootstrap-and-Monitor
+
+Combine session lifecycle events:
+
+1. `session-created` — inject project context and rules.
+2. `lsp-diagnostics` — auto-fix type errors during the session.
+3. `pre-stop` — verify no regressions before allowing completion.
+
+### Subagent Sandboxing
+
+Restrict subagent capabilities:
+
+1. `subagent-tool-use` — block `write`, `edit`, and `bash` for reviewer
+   agents. Allow only `read`, `grep`, `glob`, and `lsp`.
+2. `subagent-complete` — validate subagent output format before injecting
+   into parent context.

--- a/skills/hook-creator/references/worked-examples.md
+++ b/skills/hook-creator/references/worked-examples.md
@@ -1,0 +1,447 @@
+# Worked Hook Examples
+
+Sources: Tank specification (AGENTS.md), quality-gate reference implementation (bundles/quality-gate/hooks/quality-gate.ts), production adapter patterns
+
+Covers: four complete hook implementations with full tank.json wiring, handler code, and rationale. Each example targets a different event category and handler type.
+
+## Example 1: Pre-Stop Quality Blocker (JS Handler)
+
+### Problem
+
+The agent finishes work but leaves behind bugs, missing error handling, or
+security issues. There is no checkpoint before completion.
+
+### Solution
+
+A `pre-stop` hook that delegates to a code-reviewer subagent, parses the
+review output, and blocks the stop if critical or high issues exist.
+
+### tank.json
+
+```json
+{
+  "name": "@tank/quality-gate",
+  "version": "1.0.0",
+  "description": "Blocks agent completion until code review passes.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "hook",
+      "name": "quality-gate",
+      "event": "pre-stop",
+      "handler": {
+        "type": "js",
+        "entry": "./hooks/quality-gate.ts"
+      }
+    },
+    {
+      "kind": "agent",
+      "name": "code-reviewer",
+      "role": "Senior code reviewer. Review ONLY the modified files/hunks. Categorize every issue as critical, high, medium, or low.",
+      "tools": ["read", "grep", "glob", "lsp"],
+      "model": "fast",
+      "readonly": true
+    }
+  ]
+}
+```
+
+### Handler: hooks/quality-gate.ts
+
+Key architectural decisions:
+
+1. **Filter changed files.** Only review code files that were actually
+   modified. Ignore config, docs, and excluded paths.
+2. **Delegate to a named subagent.** The `code-reviewer` agent is declared
+   as a companion atom and invoked via `ctx.delegateToAgent`.
+3. **Parse structured output.** The reviewer outputs one line per issue in
+   `[SEVERITY] - file:line - description` format. The handler parses this
+   into typed `ReviewIssue` objects.
+4. **Block on critical/high.** Call `ctx.continueWithMessage(...)` with
+   the formatted issue list. The agent receives this as a new prompt and
+   must fix the issues before trying to stop again.
+5. **Track re-runs.** A module-level `Map` counts how many times the gate
+   has run per session. On re-runs, the prompt asks the agent to verify
+   previous fixes rather than do a full review.
+
+```typescript
+const CODE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".py", ".go"]);
+
+interface FileChange {
+  path: string;
+  hunks?: string;
+}
+
+interface ReviewIssue {
+  file: string;
+  line?: number;
+  severity: "critical" | "high" | "medium" | "low";
+  message: string;
+}
+
+function hasCodeChanges(files: FileChange[]): boolean {
+  return files.some((f) => {
+    const ext = f.path.slice(f.path.lastIndexOf("."));
+    return CODE_EXTENSIONS.has(ext);
+  });
+}
+
+function parseReviewOutput(output: string): ReviewIssue[] {
+  const issues: ReviewIssue[] = [];
+  for (const line of output.split("\n")) {
+    const match = line.match(
+      /^\[?(critical|high|medium|low)\]?\s*[-:]\s*(?:(.+?):(\d+)\s*[-:]\s*)?(.+)/i,
+    );
+    if (match) {
+      issues.push({
+        severity: match[1].toLowerCase() as ReviewIssue["severity"],
+        file: match[2] ?? "unknown",
+        line: match[3] ? parseInt(match[3], 10) : undefined,
+        message: match[4].trim(),
+      });
+    }
+  }
+  return issues;
+}
+
+const _runCount = new Map<string, number>();
+
+export default async function handler(event, ctx): Promise<void> {
+  const sessionId = event.properties?.sessionID as string;
+  if (!sessionId) return;
+
+  // Gather changed files
+  let changedFiles: FileChange[] = [];
+  try {
+    const output = await ctx.$`git diff --name-only HEAD`.text();
+    changedFiles = output.split("\n").filter(Boolean).map((p) => ({ path: p }));
+  } catch {
+    return;
+  }
+
+  if (!hasCodeChanges(changedFiles)) return;
+
+  const run = (_runCount.get(sessionId) ?? 0) + 1;
+  _runCount.set(sessionId, run);
+
+  // Build review prompt
+  const fileList = changedFiles.map((f) => `- ${f.path}`).join("\n");
+  const prompt = run === 1
+    ? `Review these files for bugs and security issues:\n${fileList}`
+    : `Re-check #${run}: are previous critical/high issues fixed? ${fileList}`;
+
+  // Delegate to subagent via session prompt
+  await ctx.client.session.prompt({
+    path: { id: sessionId },
+    body: { parts: [{ type: "text", text: prompt }] },
+  });
+}
+```
+
+The full production implementation is at
+`bundles/quality-gate/hooks/quality-gate.ts` (277 lines) with additional
+features: excluded path filtering, diff content in first-run prompts, and
+formatted issue reporting with blocking/non-blocking categorization.
+
+## Example 2: Post-File-Write Auto-Formatter (JS Handler)
+
+### Problem
+
+The agent writes TypeScript or CSS files but does not run the project's
+formatter. Code style drifts from the team standard.
+
+### Solution
+
+A `post-file-write` hook that detects the file type and runs the appropriate
+formatter.
+
+### tank.json
+
+```json
+{
+  "name": "@tank/auto-format",
+  "version": "1.0.0",
+  "description": "Auto-formats files after the agent writes them.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "hook",
+      "name": "auto-format",
+      "event": "post-file-write",
+      "handler": {
+        "type": "js",
+        "entry": "./hooks/auto-format.ts"
+      }
+    }
+  ]
+}
+```
+
+Note: `subprocess: true` because the hook runs external formatters.
+
+### Handler: hooks/auto-format.ts
+
+```typescript
+const FORMATTERS: Record<string, string> = {
+  ".ts": "npx prettier --write",
+  ".tsx": "npx prettier --write",
+  ".js": "npx prettier --write",
+  ".jsx": "npx prettier --write",
+  ".css": "npx prettier --write",
+  ".scss": "npx prettier --write",
+  ".json": "npx prettier --write",
+  ".md": "npx prettier --write",
+  ".py": "python3 -m black",
+  ".go": "gofmt -w",
+  ".rs": "rustfmt",
+};
+
+export default async function handler(event, ctx): Promise<void> {
+  const filePath = event.properties?.filePath as string;
+  if (!filePath) return;
+
+  const ext = filePath.slice(filePath.lastIndexOf("."));
+  const formatter = FORMATTERS[ext];
+  if (!formatter) return;
+
+  try {
+    await ctx.$`${formatter} ${filePath}`.text();
+  } catch {
+    // Formatter not installed or failed — do not block the agent.
+    // Post-events cannot block, so this is purely best-effort.
+  }
+}
+```
+
+Key points:
+- Post-events cannot block. If the formatter fails, the agent continues.
+- The hook runs the project's formatter, not its own. It respects
+  `.prettierrc`, `pyproject.toml`, etc.
+- Add more extensions and formatters as needed.
+
+## Example 3: Pre-Command Safety Gate (DSL Handler)
+
+### Problem
+
+The agent runs shell commands that could be destructive (deleting files,
+force-pushing, modifying system state).
+
+### Solution
+
+A `pre-command` hook using a DSL handler with an allowlist pattern.
+
+### tank.json
+
+```json
+{
+  "name": "@tank/command-safety",
+  "version": "1.0.0",
+  "description": "Blocks dangerous shell commands, allows safe ones.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "hook",
+      "event": "pre-command",
+      "handler": {
+        "type": "dsl",
+        "actions": [
+          { "action": "block", "match": "rm -rf /", "reason": "Cannot delete root filesystem" },
+          { "action": "block", "match": "rm -rf ~", "reason": "Cannot delete home directory" },
+          { "action": "block", "match": "sudo", "reason": "Elevated privileges not permitted" },
+          { "action": "block", "match": "git push --force", "reason": "Force push blocked. Use --force-with-lease instead" },
+          { "action": "block", "match": "chmod 777", "reason": "World-writable permissions not allowed" },
+          { "action": "block", "match": "curl | sh", "reason": "Pipe-to-shell execution blocked" },
+          { "action": "block", "match": "curl | bash", "reason": "Pipe-to-shell execution blocked" },
+          { "action": "rewrite", "match": "python ", "to": "python3 " }
+        ]
+      }
+    }
+  ]
+}
+```
+
+Key points:
+- No JS needed. Pure declarative safety rules.
+- Actions evaluate top-to-bottom. First match wins.
+- The `rewrite` action silently transforms `python` to `python3`.
+- Unmatched commands are allowed by default.
+- Portable across all adapters — no runtime dependency.
+
+### Strict Allowlist Variant
+
+For high-security environments, invert the pattern — allow only known-safe
+commands and block everything else:
+
+```json
+{
+  "actions": [
+    { "action": "allow", "match": "npm test" },
+    { "action": "allow", "match": "npm run lint" },
+    { "action": "allow", "match": "npm run build" },
+    { "action": "allow", "match": "npm run typecheck" },
+    { "action": "allow", "match": "git status" },
+    { "action": "allow", "match": "git diff" },
+    { "action": "allow", "match": "git log" },
+    { "action": "allow", "match": "git add" },
+    { "action": "allow", "match": "git commit" },
+    { "action": "block", "match": "*", "reason": "Command not in allowlist. Only npm scripts and safe git commands permitted." }
+  ]
+}
+```
+
+The wildcard `*` at the end catches everything not explicitly allowed.
+
+## Example 4: Session-Start Context Injector (DSL Handler)
+
+### Problem
+
+The agent starts a session without knowledge of the project's conventions,
+architecture decisions, or team rules.
+
+### Solution
+
+A `session-created` hook that injects project context at session start.
+
+### tank.json
+
+```json
+{
+  "name": "@tank/project-context",
+  "version": "1.0.0",
+  "description": "Injects project rules and context when a session starts.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "hook",
+      "event": "session-created",
+      "handler": {
+        "type": "dsl",
+        "actions": [
+          {
+            "action": "injectContext",
+            "content": "Project rules:\n- Use TypeScript strict mode.\n- All functions must have JSDoc comments.\n- No default exports — use named exports only.\n- Test files colocated with source: `foo.ts` -> `foo.test.ts`.\n- Use pnpm, not npm or yarn.\n- Commit messages follow Conventional Commits.\n- Never modify files in `generated/` — they are auto-generated."
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+Key points:
+- DSL is sufficient for static context injection.
+- The `content` field supports multi-line strings.
+- The injected context becomes part of the agent's working knowledge for the
+  entire session.
+- Combine with `system-prompt-transform` for dynamic context that adapts
+  based on the session state.
+
+### Dynamic Variant (JS Handler)
+
+When context depends on the project state (detected framework, branch name,
+recent changes), use a JS handler:
+
+```typescript
+export default async function handler(event, ctx): Promise<void> {
+  // Detect project type
+  let framework = "unknown";
+  try {
+    const pkg = await ctx.$`cat package.json 2>/dev/null`.text();
+    if (pkg.includes("next")) framework = "Next.js";
+    else if (pkg.includes("angular")) framework = "Angular";
+    else if (pkg.includes("vue")) framework = "Vue";
+  } catch {}
+
+  // Detect branch
+  let branch = "unknown";
+  try {
+    branch = (await ctx.$`git branch --show-current`.text()).trim();
+  } catch {}
+
+  // Build dynamic context
+  const context = [
+    `Detected framework: ${framework}`,
+    `Current branch: ${branch}`,
+    branch.startsWith("hotfix/")
+      ? "HOTFIX BRANCH: Focus on minimal, targeted changes only."
+      : "Standard branch: normal development rules apply.",
+  ].join("\n");
+
+  // Inject via session prompt
+  const sessionId = event.properties?.sessionID as string;
+  if (sessionId) {
+    await ctx.client.session.prompt({
+      path: { id: sessionId },
+      body: { parts: [{ type: "text", text: context }] },
+    });
+  }
+}
+```
+
+## Wiring Patterns Summary
+
+| Example                  | Event            | Handler | Companion Atoms | Subprocess |
+| ------------------------ | ---------------- | ------- | --------------- | ---------- |
+| Pre-Stop Quality Blocker | `pre-stop`       | JS      | `agent`         | No         |
+| Post-File-Write Formatter| `post-file-write`| JS      | None            | Yes        |
+| Pre-Command Safety Gate  | `pre-command`     | DSL     | None            | No         |
+| Session-Start Injector   | `session-created`| DSL     | None            | No         |
+
+## Common Mistakes
+
+### Blocking in post-events
+
+Post-events (`post-tool-use`, `post-file-write`, `post-command`) cannot block.
+Calling `ctx.continueWithMessage` in a post-event handler is a no-op. If you
+need to block, use the corresponding pre-event.
+
+### Missing companion agent atom
+
+If a JS handler calls `ctx.delegateToAgent("reviewer", ...)` but no
+`kind: "agent"` atom named `"reviewer"` exists in the same `tank.json`, the
+delegation fails silently. Always declare companion agents.
+
+### Over-broad match patterns
+
+A DSL action with `"match": "rm"` blocks `rm file.txt`, `npm run dev`
+(contains "rm" in "run"), and `git format-patch`. Use specific patterns:
+`"match": "rm -rf"` or regex `"match": "/^rm\\s/"`.
+
+### Forgetting subprocess permission
+
+JS handlers that run shell commands via `ctx.$` require
+`"subprocess": true` in the package permissions. Without it, the adapter
+may reject the command.
+
+### Stateful DSL expectations
+
+DSL handlers are stateless. Each invocation evaluates actions independently.
+If you need to track state (e.g., "block after 3 failures"), migrate to a
+JS handler.
+
+### Inventing event names
+
+Only use canonical event names from the Tank specification. Custom event names
+are not supported. If you need a custom trigger, use a combination of
+existing events with conditional logic in a JS handler.
+See `references/hook-events-catalog.md` for the complete list.

--- a/skills/hook-creator/tank.json
+++ b/skills/hook-creator/tank.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tank/hook-creator",
+  "version": "1.0.0",
+  "description": "Author Tank hook atoms that intercept agent lifecycle events. Covers canonical hook events, DSL and JS/TS handlers, manifest wiring, and production patterns. Triggers: create hook, hook atom, tank hook, pre-stop hook, DSL handler, JS handler, lifecycle hook, agent gate.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/skills/opencode-agent-creator/SKILL.md
+++ b/skills/opencode-agent-creator/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: "@tank/opencode-agent-creator"
+deprecated: true
+superseded_by: "@tank/agent-creator"
 description: |
-  Create specialized OpenCode agents that assume specific roles — frontend
-  architect, DevOps SRE, database specialist, code reviewer, or any domain
-  expert. Covers agent anatomy (markdown and JSON formats), role design
+  DEPRECATED: Use @tank/agent-creator instead for harness-agnostic agent
+  creation. This skill is OpenCode-specific; @tank/agent-creator covers
+  the generic Tank agent atom format that works across all harnesses.
+
+  Original: Create specialized OpenCode agents that assume specific roles —
+  frontend architect, DevOps SRE, database specialist, code reviewer, or any
+  domain expert. Covers agent anatomy (markdown and JSON formats), role design
   (persona, expertise, behavioral directives), system prompt engineering,
   tool permissions, oh-my-opencode integration (categories, skill injection,
   delegation wiring), and converting existing Tank skills into standalone

--- a/skills/prompt-creator/SKILL.md
+++ b/skills/prompt-creator/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: "@tank/prompt-creator"
+description: |
+  Author Tank prompt atoms -- reusable invocable templates declared in
+  bundle tank.json files. Covers the prompt atom schema (name, template),
+  template variable syntax, structured output guidance, multi-step workflow
+  templates, composing prompts with agent and hook atoms, and when to use
+  a prompt atom vs an instruction atom. Synthesizes the Tank Contributing
+  Standard (AGENTS.md), the ECC command-to-prompt migration pattern, and
+  prompt engineering best practices from Anthropic and OpenAI documentation.
+
+  Trigger phrases: "create prompt", "prompt template", "tank prompt atom",
+  "slash command", "workflow template", "prompt atom", "write a prompt",
+  "invocable template", "parameterized prompt", "reusable prompt",
+  "prompt variable", "commit message template", "PR description template",
+  "incident report template", "code review prompt"
+---
+
+# Tank Prompt Creator
+
+Author prompt atoms that give agents on-demand templates triggered by
+name or slash command, rather than always-loaded instruction context.
+
+## Core Philosophy
+
+1. **Prompts are invocable, not ambient.** A prompt atom loads only when
+   triggered by name. An instruction atom loads every session. Put
+   workflows the agent always needs in instructions; put templates the
+   user sometimes invokes in prompts.
+   -> See `references/prompt-atom-anatomy.md`
+
+2. **Variables are contracts.** Every `{{variable}}` in a template is a
+   parameter the invoker must supply. Name variables for what the value
+   represents, not where it goes. `{{diff_output}}` beats `{{input1}}`.
+   -> See `references/template-design.md`
+
+3. **One prompt, one job.** A prompt that generates a PR description
+   should not also run linting. Compose multiple prompts in a bundle
+   if the workflow has stages, but keep each template focused.
+
+4. **Structured output over prose.** Templates that produce structured
+   formats (markdown sections, checklists, labeled fields) are more
+   useful downstream than templates that produce free-form paragraphs.
+   -> See `references/template-design.md`
+
+5. **Compose with atoms, not with bloat.** A prompt atom can reference
+   agents (for delegation), hooks (for triggering), and instructions
+   (for shared context). Keep the template lean; let companion atoms
+   handle orchestration.
+   -> See `references/worked-examples.md`
+
+## Quick-Start: Common Problems
+
+### "Turn an ECC command into a Tank prompt"
+
+1. Extract the command's template text and variable slots
+2. Map each slot to a `{{variable_name}}` with a descriptive name
+3. Add the atom to `tank.json`: `{ "kind": "prompt", "name": "...", "template": "..." }`
+4. If the command had complex logic, pair with a hook or agent atom
+   -> See `references/worked-examples.md` (PR Description Generator)
+
+### "Create a slash command for commit messages"
+
+1. Define the template with `{{diff_summary}}` and `{{ticket_id}}` variables
+2. Add the prompt atom to a bundle's `tank.json`
+3. Adapters translate the `name` field into a slash command
+   -> See `references/worked-examples.md` (Commit Message Formatter)
+
+### "Prompt vs instruction -- which do I use?"
+
+1. Check the decision tree below
+2. If the content applies every session, use an instruction atom
+3. If the content is invoked on demand by name, use a prompt atom
+   -> See `references/prompt-atom-anatomy.md` (Prompt vs Instruction)
+
+### "Template has too many variables"
+
+1. Split into multiple prompts, each handling one stage
+2. Chain prompts in a workflow by composing with agent atoms
+3. Provide sensible defaults or optional variables where possible
+   -> See `references/template-design.md` (Multi-Step Workflows)
+
+## Decision Trees
+
+### Prompt Atom vs Instruction Atom
+
+| Signal                                        | Use Prompt         | Use Instruction    |
+| --------------------------------------------- | ------------------ | ------------------ |
+| User triggers by name or slash command        | Yes                | No                 |
+| Template with variable slots                  | Yes                | No                 |
+| Always-needed behavioral context              | No                 | Yes                |
+| Agent should know this every session          | No                 | Yes                |
+| On-demand workflow or generator               | Yes                | No                 |
+
+### Template Complexity
+
+| Signal                                        | Recommendation                    |
+| --------------------------------------------- | --------------------------------- |
+| Single output, few variables                  | One prompt atom                   |
+| Multi-stage workflow, sequential outputs      | Multiple prompts + agent atom     |
+| Needs tool execution during generation        | Prompt + hook atom                |
+| Needs enforcement or validation               | Prompt + rule atom                |
+| Needs external data before rendering          | Prompt + resource atom            |
+
+### Variable Design
+
+| Variable Type     | Naming Convention        | Example                       |
+| ----------------- | ------------------------ | ----------------------------- |
+| Raw input data    | `{{noun_description}}`   | `{{diff_output}}`             |
+| Configuration     | `{{setting_name}}`       | `{{severity_threshold}}`      |
+| Context reference | `{{context_source}}`     | `{{ticket_url}}`              |
+| Output constraint | `{{format_spec}}`        | `{{max_length}}`              |
+
+### Manifest Wiring
+
+| Component          | Location in tank.json                                     |
+| ------------------ | --------------------------------------------------------- |
+| Prompt atom        | `atoms[]` with `kind: "prompt"`                           |
+| Name (slash cmd)   | `name` field on the prompt atom                           |
+| Template body      | `template` field (inline string or file reference)        |
+| Companion agent    | Separate atom with `kind: "agent"`                        |
+| Companion hook     | Separate atom with `kind: "hook"` for triggering logic    |
+
+## Atom Schema Quick Reference
+
+```json
+{
+  "kind": "prompt",
+  "name": "commit-message",
+  "template": "Generate a commit message for these changes:\n\n{{diff_summary}}\n\nTicket: {{ticket_id}}\n\nFormat: conventional commits (type: description)"
+}
+```
+
+Required fields: `name`, `template`. Optional: `extensions` for
+platform-specific overrides.
+
+## Reference Index
+
+| File                                  | Contents                                              |
+| ------------------------------------- | ----------------------------------------------------- |
+| `references/prompt-atom-anatomy.md`   | Prompt atom schema, variable syntax, prompt vs instruction distinction |
+| `references/template-design.md`       | Variable naming, structured output, multi-step workflows, composition |
+| `references/worked-examples.md`       | 4+ worked prompt atoms with full bundle context        |

--- a/skills/prompt-creator/references/prompt-atom-anatomy.md
+++ b/skills/prompt-creator/references/prompt-atom-anatomy.md
@@ -1,0 +1,307 @@
+# Prompt Atom Anatomy
+
+Sources: Tank Contributing Standard (AGENTS.md 2025-2026), Anthropic Prompt Engineering Guide, OpenAI Prompt Best Practices
+
+Covers: The Tank prompt atom schema, required and optional fields, template variable syntax, how prompt atoms differ from instruction atoms, how adapters translate prompt atoms into platform-specific slash commands or invocable templates, and the lifecycle of a prompt invocation.
+
+## What is a Prompt Atom
+
+A prompt atom is a typed primitive in a Tank bundle's `tank.json` `atoms` array. It declares a reusable template that an agent can invoke by name, rather than absorbing automatically on session start. Think of it as a parameterized macro the user or agent triggers on demand.
+
+Prompt atoms serve the same purpose as vendor-specific "commands" (Cursor's `.md` files in `commands/`, OpenCode's slash commands) but are declared portably in Tank's atom format. Adapters translate them to each platform's native mechanism.
+
+### Atom Kind Table
+
+| Kind          | Loaded When          | Purpose                            | Required Fields       |
+| ------------- | -------------------- | ---------------------------------- | --------------------- |
+| `instruction` | Every session start  | Behavioral context, always-on      | `content`             |
+| `prompt`      | On invocation only   | Reusable template, on-demand       | `name`, `template`    |
+| `hook`        | At lifecycle event   | Intercept and gate agent actions   | `event`, `handler`    |
+| `agent`       | When delegated to    | Named sub-agent with tools         | `name`, `role`        |
+| `rule`        | At lifecycle event   | Declarative policy enforcement     | `event`, `policy`     |
+| `tool`        | When called          | MCP server registration            | `name`                |
+| `resource`    | When read            | Data/context source                | `uri`                 |
+
+## Schema Definition
+
+### Required Fields
+
+```json
+{
+  "kind": "prompt",
+  "name": "pr-description",
+  "template": "Write a pull request description for the following changes:\n\n{{diff_output}}\n\nInclude: summary, motivation, testing done."
+}
+```
+
+**`name`** (string, required): The invocation identifier. Adapters translate
+this into a slash command (`/pr-description`), a menu entry, or a callable
+name depending on the platform.
+
+Naming rules:
+- Kebab-case: `commit-message`, `incident-report`, `code-review-checklist`
+- Descriptive of the output, not the mechanism: `pr-description` not `run-template-3`
+- Unique within the bundle: no two prompt atoms share a name
+- Max 64 characters
+
+**`template`** (string, required): The prompt text with optional variable
+placeholders. This is the literal text sent to the model when the prompt is
+invoked. It can be a single line or a multi-line string.
+
+### Optional Fields
+
+**`extensions`** (object, optional): Platform-specific overrides. Adapters
+pass these through without validation.
+
+```json
+{
+  "kind": "prompt",
+  "name": "commit-message",
+  "template": "...",
+  "extensions": {
+    "cursor": { "showInCommandPalette": true },
+    "opencode": { "shortcut": "/cm" }
+  }
+}
+```
+
+Extensions are the escape hatch for platform behaviors that Tank's portable
+schema does not model. Use sparingly -- every extension is a portability cost.
+
+## Template Variable Syntax
+
+### Double-Brace Placeholders
+
+Variables use `{{variable_name}}` syntax. The adapter collects values from
+the invoker (user input, tool output, or context) and substitutes them
+before sending the rendered template to the model.
+
+```
+Generate a code review for:
+
+Repository: {{repo_name}}
+Files changed: {{changed_files}}
+Diff:
+{{diff_output}}
+
+Focus areas: {{focus_areas}}
+```
+
+### Variable Naming Rules
+
+| Rule                    | Good                     | Bad                      |
+| ----------------------- | ------------------------ | ------------------------ |
+| Descriptive noun        | `{{diff_output}}`        | `{{input1}}`             |
+| Snake_case              | `{{ticket_url}}`         | `{{ticketUrl}}`          |
+| No reserved words       | `{{file_content}}`       | `{{template}}`           |
+| Specific over generic   | `{{error_stack_trace}}`  | `{{data}}`               |
+| Indicate type if useful | `{{severity_level}}`     | `{{level}}`              |
+
+### Optional Variables
+
+Mark optional variables with a trailing question mark inside the braces.
+Adapters omit the line or section if the value is not supplied.
+
+```
+{{changelog_entry?}}
+```
+
+This convention is adapter-dependent. Document which variables are required
+vs optional in the template itself when possible.
+
+### Multi-Line Templates
+
+For complex templates, use JSON string escaping with `\n` for newlines,
+or reference an external file. Inline is preferred for short templates
+(under ~20 lines). For longer templates, consider splitting into multiple
+prompt atoms that compose as a workflow.
+
+```json
+{
+  "kind": "prompt",
+  "name": "incident-report",
+  "template": "## Incident Report\n\nSeverity: {{severity}}\nDate: {{date}}\n\n### Summary\n{{incident_summary}}\n\n### Timeline\n{{timeline}}\n\n### Root Cause\nAnalyze the above and determine root cause.\n\n### Action Items\nList 3-5 concrete action items to prevent recurrence."
+}
+```
+
+## Prompt vs Instruction: The Loading Model
+
+This is the critical distinction. Confusing the two wastes context tokens
+or hides useful templates where users cannot find them.
+
+### Loading Behavior
+
+| Aspect          | Instruction Atom                  | Prompt Atom                        |
+| --------------- | --------------------------------- | ---------------------------------- |
+| When loaded     | Every session, automatically      | On invocation only                 |
+| Token cost      | Always consumed                   | Zero until invoked                 |
+| User triggers   | Never -- agent absorbs silently   | By name, slash command, or menu    |
+| Parameterized   | No (static text)                  | Yes ({{variables}})                |
+| Typical use     | Coding standards, project context | Generators, formatters, workflows  |
+| Context budget  | Counts against session budget     | Counts only when rendered          |
+
+### Decision Framework
+
+Use an **instruction atom** when:
+- The agent needs this information in every session
+- The content defines behavioral rules or coding standards
+- There are no variable slots -- the text is static
+- Forgetting this context would cause incorrect behavior
+
+Use a **prompt atom** when:
+- A user or agent invokes the template by name
+- The template has variable slots that change per invocation
+- The workflow is occasional, not continuous
+- The output is a generated artifact (PR description, commit message, report)
+
+### Gray Areas
+
+Some content could go either way. Apply this tiebreaker: if the agent
+needs the information even when the user has not asked for it, use an
+instruction. If the information is only relevant when explicitly requested,
+use a prompt.
+
+| Scenario                                  | Verdict           | Why                                  |
+| ----------------------------------------- | ----------------- | ------------------------------------ |
+| "Always use conventional commits"         | Instruction       | Behavioral rule, every session       |
+| "Generate a conventional commit message"  | Prompt            | On-demand generator with variables   |
+| "Our API uses REST conventions"           | Instruction       | Context needed for all API work      |
+| "Generate an API endpoint scaffold"       | Prompt            | Template invoked when building new   |
+| "Code review checklist"                   | Prompt            | Invoked per review, not always       |
+| "Never commit secrets"                    | Instruction (rule) | Safety rule, always active           |
+
+## Adapter Translation
+
+Adapters translate prompt atoms into platform-native mechanisms. The
+Tank runtime does not execute prompts directly -- it declares them, and
+adapters bridge the gap.
+
+### Translation Table
+
+| Platform    | Prompt Atom Becomes                           |
+| ----------- | --------------------------------------------- |
+| Cursor      | `.md` file in `.cursor/commands/`             |
+| OpenCode    | Slash command registered in config            |
+| Claude Code | Callable prompt template                      |
+| Windsurf    | Custom command                                |
+| VS Code     | Command palette entry via extension           |
+
+### Invocation Flow
+
+1. User or agent triggers the prompt by name
+2. Adapter collects variable values (from user input, context, or tools)
+3. Adapter substitutes variables into the template string
+4. Rendered template is sent to the model as a user message or injected prompt
+5. Model generates the output
+6. Output is returned to the user or passed to the next step
+
+## Prompt Atom in tank.json
+
+### Placement
+
+Prompt atoms live in the `atoms` array alongside other atom kinds. A
+bundle can have zero, one, or many prompt atoms.
+
+```json
+{
+  "name": "@tank/git-workflows",
+  "version": "1.0.0",
+  "atoms": [
+    { "kind": "instruction", "content": "./SKILL.md" },
+    {
+      "kind": "prompt",
+      "name": "commit-message",
+      "template": "Generate a conventional commit message for:\n\n{{diff_summary}}\n\nTicket: {{ticket_id}}"
+    },
+    {
+      "kind": "prompt",
+      "name": "pr-description",
+      "template": "Write a PR description for:\n\n{{diff_output}}\n\nInclude summary, motivation, and testing notes."
+    }
+  ]
+}
+```
+
+### Validation Checklist
+
+- [ ] `kind` is exactly `"prompt"`
+- [ ] `name` is present, kebab-case, unique within the bundle
+- [ ] `template` is present and non-empty
+- [ ] All `{{variables}}` use snake_case naming
+- [ ] No `{{variable}}` shadows a reserved field name (`name`, `kind`, `template`)
+- [ ] `extensions` (if present) uses platform names as keys
+- [ ] Template renders correctly with sample variable values
+
+## Prompt Atom Lifecycle
+
+Understanding the full lifecycle of a prompt invocation helps debug
+issues and design templates that work reliably across adapters.
+
+### Stage 1: Registration
+
+When a bundle with prompt atoms is installed, the adapter reads each
+prompt atom and registers it in the platform's command system. The
+`name` field becomes the invocation key. Registration happens once
+at install time, not per session.
+
+### Stage 2: Discovery
+
+Users discover available prompts through the platform's command palette,
+slash command autocomplete, or documentation. The `name` field is the
+primary discovery mechanism. Descriptive names (`pr-description`) beat
+cryptic abbreviations (`prd`).
+
+### Stage 3: Invocation
+
+The user triggers the prompt by name. The adapter determines which
+variables the template requires by scanning for `{{variable_name}}`
+patterns. It collects values from:
+- User input (typed or selected)
+- Agent context (current file, selection, session state)
+- Tool output (git diff, file content, command results)
+
+### Stage 4: Rendering
+
+The adapter substitutes collected values into the template string,
+replacing each `{{variable_name}}` with its value. Optional variables
+(`{{variable?}}`) that have no value are either removed or replaced
+with an empty string, depending on the adapter.
+
+### Stage 5: Execution
+
+The rendered template is sent to the model as a prompt. The model
+generates the output according to the template's format instructions.
+
+### Stage 6: Output
+
+The generated output is returned to the user or passed to the next
+step in a workflow (another prompt, a tool invocation, or a file write).
+
+## Common Mistakes
+
+| Mistake                                          | Fix                                         |
+| ------------------------------------------------ | ------------------------------------------- |
+| Using a prompt atom for always-on context        | Convert to instruction atom                 |
+| Putting complex logic in the template            | Pair with a hook or agent atom              |
+| Unnamed or generic variable names                | Use descriptive snake_case names            |
+| Template longer than ~30 lines inline            | Split into multiple prompts or stages       |
+| Duplicating template text across atoms           | Extract shared preamble to an instruction   |
+| Using prompt atom where a rule atom fits         | Rules enforce; prompts generate             |
+
+## Tank Prompt Atoms vs MCP Prompts
+
+Tank prompt atoms and MCP prompt primitives share terminology but are
+different mechanisms. Avoid confusing the two.
+
+| Aspect             | Tank Prompt Atom                      | MCP Prompt                           |
+| ------------------ | ------------------------------------- | ------------------------------------ |
+| Declared in        | `tank.json` atoms array               | MCP server manifest                  |
+| Schema             | `{ kind, name, template }`            | `{ name, description, arguments }`   |
+| Execution          | Adapter renders and sends to model    | MCP client resolves from server      |
+| Variable syntax    | `{{double_braces}}`                   | JSON Schema arguments                |
+| Portability        | Across all Tank adapters              | Across MCP-compatible clients        |
+| Purpose            | Reusable agent prompt template        | Server-provided prompt suggestions   |
+
+When authoring Tank bundles, use Tank prompt atoms for templates the
+bundle owns. Use MCP tool atoms to connect to external MCP servers
+that may expose their own prompts.

--- a/skills/prompt-creator/references/template-design.md
+++ b/skills/prompt-creator/references/template-design.md
@@ -1,0 +1,359 @@
+# Template Design Patterns
+
+Sources: Anthropic Prompt Engineering Guide (2025), OpenAI Prompt Best Practices (2025), Tank Contributing Standard (AGENTS.md), ECC command migration patterns (2025-2026)
+
+Covers: Designing effective prompt templates for Tank prompt atoms -- variable naming conventions, structured output guidance, multi-step workflow templates, composing prompts with other atoms, and the distinction between template design and prompt engineering.
+
+## Template Design vs Prompt Engineering
+
+Template design is a subset of prompt engineering focused on creating
+reusable, parameterized prompts rather than one-off queries. The
+constraints are different:
+
+| Concern                | One-Off Prompt           | Prompt Template                   |
+| ---------------------- | ------------------------ | --------------------------------- |
+| Variable inputs        | Hardcoded                | Parameterized with `{{slots}}`    |
+| Audience               | You, right now           | Any user, any time                |
+| Stability              | Adjust on the fly        | Must work across invocations      |
+| Context assumptions    | Full session context     | Minimal -- only what's injected   |
+| Output format          | Whatever works           | Consistent, structured            |
+
+## Variable Design
+
+### Naming Convention Reference
+
+All variables use `{{snake_case}}` inside double braces.
+
+| Category        | Pattern                  | Examples                                  |
+| --------------- | ------------------------ | ----------------------------------------- |
+| Raw data        | `{{noun_descriptor}}`    | `{{diff_output}}`, `{{error_log}}`        |
+| Identifiers     | `{{entity_id}}`          | `{{ticket_id}}`, `{{pr_number}}`          |
+| Configuration   | `{{setting_name}}`       | `{{severity_threshold}}`, `{{max_items}}` |
+| Context refs    | `{{context_source}}`     | `{{repo_url}}`, `{{branch_name}}`         |
+| Content blocks  | `{{content_type}}`       | `{{test_output}}`, `{{stack_trace}}`      |
+| Constraints     | `{{format_constraint}}`  | `{{max_length}}`, `{{output_format}}`     |
+
+### Variable Density Guidelines
+
+Templates with too many variables become difficult to invoke and maintain.
+Templates with too few become inflexible.
+
+| Variable Count | Template Type                 | Guidance                          |
+| -------------- | ----------------------------- | --------------------------------- |
+| 1-2            | Simple generator              | Ideal for focused tasks           |
+| 3-5            | Standard workflow template    | Sweet spot for most prompts       |
+| 6-8            | Complex report template       | Consider splitting into stages    |
+| 9+             | Over-parameterized            | Split into multiple prompt atoms  |
+
+### Required vs Optional Variables
+
+Distinguish required variables (template breaks without them) from optional
+variables (template works with a default or omission).
+
+Inline documentation approach -- add a comment block at the top of the template:
+
+```
+Variables:
+- diff_output (required): Git diff of changes to describe
+- ticket_id (optional): Jira/GitHub issue reference
+- breaking_changes (optional): List of breaking changes if any
+
+---
+
+Write a pull request description for the following changes:
+
+{{diff_output}}
+
+Ticket: {{ticket_id}}
+Breaking changes: {{breaking_changes?}}
+```
+
+The `---` separator between the variable documentation and the template body
+is a convention, not a parsed syntax. Adapters pass the entire template
+string; the model reads the documentation block as context.
+
+## Structured Output Patterns
+
+Templates that produce structured output are more useful than templates
+that produce free-form text. Structure makes output parseable, consistent,
+and composable.
+
+### Section Headers Pattern
+
+Define the output format explicitly with markdown headers:
+
+```
+Generate a code review report.
+
+## Files Reviewed
+{{changed_files}}
+
+## Diff
+{{diff_output}}
+
+---
+
+Produce the review in this format:
+
+## Summary
+One paragraph overview of the changes.
+
+## Issues Found
+For each issue:
+- **File**: filename
+- **Line**: line number
+- **Severity**: critical / high / medium / low
+- **Description**: what is wrong and why
+
+## Recommendations
+Numbered list of improvement suggestions.
+
+## Verdict
+APPROVE, REQUEST_CHANGES, or COMMENT with one-sentence justification.
+```
+
+### Checklist Pattern
+
+For templates that produce actionable checklists:
+
+```
+Generate a pre-deploy checklist for this release.
+
+Changes: {{release_notes}}
+Environment: {{target_environment}}
+
+Produce a markdown checklist:
+
+## Pre-Deploy Checklist
+
+### Code Quality
+- [ ] All tests pass
+- [ ] No critical or high lint issues
+- [ ] ...add items based on the changes
+
+### Infrastructure
+- [ ] Database migrations reviewed
+- [ ] ...add items based on the changes
+
+### Communication
+- [ ] Stakeholders notified
+- [ ] ...add items based on the changes
+```
+
+### Labeled Fields Pattern
+
+For templates that produce key-value structured data:
+
+```
+Generate a commit message for these changes.
+
+Diff: {{diff_summary}}
+Ticket: {{ticket_id}}
+
+Output format:
+Type: <conventional commit type>
+Scope: <affected module>
+Subject: <imperative description under 72 chars>
+Body: <detailed explanation if needed>
+Breaking: <yes/no, with migration note if yes>
+```
+
+### Table Pattern
+
+For templates that produce comparison or analysis tables:
+
+```
+Compare these two implementation approaches.
+
+Approach A: {{approach_a}}
+Approach B: {{approach_b}}
+Criteria: {{evaluation_criteria}}
+
+Output as a markdown table:
+
+| Criterion | Approach A | Approach B | Winner |
+|-----------|-----------|-----------|--------|
+| ...       | ...       | ...       | ...    |
+
+## Recommendation
+State which approach to use and why.
+```
+
+## Multi-Step Workflow Templates
+
+Complex workflows that exceed a single prompt atom's scope should be
+decomposed into multiple prompt atoms, each handling one stage.
+
+### Decomposition Strategy
+
+Split a workflow when:
+- The output of one stage feeds as input to the next
+- Different stages need different variable sets
+- Users may want to invoke individual stages independently
+- The combined template exceeds ~25 lines
+
+### Workflow Composition Pattern
+
+Define multiple prompt atoms in the same bundle. Name them with a shared
+prefix to signal they belong to a workflow.
+
+```json
+{
+  "atoms": [
+    {
+      "kind": "prompt",
+      "name": "release-notes-gather",
+      "template": "List all commits between {{base_tag}} and {{head_ref}}.\n\nGroup by: feature, fix, chore, breaking.\nFormat as bullet points under each group."
+    },
+    {
+      "kind": "prompt",
+      "name": "release-notes-draft",
+      "template": "Draft release notes from these grouped commits:\n\n{{grouped_commits}}\n\nVersion: {{version}}\n\nInclude: highlights section, full changelog, migration notes for breaking changes."
+    },
+    {
+      "kind": "prompt",
+      "name": "release-notes-review",
+      "template": "Review these draft release notes for:\n\n{{draft_notes}}\n\nCheck: accuracy vs commits, tone consistency, missing breaking change warnings.\nOutput: corrected release notes or LGTM."
+    }
+  ]
+}
+```
+
+### Chaining with Agent Atoms
+
+For automated multi-step execution, pair workflow prompts with an agent
+atom that orchestrates the chain:
+
+```json
+{
+  "kind": "agent",
+  "name": "release-manager",
+  "role": "Orchestrate release note generation by invoking release-notes-gather, then release-notes-draft, then release-notes-review in sequence. Pass output of each stage as input to the next.",
+  "tools": ["git", "read"],
+  "model": "balanced"
+}
+```
+
+The agent invokes each prompt in sequence, feeding outputs forward.
+This pattern separates the template content (prompts) from the
+orchestration logic (agent).
+
+## Composing Prompts with Other Atoms
+
+Prompt atoms gain power when composed with companion atoms in a bundle.
+
+### Prompt + Instruction
+
+Add an instruction atom to provide the prompt with persistent context
+that every invocation needs:
+
+```json
+{
+  "atoms": [
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    },
+    {
+      "kind": "prompt",
+      "name": "api-endpoint",
+      "template": "Generate an API endpoint following our conventions.\n\nResource: {{resource_name}}\nOperations: {{crud_operations}}\nAuth: {{auth_method}}"
+    }
+  ]
+}
+```
+
+The instruction provides "our conventions" context; the prompt provides
+the parameterized generator. The instruction loads every session; the
+prompt loads only when invoked.
+
+### Prompt + Hook
+
+A hook can trigger a prompt automatically at a lifecycle event:
+
+```json
+{
+  "atoms": [
+    {
+      "kind": "hook",
+      "event": "pre-stop",
+      "handler": {
+        "type": "js",
+        "entry": "./hooks/auto-commit-message.ts"
+      }
+    },
+    {
+      "kind": "prompt",
+      "name": "commit-message",
+      "template": "Generate a conventional commit message for:\n\n{{diff_summary}}"
+    }
+  ]
+}
+```
+
+The hook fires on `pre-stop`, collects the diff, and invokes the prompt
+atom to generate a commit message before the session ends.
+
+### Prompt + Rule
+
+A rule atom can validate the output of a prompt invocation:
+
+```json
+{
+  "atoms": [
+    {
+      "kind": "prompt",
+      "name": "migration-script",
+      "template": "Generate a database migration for:\n\n{{schema_change}}\n\nTarget: {{db_engine}}"
+    },
+    {
+      "kind": "rule",
+      "event": "post-tool-use",
+      "policy": "block",
+      "reason": "Migration scripts must not contain DROP TABLE without explicit user confirmation"
+    }
+  ]
+}
+```
+
+### Prompt + Resource
+
+A resource atom provides data the prompt template references:
+
+```json
+{
+  "atoms": [
+    {
+      "kind": "resource",
+      "uri": "./assets/commit-conventions.md"
+    },
+    {
+      "kind": "prompt",
+      "name": "commit-message",
+      "template": "Using the commit conventions from the project resource, generate a message for:\n\n{{diff_summary}}"
+    }
+  ]
+}
+```
+
+## Template Anti-Patterns
+
+| Anti-Pattern                              | Problem                                | Fix                                      |
+| ----------------------------------------- | -------------------------------------- | ---------------------------------------- |
+| God template (does everything)            | Fragile, hard to maintain              | Split into focused prompt atoms          |
+| Instruction masquerading as prompt        | Wastes the invocation mechanism        | Convert to instruction atom              |
+| Hardcoded values that should be variables | Inflexible across projects             | Extract to `{{variable}}`                |
+| Vague output instructions                 | Inconsistent results                   | Add explicit format specification        |
+| No variable documentation                 | Users do not know what to supply       | Add variable block at template top       |
+| Template assumes session context          | Breaks when invoked in isolation       | Make all needed context explicit as vars  |
+| Prompt doing tool work                    | Models cannot execute tools in prompts | Pair with hook or agent atom             |
+
+## Template Quality Checklist
+
+- [ ] Every `{{variable}}` has a descriptive snake_case name
+- [ ] Required vs optional variables are documented or obvious
+- [ ] Output format is explicitly specified (sections, checklist, table, fields)
+- [ ] Template works with only the declared variables (no hidden dependencies)
+- [ ] Template is under ~25 lines; longer workflows are split into stages
+- [ ] No duplicated text across prompt atoms in the same bundle
+- [ ] Template tested with sample values to verify coherent output

--- a/skills/prompt-creator/references/worked-examples.md
+++ b/skills/prompt-creator/references/worked-examples.md
@@ -1,0 +1,310 @@
+# Worked Prompt Atom Examples
+
+Sources: Tank Contributing Standard (AGENTS.md 2025-2026), ECC command migration patterns, production bundle analysis (@tank/quality-gate)
+
+Covers: Four complete prompt atom examples with full bundle context, showing how each prompt composes with companion atoms. Each example includes the problem statement, the tank.json atoms array, the template text with variable annotations, and adapter behavior notes.
+
+## Example 1: PR Description Generator
+
+### Problem
+
+Developers need consistent, well-structured pull request descriptions.
+The template should accept a diff and optional ticket reference, then
+produce a description with summary, motivation, changes, and testing
+sections.
+
+### tank.json
+
+```json
+{
+  "name": "@tank/pr-workflows",
+  "version": "1.0.0",
+  "description": "PR description and review workflow templates.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    },
+    {
+      "kind": "prompt",
+      "name": "pr-description",
+      "template": "Variables:\n- diff_output (required): Full git diff of the PR\n- ticket_id (optional): Issue or ticket reference\n- base_branch (optional): Target branch name\n\n---\n\nGenerate a pull request description for the following changes.\n\nDiff:\n{{diff_output}}\n\nTicket: {{ticket_id?}}\nBase branch: {{base_branch?}}\n\nProduce the description in this format:\n\n## Summary\nOne paragraph explaining what this PR does and why.\n\n## Motivation\nWhat problem does this solve? Link to the ticket if provided.\n\n## Changes\nBullet list of the key changes, grouped by area.\n\n## Testing\nHow were these changes tested? List manual and automated steps.\n\n## Checklist\n- [ ] Tests added/updated\n- [ ] Documentation updated if needed\n- [ ] No breaking changes (or migration notes added)"
+    }
+  ]
+}
+```
+
+### Template Anatomy
+
+The template has three zones:
+
+1. **Variable documentation block** (lines 1-5): Lists variables with
+   required/optional status and descriptions. This is read by the model
+   as context, not parsed by the adapter.
+
+2. **Separator** (`---`): Visual break between documentation and template.
+
+3. **Template body** (remaining lines): The actual prompt with variable
+   placeholders and explicit output format specification.
+
+### Composition Notes
+
+- The `instruction` atom (`./SKILL.md`) provides project-specific PR
+  conventions. The prompt atom references these implicitly ("our format").
+- No hook or agent atom needed -- this is a standalone on-demand template.
+- A future enhancement could add a `hook` atom on `pre-stop` that
+  auto-generates the PR description when the agent completes work.
+
+### Adapter Behavior
+
+| Platform    | Invocation                              |
+| ----------- | --------------------------------------- |
+| Cursor      | `/pr-description` in command palette    |
+| OpenCode    | `/pr-description` slash command         |
+| Claude Code | `pr-description` callable template      |
+
+## Example 2: Commit Message Formatter
+
+### Problem
+
+Enforce conventional commit format across a team. The template accepts
+a diff summary and optional ticket ID, producing a properly formatted
+conventional commit message.
+
+### tank.json
+
+```json
+{
+  "name": "@tank/git-conventions",
+  "version": "1.0.0",
+  "description": "Git workflow templates: commit messages, branch naming, changelog entries.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    },
+    {
+      "kind": "prompt",
+      "name": "commit-message",
+      "template": "Variables:\n- diff_summary (required): Summary of staged changes\n- ticket_id (optional): Issue tracker reference\n\n---\n\nGenerate a conventional commit message for these staged changes:\n\n{{diff_summary}}\n\nTicket: {{ticket_id?}}\n\nRules:\n1. Type must be one of: feat, fix, refactor, docs, test, chore, ci, perf, build\n2. Scope is the module or area affected (optional, in parentheses)\n3. Subject line is imperative, lowercase, no period, under 72 characters\n4. Body explains what and why (not how), wrapped at 72 characters\n5. Footer references the ticket if provided\n\nOutput format:\n```\ntype(scope): subject\n\nbody\n\nRefs: #ticket\n```"
+    },
+    {
+      "kind": "prompt",
+      "name": "changelog-entry",
+      "template": "Variables:\n- commits (required): List of commits since last release\n- version (required): New version number\n\n---\n\nGenerate a changelog entry for version {{version}}.\n\nCommits:\n{{commits}}\n\nGroup entries under:\n## Added\n## Changed\n## Fixed\n## Removed\n\nOmit empty groups. Use past tense. One line per entry."
+    }
+  ]
+}
+```
+
+### Template Anatomy
+
+The `commit-message` prompt encodes formatting rules directly in the
+template rather than relying on ambient instruction context. This makes
+the prompt self-contained -- it works correctly even if the instruction
+atom is not loaded.
+
+The `changelog-entry` prompt demonstrates a second prompt atom in the
+same bundle. Both serve the "git conventions" capability but are
+invoked independently.
+
+### Composition Notes
+
+- Two prompts in one bundle, each independently invocable.
+- The instruction atom provides broader git workflow context (branch
+  naming, merge strategy) that both prompts can reference.
+- These prompts could be chained: generate commit messages during
+  development, then generate changelog from accumulated commits at
+  release time.
+
+### Why Two Prompt Atoms, Not One
+
+A single prompt that both formats commits and generates changelogs would
+violate the "one prompt, one job" principle. Users invoke these at
+different times (per-commit vs per-release) with different inputs.
+
+## Example 3: Incident Report Template
+
+### Problem
+
+Standardize incident reporting across a team. The template captures
+severity, timeline, summary, and analysis, producing a structured
+report that can be pasted into a wiki or ticketing system.
+
+### tank.json
+
+```json
+{
+  "name": "@tank/incident-response",
+  "version": "1.0.0",
+  "description": "Incident report generation and post-mortem workflow templates.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "prompt",
+      "name": "incident-report",
+      "template": "Variables:\n- severity (required): P0-P4 severity level\n- incident_summary (required): Brief description of what happened\n- timeline (required): Chronological events with timestamps\n- affected_services (required): List of impacted services/systems\n- detection_method (optional): How the incident was discovered\n- resolution_steps (optional): Steps taken to resolve\n\n---\n\nGenerate a structured incident report.\n\nSeverity: {{severity}}\nSummary: {{incident_summary}}\nAffected services: {{affected_services}}\nDetection: {{detection_method?}}\n\nTimeline:\n{{timeline}}\n\nResolution steps:\n{{resolution_steps?}}\n\nProduce the report in this format:\n\n# Incident Report\n\n**Severity**: <severity>\n**Status**: <resolved / investigating / monitoring>\n**Date**: <date from timeline>\n**Duration**: <calculated from timeline>\n\n## Summary\nOne paragraph describing the incident and its impact.\n\n## Timeline\n| Time | Event |\n|------|-------|\n| ...  | ...   |\n\n## Root Cause\nAnalyze the timeline and determine the most likely root cause.\n\n## Impact\n- Users affected: <estimate from affected services>\n- Services degraded: <list>\n- Data loss: <yes/no with details>\n\n## Resolution\nSteps taken to resolve, in chronological order.\n\n## Action Items\n| Priority | Action | Owner | Due Date |\n|----------|--------|-------|----------|\n| P0       | ...    | TBD   | TBD      |\n\n## Lessons Learned\n3-5 bullet points on what went well and what to improve."
+    },
+    {
+      "kind": "agent",
+      "name": "incident-analyzer",
+      "role": "Analyze incident timelines and logs to identify root causes. When the incident-report prompt is invoked, assist by reading log files and correlating events. Focus on causation chains, not symptoms.",
+      "tools": ["read", "grep", "glob"],
+      "model": "balanced",
+      "readonly": true
+    }
+  ]
+}
+```
+
+### Template Anatomy
+
+This is the most complex single-prompt example. It has six variables
+(four required, two optional) and a detailed output format with tables.
+This is near the upper limit of single-prompt complexity -- adding
+more variables would warrant splitting into gather and draft stages.
+
+### Composition Notes
+
+- The `agent` atom (`incident-analyzer`) provides analytical capability
+  the prompt alone cannot. When the user invokes `incident-report`,
+  the agent can be delegated to read log files and build the timeline
+  before the prompt renders the final report.
+- No instruction atom -- the prompt is self-contained with formatting
+  rules embedded in the template.
+- No hook atom -- incident reports are always user-initiated, never
+  auto-triggered.
+
+### Why an Agent Companion
+
+The incident report prompt produces structured output from provided
+inputs. But gathering those inputs (reading logs, correlating timestamps,
+identifying affected services) requires tool access. The agent atom
+provides that capability. The prompt defines the output format; the
+agent gathers the input data.
+
+## Example 4: Code Review Checklist
+
+### Problem
+
+Provide a consistent code review framework that adapts to the type
+of change (feature, bugfix, refactor, dependency update). The reviewer
+invokes the prompt, supplies the diff, and gets a structured checklist
+tailored to the change type.
+
+### tank.json
+
+```json
+{
+  "name": "@tank/code-review-toolkit",
+  "version": "1.0.0",
+  "description": "Code review checklist and feedback templates.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    },
+    {
+      "kind": "prompt",
+      "name": "review-checklist",
+      "template": "Variables:\n- diff_output (required): Git diff of the changes to review\n- change_type (required): One of: feature, bugfix, refactor, dependency, config\n- focus_areas (optional): Specific areas to pay attention to\n\n---\n\nPerform a code review of the following changes.\n\nChange type: {{change_type}}\nFocus areas: {{focus_areas?}}\n\nDiff:\n{{diff_output}}\n\nProduce the review as a checklist tailored to the change type.\n\n## Review: {{change_type}}\n\n### Correctness\n- [ ] Logic is correct and handles edge cases\n- [ ] Error handling is appropriate\n- [ ] ... (add items specific to the change type)\n\n### Security\n- [ ] No secrets or credentials in code\n- [ ] Input validation present where needed\n- [ ] ... (add items specific to the change type)\n\n### Testing\n- [ ] Tests cover the changed behavior\n- [ ] Edge cases have test coverage\n- [ ] ... (add items specific to the change type)\n\n### Maintainability\n- [ ] Naming is clear and consistent\n- [ ] No unnecessary complexity\n- [ ] ... (add items specific to the change type)\n\n### Issues Found\nFor each issue:\n- **File**: filename:line\n- **Severity**: critical / high / medium / low\n- **Issue**: description\n- **Suggestion**: how to fix\n\n### Verdict\nAPPROVE, REQUEST_CHANGES, or COMMENT."
+    },
+    {
+      "kind": "prompt",
+      "name": "review-response",
+      "template": "Variables:\n- review_feedback (required): Code review feedback received\n- original_diff (required): The original diff that was reviewed\n\n---\n\nAddress this code review feedback.\n\nFeedback:\n{{review_feedback}}\n\nOriginal diff:\n{{original_diff}}\n\nFor each item:\n1. State whether you agree or disagree (with reasoning)\n2. If agree, describe the fix\n3. If disagree, provide justification\n\nOutput format:\n| # | Feedback Item | Response | Action |\n|---|--------------|----------|--------|\n| 1 | ...          | Agree/Disagree + reasoning | Fix description or justification |"
+    },
+    {
+      "kind": "rule",
+      "event": "post-tool-use",
+      "policy": "block",
+      "reason": "Review checklist must include a verdict (APPROVE, REQUEST_CHANGES, or COMMENT)"
+    }
+  ]
+}
+```
+
+### Template Anatomy
+
+Two complementary prompts form a review workflow:
+
+1. `review-checklist`: The reviewer runs this against a diff. The
+   `change_type` variable adapts the checklist categories.
+2. `review-response`: The author runs this to systematically address
+   received feedback.
+
+### Composition Notes
+
+- **Instruction atom**: Provides project-specific code standards that
+  inform what "correct" and "maintainable" mean in context.
+- **Rule atom**: Validates that review output includes a verdict.
+  This demonstrates prompt + rule composition -- the rule gates the
+  output quality of the prompt.
+- **Two prompts, one workflow**: The review and response prompts
+  form a natural cycle. The output of `review-checklist` becomes
+  the `review_feedback` input of `review-response`.
+
+### ECC Migration Notes
+
+This example maps directly to ECC's "code review" command pattern.
+The ECC command was a single monolithic `.md` file with hardcoded
+instructions. The Tank version:
+
+| ECC Command                | Tank Equivalent                          |
+| -------------------------- | ---------------------------------------- |
+| `commands/code-review.md`  | Prompt atom `review-checklist`           |
+| Hardcoded review criteria  | Instruction atom with project standards  |
+| No response workflow       | Second prompt atom `review-response`     |
+| No output validation       | Rule atom enforcing verdict requirement  |
+
+This decomposition improves on the ECC pattern: each concern lives
+in a dedicated atom, independently testable and composable.
+
+## Composition Summary
+
+| Example               | Prompt | Instruction | Agent | Hook | Rule | Total Atoms |
+| --------------------- | ------ | ----------- | ----- | ---- | ---- | ----------- |
+| PR Description        | 1      | 1           | 0     | 0    | 0    | 2           |
+| Git Conventions       | 2      | 1           | 0     | 0    | 0    | 3           |
+| Incident Report       | 1      | 0           | 1     | 0    | 0    | 2           |
+| Code Review Toolkit   | 2      | 1           | 0     | 0    | 1    | 4           |
+
+### Patterns Observed
+
+1. **Prompt + Instruction** is the most common pair. The instruction
+   provides ambient context; the prompt provides the on-demand template.
+
+2. **Multiple prompts per bundle** serve related workflows. Name them
+   with a shared prefix or domain to signal cohesion.
+
+3. **Prompt + Agent** pairs appear when the prompt needs data that
+   requires tool access to gather.
+
+4. **Prompt + Rule** pairs appear when output quality needs machine
+   enforcement beyond what the template text alone can guarantee.
+
+5. **Prompt + Hook** pairs appear when prompts should fire automatically
+   at lifecycle events rather than on manual invocation.

--- a/skills/prompt-creator/tank.json
+++ b/skills/prompt-creator/tank.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tank/prompt-creator",
+  "version": "1.0.0",
+  "description": "Author Tank prompt atoms -- reusable invocable templates declared in bundle tank.json files. Covers prompt atom schema, template variable syntax, structured output, multi-step workflows, and composition with other atom kinds. Triggers: create prompt, prompt template, tank prompt atom, slash command, workflow template, invocable template, parameterized prompt.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/skills/resource-creator/SKILL.md
+++ b/skills/resource-creator/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: "@tank/resource-creator"
+description: |
+  Author Tank resource atoms -- URI-addressable data or context that agents
+  can read on demand. Covers the resource atom schema (required `uri` field),
+  URI scheme conventions, static vs dynamic resources, the pull-model
+  distinction (resources are read on demand, instructions are always injected),
+  relationship to MCP resources, permission implications, and composing
+  resources with agent atoms. Includes worked examples for project context
+  maps, style guides, config resources, and agent+resource combos.
+  Synthesizes Tank specification (AGENTS.md), MCP resource specification,
+  and production bundle patterns.
+
+  Trigger phrases: "create resource", "resource atom", "tank resource",
+  "uri resource", "context resource", "agent context", "readable resource",
+  "resource uri", "agent data source", "on-demand context",
+  "resource vs instruction", "project context map", "style guide resource",
+  "config resource", "compose resource with agent"
+---
+
+# Tank Resource Creator
+
+## Core Philosophy
+
+1. **Pull over push.** Resources exist so agents can fetch context when
+   needed, not have it forced into every prompt. Use a resource when the
+   data is large, situational, or only relevant to specific tasks.
+   -> See `references/resource-design.md`
+
+2. **URIs are contracts.** The `uri` field is the single required field on
+   a resource atom. Treat it like an API endpoint -- stable, descriptive,
+   and versioned when the schema changes.
+   -> See `references/resource-atom-anatomy.md`
+
+3. **Resources are not instructions.** Instructions inject behavioral
+   context unconditionally. Resources provide data the agent can choose to
+   read. Confusing the two bloats context windows or starves agents of
+   needed information.
+
+4. **Compose with agents.** The highest-value pattern pairs a resource atom
+   with an agent atom -- the agent reads the resource as input to its task.
+   Design resources with a specific consumer in mind.
+   -> See `references/worked-examples.md`
+
+5. **Scope permissions to the resource.** A resource that reads the
+   filesystem needs `filesystem.read` permission. A resource backed by a
+   remote MCP endpoint needs `network.outbound`. Never grant broader
+   permissions than the resource requires.
+
+## Quick-Start: Common Problems
+
+### "Expose a project architecture map to agents"
+
+1. Create a markdown file describing the codebase structure.
+2. Add a resource atom: `{ "kind": "resource", "uri": "tank://context/architecture" }`.
+3. Wire it in `tank.json` alongside an instruction or agent atom.
+   -> See `references/worked-examples.md` (Project Context Resource)
+
+### "Give an agent a style guide to reference"
+
+1. Write the style guide as a markdown reference file.
+2. Add a resource atom pointing to it.
+3. Pair it with an agent atom that has `tools: ["read"]` so it can access
+   the resource content.
+   -> See `references/worked-examples.md` (Style Guide Resource)
+
+### "Serve dynamic config that changes per environment"
+
+1. Use a `file://` or MCP-backed URI that resolves at runtime.
+2. Add the resource atom with the dynamic URI.
+3. Ensure the `permissions` block covers the access pattern.
+   -> See `references/resource-design.md` (Static vs Dynamic Resources)
+
+### "Decide: resource or instruction?"
+
+1. Check the decision tree below.
+2. If the content is always needed and under 50 lines, use an instruction.
+3. If the content is situational, large, or task-specific, use a resource.
+   -> See `references/resource-design.md`
+
+## Decision Trees
+
+### Resource vs Instruction
+
+| Signal                                    | Use Resource     | Use Instruction  |
+| ----------------------------------------- | ---------------- | ---------------- |
+| Content is always relevant to every task  | No               | Yes              |
+| Content is large (>50 lines)              | Yes              | Bloats context   |
+| Content is only needed for specific tasks | Yes              | Wasteful         |
+| Content changes per environment/run       | Yes              | Cannot           |
+| Content is behavioral (rules, persona)    | Rarely           | Yes              |
+| Content is data (schemas, maps, specs)    | Yes              | Overkill         |
+
+### URI Scheme Selection
+
+| Data Location                    | URI Scheme       | Example                              |
+| -------------------------------- | ---------------- | ------------------------------------ |
+| Bundled file in the package      | `tank://`        | `tank://context/architecture`        |
+| Local filesystem path            | `file://`        | `file://./references/style-guide.md` |
+| Remote MCP resource endpoint     | `mcp://`         | `mcp://server-name/resource-path`    |
+| HTTPS endpoint (read-only)       | `https://`       | `https://api.example.com/config`     |
+
+### Manifest Wiring
+
+| Component         | Location in tank.json                     |
+| ----------------- | ----------------------------------------- |
+| Resource atom     | `atoms[]` with `kind: "resource"`         |
+| URI binding       | `uri` field on the resource atom          |
+| Companion agent   | Separate atom with `kind: "agent"`        |
+| Permissions       | Top-level `permissions` object            |
+
+## Reference Index
+
+| File                                  | Contents                                          |
+| ------------------------------------- | ------------------------------------------------- |
+| `references/resource-atom-anatomy.md` | Schema, required fields, URI schemes, relationship to MCP resources |
+| `references/resource-design.md`       | When to use resources, URI conventions, static vs dynamic, permissions |
+| `references/worked-examples.md`       | 4+ worked resource examples with full tank.json snippets |

--- a/skills/resource-creator/references/resource-atom-anatomy.md
+++ b/skills/resource-creator/references/resource-atom-anatomy.md
@@ -1,0 +1,305 @@
+# Resource Atom Anatomy
+
+Sources: Tank specification (AGENTS.md), MCP resource specification (2025-2026)
+
+Covers: the Tank `kind: "resource"` atom schema, required and optional fields,
+URI scheme conventions, how resources differ from instructions (pull vs push),
+and the relationship between Tank resource atoms and MCP resources.
+
+## The Resource Atom in the Tank Type System
+
+Tank defines seven atom kinds. Each serves a distinct role in shaping agent
+behavior. The resource atom occupies a specific niche: **data the agent can
+read on demand**.
+
+| Atom Kind     | Delivery Model | Agent Interaction                |
+| ------------- | -------------- | -------------------------------- |
+| `instruction` | Push (always)  | Injected into every prompt       |
+| `resource`    | Pull (demand)  | Read when the agent requests it  |
+| `hook`        | Event-driven   | Triggered by lifecycle events    |
+| `agent`       | Delegation     | Spawned as a named sub-agent     |
+| `rule`        | Event-driven   | Machine-enforced constraint      |
+| `tool`        | Invocation     | Called as an MCP tool             |
+| `prompt`      | Invocation     | Rendered from a template         |
+
+The critical distinction: instructions are **always loaded** into the agent's
+context window. Resources are **available but not loaded** until the agent or
+another atom requests them.
+
+## Required Fields
+
+The resource atom has one required field:
+
+```json
+{
+  "kind": "resource",
+  "uri": "tank://context/architecture"
+}
+```
+
+### `uri` (required, string)
+
+The URI that identifies and locates the resource content. Must be a valid
+URI string. The scheme portion determines how the resource is resolved.
+
+## Optional Fields
+
+### `name` (optional, string)
+
+A human-readable identifier for the resource. Useful when multiple resources
+exist in a bundle and agents or hooks need to reference a specific one.
+
+```json
+{
+  "kind": "resource",
+  "uri": "tank://context/architecture",
+  "name": "project-architecture"
+}
+```
+
+### `description` (optional, string)
+
+A brief explanation of what the resource contains. Helps agents decide
+whether to read this resource for a given task.
+
+```json
+{
+  "kind": "resource",
+  "uri": "tank://context/architecture",
+  "name": "project-architecture",
+  "description": "High-level codebase map with module boundaries and data flow"
+}
+```
+
+### `extensions` (optional, object)
+
+Platform-specific overrides. Adapters own the shape of their extension data.
+Tank passes extensions through without validation.
+
+```json
+{
+  "kind": "resource",
+  "uri": "tank://context/architecture",
+  "extensions": {
+    "opencode": { "autoLoad": true },
+    "cursor": { "pinned": true }
+  }
+}
+```
+
+## URI Schemes
+
+The `uri` field supports multiple schemes. Each scheme determines how the
+adapter resolves the resource content at runtime.
+
+### `tank://` -- Package-Relative Resources
+
+Points to a file bundled within the Tank package itself. The adapter resolves
+the path relative to the package root.
+
+```
+tank://context/architecture
+tank://data/schema-map
+tank://guides/style-guide
+```
+
+Convention: use `tank://` for any content that ships with the package and
+does not change between environments. The path segments after the scheme
+are logical names, not filesystem paths -- the adapter maps them to actual
+files.
+
+### `file://` -- Local Filesystem Resources
+
+Points to a file on the local filesystem. Can be absolute or relative to
+the project root.
+
+```
+file://./references/style-guide.md
+file://./assets/api-schema.json
+file:///absolute/path/to/config.yaml
+```
+
+Use `file://` when the resource content lives outside the package -- for
+example, a generated file in the project's build output or a config file
+in the repository root.
+
+Permission requirement: `filesystem.read` must include the target path.
+
+### `mcp://` -- MCP Server Resources
+
+Points to a resource exposed by an MCP server. The adapter delegates
+resolution to the MCP client connected to the named server.
+
+```
+mcp://database-server/schema/users
+mcp://docs-server/api-reference/auth
+```
+
+Format: `mcp://{server-name}/{resource-path}`
+
+The server name must match a configured MCP server in the agent's
+environment. The resource path is passed to the MCP server's
+`resources/read` endpoint.
+
+Permission requirement: `network.outbound` must include the MCP server
+if it is remote.
+
+### `https://` -- Remote HTTP Resources
+
+Points to a read-only HTTP endpoint. The adapter fetches the content via
+a standard GET request.
+
+```
+https://api.example.com/v1/config
+https://raw.githubusercontent.com/org/repo/main/schema.json
+```
+
+Use `https://` for external data sources that the agent needs at runtime.
+Prefer `tank://` or `file://` for content that can be bundled.
+
+Permission requirement: `network.outbound` must include the hostname.
+
+## URI Naming Conventions
+
+Follow these conventions for consistent, discoverable URIs:
+
+| Convention              | Example                          | Rationale                       |
+| ----------------------- | -------------------------------- | ------------------------------- |
+| Lowercase with hyphens  | `tank://context/code-map`        | Consistent with Tank naming     |
+| Logical path segments   | `tank://guides/style-guide`      | Describes content, not location |
+| Version suffix if needed| `tank://schemas/api-v2`          | Supports schema evolution       |
+| No file extensions      | `tank://data/config` not `.json` | URI is abstract, not a path     |
+| Descriptive leaf name   | `tank://context/module-boundaries` | Self-documenting               |
+
+## How Resources Differ from Instructions
+
+This comparison is the most common source of confusion. Internalize it.
+
+### Instruction Atom Behavior
+
+```json
+{ "kind": "instruction", "content": "./SKILL.md" }
+```
+
+- Content is loaded into the agent's system prompt or context window at
+  session start.
+- Every message the agent processes includes the instruction content.
+- Cost: consumes tokens on every turn, even when irrelevant.
+- Benefit: guarantees the agent always has the behavioral context.
+- Best for: persona, rules, constraints, behavioral directives.
+
+### Resource Atom Behavior
+
+```json
+{ "kind": "resource", "uri": "tank://context/architecture" }
+```
+
+- Content is registered as available but not loaded by default.
+- The agent (or a companion agent/hook) reads the resource when needed.
+- Cost: zero tokens when not read; full content when read.
+- Benefit: large data sets do not bloat every prompt.
+- Best for: reference data, schemas, maps, specs, style guides.
+
+### Side-by-Side Comparison
+
+| Dimension           | Instruction                | Resource                    |
+| ------------------- | -------------------------- | --------------------------- |
+| Loading model       | Push (always injected)     | Pull (read on demand)       |
+| Context cost        | Every turn                 | Only when accessed          |
+| Content type        | Behavioral (rules, tone)   | Data (schemas, maps, specs) |
+| Size sweet spot     | Under 50 lines             | Any size                    |
+| Mutability          | Static per session         | Can resolve dynamically     |
+| Required field      | `content` (file path)      | `uri` (URI string)          |
+
+## Relationship to MCP Resources
+
+Tank resource atoms and MCP resources are related but operate at different
+abstraction layers.
+
+### MCP Resources (Protocol Level)
+
+MCP defines a `resources/list` and `resources/read` protocol for servers
+to expose data to clients. An MCP resource has:
+
+- A URI (unique identifier)
+- A name and optional description
+- A MIME type
+- Content (text or binary blob)
+
+MCP resources are a **transport mechanism** -- they define how data moves
+between a server and a client over the MCP protocol.
+
+### Tank Resource Atoms (Package Level)
+
+A Tank resource atom is a **package primitive** that declares data an agent
+can access. It may or may not be backed by an MCP resource.
+
+- `tank://` and `file://` URIs: resolved by the adapter directly, no MCP
+  involved.
+- `mcp://` URIs: delegated to an MCP server's `resources/read` endpoint.
+- `https://` URIs: fetched via HTTP, no MCP involved.
+
+### When They Overlap
+
+A Tank resource atom with an `mcp://` URI is a thin wrapper around an MCP
+resource. The Tank atom adds:
+
+- Package-level declaration (the resource is part of a versioned bundle)
+- Permission enforcement (the `permissions` block gates access)
+- Discoverability (agents know the resource exists from the manifest)
+- Composition (the resource can be paired with agent/hook atoms)
+
+### When They Do Not Overlap
+
+A Tank resource atom with a `tank://`, `file://`, or `https://` URI has
+no MCP involvement. The adapter resolves the URI directly without any
+MCP server interaction.
+
+Rule of thumb: use `mcp://` only when the data originates from an MCP
+server that is already configured in the environment. For everything else,
+use `tank://` (bundled) or `file://` (local).
+
+## Minimal Valid Resource Atom
+
+```json
+{
+  "kind": "resource",
+  "uri": "tank://context/architecture"
+}
+```
+
+## Fully Specified Resource Atom
+
+```json
+{
+  "kind": "resource",
+  "uri": "tank://context/architecture",
+  "name": "project-architecture",
+  "description": "Module boundaries, data flow, and dependency graph for the monorepo",
+  "extensions": {
+    "opencode": { "autoLoad": true }
+  }
+}
+```
+
+## Validation Rules
+
+The adapter validates resource atoms at package load time:
+
+| Rule                          | Enforcement                              |
+| ----------------------------- | ---------------------------------------- |
+| `kind` must be `"resource"`   | Schema validation                        |
+| `uri` must be a valid URI     | URI parsing (scheme required)            |
+| `uri` scheme must be known    | Warn on unknown schemes                  |
+| `name` must be unique in bundle | Collision detection across atoms       |
+| Permissions must cover access | `filesystem.read` for `file://`, `network.outbound` for `https://` and remote `mcp://` |
+
+## Anti-Patterns
+
+| Anti-Pattern                          | Problem                                   | Fix                                |
+| ------------------------------------- | ----------------------------------------- | ---------------------------------- |
+| Using a resource for behavioral rules | Agent may not read it; rules get ignored  | Use an instruction atom instead    |
+| Hardcoding absolute `file://` paths   | Breaks on other machines                  | Use `tank://` or relative paths    |
+| No `name` on multiple resources       | Ambiguous references from agents/hooks    | Add a descriptive `name` field     |
+| `mcp://` without configured server    | Resolution fails at runtime               | Verify server exists or use `tank://` |
+| Giant resource with no description    | Agent cannot decide if it is relevant     | Add a concise `description` field  |

--- a/skills/resource-creator/references/resource-design.md
+++ b/skills/resource-creator/references/resource-design.md
@@ -1,0 +1,321 @@
+# Resource Design Patterns
+
+Sources: Tank specification (AGENTS.md), MCP specification (2025-2026),
+information architecture patterns
+
+Covers: when to use a resource vs an instruction atom, URI naming conventions,
+static vs dynamic resources, composing resources with agents, and permission
+implications for each URI scheme.
+
+## The Resource Selection Framework
+
+Every piece of context in a Tank bundle must be delivered through an atom.
+The first design decision is always: **instruction or resource?**
+
+### The Three Questions
+
+Ask these in order. Stop at the first "yes."
+
+1. **Is this behavioral context (rules, tone, persona)?**
+   Yes -> Instruction atom. Agents need behavioral context on every turn.
+
+2. **Is this small (<50 lines) and always relevant?**
+   Yes -> Instruction atom. The context cost is negligible.
+
+3. **Is this data, reference material, or situational context?**
+   Yes -> Resource atom. Pull it when needed, save tokens otherwise.
+
+### Decision Matrix
+
+| Content Type                  | Size    | Frequency Needed | Atom Type     |
+| ----------------------------- | ------- | ---------------- | ------------- |
+| Persona / role definition     | Small   | Every turn       | Instruction   |
+| Coding standards / rules      | Small   | Every turn       | Instruction   |
+| API schema reference          | Large   | Some tasks       | Resource      |
+| Project architecture map      | Medium  | Some tasks       | Resource      |
+| Style guide                   | Medium  | Some tasks       | Resource      |
+| Environment configuration     | Small   | Some tasks       | Resource      |
+| Database schema documentation | Large   | Rare tasks       | Resource      |
+| Third-party API specs         | Large   | Rare tasks       | Resource      |
+| Error code catalog            | Medium  | Debugging only   | Resource      |
+| Deployment runbook            | Large   | Deployment only  | Resource      |
+
+### Edge Cases
+
+**Small but situational content (10-30 lines, not always needed):**
+Use a resource. Even though the content is small, injecting it into every
+prompt wastes tokens across hundreds of turns. A 20-line resource read
+once costs 20 tokens. A 20-line instruction costs 20 tokens per turn --
+over 100 turns, that is 2000 tokens wasted.
+
+**Large but always-needed content (>100 lines, every task):**
+Split it. Extract the always-needed core (rules, constraints) into an
+instruction atom (<50 lines). Put the full reference material into a
+resource atom. The instruction tells the agent the resource exists.
+
+**Behavioral context that varies by task:**
+Use a resource with a descriptive `description` field. The agent reads the
+behavioral context only when the task matches. This is the one case where
+behavioral content belongs in a resource.
+
+## URI Naming Conventions
+
+### Namespace Structure
+
+Organize URIs with logical path segments that group related resources:
+
+```
+tank://context/{resource-name}      -- Project-level context
+tank://schemas/{schema-name}        -- Data schemas and API specs
+tank://guides/{guide-name}          -- Style guides, runbooks, standards
+tank://data/{dataset-name}          -- Static data sets
+tank://config/{config-name}         -- Configuration data
+```
+
+### Naming Rules
+
+| Rule                         | Good                           | Bad                              |
+| ---------------------------- | ------------------------------ | -------------------------------- |
+| Lowercase with hyphens       | `tank://guides/code-style`     | `tank://Guides/CodeStyle`        |
+| Descriptive leaf names       | `tank://context/module-map`    | `tank://context/data`            |
+| No file extensions           | `tank://schemas/user-api`      | `tank://schemas/user-api.json`   |
+| Logical grouping             | `tank://guides/commit-format`  | `tank://commit-format`           |
+| Version suffix when needed   | `tank://schemas/api-v2`        | `tank://schemas/api-new`         |
+| Unique within the bundle     | (enforce at validation time)   | Duplicate URIs cause collisions  |
+
+### URI Length
+
+Keep URIs under 80 characters. If the path exceeds this, the naming
+is too granular -- consolidate or restructure.
+
+## Static vs Dynamic Resources
+
+### Static Resources
+
+Content is fixed at package publish time. The adapter reads a bundled file.
+
+```json
+{
+  "kind": "resource",
+  "uri": "tank://context/architecture",
+  "name": "project-architecture"
+}
+```
+
+Characteristics:
+- Deterministic -- same content on every read.
+- No external dependencies -- works offline.
+- Versioned with the package -- changes require a new publish.
+- No permission implications beyond `filesystem.read`.
+
+Best for: architecture maps, style guides, schema references, error
+catalogs, coding standards.
+
+### Dynamic Resources (file://)
+
+Content is read from the local filesystem at runtime. The actual content
+depends on the state of the filesystem when the agent reads it.
+
+```json
+{
+  "kind": "resource",
+  "uri": "file://./generated/api-schema.json",
+  "name": "api-schema"
+}
+```
+
+Characteristics:
+- Content may change between reads.
+- Depends on the file existing at the expected path.
+- Useful for generated artifacts, build output, or project-specific files.
+- Requires `filesystem.read` permission covering the path.
+
+Best for: generated schemas, build artifacts, project-specific configs
+that live outside the package.
+
+### Dynamic Resources (mcp://)
+
+Content is fetched from an MCP server at runtime. The server may compute
+the response dynamically.
+
+```json
+{
+  "kind": "resource",
+  "uri": "mcp://database-server/schema/users",
+  "name": "users-schema"
+}
+```
+
+Characteristics:
+- Content is computed or fetched on demand.
+- Requires a configured and running MCP server.
+- May involve network latency.
+- Requires `network.outbound` if the MCP server is remote.
+
+Best for: live database schemas, API specs from running services,
+real-time configuration.
+
+### Dynamic Resources (https://)
+
+Content is fetched from an HTTP endpoint at runtime.
+
+```json
+{
+  "kind": "resource",
+  "uri": "https://api.internal.example.com/v1/feature-flags",
+  "name": "feature-flags"
+}
+```
+
+Characteristics:
+- Content depends on the remote server state.
+- Requires network access.
+- May be slow or unavailable.
+- Requires `network.outbound` with the hostname.
+
+Best for: feature flags, remote configuration, external API specs that
+change frequently.
+
+### Selection Guide
+
+| Factor                     | Static (`tank://`) | File (`file://`) | MCP (`mcp://`)  | HTTP (`https://`) |
+| -------------------------- | ------------------ | ---------------- | --------------- | ----------------- |
+| Offline support            | Yes                | Yes              | Depends         | No                |
+| Deterministic content      | Yes                | No               | No              | No                |
+| Versioned with package     | Yes                | No               | No              | No                |
+| External dependency        | None               | Filesystem       | MCP server      | HTTP endpoint     |
+| Permission requirement     | None               | `fs.read`        | `network` maybe | `network`         |
+| Latency                    | Zero               | Low              | Variable        | Variable          |
+
+## Composing Resources with Agents
+
+The most powerful pattern in Tank bundles is the **agent + resource combo**.
+An agent atom declares what it does; a resource atom provides the data it
+needs to do it well.
+
+### Composition Pattern
+
+```json
+{
+  "atoms": [
+    {
+      "kind": "resource",
+      "uri": "tank://guides/code-style",
+      "name": "code-style-guide",
+      "description": "TypeScript coding standards for this project"
+    },
+    {
+      "kind": "agent",
+      "name": "style-reviewer",
+      "role": "Review code against the project style guide. Read the code-style-guide resource first, then check each file for violations.",
+      "tools": ["read", "grep"],
+      "readonly": true
+    }
+  ]
+}
+```
+
+The agent's `role` field references the resource by name. The adapter makes
+the resource available to the agent through its configured read mechanism.
+
+### Design Rules for Agent+Resource Combos
+
+| Rule                                         | Rationale                                    |
+| -------------------------------------------- | -------------------------------------------- |
+| Name every resource in a combo               | Agent needs a stable reference               |
+| Describe the resource in the agent's `role`  | Agent knows to read it before acting         |
+| Give the agent `read` tool access            | Required to fetch resource content           |
+| One resource per concern                     | Keeps resources focused and reusable         |
+| Keep the resource under 500 lines            | Larger resources degrade agent performance   |
+
+### Multiple Resources per Agent
+
+An agent can reference multiple resources when its task requires several
+data sources:
+
+```json
+{
+  "atoms": [
+    { "kind": "resource", "uri": "tank://schemas/api-v2", "name": "api-schema" },
+    { "kind": "resource", "uri": "tank://guides/error-codes", "name": "error-catalog" },
+    {
+      "kind": "agent",
+      "name": "api-validator",
+      "role": "Validate API implementations against the api-schema resource. Cross-reference error responses with the error-catalog resource.",
+      "tools": ["read", "grep", "glob"]
+    }
+  ]
+}
+```
+
+Limit to 3 resources per agent. Beyond that, consider splitting into
+multiple agents with focused resource sets.
+
+## Permission Implications
+
+Every URI scheme has a permission footprint. Declare only what the resource
+needs.
+
+### Permission Matrix
+
+| URI Scheme  | Permission Field         | Value Required                  |
+| ----------- | ------------------------ | ------------------------------- |
+| `tank://`   | (none)                   | Bundled content, always allowed |
+| `file://`   | `filesystem.read`        | Path or glob covering the file  |
+| `mcp://`    | `network.outbound`       | Server hostname (if remote)     |
+| `https://`  | `network.outbound`       | `["api.example.com"]`           |
+
+### Minimal Permission Examples
+
+Static resource (no extra permissions):
+```json
+{
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  }
+}
+```
+
+Resource reading a local generated file:
+```json
+{
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["./generated/**", "**/*"], "write": [] },
+    "subprocess": false
+  }
+}
+```
+
+Resource reading from a remote API:
+```json
+{
+  "permissions": {
+    "network": { "outbound": ["api.example.com"] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  }
+}
+```
+
+### Security Considerations
+
+| Risk                              | Mitigation                                       |
+| --------------------------------- | ------------------------------------------------ |
+| Resource URI points to secrets    | Never use `file://` pointing to `.env` or creds  |
+| MCP server returns untrusted data | Validate resource content in the consuming agent  |
+| HTTPS endpoint changes content    | Pin to versioned endpoints, add cache headers     |
+| Overly broad filesystem read      | Scope `filesystem.read` to specific directories   |
+
+## Anti-Patterns
+
+| Anti-Pattern                               | Problem                                    | Fix                                     |
+| ------------------------------------------ | ------------------------------------------ | --------------------------------------- |
+| Instruction for large reference data       | Bloats every prompt with 200+ lines        | Move to a resource atom                 |
+| Resource for critical behavioral rules     | Agent may skip reading it                  | Use an instruction atom                 |
+| Dynamic URI without fallback               | Agent fails if server/file is unavailable  | Provide a static fallback or error msg  |
+| No description on resources in combos      | Agent cannot decide relevance              | Add a clear, concise description        |
+| Bundling secrets in `tank://` resources    | Secrets shipped with the package           | Use `file://` pointing to `.env.local`  |
+| Resource without a consuming agent/hook    | Orphaned data nobody reads                 | Remove or wire a consumer               |

--- a/skills/resource-creator/references/worked-examples.md
+++ b/skills/resource-creator/references/worked-examples.md
@@ -1,0 +1,446 @@
+# Worked Resource Examples
+
+Sources: Tank specification (AGENTS.md), quality-gate bundle reference
+implementation, production bundle patterns
+
+Covers: four complete resource atom examples with full tank.json manifests,
+showing project context resources, style guide resources, config resources,
+and agent+resource combos. Each example includes rationale, the resource
+atom, the full manifest, and usage notes.
+
+## Example 1: Project Context Resource
+
+### Scenario
+
+A monorepo has 50+ packages. Agents working in the repo need to understand
+module boundaries, ownership, and data flow -- but only when navigating
+across modules. Injecting this map into every prompt wastes tokens.
+
+### The Resource File
+
+Create `references/architecture.md` in the bundle:
+
+```markdown
+# Project Architecture
+
+## Module Boundaries
+
+| Module        | Owner       | Purpose                    | Dependencies         |
+| ------------- | ----------- | -------------------------- | -------------------- |
+| @app/api      | backend     | REST API gateway           | @app/db, @app/auth   |
+| @app/web      | frontend    | Next.js web application    | @app/ui, @app/api    |
+| @app/ui       | frontend    | Shared component library   | none                 |
+| @app/db       | backend     | Database models and queries| none                 |
+| @app/auth     | backend     | Authentication service     | @app/db              |
+
+## Data Flow
+
+API requests: @app/web -> @app/api -> @app/auth -> @app/db
+UI components: @app/web imports from @app/ui
+```
+
+### The Resource Atom
+
+```json
+{
+  "kind": "resource",
+  "uri": "tank://context/architecture",
+  "name": "project-architecture",
+  "description": "Module boundaries, ownership, dependencies, and data flow for the monorepo"
+}
+```
+
+### Full tank.json
+
+```json
+{
+  "name": "@tank/monorepo-context",
+  "version": "1.0.0",
+  "description": "Project architecture context for monorepo navigation.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    },
+    {
+      "kind": "resource",
+      "uri": "tank://context/architecture",
+      "name": "project-architecture",
+      "description": "Module boundaries, ownership, dependencies, and data flow for the monorepo"
+    }
+  ]
+}
+```
+
+### Why Resource, Not Instruction
+
+The architecture map is 30+ lines and only relevant when the agent works
+across module boundaries. On single-module tasks (most tasks), it adds
+noise. As a resource, it costs zero tokens until the agent actually needs
+cross-module context.
+
+### Usage Pattern
+
+An agent or instruction references the resource by name. The adapter
+resolves `tank://context/architecture` to the bundled file.
+
+---
+
+## Example 2: Style Guide Resource
+
+### Scenario
+
+A frontend team enforces specific TypeScript and CSS conventions. A code
+reviewer agent needs these conventions as reference material, but other
+agents in the bundle (linters, formatters) do not.
+
+### The Resource File
+
+Create `references/style-guide.md` in the bundle:
+
+```markdown
+# Frontend Style Guide
+
+## TypeScript
+
+- Prefer `interface` over `type` for object shapes.
+- Use `unknown` instead of `any` -- narrow with type guards.
+- Name boolean variables with `is`, `has`, `should` prefixes.
+- Export types separately: `export type { UserProps }`.
+- Maximum function length: 30 lines.
+
+## CSS / Tailwind
+
+- Use semantic color tokens: `text-primary` not `text-blue-600`.
+- Mobile-first: start with `sm:` breakpoints.
+- No arbitrary values in Tailwind: define tokens in `tailwind.config`.
+- Component styles in co-located `.module.css` files.
+
+## Naming
+
+- Components: PascalCase (`UserCard.tsx`).
+- Hooks: camelCase with `use` prefix (`useAuth.ts`).
+- Utils: camelCase (`formatDate.ts`).
+- Constants: SCREAMING_SNAKE (`MAX_RETRIES`).
+```
+
+### The Resource Atom
+
+```json
+{
+  "kind": "resource",
+  "uri": "tank://guides/code-style",
+  "name": "code-style-guide",
+  "description": "TypeScript and CSS/Tailwind conventions for the frontend team"
+}
+```
+
+### Full tank.json
+
+```json
+{
+  "name": "@tank/frontend-standards",
+  "version": "1.0.0",
+  "description": "Frontend coding standards with style-aware code review.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "resource",
+      "uri": "tank://guides/code-style",
+      "name": "code-style-guide",
+      "description": "TypeScript and CSS/Tailwind conventions for the frontend team"
+    },
+    {
+      "kind": "agent",
+      "name": "style-reviewer",
+      "role": "Review modified files for style guide violations. Read the code-style-guide resource first, then check each file against the conventions. Report violations with file, line, and the specific rule broken.",
+      "tools": ["read", "grep", "glob"],
+      "model": "fast",
+      "readonly": true
+    }
+  ]
+}
+```
+
+### Why a Resource+Agent Combo
+
+The style guide is only needed by the reviewer agent, not by every agent
+in the system. Making it a resource means:
+
+1. The reviewer reads it once per review session.
+2. Other agents never load it.
+3. The guide can be updated independently of the reviewer's role prompt.
+
+The agent's `role` explicitly tells it to read the resource first. This
+is the recommended pattern -- do not rely on the agent discovering the
+resource on its own.
+
+---
+
+## Example 3: Config Resource
+
+### Scenario
+
+A deployment bundle needs environment-specific configuration. The config
+varies between staging and production but the bundle logic is identical.
+The config includes feature flags, API endpoints, and rate limits.
+
+### The Resource Atom (Dynamic)
+
+```json
+{
+  "kind": "resource",
+  "uri": "file://./config/environment.json",
+  "name": "env-config",
+  "description": "Environment-specific configuration: feature flags, API endpoints, rate limits"
+}
+```
+
+### The Config File
+
+At `./config/environment.json` in the project (not the package):
+
+```json
+{
+  "environment": "staging",
+  "features": {
+    "dark_mode": true,
+    "beta_api": false,
+    "new_checkout": true
+  },
+  "endpoints": {
+    "api": "https://staging-api.example.com",
+    "auth": "https://staging-auth.example.com"
+  },
+  "limits": {
+    "requests_per_minute": 100,
+    "max_upload_mb": 25
+  }
+}
+```
+
+### Full tank.json
+
+```json
+{
+  "name": "@tank/deploy-config",
+  "version": "1.0.0",
+  "description": "Environment-aware deployment configuration resource.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["./config/**", "**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    },
+    {
+      "kind": "resource",
+      "uri": "file://./config/environment.json",
+      "name": "env-config",
+      "description": "Environment-specific feature flags, API endpoints, and rate limits"
+    }
+  ]
+}
+```
+
+### Why file:// Instead of tank://
+
+The config file lives in the **project**, not the **package**. It changes
+per environment without requiring a new package version. Using `file://`
+means the resource resolves to whatever config is present in the current
+working directory.
+
+### Permission Note
+
+The `filesystem.read` permission explicitly includes `./config/**` to
+cover the config file location. The default `**/*` glob would also match,
+but being explicit documents intent and allows tighter scoping in
+security-sensitive environments.
+
+---
+
+## Example 4: Agent+Resource Combo (API Validator)
+
+### Scenario
+
+A backend team needs automated API contract validation. An agent reads the
+API schema and error code catalog, then validates that new API endpoints
+conform to the contract. This is the most sophisticated resource pattern:
+multiple resources feeding a single specialized agent.
+
+### The Resource Files
+
+`references/api-schema.md`:
+
+```markdown
+# API Schema Contract
+
+## Authentication
+
+All endpoints require Bearer token in Authorization header.
+Rate limit: 100 requests/minute per token.
+
+## Standard Response Envelope
+
+Every response must follow this structure:
+
+{ "data": <payload>, "meta": { "request_id": "<uuid>", "timestamp": "<iso8601>" } }
+
+Error responses:
+
+{ "error": { "code": "<ERROR_CODE>", "message": "<human readable>", "details": {} } }
+
+## Endpoint Conventions
+
+- Resource URLs: plural nouns (`/users`, `/orders`).
+- Actions: POST to `/users/{id}/actions/{action-name}`.
+- Pagination: `?page=1&per_page=20`, response includes `meta.total`.
+- Filtering: `?filter[status]=active&filter[role]=admin`.
+- Sorting: `?sort=-created_at` (prefix `-` for descending).
+```
+
+`references/error-codes.md`:
+
+```markdown
+# Error Code Catalog
+
+## Client Errors (4xx)
+
+| Code              | HTTP Status | Description                    |
+| ----------------- | ----------- | ------------------------------ |
+| AUTH_EXPIRED      | 401         | Token has expired              |
+| AUTH_INVALID      | 401         | Token is malformed or invalid  |
+| FORBIDDEN         | 403         | Valid token, insufficient role  |
+| NOT_FOUND         | 404         | Resource does not exist         |
+| VALIDATION_FAILED | 422         | Request body failed validation  |
+| RATE_LIMITED      | 429         | Too many requests              |
+
+## Server Errors (5xx)
+
+| Code              | HTTP Status | Description                    |
+| ----------------- | ----------- | ------------------------------ |
+| INTERNAL          | 500         | Unexpected server error        |
+| SERVICE_UNAVAILABLE | 503       | Dependency is down             |
+| TIMEOUT           | 504         | Upstream request timed out     |
+```
+
+### The Resource Atoms
+
+```json
+{
+  "kind": "resource",
+  "uri": "tank://schemas/api-contract",
+  "name": "api-schema",
+  "description": "API response envelope, endpoint conventions, pagination, filtering, and sorting standards"
+},
+{
+  "kind": "resource",
+  "uri": "tank://data/error-codes",
+  "name": "error-catalog",
+  "description": "Standard error codes with HTTP status mappings for client and server errors"
+}
+```
+
+### Full tank.json
+
+```json
+{
+  "name": "@tank/api-contract-validator",
+  "version": "1.0.0",
+  "description": "Validate API implementations against schema and error contracts.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "resource",
+      "uri": "tank://schemas/api-contract",
+      "name": "api-schema",
+      "description": "API response envelope, endpoint conventions, pagination, filtering, sorting"
+    },
+    {
+      "kind": "resource",
+      "uri": "tank://data/error-codes",
+      "name": "error-catalog",
+      "description": "Standard error codes with HTTP status mappings"
+    },
+    {
+      "kind": "agent",
+      "name": "api-validator",
+      "role": "Validate API route implementations against the project contract. Read the api-schema resource for endpoint conventions and the error-catalog resource for error code standards. For each route file, check: response envelope structure, error code usage, pagination implementation, and naming conventions. Report violations with file, line, severity (critical/high/medium), and the specific contract rule broken.",
+      "tools": ["read", "grep", "glob"],
+      "model": "balanced",
+      "readonly": true
+    },
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    }
+  ]
+}
+```
+
+### Composition Anatomy
+
+The instruction provides behavioral context (always loaded). The resources
+provide reference data (loaded when the agent reads them). The agent
+orchestrates the validation using both.
+
+### Key Design Decisions
+
+1. **Two resources, not one.** The API schema and error catalog are
+   distinct concerns. Splitting them means a future "error code linter"
+   agent can reuse the error-catalog resource without pulling the full
+   API schema.
+
+2. **Agent references resources by name.** The `role` field explicitly
+   names both resources. This removes ambiguity about which resources
+   the agent should read.
+
+3. **readonly: true.** The validator only reads and reports -- it does
+   not modify files. This permission constraint is enforced by the
+   adapter.
+
+4. **model: balanced.** Schema validation requires reasoning about
+   structure, not just pattern matching. The `fast` tier would miss
+   subtle contract violations.
+
+## Pattern Summary
+
+| Example               | Resource Scheme | Agent Combo | Key Pattern                     |
+| --------------------- | --------------- | ----------- | ------------------------------- |
+| Project Context       | `tank://`       | No          | Standalone reference data       |
+| Style Guide           | `tank://`       | Yes         | Single resource + reviewer      |
+| Config                | `file://`       | No          | Dynamic environment data        |
+| API Validator         | `tank://`       | Yes         | Multiple resources + validator  |
+
+## Checklist for New Resources
+
+| Check                                           | Required |
+| ----------------------------------------------- | -------- |
+| Content fits resource (not instruction) model   | Yes      |
+| URI follows naming conventions                  | Yes      |
+| URI scheme matches data location                | Yes      |
+| `name` set if referenced by agent/hook          | Yes      |
+| `description` set if multiple resources exist   | Yes      |
+| Permissions cover the URI scheme access pattern  | Yes      |
+| A consuming agent or hook exists                | Yes      |
+| Resource content under 500 lines                | Yes      |

--- a/skills/resource-creator/tank.json
+++ b/skills/resource-creator/tank.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tank/resource-creator",
+  "version": "1.0.0",
+  "description": "Author Tank resource atoms -- URI-addressable data or context that agents can read on demand. Covers the resource atom schema, URI schemes, static vs dynamic resources, resource vs instruction selection, and agent+resource composition. Triggers: create resource, resource atom, tank resource, uri resource, context resource, agent context, readable resource.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/skills/rule-creator/SKILL.md
+++ b/skills/rule-creator/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: "@tank/rule-creator"
+description: |
+  Author Tank rule atoms -- declarative, machine-enforced validation constraints
+  that block, allow, or warn on agent behavior at any lifecycle event. Covers the
+  rule atom schema (event, policy, reason, match, extensions), policy design
+  (block vs warn vs allow, ordering, precedence, false-positive mitigation),
+  composing rule sets inside multi-atom bundles, and worked examples for safety,
+  code-style, tool-gating, and combined rule+instruction patterns.
+  Synthesizes Tank specification (AGENTS.md), policy-as-code patterns (OPA/Rego,
+  Sentinel), and production rule bundle analysis.
+
+  Trigger phrases: "create rule", "tank rule atom", "rule atom", "block policy",
+  "warn policy", "allow policy", "safety rule", "enforce rule", "validation rule",
+  "guard rule", "write a rule", "rule bundle", "policy set", "pre-command rule",
+  "pre-tool-use rule", "block rm -rf", "block destructive", "code style rule"
+---
+
+# Rule Creator
+
+Author declarative rule atoms that enforce constraints on agent behavior
+without writing code. Rules are data, not logic -- the runtime evaluates them.
+
+## Core Philosophy
+
+1. **Rules are data, hooks are code** -- A rule declares "block X when Y" as
+   a JSON object. A hook executes arbitrary TypeScript. Prefer rules for
+   anything expressible as a match-and-act pair. Reach for hooks only when
+   rules lack the expressiveness.
+2. **Block is a last resort** -- Blocking halts the agent. Use `warn` for
+   guidance, `allow` for explicit permission, `block` only for genuinely
+   dangerous operations. Over-blocking creates a useless agent.
+3. **Reason is not optional** -- Every rule must include a `reason` field
+   explaining *why* the constraint exists. The agent reads reasons to adjust
+   behavior before hitting the wall.
+4. **Compose, don't monolith** -- Ship rule sets as arrays inside a bundle's
+   `atoms`. Each rule targets one concern. Ten focused rules beat one
+   mega-rule with complex match logic.
+5. **Test by triggering** -- Verify a rule works by deliberately triggering
+   its condition. A rule you have never seen fire is a rule you cannot trust.
+
+## Quick-Start: Common Problems
+
+### "Block a dangerous shell command"
+
+1. Create a multi-atom bundle under `bundles/`
+2. Add a `kind: "rule"` atom with `event: "pre-command"`
+3. Set `policy: "block"`, add `match` and `reason`
+   -> See `references/rule-atom-anatomy.md` for field schema
+   -> See `references/worked-examples.md` for `rm -rf` example
+
+### "Warn when agent writes bad patterns"
+
+1. Add a `kind: "rule"` atom with `event: "post-file-write"`
+2. Set `policy: "warn"`, match against the pattern (e.g., `as any`)
+3. Pair with an instruction atom explaining the preferred alternative
+   -> See `references/policy-design.md` for warn vs block guidance
+   -> See `references/worked-examples.md` for `as any` example
+
+### "Restrict which tools the agent can use"
+
+1. Add a `kind: "rule"` atom with `event: "pre-tool-use"`
+2. Set `policy: "allow"` with a `match` on the approved tool list
+3. Add a second rule with `policy: "block"` as a catch-all deny
+   -> See `references/worked-examples.md` for allow-list example
+
+### "Ship a complete policy set"
+
+1. Create a `bundles/{name}/` directory
+2. Add an `atoms` array with multiple rule atoms + an instruction atom
+3. The instruction explains the rationale; rules enforce it
+   -> See `references/policy-design.md` for composition patterns
+   -> See `references/worked-examples.md` for combined bundle example
+
+## Decision Trees
+
+### Policy Selection
+
+| Signal                                    | Policy  | Rationale                              |
+| ----------------------------------------- | ------- | -------------------------------------- |
+| Data loss, credential leak, system damage | `block` | Irreversible harm, stop immediately    |
+| Code smell, style violation, minor risk   | `warn`  | Educate without halting                |
+| Known-safe operation in a restricted set  | `allow` | Explicit permission overrides defaults |
+
+### Event Selection
+
+| Constraint target      | Event                | Category |
+| ---------------------- | -------------------- | -------- |
+| Shell command content   | `pre-command`        | Shell    |
+| Tool invocation         | `pre-tool-use`       | Tool     |
+| File content after save | `post-file-write`    | File     |
+| File content before save| `pre-file-write`     | File     |
+| MCP tool call           | `pre-mcp-tool-use`   | MCP      |
+| Agent finishing work    | `pre-stop`           | Stop     |
+| Agent response          | `post-response`      | Convo    |
+
+### Rule vs Hook
+
+| Need                                        | Use   |
+| ------------------------------------------- | ----- |
+| Match string/pattern, act with fixed policy | Rule  |
+| Conditional logic, external API calls       | Hook  |
+| Multiple rules composing a policy set       | Rules |
+| Dynamic rewriting of commands/content       | Hook  |
+| Simple block/warn/allow on a known pattern  | Rule  |
+
+## Atom Schema Quick Reference
+
+```json
+{
+  "kind": "rule",
+  "event": "pre-command",
+  "policy": "block",
+  "match": "rm -rf",
+  "reason": "Destructive file deletion is not permitted",
+  "extensions": {}
+}
+```
+
+Required: `kind`, `event`, `policy`. Strongly recommended: `reason`.
+Optional: `match`, `name`, `extensions`.
+
+-> See `references/rule-atom-anatomy.md` for complete field reference.
+
+## Reference Index
+
+| File                               | Contents                                         |
+| ---------------------------------- | ------------------------------------------------ |
+| `references/rule-atom-anatomy.md`  | Full rule atom schema, fields, types, events     |
+| `references/policy-design.md`      | Policy strategy, composition, precedence, safety |
+| `references/worked-examples.md`    | 4+ complete rule examples with tank.json context |

--- a/skills/rule-creator/references/policy-design.md
+++ b/skills/rule-creator/references/policy-design.md
@@ -1,0 +1,284 @@
+# Policy Design
+
+Sources: Tank specification (AGENTS.md), OPA best practices (Styra), HashiCorp Sentinel
+policy-as-code patterns, AWS Service Control Policies, Zero Trust architecture principles
+
+Covers: designing effective rule policies -- when to block vs warn vs allow, composing
+multiple rules into policy sets, ordering and precedence, false positive mitigation,
+user escape hatches, and the relationship between rules and instructions.
+
+## The Policy Spectrum
+
+Every rule enforces a position on the restriction spectrum:
+
+```
+PERMISSIVE                                                    RESTRICTIVE
+   |                                                               |
+   allow-list     warn on smell     warn on risk     block danger  block all
+   (explicit      (advisory,        (strong          (hard stop,   (lockdown,
+    green-light)   proceed ok)       nudge)           must reroute) deny-by-default)
+```
+
+Position rules according to the severity of the consequence if the agent proceeds.
+
+## When to Block
+
+Block when the operation causes irreversible harm or violates a hard security boundary.
+
+| Signal                                       | Example                            |
+| -------------------------------------------- | ---------------------------------- |
+| Data destruction without backup              | `rm -rf`, `DROP TABLE`, `--force`  |
+| Credential or secret exposure                | Writing `.env` to stdout, logs     |
+| Production system mutation from dev context  | `kubectl delete` in prod namespace |
+| Compliance violation (legal, regulatory)     | PII in logs, unencrypted storage   |
+| Dependency on external irreversible action   | Sending emails, publishing packages|
+
+### Block rules: design principles
+
+1. **Narrow the match** -- Block `rm -rf /` not `rm`. Block `git push --force origin main`
+   not `git push`. Over-broad matches create false positives that erode trust.
+2. **Offer an alternative in the reason** -- "Use `trash-cli` instead of `rm -rf`" gives
+   the agent a path forward. A block without an alternative is a dead end.
+3. **Pair with an instruction atom** -- The instruction explains *why* the rule exists
+   and describes the approved workflow. The rule enforces; the instruction educates.
+
+## When to Warn
+
+Warn when the operation is suboptimal but not dangerous. The agent should know
+about the concern and may choose to proceed.
+
+| Signal                                       | Example                            |
+| -------------------------------------------- | ---------------------------------- |
+| Code quality issue                           | `as any`, `eslint-disable`, `TODO` |
+| Deprecated API usage                         | Old library imports, legacy syntax |
+| Performance concern                          | N+1 queries, unbounded loops       |
+| Style deviation from project standards       | Wrong naming convention            |
+| Potential security weakness (not critical)   | Missing input validation           |
+
+### Warn rules: design principles
+
+1. **Be specific about the problem** -- "Using `as any` bypasses TypeScript safety --
+   prefer a proper type assertion or generic" teaches more than "Bad practice."
+2. **Accept that warnings get overridden** -- Warnings are advisory. If the agent
+   proceeds, that is by design. If the constraint must be enforced, escalate to block.
+3. **Batch related warnings** -- Five warnings for the same pattern in one file
+   overwhelm the agent. Consider one rule with a broader match over many narrow ones.
+
+## When to Allow
+
+Allow when operating inside a restricted policy set and specific operations need
+explicit permission. Allow-list patterns require a default-deny (block) rule.
+
+| Signal                                       | Example                            |
+| -------------------------------------------- | ---------------------------------- |
+| Known-safe tool in a restricted environment  | `read`, `grep` in audit-only mode |
+| Approved command in a locked-down shell      | `ls`, `cat` when shell is limited  |
+| Exemption from a broader block               | Allow `rm` for temp files only     |
+
+### Allow rules: design principles
+
+1. **Always pair with a catch-all block** -- An allow rule without a default deny
+   is meaningless. The pattern is: specific allows + one broad block.
+2. **Document what is allowed, not just what is blocked** -- Users reading the
+   policy should understand the positive intent, not just the restrictions.
+3. **Keep the allow-list minimal** -- Every allowed operation is an attack surface.
+   Start with zero and add permissions as justified.
+
+## Composing Rule Sets
+
+### Multiple rules in one bundle
+
+A bundle's `atoms` array can contain any number of rule atoms. Each rule is
+independent -- the runtime evaluates all rules bound to the triggering event.
+
+```json
+{
+  "atoms": [
+    { "kind": "rule", "event": "pre-command", "policy": "block", "match": "rm -rf", "reason": "..." },
+    { "kind": "rule", "event": "pre-command", "policy": "block", "match": "chmod 777", "reason": "..." },
+    { "kind": "rule", "event": "pre-command", "policy": "warn", "match": "sudo", "reason": "..." },
+    { "kind": "rule", "event": "pre-tool-use", "policy": "block", "match": "browser", "reason": "..." },
+    { "kind": "instruction", "content": "./SKILL.md" }
+  ]
+}
+```
+
+### Policy set design patterns
+
+#### Pattern 1: Safety net
+
+Block a handful of known-dangerous operations. Everything else is allowed.
+
+```
+Rules: 3-5 block rules on pre-command
+Instruction: explains what is blocked and why
+Default: permissive (agent can do anything not blocked)
+```
+
+Best for: general-purpose safety in any project.
+
+#### Pattern 2: Allow-list (zero trust)
+
+Block everything by default. Allow only approved operations.
+
+```
+Rules: N allow rules for specific tools/commands + 1 catch-all block
+Instruction: explains the approved workflow
+Default: restrictive (agent can only do what is explicitly allowed)
+```
+
+Best for: sensitive environments, compliance-heavy projects.
+
+#### Pattern 3: Style guide enforcement
+
+Warn on patterns that violate project standards. No blocking.
+
+```
+Rules: 5-15 warn rules on post-file-write
+Instruction: explains the style guide and preferred patterns
+Default: permissive with guidance
+```
+
+Best for: code quality, consistency, onboarding new agents to a codebase.
+
+#### Pattern 4: Layered defense
+
+Combine block rules for safety, warn rules for quality, and an instruction
+for education.
+
+```
+Rules: 2-3 block rules (safety) + 5-10 warn rules (quality)
+Instruction: comprehensive policy explanation
+Default: mixed -- hard limits on danger, soft guidance on quality
+```
+
+Best for: mature projects with established standards.
+
+## Precedence and Ordering
+
+### Evaluation model
+
+When an event fires, the runtime collects all rules bound to that event and
+evaluates them. The evaluation follows this precedence:
+
+1. **Block wins over warn** -- If any rule blocks, the operation is blocked
+   regardless of other rules that warn or allow.
+2. **Allow exempts from block** -- An allow rule with a more specific match
+   can exempt an operation from a broader block rule.
+3. **Warn accumulates** -- Multiple warn rules can all fire. The agent sees
+   all warnings.
+
+### Specificity determines exemption
+
+When an allow rule and a block rule both match:
+
+```json
+{ "kind": "rule", "event": "pre-tool-use", "policy": "block", "reason": "No tools by default" },
+{ "kind": "rule", "event": "pre-tool-use", "policy": "allow", "match": "read", "reason": "Read is safe" }
+```
+
+The runtime treats the allow with a `match` as more specific than the block
+without one. The `read` tool is permitted; all others are blocked.
+
+### Array order is not precedence
+
+Rule evaluation order is determined by specificity and policy weight, not by
+position in the `atoms` array. Place rules in logical reading order for humans
+but do not rely on array index for enforcement behavior.
+
+## False Positive Mitigation
+
+False positives -- rules that fire incorrectly -- are the primary risk of
+rule-based policies. They erode agent trust and developer patience.
+
+### Prevention strategies
+
+| Strategy                          | Implementation                              |
+| --------------------------------- | ------------------------------------------- |
+| Narrow match patterns             | `rm -rf /` not `rm`                         |
+| Test before shipping              | Trigger the rule deliberately                |
+| Use warn before block             | Deploy as warn, observe, escalate to block   |
+| Combine with instruction context  | Agent understands the rule's intent          |
+| Provide escape in reason          | "If this is intentional, use --force flag"   |
+
+### Progressive enforcement
+
+Start all new rules as `warn`. Observe how often they fire and whether the
+triggers are correct. After validation, escalate critical rules to `block`.
+
+```
+Week 1: Deploy as warn, monitor triggers
+Week 2: Review false positive rate
+Week 3: Escalate validated rules to block
+Week 4: Remove or adjust rules with high false positive rates
+```
+
+## Escape Hatches
+
+Sometimes the agent legitimately needs to do something a rule blocks. Design
+for this:
+
+1. **Reason field as guidance** -- Include the approved alternative in the reason.
+   "Blocked: use `trash` instead of `rm -rf`" gives a path forward.
+2. **Allow-list exemptions** -- Add a specific allow rule for the justified case.
+3. **Instruction context** -- The paired instruction atom can describe conditions
+   under which the rule can be reconsidered.
+4. **Extension overrides** -- Platform-specific extensions can soften enforcement
+   for certain environments (e.g., CI vs local).
+
+Do NOT design rules that can be bypassed by the agent rephrasing its request.
+If a block can be circumvented by rewording, the match pattern is too narrow.
+
+## Rules + Instructions: The Complete Pattern
+
+Rules enforce. Instructions educate. Ship both.
+
+A rule alone tells the agent "no" but not "why" or "what instead." An instruction
+alone hopes the agent follows guidance but cannot enforce it. Together they form
+a complete policy.
+
+```json
+{
+  "atoms": [
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    },
+    {
+      "kind": "rule",
+      "event": "pre-command",
+      "policy": "block",
+      "match": "rm -rf",
+      "reason": "Use trash-cli for safe deletion. See SKILL.md for approved file operations."
+    }
+  ]
+}
+```
+
+The instruction (`SKILL.md`) explains the project's file operation policy, lists
+approved tools, and describes the rationale. The rule enforces the hard limit.
+
+## Anti-Patterns
+
+| Anti-pattern                  | Problem                                    | Fix                          |
+| ----------------------------- | ------------------------------------------ | ---------------------------- |
+| Block without reason          | Agent has no path forward                  | Add actionable reason        |
+| Over-broad match              | Blocks legitimate operations               | Narrow the pattern           |
+| All-block, no-allow           | Agent is paralyzed                         | Add explicit allow rules     |
+| Warn for critical safety      | Agent ignores and proceeds                 | Escalate to block            |
+| Rule without instruction      | Agent cannot learn the policy              | Add instruction atom         |
+| Duplicate rules               | Confusing, hard to maintain                | Consolidate into one         |
+| Regex in match                | Portability risk across adapters           | Use simple substring matches |
+
+## Checklist: Designing a Policy Set
+
+- [ ] Identified all dangerous operations (block candidates)
+- [ ] Identified all suboptimal patterns (warn candidates)
+- [ ] Determined default posture (permissive or restrictive)
+- [ ] Each rule has a clear, actionable `reason`
+- [ ] Block rules offer alternatives
+- [ ] Match patterns are narrow enough to avoid false positives
+- [ ] Rules are paired with an instruction atom
+- [ ] Tested each rule by deliberately triggering its condition
+- [ ] Reviewed for over-restriction (agent must remain useful)
+- [ ] Rules live in a `bundles/` directory (multi-atom format)

--- a/skills/rule-creator/references/rule-atom-anatomy.md
+++ b/skills/rule-creator/references/rule-atom-anatomy.md
@@ -1,0 +1,278 @@
+# Rule Atom Anatomy
+
+Sources: Tank specification (AGENTS.md), OPA/Rego policy language, Sentinel (HashiCorp), AWS SCPs
+
+Covers: the complete `kind: "rule"` atom schema -- every field, its type, constraints, and
+relationship to the Tank lifecycle event system.
+
+## What a Rule Atom Is
+
+A rule atom is a declarative JSON object inside a `tank.json` `atoms` array. It expresses
+a single validation constraint: "at this lifecycle point, if this condition matches,
+apply this policy." The Tank runtime evaluates rules -- no code executes. Rules are
+the declarative counterpart to hook atoms.
+
+```json
+{
+  "kind": "rule",
+  "event": "pre-command",
+  "policy": "block",
+  "match": "rm -rf",
+  "reason": "Destructive file deletion is prohibited in this project"
+}
+```
+
+## Required Fields
+
+### `kind`
+
+Always the literal string `"rule"`. Identifies this atom as a machine-enforced
+validation constraint.
+
+```json
+"kind": "rule"
+```
+
+### `event`
+
+The canonical lifecycle event this rule binds to. The rule fires when the runtime
+reaches this event. Use events from the Tank canonical event table.
+
+```json
+"event": "pre-command"
+```
+
+Rules bind to events identically to hooks. The difference: hooks execute handler
+code; rules evaluate a policy decision from data.
+
+### `policy`
+
+The enforcement action. One of three values:
+
+| Policy  | Behavior                                         | Agent impact              |
+| ------- | ------------------------------------------------ | ------------------------- |
+| `block` | Halt the operation. The agent cannot proceed.    | Hard stop, must reroute   |
+| `warn`  | Surface the reason. The agent may continue.      | Soft guidance, no halt    |
+| `allow` | Explicitly permit. Overrides broader restrictions.| Green-light signal        |
+
+```json
+"policy": "block"
+```
+
+#### Policy semantics
+
+- **block**: The runtime prevents the triggering action from executing. The agent
+  receives the `reason` and must find an alternative. Use for irreversible or
+  dangerous operations.
+- **warn**: The runtime surfaces the `reason` to the agent as advisory context.
+  The operation proceeds. Use for code quality, style, and soft constraints.
+- **allow**: The runtime explicitly permits the operation. Useful in allow-list
+  patterns where a catch-all block exists and specific operations are exempted.
+
+## Strongly Recommended Fields
+
+### `reason`
+
+A human-readable string explaining why the rule exists. The agent reads this.
+Write it as an instruction the agent can act on.
+
+```json
+"reason": "Use structured error handling instead of bare try/catch with no action"
+```
+
+Good reasons:
+- Explain the risk: "Credential files must not be committed to version control"
+- Suggest an alternative: "Use `trash` CLI instead of `rm -rf` for safe deletion"
+- Reference a standard: "Violates project TypeScript strict mode -- no `as any` casts"
+
+Bad reasons:
+- Vague: "Not allowed"
+- Accusatory: "You should know better"
+- Missing: (omitted entirely)
+
+## Optional Fields
+
+### `match`
+
+A string or pattern the runtime checks against the event payload. The matching
+semantics depend on the adapter (substring, glob, regex). Keep patterns simple
+and portable.
+
+```json
+"match": "rm -rf"
+```
+
+Match targets by event type:
+
+| Event              | Match target                              |
+| ------------------ | ----------------------------------------- |
+| `pre-command`      | The shell command string                  |
+| `post-command`     | The shell command string                  |
+| `pre-tool-use`     | The tool name (canonical or custom)       |
+| `post-tool-use`    | The tool name                             |
+| `pre-file-write`   | The file path or content                  |
+| `post-file-write`  | The file path or content                  |
+| `pre-file-read`    | The file path                             |
+| `pre-mcp-tool-use` | The MCP tool name                         |
+| `pre-stop`         | (no match target -- fires unconditionally)|
+
+When `match` is omitted, the rule fires unconditionally for every occurrence
+of the bound event.
+
+### `name`
+
+An optional identifier for the rule. Useful for logging, debugging, and
+referencing specific rules in documentation.
+
+```json
+"name": "no-force-push"
+```
+
+### `extensions`
+
+Platform-specific overrides. Adapters translate generic rule semantics into
+platform-native enforcement. Extensions are passed through without validation.
+
+```json
+"extensions": {
+  "cursor": { "severity": "error" },
+  "opencode": { "scope": "project" }
+}
+```
+
+## Complete Field Reference
+
+| Field        | Required | Type   | Values / Constraints                    |
+| ------------ | -------- | ------ | --------------------------------------- |
+| `kind`       | Yes      | string | `"rule"` (literal)                      |
+| `event`      | Yes      | string | Any canonical event from Tank spec      |
+| `policy`     | Yes      | string | `"block"`, `"warn"`, `"allow"`          |
+| `reason`     | No*      | string | Human-readable explanation              |
+| `match`      | No       | string | Pattern matched against event payload   |
+| `name`       | No       | string | Identifier for logging/debugging        |
+| `extensions` | No       | object | Platform-specific overrides             |
+
+*Strongly recommended. Omitting `reason` produces rules the agent cannot learn from.
+
+## Canonical Events Rules Can Bind To
+
+Rules can bind to any canonical event. The most common bindings:
+
+### Shell events
+
+| Event          | Fires when                    | Typical use                  |
+| -------------- | ----------------------------- | ---------------------------- |
+| `pre-command`  | Before a shell command runs   | Block dangerous commands     |
+| `post-command` | After a shell command returns | Audit command history        |
+
+### Tool events
+
+| Event          | Fires when                    | Typical use                  |
+| -------------- | ----------------------------- | ---------------------------- |
+| `pre-tool-use` | Before any tool invocation    | Tool allow-lists, deny-lists |
+| `post-tool-use`| After a tool returns          | Output validation            |
+
+### File events
+
+| Event              | Fires when                    | Typical use                |
+| ------------------ | ----------------------------- | -------------------------- |
+| `pre-file-write`   | Before a file is written      | Block writes to protected paths |
+| `post-file-write`  | After a file is written       | Content quality checks     |
+| `pre-file-read`    | Before a file is read         | Sensitive file access control |
+
+### MCP events
+
+| Event               | Fires when                   | Typical use               |
+| ------------------- | ---------------------------- | ------------------------- |
+| `pre-mcp-tool-use`  | Before an MCP tool call      | MCP tool restrictions     |
+| `post-mcp-tool-use` | After an MCP tool returns    | Response validation       |
+
+### Session and stop events
+
+| Event          | Fires when                    | Typical use                  |
+| -------------- | ----------------------------- | ---------------------------- |
+| `pre-stop`     | Agent attempts to stop        | Final quality gates          |
+| `session-idle` | Session goes idle             | Timeout warnings             |
+
+### Conversation events
+
+| Event           | Fires when                    | Typical use                 |
+| --------------- | ----------------------------- | --------------------------- |
+| `post-response` | After the agent responds      | Output content policies     |
+| `pre-user-prompt`| Before user input is processed| Input sanitization rules   |
+
+## Minimal Valid Rule
+
+The absolute minimum:
+
+```json
+{
+  "kind": "rule",
+  "event": "pre-command",
+  "policy": "block"
+}
+```
+
+This blocks every shell command unconditionally. Not useful, but valid.
+
+## Recommended Minimal Rule
+
+Include `match` and `reason` for a rule that actually works:
+
+```json
+{
+  "kind": "rule",
+  "event": "pre-command",
+  "policy": "block",
+  "match": "rm -rf /",
+  "reason": "Root filesystem deletion is catastrophic and irreversible"
+}
+```
+
+## Rule vs Hook Decision
+
+| Characteristic         | Rule                        | Hook                         |
+| ---------------------- | --------------------------- | ---------------------------- |
+| Expressed as           | JSON data                   | TypeScript/JavaScript code   |
+| Complexity             | Match + policy              | Arbitrary logic              |
+| Composability          | Array of atoms              | Single handler per event     |
+| Portability            | Cross-platform (adapters)   | Platform-dependent runtime   |
+| Debugging              | Inspect JSON                | Debug code execution         |
+| Dynamic conditions     | Not supported               | Full language access         |
+| External API calls     | Not supported               | Supported                    |
+| State management       | Stateless                   | Can maintain state           |
+
+Choose rules when the constraint is expressible as "if X matches, then Y."
+Choose hooks when the constraint requires logic, conditionals, or side effects.
+
+## Placement in tank.json
+
+Rules live inside the `atoms` array alongside other atom kinds:
+
+```json
+{
+  "name": "@tank/my-safety-rules",
+  "version": "1.0.0",
+  "atoms": [
+    { "kind": "instruction", "content": "./SKILL.md" },
+    { "kind": "rule", "event": "pre-command", "policy": "block", "match": "rm -rf", "reason": "..." },
+    { "kind": "rule", "event": "pre-tool-use", "policy": "warn", "match": "bash", "reason": "..." }
+  ]
+}
+```
+
+Order within the array does not determine evaluation order. The runtime evaluates
+all rules bound to a given event. See `references/policy-design.md` for
+precedence and composition patterns.
+
+## Validation Checklist
+
+Before publishing a rule atom:
+
+- [ ] `kind` is exactly `"rule"`
+- [ ] `event` is a valid canonical event from the Tank spec
+- [ ] `policy` is one of `"block"`, `"warn"`, `"allow"`
+- [ ] `reason` is present and actionable
+- [ ] `match` targets the correct payload for the bound event
+- [ ] Rule is testable -- you can deliberately trigger the condition
+- [ ] Rule lives inside a multi-atom bundle (bundles/, not skills/)

--- a/skills/rule-creator/references/worked-examples.md
+++ b/skills/rule-creator/references/worked-examples.md
@@ -1,0 +1,408 @@
+# Worked Examples
+
+Sources: Tank specification (AGENTS.md), production rule bundle patterns, OPA policy
+examples, AWS SCP examples
+
+Covers: four complete rule examples with full `tank.json` context -- a safety rule
+blocking destructive commands, a code-style rule warning on bad patterns, an allow-list
+rule restricting tool access, and a combined rule+instruction bundle.
+
+## Example 1: Safety Rule -- Block Destructive Commands
+
+### Problem
+
+An agent running shell commands could accidentally delete critical files, force-push
+to main, or drop database tables. These operations are irreversible.
+
+### Design decisions
+
+- **Event**: `pre-command` -- intercept before the command executes
+- **Policy**: `block` -- irreversible harm justifies hard stop
+- **Match**: target specific dangerous patterns, not broad categories
+- **Reason**: explain the risk and suggest an alternative
+
+### tank.json
+
+```json
+{
+  "name": "@tank/safety-net",
+  "version": "1.0.0",
+  "description": "Block destructive shell commands. Prevents rm -rf, force push to main, and database drops.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    },
+    {
+      "kind": "rule",
+      "name": "no-rm-rf",
+      "event": "pre-command",
+      "policy": "block",
+      "match": "rm -rf",
+      "reason": "Recursive forced deletion is irreversible. Use trash-cli (`trash <path>`) for safe deletion, or remove specific files with `rm <file>` (no -rf)."
+    },
+    {
+      "kind": "rule",
+      "name": "no-force-push-main",
+      "event": "pre-command",
+      "policy": "block",
+      "match": "push --force origin main",
+      "reason": "Force-pushing to main rewrites shared history. Use `git push --force-with-lease` on feature branches only."
+    },
+    {
+      "kind": "rule",
+      "name": "no-drop-table",
+      "event": "pre-command",
+      "policy": "block",
+      "match": "DROP TABLE",
+      "reason": "Dropping tables is irreversible in production. Use migrations with rollback support instead."
+    },
+    {
+      "kind": "rule",
+      "name": "no-chmod-777",
+      "event": "pre-command",
+      "policy": "block",
+      "match": "chmod 777",
+      "reason": "World-writable permissions are a security vulnerability. Use specific permissions: chmod 755 for directories, chmod 644 for files."
+    }
+  ]
+}
+```
+
+### Supporting SKILL.md (excerpt)
+
+```markdown
+# Safety Net
+
+This bundle blocks destructive shell commands that could cause irreversible harm.
+
+## Blocked Operations
+
+| Command pattern      | Risk                        | Safe alternative              |
+| -------------------- | --------------------------- | ----------------------------- |
+| `rm -rf`             | Recursive deletion          | `trash <path>` (trash-cli)    |
+| `push --force main`  | History rewrite on main     | `push --force-with-lease`     |
+| `DROP TABLE`         | Permanent data loss         | Migration with rollback       |
+| `chmod 777`          | World-writable permissions  | `chmod 755` or `chmod 644`    |
+
+## Approved File Operations
+
+- Delete single files: `rm <file>` (without -rf)
+- Delete directories safely: `trash <directory>`
+- Remove empty directories: `rmdir <directory>`
+```
+
+### Key takeaways
+
+- Each rule targets one specific pattern -- not a broad category
+- Reasons include the *why* (risk) and the *what instead* (alternative)
+- The instruction atom provides a complete reference the agent can consult
+- Four rules compose into a coherent safety policy
+
+## Example 2: Code Style Rule -- Warn on `as any`
+
+### Problem
+
+A TypeScript project enforces strict typing. The agent should avoid `as any`
+casts, but occasionally they are justified (e.g., third-party library gaps).
+A block would be too aggressive; a warning educates without halting.
+
+### Design decisions
+
+- **Event**: `post-file-write` -- check content after the file is saved
+- **Policy**: `warn` -- typing shortcuts are suboptimal but not dangerous
+- **Match**: `as any` -- the specific TypeScript anti-pattern
+- **Reason**: explain why it matters and what to do instead
+
+### tank.json
+
+```json
+{
+  "name": "@tank/typescript-strict",
+  "version": "1.0.0",
+  "description": "Warn on TypeScript anti-patterns in written files. Catches as-any casts, eslint-disable comments, and bare catch blocks.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    },
+    {
+      "kind": "rule",
+      "name": "no-as-any",
+      "event": "post-file-write",
+      "policy": "warn",
+      "match": "as any",
+      "reason": "Avoid `as any` -- it disables TypeScript safety. Use a proper type, generic, or `unknown` with a type guard. If unavoidable, add a // eslint-disable-next-line comment with justification."
+    },
+    {
+      "kind": "rule",
+      "name": "no-eslint-disable-blanket",
+      "event": "post-file-write",
+      "policy": "warn",
+      "match": "eslint-disable ",
+      "reason": "Blanket eslint-disable disables all rules for the file. Use eslint-disable-next-line with a specific rule name instead."
+    },
+    {
+      "kind": "rule",
+      "name": "no-bare-catch",
+      "event": "post-file-write",
+      "policy": "warn",
+      "match": "catch (e) {}",
+      "reason": "Empty catch blocks silently swallow errors. Log the error, rethrow, or handle it explicitly."
+    }
+  ]
+}
+```
+
+### Key takeaways
+
+- `warn` policy is appropriate because these are quality concerns, not safety risks
+- Matching `post-file-write` catches the pattern after the agent writes code
+- Each reason suggests a concrete alternative
+- The match `eslint-disable ` (with trailing space) avoids matching `eslint-disable-next-line`
+
+## Example 3: Allow-List Rule -- Restrict Tool Access
+
+### Problem
+
+A read-only audit agent should only use `read`, `grep`, and `glob`. All other
+tools -- especially `write`, `edit`, `bash` -- must be blocked. This requires
+an allow-list pattern with a default-deny.
+
+### Design decisions
+
+- **Event**: `pre-tool-use` -- intercept before any tool invocation
+- **Policy**: `allow` for approved tools, `block` as catch-all deny
+- **Match**: canonical tool names from the Tank spec
+- **Reason**: explain the audit-only restriction
+
+### tank.json
+
+```json
+{
+  "name": "@tank/audit-only",
+  "version": "1.0.0",
+  "description": "Restrict agent to read-only tools. Blocks write, edit, bash, and all other tools except read, grep, and glob.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    },
+    {
+      "kind": "rule",
+      "name": "allow-read",
+      "event": "pre-tool-use",
+      "policy": "allow",
+      "match": "read",
+      "reason": "Read is approved for audit operations"
+    },
+    {
+      "kind": "rule",
+      "name": "allow-grep",
+      "event": "pre-tool-use",
+      "policy": "allow",
+      "match": "grep",
+      "reason": "Grep is approved for audit operations"
+    },
+    {
+      "kind": "rule",
+      "name": "allow-glob",
+      "event": "pre-tool-use",
+      "policy": "allow",
+      "match": "glob",
+      "reason": "Glob is approved for audit operations"
+    },
+    {
+      "kind": "rule",
+      "name": "allow-lsp",
+      "event": "pre-tool-use",
+      "policy": "allow",
+      "match": "lsp",
+      "reason": "LSP is approved for code navigation during audit"
+    },
+    {
+      "kind": "rule",
+      "name": "deny-all-other-tools",
+      "event": "pre-tool-use",
+      "policy": "block",
+      "reason": "This agent operates in audit-only mode. Only read, grep, glob, and lsp tools are permitted. Do not attempt to modify files, run commands, or use other tools."
+    }
+  ]
+}
+```
+
+### How the allow-list works
+
+1. Agent invokes `read` -- matches `allow-read` rule, operation proceeds
+2. Agent invokes `bash` -- no allow rule matches, hits `deny-all-other-tools`, blocked
+3. Agent invokes `write` -- no allow rule matches, hits catch-all block, blocked
+
+The catch-all block rule has no `match` field, so it fires for every `pre-tool-use`
+event. The specific allow rules override it for approved tools because they have
+more specific matches.
+
+### Key takeaways
+
+- Allow-list requires explicit allow rules + a catch-all block
+- The catch-all block has no `match` -- it catches everything
+- Allow rules use canonical tool names from the Tank spec
+- The catch-all reason explains the restriction and sets expectations
+
+## Example 4: Combined Bundle -- Safety + Style + Education
+
+### Problem
+
+A team wants a comprehensive policy for their Node.js project:
+- Block dangerous operations (safety)
+- Warn on code quality issues (style)
+- Educate the agent about project conventions (instruction)
+
+This example demonstrates the layered defense pattern.
+
+### tank.json
+
+```json
+{
+  "name": "@tank/node-project-policy",
+  "version": "1.0.0",
+  "description": "Comprehensive policy for Node.js projects. Blocks dangerous commands, warns on code quality issues, and educates the agent on project conventions.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    },
+    {
+      "kind": "rule",
+      "name": "no-rm-rf",
+      "event": "pre-command",
+      "policy": "block",
+      "match": "rm -rf",
+      "reason": "Use trash-cli for safe deletion"
+    },
+    {
+      "kind": "rule",
+      "name": "no-npm-install-global",
+      "event": "pre-command",
+      "policy": "block",
+      "match": "npm install -g",
+      "reason": "Global installs pollute the system. Use npx for one-off tools or add to devDependencies."
+    },
+    {
+      "kind": "rule",
+      "name": "no-force-push",
+      "event": "pre-command",
+      "policy": "block",
+      "match": "push --force",
+      "reason": "Use --force-with-lease to prevent overwriting others' work"
+    },
+    {
+      "kind": "rule",
+      "name": "warn-console-log",
+      "event": "post-file-write",
+      "policy": "warn",
+      "match": "console.log(",
+      "reason": "Remove console.log before committing. Use the project logger (src/lib/logger.ts) for production logging."
+    },
+    {
+      "kind": "rule",
+      "name": "warn-todo-comment",
+      "event": "post-file-write",
+      "policy": "warn",
+      "match": "// TODO",
+      "reason": "TODO comments indicate unfinished work. Complete the task or create a GitHub issue and reference it: // TODO(#123): description"
+    },
+    {
+      "kind": "rule",
+      "name": "warn-any-cast",
+      "event": "post-file-write",
+      "policy": "warn",
+      "match": "as any",
+      "reason": "Avoid `as any` -- use proper types or `unknown` with type guards"
+    },
+    {
+      "kind": "rule",
+      "name": "warn-env-direct",
+      "event": "post-file-write",
+      "policy": "warn",
+      "match": "process.env.",
+      "reason": "Access environment variables through src/config.ts, not directly via process.env. This centralizes validation and provides type safety."
+    }
+  ]
+}
+```
+
+### Supporting SKILL.md (full example)
+
+```markdown
+# Node.js Project Policy
+
+This bundle enforces safety constraints and quality standards for this project.
+
+## Safety Rules (Enforced -- agent is blocked)
+
+- No `rm -rf` -- use trash-cli
+- No global npm installs -- use npx or devDependencies
+- No force push -- use --force-with-lease
+
+## Quality Rules (Advisory -- agent is warned)
+
+- No `console.log` -- use src/lib/logger.ts
+- No bare TODO comments -- link to GitHub issues
+- No `as any` -- use proper types
+- No direct process.env access -- use src/config.ts
+
+## Project Conventions
+
+- Package manager: pnpm (not npm or yarn)
+- Test runner: vitest
+- Linter: biome (not eslint)
+- Logger: src/lib/logger.ts (pino-based)
+- Config: src/config.ts (zod-validated env vars)
+```
+
+### Key takeaways
+
+- Three block rules for safety, four warn rules for quality
+- The instruction atom documents both the rules and broader project conventions
+- The agent gets education (instruction) and enforcement (rules) together
+- Block reasons suggest specific alternatives; warn reasons explain the project pattern
+- Rules are named for easy identification in logs and debugging
+
+## Summary: Rule Design Checklist
+
+| Step | Action                                                       |
+| ---- | ------------------------------------------------------------ |
+| 1    | Identify the constraint (what must not / should not happen)  |
+| 2    | Choose the event (when in the lifecycle to check)            |
+| 3    | Choose the policy (block for danger, warn for quality)       |
+| 4    | Write the match pattern (narrow, specific, portable)         |
+| 5    | Write the reason (explain risk + suggest alternative)        |
+| 6    | Add an instruction atom (educate the agent on the policy)    |
+| 7    | Place rules in a `bundles/` directory with `atoms` array     |
+| 8    | Test each rule by deliberately triggering its condition      |
+| 9    | Review for false positives and over-restriction              |
+| 10   | Ship as warn first, escalate to block after validation       |

--- a/skills/rule-creator/tank.json
+++ b/skills/rule-creator/tank.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tank/rule-creator",
+  "version": "1.0.0",
+  "description": "Author Tank rule atoms -- declarative validation constraints that block, allow, or warn on agent behavior. Covers rule atom schema, policy design, event binding, composition in bundles, and worked examples. Triggers: create rule, tank rule atom, block policy, warn policy, safety rule, enforce rule, rule bundle, policy set.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/skills/tool-creator/SKILL.md
+++ b/skills/tool-creator/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: "@tank/tool-creator"
+description: |
+  Author Tank tool atoms that wire MCP (Model Context Protocol) servers into
+  agent harnesses. Covers the tool atom schema (name, extensions, permissions),
+  STDIO vs HTTP transport wiring, OAuth configuration for remote servers,
+  permission scoping (network.outbound), extension bags for cross-platform
+  support (Claude Code, OpenCode, Cursor), and composing tool atoms with
+  instruction atoms for usage guidance. Does NOT reimplement MCP servers --
+  teaches how to declare thin wiring layers that register upstream servers.
+  Synthesizes MCP Specification (2025-06-18), Tank AGENTS.md atom system,
+  and production MCP server configuration patterns.
+
+  Trigger phrases: "create mcp tool", "wire mcp server", "tank tool atom",
+  "mcp wiring bundle", "register mcp server", "tool atom", "add mcp to tank",
+  "mcp tool bundle", "create tool bundle", "mcp config as tank package",
+  "wire tool into agent", "tank mcp integration", "tool atom schema",
+  "mcp server wiring", "convert mcp config to tank"
+---
+
+# Tool Creator
+
+## Core Philosophy
+
+1. **Thin wiring, not reimplementation** -- A tool atom declares "register
+   this MCP server." It never contains server code. The upstream server is
+   the source of truth; the atom is a pointer.
+2. **Extension bags carry platform details** -- The `kind: "tool"` atom has
+   one required field: `name`. Everything else (command, args, env, url,
+   oauth) lives in `extensions` keyed by platform. This keeps the atom
+   portable while letting each harness get exactly what it needs.
+3. **Permission scoping protects the user** -- A tool bundle that calls a
+   remote server MUST declare `network.outbound` with the exact hostnames.
+   A local STDIO server needs `subprocess: true`. State this in `tank.json`
+   permissions, not buried in extension bags.
+4. **Compose instruction + tool** -- A bare tool atom registers machinery.
+   Pair it with an instruction atom that explains WHEN and WHY to use the
+   tool. Agents perform better when they understand intent, not just API.
+5. **One bundle per server** -- Each MCP server gets its own Tank bundle.
+   Do not bundle unrelated servers together. Users install what they need.
+
+## Quick-Start: Common Problems
+
+### "I have an MCP server config and want to package it as a Tank bundle"
+
+1. Identify the transport: STDIO (local binary/script) or HTTP (remote URL)
+2. Create `bundles/{server-name}/tank.json` with a tool atom
+3. Add extension bags for each target platform
+4. Set permissions: `subprocess: true` for STDIO, `network.outbound` for HTTP
+5. Optionally add an instruction atom with usage guidance
+   -> See `references/tool-atom-anatomy.md`
+
+### "I need to wire a remote MCP server that requires OAuth"
+
+1. Declare the tool atom with `name` matching the server identity
+2. Add `extensions` with the OAuth metadata (provider URL, scopes, client ID)
+3. Set `network.outbound` to the server hostname AND the OAuth provider
+4. Document required env vars for credentials in the instruction atom
+   -> See `references/worked-examples.md` (remote HTTP + OAuth example)
+
+### "How is a tool atom different from an MCP server?"
+
+1. An MCP server is running code that exposes tools/resources/prompts
+2. A tool atom is a Tank manifest entry that tells the agent harness:
+   "connect to this MCP server and make its tools available"
+3. The tool atom is to an MCP server what a `docker-compose.yml` service
+   entry is to a Docker image -- declaration, not implementation
+   -> See `references/mcp-primer.md`
+
+### "My tool atom works in OpenCode but not in Claude Code"
+
+1. Each platform reads different extension bag keys
+2. Verify extension bags exist for all target platforms
+3. Check that env var names match platform conventions
+4. Use `references/tool-atom-anatomy.md` extension bag reference table
+
+## Decision Trees
+
+### Transport Selection
+
+| Signal | Transport | Permission Needed |
+|--------|-----------|-------------------|
+| Server runs as local binary/script | STDIO | `subprocess: true` |
+| Server is a remote URL | HTTP | `network.outbound: ["hostname"]` |
+| Server needs authentication | HTTP + OAuth | `network.outbound: ["hostname", "auth-provider"]` |
+| Server needs local files | STDIO | `subprocess: true`, `filesystem.read` |
+
+### Bundle Complexity
+
+| Scenario | Atoms Needed |
+|----------|-------------|
+| Simple STDIO server, self-explanatory | 1 tool atom |
+| STDIO server with non-obvious usage | 1 tool + 1 instruction |
+| Remote server with OAuth + usage guide | 1 tool + 1 instruction |
+| Server with custom pre-use validation | 1 tool + 1 instruction + 1 hook |
+
+### Extension Bag Platform Keys
+
+| Platform | Extension Key | Transport Config Fields |
+|----------|--------------|------------------------|
+| Claude Code | `claude-code` | `command`, `args`, `env` (STDIO); `url` (HTTP) |
+| OpenCode | `opencode` | `command`, `args`, `env` (STDIO); `url`, `headers` (HTTP) |
+| Cursor | `cursor` | `command`, `args`, `env` (STDIO); `url` (HTTP) |
+| Windsurf | `windsurf` | `command`, `args`, `env` (STDIO) |
+| Generic | `default` | Fallback for unrecognized platforms |
+
+## Anti-Patterns
+
+| Pattern | Problem | Fix |
+|---------|---------|-----|
+| Bundling server source code | Bundle becomes stale, hard to update | Point to upstream package via `command`/`url` |
+| No instruction atom | Agent sees tools but lacks usage context | Add instruction explaining when/why |
+| Wildcard network permissions | Security risk | List exact hostnames in `network.outbound` |
+| Hardcoded credentials in extensions | Secret leakage | Use env var references (`${ENV_VAR}`) |
+| Multiple servers in one bundle | Violates single-responsibility | One bundle per MCP server |
+
+## Reference Index
+
+| File | Contents |
+|------|----------|
+| `references/mcp-primer.md` | MCP architecture, host/client/server model, STDIO vs HTTP transports, OAuth flow, tool vs resource vs prompt primitives, how agents discover and invoke MCP tools |
+| `references/tool-atom-anatomy.md` | Tank tool atom schema, required and optional fields, extension bags per platform, permission scoping, composing tool + instruction atoms, tank.json manifest patterns |
+| `references/worked-examples.md` | Four complete tool bundle examples: local STDIO wrap, remote HTTP with OAuth, tool with command/env config, tool + instruction composite bundle |

--- a/skills/tool-creator/references/mcp-primer.md
+++ b/skills/tool-creator/references/mcp-primer.md
@@ -1,0 +1,308 @@
+# MCP Primer for Tool Wiring
+
+Sources: MCP Specification (2025-06-18), Anthropic MCP documentation, OWASP MCP Security Cheat Sheet
+
+Covers: what MCP is, the host/client/server architecture, transport mechanisms,
+authentication, and how the three MCP primitives (tools, resources, prompts)
+map to agent capabilities. This reference focuses on the consumer side --
+understanding MCP well enough to wire servers, not build them.
+
+## What MCP Is
+
+The Model Context Protocol is a JSON-RPC 2.0 based protocol that standardizes
+how AI agent hosts (Claude Desktop, OpenCode, Cursor) connect to external
+capability servers. Before MCP, every host had its own plugin format. MCP
+provides one interface that works across hosts.
+
+Key terminology:
+
+| Term | Role | Example |
+|------|------|---------|
+| Host | The AI application the user runs | Claude Desktop, OpenCode, Cursor |
+| Client | Protocol handler inside the host | One client per connected server |
+| Server | External process exposing capabilities | `@modelcontextprotocol/server-github` |
+| Transport | Wire format between client and server | STDIO pipes, HTTP requests |
+
+The relationship is always: Host contains Client(s), each Client connects to
+exactly one Server over a Transport.
+
+## Architecture: How Hosts Discover Servers
+
+Hosts maintain a configuration that lists MCP servers to connect to. The
+configuration format varies by host, but the pattern is consistent:
+
+1. User (or a package manager like Tank) adds a server entry to the config
+2. Host reads the config on startup (or reload)
+3. Host creates a Client for each server entry
+4. Client connects to the Server using the declared transport
+5. Client calls `initialize` to negotiate capabilities
+6. Client calls `tools/list`, `resources/list`, `prompts/list` to discover
+   what the server offers
+7. Host presents discovered tools to the LLM as callable functions
+
+This is the flow a Tank tool atom automates. Instead of editing host config
+files manually, the tool atom declares the server connection, and the Tank
+adapter writes the platform-specific config entry.
+
+## Transport: STDIO vs HTTP
+
+MCP defines two transport mechanisms. The transport choice is fundamental --
+it determines how the server process is managed and how data flows.
+
+### STDIO Transport
+
+The host spawns the server as a child process. Communication happens over
+the process's stdin (client-to-server) and stdout (server-to-client). Stderr
+is reserved for logging.
+
+```
+Host Process
+  |
+  +-- spawns --> Server Process
+       stdin  <-- JSON-RPC requests
+       stdout --> JSON-RPC responses
+       stderr --> diagnostic logs (ignored by protocol)
+```
+
+Characteristics:
+
+| Property | Value |
+|----------|-------|
+| Lifecycle | Host manages server process (start/stop) |
+| Connectivity | Local only -- no network |
+| Authentication | Not needed -- same machine trust |
+| Session | One client per process |
+| Config required | `command` (executable), `args` (optional), `env` (optional) |
+
+STDIO is the dominant transport for local tool servers. Most MCP servers in
+the wild (GitHub, filesystem, fetch, Playwright) use STDIO.
+
+### Streamable HTTP Transport
+
+The server runs as an HTTP endpoint. The client sends JSON-RPC requests as
+HTTP POST to a well-known path (typically `/mcp`). The server can return
+responses inline or open a Server-Sent Events (SSE) stream for streaming.
+
+```
+Host Process
+  |
+  +-- HTTP POST /mcp --> Remote Server
+  <-- 200 OK (JSON-RPC response)
+  <-- or SSE stream (for streaming responses)
+```
+
+Characteristics:
+
+| Property | Value |
+|----------|-------|
+| Lifecycle | Server runs independently -- host does not manage it |
+| Connectivity | Network -- can be remote |
+| Authentication | OAuth 2.1, bearer tokens, or API keys |
+| Session | Multiple clients, stateful via session tokens |
+| Config required | `url` (server endpoint), auth credentials |
+
+HTTP transport is used for remote/hosted MCP servers, SaaS integrations, and
+serverless deployments.
+
+### Choosing Transport
+
+| Scenario | Transport |
+|----------|-----------|
+| Server is an npm package the user installs | STDIO |
+| Server is a Python script in the repo | STDIO |
+| Server is hosted by a SaaS provider | HTTP |
+| Server needs to serve multiple users | HTTP |
+| Server accesses local filesystem | STDIO (inherits user permissions) |
+| Server needs OAuth with a third-party API | HTTP (or STDIO with env tokens) |
+
+## Authentication: OAuth 2.1 for Remote Servers
+
+Remote HTTP servers typically require authentication. MCP specifies OAuth 2.1
+as the standard auth flow:
+
+1. Client discovers the OAuth metadata at the server's well-known endpoint
+2. Client initiates Authorization Code + PKCE flow
+3. User authenticates in browser, grants scopes
+4. Client receives access token, attaches to subsequent MCP requests
+5. Client uses refresh token to maintain session
+
+For Tank tool atoms, this means:
+
+- The tool atom's extension bag declares the OAuth provider URL and scopes
+- The host handles the actual OAuth flow (redirect, token exchange)
+- Tank bundles store client IDs but NEVER client secrets
+- Env vars reference secrets: `"GITHUB_TOKEN": "${GITHUB_TOKEN}"`
+
+Some simpler servers accept static bearer tokens or API keys instead of full
+OAuth. These are passed via environment variables in STDIO or headers in HTTP.
+
+## The Three MCP Primitives
+
+MCP servers expose capabilities through three primitive types. Understanding
+these is critical for writing accurate instruction atoms that guide usage.
+
+### Tools
+
+Tools are model-invoked functions. The LLM decides when to call them based
+on the tool's name and description. Tools are the primary interaction point.
+
+| Property | Purpose |
+|----------|---------|
+| `name` | Identifier the LLM uses to invoke the tool |
+| `description` | Natural language guide for when to use it |
+| `inputSchema` | JSON Schema defining required parameters |
+| `outputSchema` | Optional schema for structured return values |
+| `annotations` | Metadata: `readOnlyHint`, `destructiveHint`, `openWorldHint` |
+
+Example tools from well-known servers:
+
+| Server | Tool | Purpose |
+|--------|------|---------|
+| GitHub | `create_issue` | Create a GitHub issue |
+| Filesystem | `read_file` | Read a file from disk |
+| Fetch | `fetch` | HTTP GET/POST to a URL |
+| Playwright | `browser_navigate` | Navigate browser to URL |
+
+### Resources
+
+Resources are application-controlled data sources. Unlike tools, the LLM
+does not decide when to read resources -- the host application or user does.
+Resources provide context that supplements tool usage.
+
+| Property | Purpose |
+|----------|---------|
+| `uri` | Unique identifier (e.g., `file:///path`, `github://repo/issues`) |
+| `name` | Human-readable label |
+| `description` | What the resource contains |
+| `mimeType` | Content type (text/plain, application/json) |
+
+Resources are relevant to tool atoms only insofar as the instruction atom
+should document what resources the server exposes alongside its tools.
+
+### Prompts
+
+Prompts are user-invoked templates -- canned interaction patterns. They are
+less common than tools and resources.
+
+| Property | Purpose |
+|----------|---------|
+| `name` | Identifier (often exposed as slash commands) |
+| `description` | When to use this prompt |
+| `arguments` | Parameters the user fills in |
+
+## How Agents Invoke MCP Tools
+
+When a Tank tool atom is installed and the adapter writes the config:
+
+1. Host starts/connects to the MCP server
+2. Host calls `tools/list` and receives tool definitions
+3. Host injects these tools into the LLM's available function set
+4. LLM sees tool names + descriptions alongside other tools
+5. When the LLM decides to use a tool, it generates a `tools/call` request
+6. Host routes the call through the Client to the Server
+7. Server executes and returns results
+8. Host passes results back to the LLM
+
+The tool atom makes step 1-2 happen automatically. The instruction atom
+(if present) helps step 4 by giving the LLM context about when the tools
+are appropriate.
+
+## MCP vs Tank Atoms: Disambiguation
+
+These terms overlap and cause confusion. Clarify:
+
+| Concept | Belongs To | Purpose |
+|---------|-----------|---------|
+| MCP Tool | MCP Protocol | A callable function exposed by an MCP server |
+| MCP Resource | MCP Protocol | A readable data source exposed by an MCP server |
+| MCP Prompt | MCP Protocol | A canned interaction template exposed by an MCP server |
+| Tank `tool` atom | Tank Package System | A manifest entry that wires an MCP server to a host |
+| Tank `resource` atom | Tank Package System | A manifest entry that provides data/context to an agent |
+| Tank `instruction` atom | Tank Package System | A manifest entry that injects behavioral context |
+
+A Tank `tool` atom registers an MCP server. That server may expose MCP tools,
+resources, and prompts. The Tank atom is the wiring; the MCP server is the
+capability provider.
+
+## Security Considerations for Tool Wiring
+
+When wiring MCP servers via Tank tool atoms, enforce these constraints:
+
+| Risk | Mitigation |
+|------|-----------|
+| Overly broad network access | Declare exact hostnames in `network.outbound` |
+| Secret leakage in config | Use env var references, never inline secrets |
+| Tool poisoning (malicious tool descriptions) | Only wire trusted, audited MCP servers |
+| Privilege escalation via subprocess | Use `subprocess: true` only for STDIO servers |
+| Confused deputy (server accesses resources on behalf of user) | Scope OAuth to minimum required permissions |
+
+See `references/tool-atom-anatomy.md` for how these map to `tank.json` fields.
+
+## Server Discovery and Capability Negotiation
+
+When a host connects to an MCP server, the first exchange is the
+`initialize` handshake. Understanding this flow explains what happens
+behind the scenes after a Tank tool atom registers a server.
+
+### The Initialize Handshake
+
+```
+Client -> Server:  initialize { protocolVersion, capabilities, clientInfo }
+Server -> Client:  initialize response { protocolVersion, capabilities, serverInfo }
+Client -> Server:  notifications/initialized
+```
+
+The client declares its capabilities (e.g., "I support sampling"). The server
+declares its capabilities (e.g., "I provide tools and resources"). Both sides
+agree on the protocol version. This negotiation happens once per connection.
+
+### Capability Discovery
+
+After initialization, the client queries available primitives:
+
+| Request | Response | Purpose |
+|---------|----------|---------|
+| `tools/list` | Array of tool definitions | Discover callable functions |
+| `resources/list` | Array of resource URIs | Discover available data |
+| `prompts/list` | Array of prompt templates | Discover canned interactions |
+
+The host injects discovered tools into the LLM's function-calling schema.
+Resource URIs are made available for context attachment. Prompt templates
+may appear as slash commands in the host's UI.
+
+### Tool Invocation Flow
+
+When the LLM decides to call a tool:
+
+```
+LLM output:     tool_use { name: "create_issue", input: { title: "Bug", body: "..." } }
+Host:            routes to the Client connected to the server owning "create_issue"
+Client -> Server: tools/call { name: "create_issue", arguments: { title: "Bug", body: "..." } }
+Server:          executes logic, returns result
+Server -> Client: { content: [{ type: "text", text: "Created issue #42" }] }
+Host:            passes result back to LLM as tool_result
+```
+
+The host maintains a mapping of tool names to servers. If two servers expose
+tools with the same name, the host must disambiguate (typically by prefixing
+the server name). This is another reason Tank uses one bundle per server --
+name collisions are easier to manage when each bundle is independent.
+
+## Lifecycle: Server Startup and Shutdown
+
+### STDIO Lifecycle
+
+1. Host reads config, finds STDIO server entry
+2. Host spawns process: `command args...` with `env` applied
+3. Host sends `initialize` over stdin
+4. Server responds over stdout
+5. Normal operation: JSON-RPC messages over stdin/stdout
+6. On shutdown: host sends `notifications/cancelled`, then terminates process
+
+### HTTP Lifecycle
+
+1. Host reads config, finds HTTP server entry
+2. Host sends `initialize` as HTTP POST to `url`
+3. Server responds with capabilities
+4. Normal operation: each tool call is an HTTP POST
+5. Server manages its own lifecycle -- host does not stop it

--- a/skills/tool-creator/references/tool-atom-anatomy.md
+++ b/skills/tool-creator/references/tool-atom-anatomy.md
@@ -1,0 +1,292 @@
+# Tool Atom Anatomy
+
+Sources: Tank AGENTS.md atom system, MCP Specification (2025-06-18), production MCP configuration patterns from Claude Code, OpenCode, and Cursor
+
+Covers: the Tank `kind: "tool"` atom schema, required and optional fields,
+extension bags for cross-platform wiring, permission scoping in tank.json,
+composing tool atoms with instruction atoms, and the full manifest structure
+for tool bundles.
+
+## The Tool Atom Schema
+
+A tool atom is the simplest multi-atom primitive. It has one required field:
+
+```json
+{
+  "kind": "tool",
+  "name": "github"
+}
+```
+
+That is a valid tool atom. The `name` field identifies the MCP server being
+wired. Convention: use the server's well-known name (e.g., `github`,
+`filesystem`, `fetch`, `playwright`, `postgres`).
+
+### Required Fields
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `kind` | `"tool"` | Identifies this atom as a tool registration |
+| `name` | string | The MCP server identity. Used by adapters to generate config entries |
+
+### Optional Fields
+
+Any additional fields beyond `kind` and `name` are either:
+- Standard atom fields (`extensions`)
+- Extension-bag territory (platform-specific config)
+
+The tool atom itself is deliberately minimal. Platform-specific details
+(command paths, URLs, environment variables, OAuth metadata) belong in
+extension bags.
+
+## Extension Bags: Platform-Specific Wiring
+
+Extension bags carry the configuration each platform needs to connect to the
+MCP server. Tank adapters read their platform key and ignore others.
+
+```json
+{
+  "kind": "tool",
+  "name": "github",
+  "extensions": {
+    "claude-code": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    },
+    "opencode": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    },
+    "cursor": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+### Extension Bag Fields by Transport
+
+#### STDIO Transport
+
+| Field | Type | Required | Purpose |
+|-------|------|----------|---------|
+| `command` | string | Yes | Executable to spawn (e.g., `npx`, `uvx`, `node`, `python`) |
+| `args` | string[] | No | Arguments passed to the command |
+| `env` | object | No | Environment variables. Use `${VAR}` for secret references |
+| `cwd` | string | No | Working directory for the spawned process |
+
+#### HTTP Transport
+
+| Field | Type | Required | Purpose |
+|-------|------|----------|---------|
+| `url` | string | Yes | The MCP server endpoint URL |
+| `headers` | object | No | Static headers (e.g., API keys) |
+| `oauth` | object | No | OAuth metadata (provider URL, scopes, client ID) |
+
+#### OAuth Metadata (nested under HTTP extensions)
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `provider` | string | OAuth authorization server URL |
+| `scopes` | string[] | Requested permission scopes |
+| `clientId` | string | Public client identifier |
+| `clientIdEnvVar` | string | Env var containing client ID (alternative to inline) |
+
+### Platform Key Reference
+
+| Platform | Key | Notes |
+|----------|-----|-------|
+| Claude Code (claude) | `claude-code` | Writes to `~/.claude/mcp_servers.json` or project `.mcp.json` |
+| OpenCode | `opencode` | Writes to `opencode.json` mcpServers section |
+| Cursor | `cursor` | Writes to `.cursor/mcp.json` |
+| Windsurf | `windsurf` | Writes to `~/.windsurf/mcp_servers.json` |
+| Generic fallback | `default` | Used when no platform-specific key matches |
+
+When multiple platforms share identical config (common for STDIO), repeat
+the block under each key rather than relying on `default`. Explicit is
+better -- adapters may add platform-specific fields in the future.
+
+## Permission Scoping in tank.json
+
+The `permissions` field in `tank.json` controls what the bundle is allowed to
+do at the system level. Tool atoms have specific permission requirements
+based on transport.
+
+### STDIO Server Permissions
+
+```json
+{
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": true
+  }
+}
+```
+
+`subprocess: true` is required because the host spawns the MCP server as a
+child process. Without it, the adapter cannot start the server.
+
+If the MCP server itself accesses the filesystem, add the relevant paths:
+
+```json
+{
+  "permissions": {
+    "filesystem": {
+      "read": ["**/*"],
+      "write": ["./output/**"]
+    },
+    "subprocess": true
+  }
+}
+```
+
+### HTTP Server Permissions
+
+```json
+{
+  "permissions": {
+    "network": {
+      "outbound": ["api.github.com", "github.com"]
+    },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  }
+}
+```
+
+List every hostname the tool communicates with. Include both the MCP server
+host and any OAuth provider hosts.
+
+### Permission Decision Table
+
+| Transport | subprocess | network.outbound | filesystem.write |
+|-----------|-----------|-------------------|-----------------|
+| STDIO, no file writes | `true` | `[]` | `[]` |
+| STDIO, writes files | `true` | `[]` | specific paths |
+| STDIO, calls APIs | `true` | API hostnames | `[]` |
+| HTTP, no OAuth | `false` | server hostname | `[]` |
+| HTTP, with OAuth | `false` | server + auth hostnames | `[]` |
+
+## Composing Tool + Instruction Atoms
+
+A tool atom alone registers machinery. An instruction atom adds context.
+Combine them in the `atoms` array for bundles where the agent needs guidance.
+
+### When to Add an Instruction Atom
+
+| Scenario | Instruction Needed? |
+|----------|-------------------|
+| Tools are self-explanatory (filesystem read/write) | No |
+| Tools require specific workflows (GitHub PR flow) | Yes |
+| Tools have non-obvious limitations | Yes |
+| Tools interact with other tools in the bundle | Yes |
+| Server exposes 10+ tools | Yes (guide prioritization) |
+
+### Structure of a Composed Bundle
+
+```json
+{
+  "atoms": [
+    {
+      "kind": "tool",
+      "name": "github",
+      "extensions": { ... }
+    },
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    }
+  ]
+}
+```
+
+The instruction atom's `content` field points to a SKILL.md file that
+describes when and how to use the wired tools. This file follows standard
+Tank SKILL.md conventions (frontmatter + body under 200 lines).
+
+### Instruction Content Guidelines for Tool Bundles
+
+The SKILL.md paired with a tool atom should cover:
+
+1. What the MCP server does (one paragraph)
+2. Which tools are most important (prioritized list)
+3. Common workflows combining multiple tools
+4. Gotchas, rate limits, or authentication prerequisites
+5. Environment variables the user must set
+
+Keep it under 100 lines for simple servers, up to 200 for complex ones.
+
+## Full Manifest Structure
+
+A complete `tank.json` for a tool bundle:
+
+```json
+{
+  "name": "@tank/{server-name}",
+  "version": "1.0.0",
+  "description": "Wire the {server-name} MCP server for {purpose}. Triggers: ...",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "tool",
+      "name": "{server-name}",
+      "extensions": {
+        "claude-code": { "command": "...", "args": [...], "env": {...} },
+        "opencode": { "command": "...", "args": [...], "env": {...} },
+        "cursor": { "command": "...", "args": [...], "env": {...} }
+      }
+    },
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    }
+  ]
+}
+```
+
+### Naming Conventions
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Directory | `bundles/{server-name}/` | `bundles/github/` |
+| Package name | `@tank/{server-name}` | `@tank/github` |
+| Tool atom name | `{server-name}` (no prefix) | `github` |
+| Instruction file | `SKILL.md` | Always |
+
+### Versioning
+
+- Start at `1.0.0` for new bundles
+- Bump minor when adding platform support or updating extension configs
+- Bump major when changing the MCP server package (breaking upstream change)
+- The bundle version is independent of the upstream MCP server version
+
+## Validation Checklist
+
+Before publishing a tool bundle, verify:
+
+- [ ] `name` in tank.json matches `@tank/{directory-name}`
+- [ ] Tool atom `name` matches the MCP server identity
+- [ ] Extension bags exist for at least two platforms
+- [ ] `subprocess: true` if transport is STDIO
+- [ ] `network.outbound` lists all remote hostnames if transport is HTTP
+- [ ] No secrets inline -- all credentials use `${ENV_VAR}` references
+- [ ] Instruction atom present if tools require usage guidance
+- [ ] `tank publish --dry-run` passes without errors
+
+See `references/worked-examples.md` for complete bundle implementations.

--- a/skills/tool-creator/references/worked-examples.md
+++ b/skills/tool-creator/references/worked-examples.md
@@ -1,0 +1,365 @@
+# Worked Examples: Tool Bundles
+
+Sources: MCP Specification (2025-06-18), Tank AGENTS.md, production MCP server configurations from @modelcontextprotocol packages, Playwright MCP, and community servers
+
+Covers: four complete tool bundle implementations demonstrating local STDIO
+wiring, remote HTTP with OAuth, tool with command/env configuration, and a
+composite bundle pairing a tool atom with an instruction atom.
+
+## Example 1: Local STDIO Server -- Filesystem
+
+The `@modelcontextprotocol/server-filesystem` server provides file read/write
+tools over STDIO. This is the simplest wiring pattern.
+
+### Directory Structure
+
+```
+bundles/filesystem/
+  tank.json
+```
+
+No SKILL.md needed -- filesystem tools are self-explanatory.
+
+### tank.json
+
+```json
+{
+  "name": "@tank/filesystem",
+  "version": "1.0.0",
+  "description": "Wire the MCP filesystem server for local file operations. Provides read_file, write_file, list_directory, search_files, and move_file tools. Triggers: filesystem mcp, file tools, local file access, mcp filesystem.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": ["**/*"] },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "tool",
+      "name": "filesystem",
+      "extensions": {
+        "claude-code": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+          "env": {}
+        },
+        "opencode": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+          "env": {}
+        },
+        "cursor": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+          "env": {}
+        }
+      }
+    }
+  ]
+}
+```
+
+### Key Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| No instruction atom | Tools like `read_file` and `write_file` are self-documenting |
+| `subprocess: true` | STDIO transport requires spawning the server process |
+| `filesystem.write: ["**/*"]` | Server writes files -- permission must reflect this |
+| `"."` as final arg | Scopes the server to the current working directory |
+| No `network.outbound` | Purely local -- no network access needed |
+
+## Example 2: Remote HTTP Server with OAuth -- GitHub
+
+A hypothetical remote GitHub MCP server hosted at `mcp.github.com` that
+requires OAuth to access the GitHub API on behalf of the user.
+
+### Directory Structure
+
+```
+bundles/github-remote/
+  tank.json
+  SKILL.md
+```
+
+### tank.json
+
+```json
+{
+  "name": "@tank/github-remote",
+  "version": "1.0.0",
+  "description": "Wire the remote GitHub MCP server over HTTP with OAuth. Provides issue, PR, repo, and search tools. Triggers: github mcp remote, github oauth mcp, github tools http.",
+  "permissions": {
+    "network": {
+      "outbound": ["mcp.github.com", "github.com"]
+    },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "tool",
+      "name": "github-remote",
+      "extensions": {
+        "claude-code": {
+          "url": "https://mcp.github.com/v1/mcp",
+          "oauth": {
+            "provider": "https://github.com/login/oauth",
+            "scopes": ["repo", "read:org", "read:user"],
+            "clientId": "Iv1.abc123def456"
+          }
+        },
+        "opencode": {
+          "url": "https://mcp.github.com/v1/mcp",
+          "oauth": {
+            "provider": "https://github.com/login/oauth",
+            "scopes": ["repo", "read:org", "read:user"],
+            "clientIdEnvVar": "GITHUB_OAUTH_CLIENT_ID"
+          }
+        },
+        "cursor": {
+          "url": "https://mcp.github.com/v1/mcp",
+          "oauth": {
+            "provider": "https://github.com/login/oauth",
+            "scopes": ["repo", "read:org", "read:user"],
+            "clientId": "Iv1.abc123def456"
+          }
+        }
+      }
+    },
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    }
+  ]
+}
+```
+
+### Key Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| `subprocess: false` | HTTP transport -- no process to spawn |
+| Both `mcp.github.com` and `github.com` in outbound | Server host + OAuth provider host |
+| OAuth scopes minimized | Only `repo`, `read:org`, `read:user` -- not `admin` |
+| `clientId` inline (public) | OAuth client IDs are not secrets -- safe to include |
+| `clientIdEnvVar` variant for OpenCode | Some platforms prefer env var indirection |
+| Instruction atom included | GitHub tools have complex workflows (PR creation, issue linking) |
+
+### SKILL.md (excerpt for the instruction atom)
+
+The SKILL.md paired with this tool would document:
+
+- How to authenticate (first-run OAuth flow)
+- Priority tools: `create_issue`, `create_pull_request`, `search_repos`
+- Workflow: create branch -> commit -> open PR -> link to issue
+- Rate limit awareness: 5000 requests/hour for authenticated users
+- Required: user must have GitHub account and grant OAuth permissions
+
+## Example 3: STDIO Server with Command and Env Config -- Playwright
+
+The `@playwright/mcp` server provides browser automation tools. It requires
+specific environment configuration for headless vs headed mode.
+
+### Directory Structure
+
+```
+bundles/playwright/
+  tank.json
+```
+
+### tank.json
+
+```json
+{
+  "name": "@tank/playwright",
+  "version": "1.0.0",
+  "description": "Wire the Playwright MCP server for browser automation. Provides navigation, clicking, typing, screenshot, and PDF generation tools. Triggers: playwright mcp, browser automation, browser tools, web scraping mcp.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": ["./screenshots/**", "./pdfs/**"] },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "tool",
+      "name": "playwright",
+      "extensions": {
+        "claude-code": {
+          "command": "npx",
+          "args": ["-y", "@playwright/mcp", "--headless"],
+          "env": {
+            "PLAYWRIGHT_BROWSERS_PATH": "${PLAYWRIGHT_BROWSERS_PATH:-0}"
+          }
+        },
+        "opencode": {
+          "command": "npx",
+          "args": ["-y", "@playwright/mcp", "--headless"],
+          "env": {
+            "PLAYWRIGHT_BROWSERS_PATH": "${PLAYWRIGHT_BROWSERS_PATH:-0}"
+          }
+        },
+        "cursor": {
+          "command": "npx",
+          "args": ["-y", "@playwright/mcp"],
+          "env": {
+            "PLAYWRIGHT_BROWSERS_PATH": "${PLAYWRIGHT_BROWSERS_PATH:-0}"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+### Key Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| `--headless` flag for Claude Code and OpenCode | These run in terminal -- no GUI available |
+| No `--headless` for Cursor | IDE context may support headed browser |
+| `PLAYWRIGHT_BROWSERS_PATH` env var | Allows custom browser location; `0` default uses bundled |
+| `filesystem.write` scoped to output dirs | Screenshots and PDFs need write access |
+| No instruction atom | Playwright tools are well-named (`browser_navigate`, `browser_click`) |
+| No `network.outbound` | Server runs locally; browser fetches are user-directed |
+
+### Platform-Specific Variations
+
+This example demonstrates a key pattern: extension bags can differ across
+platforms beyond just the key name. Claude Code and OpenCode get `--headless`
+because they run headless. Cursor omits it because the IDE provides a window
+context. The tool atom handles this cleanly through per-platform bags.
+
+## Example 4: Composite Bundle -- Fetch with Usage Guidance
+
+The `@modelcontextprotocol/server-fetch` server wraps HTTP requests. Pairing
+it with an instruction atom prevents common misuse (agents fetching
+excessively, hitting rate limits, or leaking internal URLs).
+
+### Directory Structure
+
+```
+bundles/fetch/
+  tank.json
+  SKILL.md
+```
+
+### tank.json
+
+```json
+{
+  "name": "@tank/fetch",
+  "version": "1.0.0",
+  "description": "Wire the MCP fetch server with usage guidance for safe HTTP requests. Provides fetch tool for GET/POST with rate awareness. Triggers: fetch mcp, http tools, web request mcp, api fetch tool.",
+  "permissions": {
+    "network": {
+      "outbound": ["*"]
+    },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages",
+  "atoms": [
+    {
+      "kind": "tool",
+      "name": "fetch",
+      "extensions": {
+        "claude-code": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-fetch"],
+          "env": {}
+        },
+        "opencode": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-fetch"],
+          "env": {}
+        },
+        "cursor": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-fetch"],
+          "env": {}
+        }
+      }
+    },
+    {
+      "kind": "instruction",
+      "content": "./SKILL.md"
+    }
+  ]
+}
+```
+
+### SKILL.md
+
+```markdown
+---
+name: "@tank/fetch"
+description: |
+  Usage guidance for the MCP fetch tool. Prevents excessive requests,
+  URL leakage, and rate limit violations.
+
+  Trigger phrases: "fetch tool", "http request", "web fetch", "api call"
+---
+
+# Fetch Tool Usage
+
+## Rules
+
+1. Prefer project-local data over fetching external URLs
+2. Cache responses mentally -- do not re-fetch the same URL in one session
+3. Never fetch internal/private network URLs (10.x, 192.168.x, localhost)
+4. Respect rate limits: max 3 requests per minute to any single domain
+5. Use GET for reading, POST only when the user explicitly requests mutation
+6. Always tell the user what URL you are about to fetch before calling
+
+## Tool Reference
+
+| Tool | Purpose | When to Use |
+|------|---------|-------------|
+| `fetch` | HTTP GET/POST to a URL | User asks for web content, API data, or documentation |
+
+## Common Patterns
+
+- Fetching documentation: `fetch` with URL, then summarize
+- API exploration: `fetch` the endpoint, parse the response JSON
+- Web scraping: `fetch` the page, extract relevant text
+```
+
+### Key Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| `network.outbound: ["*"]` | Fetch tool can reach any URL -- wildcard is honest |
+| Instruction atom with rules | Prevents agent from making unbounded requests |
+| Rate limit guidance | Protects both the user and target servers |
+| Internal URL prohibition | Prevents SSRF-like behavior from agent |
+| Short SKILL.md (~30 lines) | Guidance for a single-tool server stays minimal |
+
+## Pattern Summary
+
+| Example | Transport | Atoms | Permissions Key | Complexity |
+|---------|-----------|-------|-----------------|-----------|
+| Filesystem | STDIO | 1 tool | subprocess | Minimal |
+| GitHub Remote | HTTP | 1 tool + 1 instruction | network.outbound | OAuth |
+| Playwright | STDIO | 1 tool | subprocess + filesystem.write | Platform-variant args |
+| Fetch | STDIO | 1 tool + 1 instruction | subprocess + network wildcard | Usage guardrails |
+
+## Scaffolding Checklist
+
+When creating a new tool bundle from scratch:
+
+1. Identify the upstream MCP server package name and version
+2. Determine transport: check if the server uses STDIO or HTTP
+3. Create `bundles/{name}/tank.json`
+4. Add the tool atom with `kind: "tool"` and `name`
+5. Add extension bags for at least Claude Code and OpenCode
+6. Set `subprocess: true` for STDIO or `network.outbound` for HTTP
+7. Decide if an instruction atom adds value (see decision table above)
+8. If yes, create `SKILL.md` with usage guidance
+9. Run `tank publish --dry-run` to validate
+10. Test by installing the bundle and verifying the MCP server connects
+
+See `references/tool-atom-anatomy.md` for the complete schema reference.
+See `references/mcp-primer.md` for transport and authentication details.

--- a/skills/tool-creator/tank.json
+++ b/skills/tool-creator/tank.json
@@ -1,0 +1,16 @@
+{
+  "name": "@tank/tool-creator",
+  "version": "1.0.0",
+  "description": "Author Tank tool atoms that wire MCP servers into agent harnesses. Covers tool atom schema, STDIO and HTTP transport wiring, OAuth for remote servers, extension bags for cross-platform support, permission scoping, and composing tool + instruction atoms. Triggers: create mcp tool, wire mcp server, tank tool atom, mcp wiring bundle, tool atom schema, mcp config to tank, register mcp server.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": ["**/*"],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}


### PR DESCRIPTION
## Summary

- Add 7 new instruction-only skills — one per Tank atom kind — teaching AI agents how to author each type
- Add `@tank/package-creator` meta bundle that routes users to the right creator skill via decision tree
- Deprecate `@tank/opencode-agent-creator` (superseded by generic `@tank/agent-creator`)

## New skills (instruction-only, in `skills/`)

| Skill | Atom kind | References |
|-------|-----------|------------|
| `@tank/bundle-creator` | Multi-atom package composition | tank-json-anatomy, bundle-composition, worked-examples |
| `@tank/hook-creator` | Lifecycle hooks (DSL + JS handlers) | hook-events-catalog, handler-types, worked-examples |
| `@tank/tool-creator` | MCP server wiring | mcp-primer, tool-atom-anatomy, worked-examples |
| `@tank/rule-creator` | Declarative policy atoms | rule-atom-anatomy, policy-design, worked-examples |
| `@tank/agent-creator` | Harness-agnostic agent atoms | agent-atom-anatomy, role-design, worked-examples |
| `@tank/prompt-creator` | Invocable template atoms | prompt-atom-anatomy, template-design, worked-examples |
| `@tank/resource-creator` | URI-addressable context atoms | resource-atom-anatomy, resource-design, worked-examples |

## New bundle (multi-atom, in `bundles/`)

`@tank/package-creator` — master routing guide with decision-guide and universal quality-checklist references.

## Deprecation

`@tank/opencode-agent-creator` marked `deprecated: true` with `superseded_by: @tank/agent-creator`.

## Unblocks

- Epic #125 (MCP tool bundles) — `@tank/tool-creator` provides authoring guidance
- Epic #119 (agent bundles) — `@tank/agent-creator` provides the generic agent atom spec
- Epic #122 (rule bundles) — `@tank/rule-creator` covers policy design
- Epic #123 (hook bundles) — `@tank/hook-creator` covers handler authoring
- Epic #120 (command/prompt bundles) — `@tank/prompt-creator` covers template design