### PR TITLE
feat: add 18 MCP tool bundles (epic #125)

### DIFF
--- a/bundles/mcp-browserbase/SKILL.md
+++ b/bundles/mcp-browserbase/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: "@tank/mcp-browserbase"
+description: |
+  Wire the Browserbase MCP server into any AI agent harness. Provides
+  cloud browser sessions for web scraping and automation. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "browserbase", "cloud browser", "headless browser", "web automation"
+---
+
+# Browserbase MCP Tool
+
+Registers the Browserbase MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-browserbase`
+2. Set required environment variables (see below)
+3. Restart your agent session
+
+## Required Environment Variables
+
+- `BROWSERBASE_API_KEY`: Required. Set in your environment or `.env`.
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `npx` |
+| Arguments | `-y @browserbasehq/mcp-server-browserbase` |
+| Transport | STDIO |
+| Package | `@browserbasehq/mcp-server-browserbase` |
+
+## What This Provides
+
+The Browserbase server exposes tools for cloud browser sessions for web scraping and automation.
+Load this package to give your agent access to Browserbase capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-browserbase/tank.json
+++ b/bundles/mcp-browserbase/tank.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tank/mcp-browserbase",
+  "version": "1.0.0",
+  "description": "Wire the Browserbase MCP server for cloud browser sessions for web scraping and automation. Thin config package. Triggers: browserbase, cloud browser, headless browser.",
+  "permissions": {
+    "network": {
+      "outbound": [
+        "api.browserbase.com"
+      ]
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-confluence/SKILL.md
+++ b/bundles/mcp-confluence/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: "@tank/mcp-confluence"
+description: |
+  Wire the Confluence MCP server into any AI agent harness. Provides
+  atlassian confluence wiki and documentation management. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "confluence", "atlassian", "wiki", "documentation", "knowledge base"
+---
+
+# Confluence MCP Tool
+
+Registers the Confluence MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-confluence`
+2. Set required environment variables (see below)
+3. Restart your agent session
+
+## Required Environment Variables
+
+- `CONFLUENCE_BASE_URL`: Required. Set in your environment or `.env`.
+- `CONFLUENCE_EMAIL`: Required. Set in your environment or `.env`.
+- `CONFLUENCE_API_TOKEN`: Required. Set in your environment or `.env`.
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `npx` |
+| Arguments | `-y confluence-mcp-server` |
+| Transport | STDIO |
+| Package | `confluence-mcp-server` |
+
+## What This Provides
+
+The Confluence server exposes tools for atlassian confluence wiki and documentation management.
+Load this package to give your agent access to Confluence capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-confluence/tank.json
+++ b/bundles/mcp-confluence/tank.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tank/mcp-confluence",
+  "version": "1.0.0",
+  "description": "Wire the Confluence MCP server for atlassian confluence wiki and documentation management. Thin config package. Triggers: confluence, atlassian, wiki.",
+  "permissions": {
+    "network": {
+      "outbound": [
+        "*.atlassian.net"
+      ]
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-context7/SKILL.md
+++ b/bundles/mcp-context7/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: "@tank/mcp-context7"
+description: |
+  Wire the Context7 MCP server into any AI agent harness. Provides
+  up-to-date library documentation and code examples. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "context7", "documentation", "library docs", "code examples", "API reference"
+---
+
+# Context7 MCP Tool
+
+Registers the Context7 MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-context7`
+2. No configuration needed -- works out of the box
+3. Restart your agent session
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `npx` |
+| Arguments | `-y @upstash/context7-mcp@latest` |
+| Transport | STDIO |
+| Package | `@upstash/context7-mcp@latest` |
+
+## What This Provides
+
+The Context7 server exposes tools for up-to-date library documentation and code examples.
+Load this package to give your agent access to Context7 capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-context7/tank.json
+++ b/bundles/mcp-context7/tank.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tank/mcp-context7",
+  "version": "1.0.0",
+  "description": "Wire the Context7 MCP server for up-to-date library documentation and code examples. Thin config package. Triggers: context7, documentation, library docs.",
+  "permissions": {
+    "network": {
+      "outbound": [
+        "api.context7.com"
+      ]
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-evalview/SKILL.md
+++ b/bundles/mcp-evalview/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: "@tank/mcp-evalview"
+description: |
+  Wire the EvalView MCP server into any AI agent harness. Provides
+  llm evaluation and output quality assessment. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "evalview", "evaluation", "LLM eval", "quality assessment", "model evaluation"
+---
+
+# EvalView MCP Tool
+
+Registers the EvalView MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-evalview`
+2. Set required environment variables (see below)
+3. Restart your agent session
+
+## Required Environment Variables
+
+- `OPENAI_API_KEY`: Required. Set in your environment or `.env`.
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `python3` |
+| Arguments | `-m evalview mcp serve` |
+| Transport | STDIO |
+| Package | `python3` |
+
+## What This Provides
+
+The EvalView server exposes tools for llm evaluation and output quality assessment.
+Load this package to give your agent access to EvalView capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-evalview/tank.json
+++ b/bundles/mcp-evalview/tank.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tank/mcp-evalview",
+  "version": "1.0.0",
+  "description": "Wire the EvalView MCP server for llm evaluation and output quality assessment. Thin config package. Triggers: evalview, evaluation, LLM eval.",
+  "permissions": {
+    "network": {
+      "outbound": [
+        "api.openai.com"
+      ]
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-exa-web-search/SKILL.md
+++ b/bundles/mcp-exa-web-search/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: "@tank/mcp-exa-web-search"
+description: |
+  Wire the Exa Web Search MCP server into any AI agent harness. Provides
+  ai-powered web search with semantic understanding. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "exa", "web search", "semantic search", "internet search"
+---
+
+# Exa Web Search MCP Tool
+
+Registers the Exa Web Search MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-exa-web-search`
+2. Set required environment variables (see below)
+3. Restart your agent session
+
+## Required Environment Variables
+
+- `EXA_API_KEY`: Required. Set in your environment or `.env`.
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `npx` |
+| Arguments | `-y exa-mcp-server` |
+| Transport | STDIO |
+| Package | `exa-mcp-server` |
+
+## What This Provides
+
+The Exa Web Search server exposes tools for ai-powered web search with semantic understanding.
+Load this package to give your agent access to Exa Web Search capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-exa-web-search/tank.json
+++ b/bundles/mcp-exa-web-search/tank.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tank/mcp-exa-web-search",
+  "version": "1.0.0",
+  "description": "Wire the Exa Web Search MCP server for ai-powered web search with semantic understanding. Thin config package. Triggers: exa, web search, semantic search.",
+  "permissions": {
+    "network": {
+      "outbound": [
+        "api.exa.ai"
+      ]
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-fal-ai/SKILL.md
+++ b/bundles/mcp-fal-ai/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: "@tank/mcp-fal-ai"
+description: |
+  Wire the fal.ai MCP server into any AI agent harness. Provides
+  ai model inference including image generation, video, and audio. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "fal.ai", "image generation", "AI inference", "stable diffusion", "AI models"
+---
+
+# fal.ai MCP Tool
+
+Registers the fal.ai MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-fal-ai`
+2. Set required environment variables (see below)
+3. Restart your agent session
+
+## Required Environment Variables
+
+- `FAL_KEY`: Required. Set in your environment or `.env`.
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `npx` |
+| Arguments | `-y fal-ai-mcp-server` |
+| Transport | STDIO |
+| Package | `fal-ai-mcp-server` |
+
+## What This Provides
+
+The fal.ai server exposes tools for ai model inference including image generation, video, and audio.
+Load this package to give your agent access to fal.ai capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-fal-ai/tank.json
+++ b/bundles/mcp-fal-ai/tank.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tank/mcp-fal-ai",
+  "version": "1.0.0",
+  "description": "Wire the fal.ai MCP server for ai model inference including image generation, video, and audio. Thin config package. Triggers: fal.ai, image generation, AI inference.",
+  "permissions": {
+    "network": {
+      "outbound": [
+        "*.fal.ai"
+      ]
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-filesystem/SKILL.md
+++ b/bundles/mcp-filesystem/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: "@tank/mcp-filesystem"
+description: |
+  Wire the Filesystem MCP server into any AI agent harness. Provides
+  local filesystem read/write operations for agent file access. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "filesystem", "file access", "read files", "write files", "local files"
+---
+
+# Filesystem MCP Tool
+
+Registers the Filesystem MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-filesystem`
+2. No configuration needed -- works out of the box
+3. Restart your agent session
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `npx` |
+| Arguments | `-y @modelcontextprotocol/server-filesystem /path/to/your/projects` |
+| Transport | STDIO |
+| Package | `@modelcontextprotocol/server-filesystem` |
+
+## What This Provides
+
+The Filesystem server exposes tools for local filesystem read/write operations for agent file access.
+Load this package to give your agent access to Filesystem capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-filesystem/tank.json
+++ b/bundles/mcp-filesystem/tank.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/mcp-filesystem",
+  "version": "1.0.0",
+  "description": "Wire the Filesystem MCP server for local filesystem read/write operations for agent file access. Thin config package. Triggers: filesystem, file access, read files.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-firecrawl/SKILL.md
+++ b/bundles/mcp-firecrawl/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: "@tank/mcp-firecrawl"
+description: |
+  Wire the Firecrawl MCP server into any AI agent harness. Provides
+  web scraping and crawling with structured data extraction. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "firecrawl", "web scraping", "crawling", "data extraction", "scrape"
+---
+
+# Firecrawl MCP Tool
+
+Registers the Firecrawl MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-firecrawl`
+2. Set required environment variables (see below)
+3. Restart your agent session
+
+## Required Environment Variables
+
+- `FIRECRAWL_API_KEY`: Required. Set in your environment or `.env`.
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `npx` |
+| Arguments | `-y firecrawl-mcp` |
+| Transport | STDIO |
+| Package | `firecrawl-mcp` |
+
+## What This Provides
+
+The Firecrawl server exposes tools for web scraping and crawling with structured data extraction.
+Load this package to give your agent access to Firecrawl capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-firecrawl/tank.json
+++ b/bundles/mcp-firecrawl/tank.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tank/mcp-firecrawl",
+  "version": "1.0.0",
+  "description": "Wire the Firecrawl MCP server for web scraping and crawling with structured data extraction. Thin config package. Triggers: firecrawl, web scraping, crawling.",
+  "permissions": {
+    "network": {
+      "outbound": [
+        "api.firecrawl.dev"
+      ]
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-github/SKILL.md
+++ b/bundles/mcp-github/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: "@tank/mcp-github"
+description: |
+  Wire the GitHub MCP server into any AI agent harness. Provides
+  github repository management, issues, prs, and code search. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "github", "repository", "pull request", "issues", "code search"
+---
+
+# GitHub MCP Tool
+
+Registers the GitHub MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-github`
+2. Set required environment variables (see below)
+3. Restart your agent session
+
+## Required Environment Variables
+
+- `GITHUB_PERSONAL_ACCESS_TOKEN`: Required. Set in your environment or `.env`.
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `npx` |
+| Arguments | `-y @modelcontextprotocol/server-github` |
+| Transport | STDIO |
+| Package | `@modelcontextprotocol/server-github` |
+
+## What This Provides
+
+The GitHub server exposes tools for github repository management, issues, prs, and code search.
+Load this package to give your agent access to GitHub capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-github/tank.json
+++ b/bundles/mcp-github/tank.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tank/mcp-github",
+  "version": "1.0.0",
+  "description": "Wire the GitHub MCP server for github repository management, issues, prs, and code search. Thin config package. Triggers: github, repository, pull request.",
+  "permissions": {
+    "network": {
+      "outbound": [
+        "api.github.com"
+      ]
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-jira/SKILL.md
+++ b/bundles/mcp-jira/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: "@tank/mcp-jira"
+description: |
+  Wire the Jira MCP server into any AI agent harness. Provides
+  atlassian jira issue tracking and project management. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "jira", "atlassian", "issue tracking", "project management", "tickets"
+---
+
+# Jira MCP Tool
+
+Registers the Jira MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-jira`
+2. Set required environment variables (see below)
+3. Restart your agent session
+
+## Required Environment Variables
+
+- `JIRA_URL`: Required. Set in your environment or `.env`.
+- `JIRA_EMAIL`: Required. Set in your environment or `.env`.
+- `JIRA_API_TOKEN`: Required. Set in your environment or `.env`.
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `uvx` |
+| Arguments | `mcp-atlassian==0.21.0` |
+| Transport | STDIO |
+| Package | `uvx` |
+
+## What This Provides
+
+The Jira server exposes tools for atlassian jira issue tracking and project management.
+Load this package to give your agent access to Jira capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-jira/tank.json
+++ b/bundles/mcp-jira/tank.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tank/mcp-jira",
+  "version": "1.0.0",
+  "description": "Wire the Jira MCP server for atlassian jira issue tracking and project management. Thin config package. Triggers: jira, atlassian, issue tracking.",
+  "permissions": {
+    "network": {
+      "outbound": [
+        "*.atlassian.net"
+      ]
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-magic/SKILL.md
+++ b/bundles/mcp-magic/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: "@tank/mcp-magic"
+description: |
+  Wire the Magic UI MCP server into any AI agent harness. Provides
+  magic ui design component generation and prototyping. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "magic ui", "design", "components", "UI generation", "prototyping"
+---
+
+# Magic UI MCP Tool
+
+Registers the Magic UI MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-magic`
+2. No configuration needed -- works out of the box
+3. Restart your agent session
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `npx` |
+| Arguments | `-y @magicuidesign/mcp@latest` |
+| Transport | STDIO |
+| Package | `@magicuidesign/mcp@latest` |
+
+## What This Provides
+
+The Magic UI server exposes tools for magic ui design component generation and prototyping.
+Load this package to give your agent access to Magic UI capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-magic/tank.json
+++ b/bundles/mcp-magic/tank.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tank/mcp-magic",
+  "version": "1.0.0",
+  "description": "Wire the Magic UI MCP server for magic ui design component generation and prototyping. Thin config package. Triggers: magic ui, design, components.",
+  "permissions": {
+    "network": {
+      "outbound": [
+        "magicui.design"
+      ]
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-memory/SKILL.md
+++ b/bundles/mcp-memory/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: "@tank/mcp-memory"
+description: |
+  Wire the Memory MCP server into any AI agent harness. Provides
+  persistent memory and knowledge graph for agent context across sessions. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "memory", "knowledge graph", "persistent context", "agent memory"
+---
+
+# Memory MCP Tool
+
+Registers the Memory MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-memory`
+2. No configuration needed -- works out of the box
+3. Restart your agent session
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `npx` |
+| Arguments | `-y @modelcontextprotocol/server-memory` |
+| Transport | STDIO |
+| Package | `@modelcontextprotocol/server-memory` |
+
+## What This Provides
+
+The Memory server exposes tools for persistent memory and knowledge graph for agent context across sessions.
+Load this package to give your agent access to Memory capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-memory/tank.json
+++ b/bundles/mcp-memory/tank.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/mcp-memory",
+  "version": "1.0.0",
+  "description": "Wire the Memory MCP server for persistent memory and knowledge graph for agent context across sessions. Thin config package. Triggers: memory, knowledge graph, persistent context.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-omega-memory/SKILL.md
+++ b/bundles/mcp-omega-memory/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: "@tank/mcp-omega-memory"
+description: |
+  Wire the Omega Memory MCP server into any AI agent harness. Provides
+  advanced persistent memory with semantic search and retrieval. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "omega memory", "semantic memory", "agent memory", "persistent context"
+---
+
+# Omega Memory MCP Tool
+
+Registers the Omega Memory MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-omega-memory`
+2. No configuration needed -- works out of the box
+3. Restart your agent session
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `uvx` |
+| Arguments | `omega-memory serve` |
+| Transport | STDIO |
+| Package | `uvx` |
+
+## What This Provides
+
+The Omega Memory server exposes tools for advanced persistent memory with semantic search and retrieval.
+Load this package to give your agent access to Omega Memory capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-omega-memory/tank.json
+++ b/bundles/mcp-omega-memory/tank.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/mcp-omega-memory",
+  "version": "1.0.0",
+  "description": "Wire the Omega Memory MCP server for advanced persistent memory with semantic search and retrieval. Thin config package. Triggers: omega memory, semantic memory, agent memory.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-playwright/SKILL.md
+++ b/bundles/mcp-playwright/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: "@tank/mcp-playwright"
+description: |
+  Wire the Playwright MCP server into any AI agent harness. Provides
+  browser automation, testing, and web interaction. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "playwright", "browser automation", "web testing", "browser control", "e2e"
+---
+
+# Playwright MCP Tool
+
+Registers the Playwright MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-playwright`
+2. No configuration needed -- works out of the box
+3. Restart your agent session
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `npx` |
+| Arguments | `-y @playwright/mcp --browser chrome` |
+| Transport | STDIO |
+| Package | `@playwright/mcp` |
+
+## What This Provides
+
+The Playwright server exposes tools for browser automation, testing, and web interaction.
+Load this package to give your agent access to Playwright capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-playwright/tank.json
+++ b/bundles/mcp-playwright/tank.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/mcp-playwright",
+  "version": "1.0.0",
+  "description": "Wire the Playwright MCP server for browser automation, testing, and web interaction. Thin config package. Triggers: playwright, browser automation, web testing.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-railway/SKILL.md
+++ b/bundles/mcp-railway/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: "@tank/mcp-railway"
+description: |
+  Wire the Railway MCP server into any AI agent harness. Provides
+  railway.app deployment and infrastructure management. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "railway", "deployment", "infrastructure", "hosting", "railway deploy"
+---
+
+# Railway MCP Tool
+
+Registers the Railway MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-railway`
+2. No configuration needed -- works out of the box
+3. Restart your agent session
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `npx` |
+| Arguments | `-y @railway/mcp-server` |
+| Transport | STDIO |
+| Package | `@railway/mcp-server` |
+
+## What This Provides
+
+The Railway server exposes tools for railway.app deployment and infrastructure management.
+Load this package to give your agent access to Railway capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-railway/tank.json
+++ b/bundles/mcp-railway/tank.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tank/mcp-railway",
+  "version": "1.0.0",
+  "description": "Wire the Railway MCP server for railway.app deployment and infrastructure management. Thin config package. Triggers: railway, deployment, infrastructure.",
+  "permissions": {
+    "network": {
+      "outbound": [
+        "railway.app"
+      ]
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-sequential-thinking/SKILL.md
+++ b/bundles/mcp-sequential-thinking/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: "@tank/mcp-sequential-thinking"
+description: |
+  Wire the Sequential Thinking MCP server into any AI agent harness. Provides
+  structured step-by-step reasoning and problem decomposition. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "sequential thinking", "reasoning", "problem solving", "step by step"
+---
+
+# Sequential Thinking MCP Tool
+
+Registers the Sequential Thinking MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-sequential-thinking`
+2. No configuration needed -- works out of the box
+3. Restart your agent session
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `npx` |
+| Arguments | `-y @modelcontextprotocol/server-sequential-thinking` |
+| Transport | STDIO |
+| Package | `@modelcontextprotocol/server-sequential-thinking` |
+
+## What This Provides
+
+The Sequential Thinking server exposes tools for structured step-by-step reasoning and problem decomposition.
+Load this package to give your agent access to Sequential Thinking capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-sequential-thinking/tank.json
+++ b/bundles/mcp-sequential-thinking/tank.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/mcp-sequential-thinking",
+  "version": "1.0.0",
+  "description": "Wire the Sequential Thinking MCP server for structured step-by-step reasoning and problem decomposition. Thin config package. Triggers: sequential thinking, reasoning, problem solving.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-supabase/SKILL.md
+++ b/bundles/mcp-supabase/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: "@tank/mcp-supabase"
+description: |
+  Wire the Supabase MCP server into any AI agent harness. Provides
+  supabase database, auth, storage, and edge functions. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "supabase", "database", "postgres", "auth", "storage"
+---
+
+# Supabase MCP Tool
+
+Registers the Supabase MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-supabase`
+2. No configuration needed -- works out of the box
+3. Restart your agent session
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `npx` |
+| Arguments | `-y @supabase/mcp-server-supabase@latest --project-ref=YOUR_PROJECT_REF` |
+| Transport | STDIO |
+| Package | `@supabase/mcp-server-supabase@latest` |
+
+## What This Provides
+
+The Supabase server exposes tools for supabase database, auth, storage, and edge functions.
+Load this package to give your agent access to Supabase capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-supabase/tank.json
+++ b/bundles/mcp-supabase/tank.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tank/mcp-supabase",
+  "version": "1.0.0",
+  "description": "Wire the Supabase MCP server for supabase database, auth, storage, and edge functions. Thin config package. Triggers: supabase, database, postgres.",
+  "permissions": {
+    "network": {
+      "outbound": [
+        "*.supabase.co"
+      ]
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": true
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}

--- a/bundles/mcp-token-optimizer/SKILL.md
+++ b/bundles/mcp-token-optimizer/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: "@tank/mcp-token-optimizer"
+description: |
+  Wire the Token Optimizer MCP server into any AI agent harness. Provides
+  token usage analysis and optimization for llm interactions. Thin wiring package -- does not contain the MCP server
+  itself, just the configuration to register it with the agent runtime.
+
+  Trigger phrases: "token optimizer", "token usage", "cost optimization", "LLM tokens"
+---
+
+# Token Optimizer MCP Tool
+
+Registers the Token Optimizer MCP server with the agent runtime.
+
+## Quick Start
+
+1. Install: `tank install @tank/mcp-token-optimizer`
+2. No configuration needed -- works out of the box
+3. Restart your agent session
+
+## Server Details
+
+| Field | Value |
+|-------|-------|
+| Command | `npx` |
+| Arguments | `-y token-optimizer-mcp` |
+| Transport | STDIO |
+| Package | `token-optimizer-mcp` |
+
+## What This Provides
+
+The Token Optimizer server exposes tools for token usage analysis and optimization for llm interactions.
+Load this package to give your agent access to Token Optimizer capabilities
+without manually configuring MCP server settings in each harness.

--- a/bundles/mcp-token-optimizer/tank.json
+++ b/bundles/mcp-token-optimizer/tank.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/mcp-token-optimizer",
+  "version": "1.0.0",
+  "description": "Wire the Token Optimizer MCP server for token usage analysis and optimization for llm interactions. Thin config package. Triggers: token optimizer, token usage, cost optimization.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/packages"
+}


### PR DESCRIPTION
## Summary

18 thin MCP tool wiring bundles — each registers an upstream MCP server with the agent runtime. No server code, just configuration.

Partially closes #125.

## Packages

| Bundle | MCP Server | Env Vars |
|--------|-----------|----------|
| `@tank/mcp-jira` | mcp-atlassian | JIRA_URL, JIRA_EMAIL, JIRA_API_TOKEN |
| `@tank/mcp-github` | @modelcontextprotocol/server-github | GITHUB_PERSONAL_ACCESS_TOKEN |
| `@tank/mcp-firecrawl` | firecrawl-mcp | FIRECRAWL_API_KEY |
| `@tank/mcp-supabase` | @supabase/mcp-server-supabase | (project-ref in args) |
| `@tank/mcp-memory` | @modelcontextprotocol/server-memory | (none) |
| `@tank/mcp-omega-memory` | omega-memory | (none) |
| `@tank/mcp-sequential-thinking` | @modelcontextprotocol/server-sequential-thinking | (none) |
| `@tank/mcp-railway` | @railway/mcp-server | (none) |
| `@tank/mcp-exa-web-search` | exa-mcp-server | EXA_API_KEY |
| `@tank/mcp-context7` | @upstash/context7-mcp | (none) |
| `@tank/mcp-magic` | @magicuidesign/mcp | (none) |
| `@tank/mcp-filesystem` | @modelcontextprotocol/server-filesystem | (none) |
| `@tank/mcp-playwright` | @playwright/mcp | (none) |
| `@tank/mcp-fal-ai` | fal-ai-mcp-server | FAL_KEY |
| `@tank/mcp-browserbase` | @browserbasehq/mcp-server-browserbase | BROWSERBASE_API_KEY |
| `@tank/mcp-token-optimizer` | token-optimizer-mcp | (none) |
| `@tank/mcp-confluence` | confluence-mcp-server | CONFLUENCE_BASE_URL, CONFLUENCE_EMAIL, CONFLUENCE_API_TOKEN |
| `@tank/mcp-evalview` | evalview | OPENAI_API_KEY |

## Deferred (9 stubs — no usable config in ECC source)

vercel, cloudflare-docs, cloudflare-workers-builds, cloudflare-workers-bindings, cloudflare-observability, clickhouse, browser-use, devfleet, laraplugins