### PR TITLE
fix: remove atoms field from package-creator manifest

### DIFF
--- a/bundles/package-creator/tank.json
+++ b/bundles/package-creator/tank.json
@@ -12,11 +12,5 @@
     },
     "subprocess": false
   },
-  "repository": "https://github.com/tankpkg/packages",
-  "atoms": [
-    {
-      "kind": "instruction",
-      "content": "./SKILL.md"
-    }
-  ]
+  "repository": "https://github.com/tankpkg/packages"
 }


### PR DESCRIPTION
Tank CLI 0.11.0 doesn't support the `atoms` field. Remove it so `@tank/package-creator` publishes as instruction-only. Will restore when runtime supports multi-atom packages.