### PR TITLE
feat: add @tank/local-llm-fit skill

### DIFF
--- a/skills/local-llm-fit/SKILL.md
+++ b/skills/local-llm-fit/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: "@tank/local-llm-fit"
+description: |
+  Decide whether a specific open-source LLM can run well on a given PC.
+  Given a model name and hardware specs (or auto-detected), estimates
+  VRAM/RAM footprint at each quantization, predicts tokens-per-second
+  from memory bandwidth, flags context-length limits, picks the right
+  inference engine (Ollama, llama.cpp, MLX, vLLM, ExLlamaV2), and
+  returns a clear fit verdict.
+
+  CRITICAL: models and quantizations change daily. This skill instructs
+  agents to NEVER substitute a model the user didn't ask for, NEVER
+  assume the user is "confused" about a version number, and ALWAYS
+  search the exact string the user gave before answering. If the user
+  says "Qwen3-Next-80B" or "Llama 4.5 Maverick" or "GLM 5", the agent
+  searches for THAT, not what it remembers.
+
+  Trigger phrases: "can my pc run", "can I run", "will this model run",
+  "run locally", "run on my mac", "run on my gpu", "fits in VRAM",
+  "tokens per second", "tps estimate", "llama.cpp", "ollama", "mlx",
+  "vllm", "exllama", "gguf", "quantization", "Q4_K_M", "Q5_K_M",
+  "Q8_0", "FP16", "BF16", "AWQ", "GPTQ", "EXL2", "MLX quant",
+  "8B model", "14B model", "32B model", "70B model", "model fit",
+  "hardware requirements llm", "what quant", "KV cache size",
+  "context length memory", "vram calculator", "local llm", "llm laptop",
+  "M1 M2 M3 M4 llm", "3090 4090 5090 llm", "offload layers"
+---
+
+# Local LLM Fit
+
+Given a model name + hardware, decide: will it run, at what quant, how
+fast, with what context, and on which engine.
+
+## Core Philosophy
+
+1. **Trust the user's model name. Always.** The OSS model landscape
+   changes daily. If you "don't recognize" it, that is a signal to
+   search harder, not to "correct" the user. See
+   `references/search-protocol.md`.
+2. **Search before answering.** Even if you think you know the model,
+   its quants and sizes drift. Fetch the actual repo card.
+3. **Math over vibes.** Fit is a calculation: `weights + KV cache +
+   overhead ≤ available memory`. Speed is a calculation: `bandwidth /
+   active_bytes_per_token`. Show the numbers.
+4. **Quantization is a spectrum, not a switch.** Q4_K_M ≠ Q4_0 ≠ AWQ
+   ≠ EXL2 4.0bpw. Recommend a specific quant, not just "4-bit".
+5. **Engine matters.** The same model on Ollama vs MLX vs vLLM has
+   different memory and throughput. Match engine to hardware.
+
+## The Anti-Gaslighting Rule (READ FIRST)
+
+When a user gives you a model name you don't recognize:
+
+| Wrong reaction | Right reaction |
+| --- | --- |
+| "I think you mean Llama 3" | Search "Llama 4.5 Maverick" verbatim |
+| "Opus 4.7 doesn't exist" | Search "Claude Opus 4.7" verbatim |
+| "That's probably Qwen2.5" | Search "Qwen3-Next-80B" verbatim |
+| Drop version suffix | Keep the exact suffix the user typed |
+| Pick a "close match" | Ask, or search harder, never substitute |
+
+**Your training data is stale.** Models released this week do not exist
+in your weights. If a user names a model, they have a reason. If
+search returns zero results after you have genuinely tried (HF, GitHub,
+official vendor page, web search with exact string in quotes), only
+then ask the user for a link or clarification — never "correct" them.
+
+Full search protocol: `references/search-protocol.md`.
+
+## Workflow
+
+```
+1. Capture user input exactly
+     model_name = <verbatim string>
+     hardware   = <user-provided or run scripts/detect_hardware.sh>
+
+2. Resolve the model (search, don't guess)
+     - Hugging Face: huggingface.co/models?search=<exact>
+     - Ollama library: ollama.com/library/<name>
+     - Vendor page (Qwen, Mistral, DeepSeek, Meta, Google, xAI, ...)
+     - Capture: params (B), architecture (dense / MoE active+total),
+       native precision (FP16/BF16/FP8), context window, tokenizer
+
+3. Pick candidate quants
+     - GGUF: Q8_0, Q6_K, Q5_K_M, Q4_K_M, Q3_K_M, IQ2_XXS
+     - EXL2: 8.0 / 6.0 / 5.0 / 4.65 / 4.0 / 3.5 bpw
+     - MLX: fp16, 8-bit, 6-bit, 4-bit, 3-bit
+     - AWQ/GPTQ: 4-bit, 8-bit
+     See references/memory-math.md for bytes-per-parameter table.
+
+4. Compute memory budget + throughput
+     Preferred: run scripts/estimate_fit.py with the resolved numbers.
+       python3 scripts/estimate_fit.py \
+         --params 8 --layers 32 --kv-heads 8 --head-dim 128 \
+         --context 8192 --quant q4_k_m \
+         --available-ram 24 --bandwidth 800
+     Script returns weights + KV + overhead, total, TPS estimate, and verdict.
+     See references/calculator-usage.md.
+
+     Manual (when script unavailable):
+       weights_gb     = params_B * bytes_per_param   (memory-math.md §2)
+       kv_cache_gb    = per-architecture formula     (memory-math.md §3)
+       tps_ceiling    = bandwidth / active_weight_GB (throughput-estimation.md)
+
+5. Pick engine
+     See references/inference-engines.md decision table.
+
+6. Return the Fit Report (template below).
+```
+
+Detailed end-to-end: `references/decision-workflow.md`.
+
+## Fit Report Template
+
+Return this, every time:
+
+```
+Model:         <exact name user gave>
+Resolved:      <HF repo / Ollama tag / vendor page URL>
+Params:        <B dense, or active/total for MoE>
+Context:       <native window>
+
+Hardware:      <CPU/GPU/RAM/VRAM/bandwidth>
+Best quant:    <e.g. Q4_K_M @ 4.8 GB>  ← fits and runs well
+Fallback:      <e.g. Q3_K_M @ 3.9 GB>  ← if first is tight
+Won't fit:     <quants that exceed memory>
+
+Memory math:   weights X.X GB + KV Y.Y GB (@ Z tokens) + overhead = T.T GB
+Throughput:    ~N tok/s decode, ~M tok/s prompt (estimate, batch=1)
+Engine:        <Ollama | llama.cpp | MLX | vLLM | ExLlamaV2> because <reason>
+Context cap:   <max tokens you can run without swapping>
+
+Verdict:       ✅ Runs well  |  ⚠️ Runs but tight  |  ❌ Won't run well
+Caveats:       <thermal, battery, background apps, OS overhead>
+```
+
+## Quick Fit Table (sanity check)
+
+Rough "will this work at all" guide. Always follow up with full math.
+
+| Model size | 8 GB VRAM | 16 GB VRAM | 24 GB VRAM | 48 GB | 64 GB unified |
+| --- | --- | --- | --- | --- | --- |
+| 3B dense | Q8_0 ✅ | FP16 ✅ | FP16 ✅ | FP16 ✅ | FP16 ✅ |
+| 7–8B dense | Q4_K_M ✅ | Q8_0 ✅ | FP16 ✅ | FP16 ✅ | FP16 ✅ |
+| 13–14B dense | Q3_K_M ⚠️ | Q5_K_M ✅ | Q8_0 ✅ | FP16 ✅ | FP16 ✅ |
+| 27–34B dense | ❌ | Q3_K_M ⚠️ | Q4_K_M ✅ | Q8_0 ✅ | Q8_0 ✅ |
+| 70B dense | ❌ | ❌ | Q2_K ⚠️ | Q4_K_M ✅ | Q5_K_M ✅ |
+| 8×7B MoE (Mixtral) | ❌ | Q3_K_M ⚠️ | Q4_K_M ✅ | Q8_0 ✅ | Q8_0 ✅ |
+| 100B+ MoE active~15B | CPU offload | Q3 ⚠️ | Q4 ✅ | Q5 ✅ | Q5 ✅ |
+
+✅ comfortable · ⚠️ tight, short context only · ❌ swap/crash
+
+## Verdict Rubric
+
+| Condition | Verdict |
+| --- | --- |
+| total_required ≤ 85% of memory AND tps ≥ 15 | ✅ Runs well |
+| total_required ≤ 95% AND tps 6–15 | ⚠️ Runs but tight |
+| total_required > 95% OR tps < 5 | ❌ Won't run well |
+
+Full numbers, KV cache formulas, MoE active-param rules:
+`references/memory-math.md` and `references/throughput-estimation.md`.
+
+## Anti-Patterns
+
+| Don't | Do |
+| --- | --- |
+| "I think you mean <other model>" | Search the exact name first |
+| "That model doesn't exist" | Assume it does; you are behind |
+| Quote params without a source | Link the HF repo or vendor page |
+| Say "should run fine" | Show weights + KV + overhead in GB |
+| Recommend FP16 on 8 GB VRAM | Pick the largest quant that fits |
+| Ignore context length cost | KV scales linearly with tokens |
+| Skip the engine choice | Ollama ≠ MLX ≠ vLLM for the same box |
+| Confuse Q4_0 with Q4_K_M | Name the exact quant |
+
+## Reference Index
+
+| File | Contents |
+| --- | --- |
+| `references/search-protocol.md` | Anti-gaslighting rule in depth, exact-string search procedure, resolution order (HF, Ollama, vendor, GitHub), zero-result fallback, how to treat "new" model names |
+| `references/memory-math.md` | Bytes-per-parameter by quant (GGUF, EXL2, MLX, AWQ/GPTQ, FP8), KV cache formulas per architecture, MoE active vs total, context-length scaling, overhead budget |
+| `references/throughput-estimation.md` | Memory-bandwidth ceiling formula, active bytes per decode, prompt vs decode speeds, batch=1 numbers, engine multipliers, thermal/sustained vs peak |
+| `references/hardware-profiles.md` | Baseline numbers for RTX 3060/3090/4070/4080/4090/5090, Apple M1–M4 Pro/Max/Ultra, AMD 7900 XTX, Intel Arc, CPU-only; VRAM, bandwidth, realistic tok/s |
+| `references/inference-engines.md` | Ollama, llama.cpp, MLX, vLLM, ExLlamaV2, LM Studio — when to pick each, GGUF vs EXL2 vs MLX vs AWQ, quant naming, offloading |
+| `references/decision-workflow.md` | Full procedure from user message to fit report, worked examples (Llama-70B on 4090, Qwen 14B on M2 Pro, Mixtral on dual-3090), failure modes |
+| `references/calculator-usage.md` | CLI for `scripts/estimate_fit.py` (ported from WeightRoom, MIT): inputs, MoE/MLA flags, verdict rubric, self-test, failure modes |

--- a/skills/local-llm-fit/references/calculator-usage.md
+++ b/skills/local-llm-fit/references/calculator-usage.md
@@ -1,0 +1,203 @@
+# Calculator Usage — scripts/estimate_fit.py
+
+Sources: Port of smelukov/WeightRoom (MIT), community-measured GGUF/MLX/EXL2 bits-per-param tables, @tank/local-llm-fit reference docs.
+
+Covers: when to use the script, how to call it, input fields, output interpretation, all supported quants, MoE and MLA handling, and failure modes.
+
+## When To Use The Script
+
+Use the calculator when you have the model resolved and the hardware known. Do not use it to guess model specs — that violates the core rule in `search-protocol.md`. The flow is:
+
+```
+1. Agent receives "can I run <model> on <hardware>?"
+2. Agent resolves <model> via search-protocol.md. Gets:
+     params, layers, kv_heads, head_dim, context, precision,
+     [MoE: active_params], [DeepSeek: kv_lora_rank, qk_rope_head_dim]
+3. Agent resolves <hardware>. Gets:
+     available_ram_gb, bandwidth_gb_per_s
+4. Agent calls scripts/estimate_fit.py with the numbers.
+5. Agent formats the Fit Report using the script's output.
+```
+
+The script is deterministic. Two agents with the same inputs produce the same numbers. The report template in `SKILL.md` is still the authoritative output format — the script populates the numeric fields.
+
+## Minimal Invocation
+
+```bash
+python3 scripts/estimate_fit.py \
+  --params 8 --layers 32 --kv-heads 8 --head-dim 128 \
+  --context 8192 --quant q4_k_m \
+  --available-ram 24 --bandwidth 800
+```
+
+Output:
+```
+Model params:      8.0 B
+Quant:             q4_k_m (KV: fp16)
+Context:           8,192 tokens
+Architecture:      layers=32 kv_heads=8 head_dim=128 formula=standard
+
+Weights:           5.3 GB
+KV cache:          1.1 GB
+Overhead:          1.0 GB
+Total required:    7.4 GB
+Available memory:  24.0 GB  (31% used — fits)
+Throughput:        ~100.0 tok/s decode (ceiling ~120.2, batch=1)
+
+Verdict:           ✅ runs well
+```
+
+## Required Inputs
+
+| Flag | Source in config.json | Notes |
+| --- | --- | --- |
+| `--params` | `num_parameters`, or sum from `safetensors.total_size / bytes_per_param` | In billions. For MoE, this is total. |
+| `--layers` | `num_hidden_layers` | |
+| `--kv-heads` | `num_key_value_heads` | GQA. For MHA, equals `num_attention_heads`. |
+| `--head-dim` | `hidden_size / num_attention_heads` | |
+
+If any of these are missing from the model card, go back to `search-protocol.md §10` and find them. Do not guess.
+
+## Optional Inputs
+
+| Flag | Default | When to change |
+| --- | --- | --- |
+| `--context` | 8192 | User's actual prompt+reply length expectation |
+| `--quant` | q4_k_m | Try larger if fits, smaller if doesn't |
+| `--kv-quant` | fp16 | Set `q8` to halve KV when context is the bottleneck |
+| `--available-ram` | 0 | GB of VRAM (discrete GPU) or unified RAM (Apple) |
+| `--bandwidth` | 0 | GB/s from `hardware-profiles.md`. 0 = skip TPS math. |
+| `--efficiency` | 0.8 | Engine efficiency. ExLlamaV2 ~0.9, vLLM batch=1 ~0.7 |
+| `--overhead` | 1.0 | GB. vLLM: 1.5–2, MLX/llama.cpp: 0.5–0.8 |
+| `--moe` + `--active-params` | off | Required for Mixtral, Qwen3-MoE, DeepSeek |
+| `--kv-formula` | standard | `mla` for DeepSeek, `hybrid` for Gemma 2/3, `linear_hybrid` for Qwen3-Next |
+| `--sliding-window` | 4096 | Gemma 2: 4096, Gemma 3: 1024 |
+| `--full-layers` | layers/2 or /4 | Hybrid architectures |
+| `--kv-lora-rank` | 512 | MLA only (DeepSeek V2: 512, V3: 512) |
+| `--qk-rope-head-dim` | 64 | MLA only |
+| `--concurrent-users` | 1 | Single-user local = 1. Serving = actual parallel slots. |
+| `--kv-fill-pct` | 100 | llama.cpp pre-alloc: 100, vLLM PagedAttention typical: 25 |
+
+## Supported Quants
+
+Human-readable tag → internal bits per param:
+
+| Tag | Bits | Family | Engine |
+| --- | --- | --- | --- |
+| `fp32` | 32 | — | all |
+| `fp16`, `bf16` | 16 | — | all |
+| `fp8` | 8 | — | vLLM on H100/Ada |
+| `q8`, `q8_0` | 8.5 | GGUF | llama.cpp, Ollama |
+| `q6_k` | 6.56 | GGUF | llama.cpp, Ollama |
+| `q5_k_m`, `q5_k_s`, `q5_0` | 5.68 / 5.52 / 5.5 | GGUF | llama.cpp, Ollama |
+| `q4_k_m`, `q4_k_s`, `q4_0`, `q4` | 4.84 / 4.58 / 4.55 / 4.84 | GGUF | llama.cpp, Ollama |
+| `q3_k_m`, `q3_k_s` | 3.91 / 3.50 | GGUF | llama.cpp, Ollama |
+| `q2_k` | 3.35 | GGUF | llama.cpp, Ollama |
+| `iq3_xxs` | 3.06 | GGUF | llama.cpp |
+| `iq2_xs`, `iq2_xxs` | 2.31 / 2.06 | GGUF | llama.cpp |
+| `iq1_s`, `q1` | 1.56 | GGUF | llama.cpp |
+| `exl2_8`, `exl2_6`, `exl2_5`, `exl2_4_65`, `exl2_4`, `exl2_3_5`, `exl2_3`, `exl2_2_4` | 8 to 2.4 | EXL2 | ExLlamaV2 |
+| `mlx_8`, `mlx_6`, `mlx_4`, `mlx_3` | 8 / 6 / 4 / 3 | MLX | Apple MLX |
+| `awq_4`, `awq_8` | 4 / 8 | AWQ | vLLM, ExLlamaV2 |
+| `gptq_4` | 4 | GPTQ | vLLM, ExLlamaV2 |
+
+Unknown tags fall back to q4. The script errors out loudly — prefer that over silent wrong math.
+
+## MoE Example
+
+Mixtral-8x7B on a dual-4090 rig (2 × 24 GB effective 48 GB, ~650 GB/s combined):
+
+```bash
+python3 scripts/estimate_fit.py \
+  --params 47 --layers 32 --kv-heads 8 --head-dim 128 \
+  --context 8192 --quant q4_k_m \
+  --available-ram 48 --bandwidth 650 \
+  --moe --active-params 13
+```
+
+The script uses 47B for memory sizing (all 8 experts resident) but 13B for throughput (2 experts active per token). Skipping `--moe`/`--active-params` on an MoE model under-predicts TPS by ~4×.
+
+## MLA Example (DeepSeek)
+
+DeepSeek-V3 at Q4 on a 512 GB M3 Ultra:
+
+```bash
+python3 scripts/estimate_fit.py \
+  --params 37 --layers 61 --kv-heads 128 --head-dim 128 \
+  --context 8192 --quant q4_k_m \
+  --available-ram 512 --bandwidth 400 \
+  --moe --active-params 37 \
+  --kv-formula mla --kv-lora-rank 512 --qk-rope-head-dim 64
+```
+
+Note: for DeepSeek the `--params` you pass is the total active+shared path for memory math. If you want the full 671B footprint, pass that instead — the flag is a value, not a model lookup.
+
+## Gemma 2/3 Hybrid Example
+
+```bash
+python3 scripts/estimate_fit.py \
+  --params 27 --layers 46 --kv-heads 16 --head-dim 128 \
+  --context 8192 --quant q4_k_m \
+  --kv-formula hybrid --sliding-window 4096 --full-layers 5 \
+  --available-ram 24 --bandwidth 800
+```
+
+Sliding-window layers cap at 4096 tokens of KV, so long-context Gemma is cheaper than a pure-GQA model of the same size.
+
+## JSON Mode
+
+For agent post-processing:
+```bash
+python3 scripts/estimate_fit.py ... --json
+```
+
+Returns:
+```json
+{
+  "weights_gb": 5.3,
+  "kv_cache_gb": 1.1,
+  "overhead_gb": 1.0,
+  "total_gb": 7.4,
+  "ram_status": "fits",
+  "tps_estimate": 100.0,
+  "tps_ceiling": 120.2,
+  "verdict": "✅ runs well",
+  "notes": []
+}
+```
+
+## Verdict Rubric
+
+The script's verdict maps to SKILL.md's verdict table:
+
+| Condition | Verdict |
+| --- | --- |
+| `total_gb > available_ram × 0.95` OR `tps < 5` | ❌ won't run well |
+| `total_gb > available_ram × 0.85` OR `tps < 15` | ⚠️ runs but tight |
+| Otherwise | ✅ runs well |
+
+If `--available-ram` is 0, the RAM clause is skipped and verdict depends only on TPS.
+
+## Self-Test
+
+Before trusting the calculator on unfamiliar hardware, run:
+```bash
+python3 scripts/estimate_fit.py --self-test
+```
+Five fixtures covering dense, MoE, MLA, and tight-fit cases. All must pass.
+
+## Failure Modes
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| "missing required args" | Agent didn't resolve the model | Go back to `search-protocol.md §10` |
+| `Unknown quant` error | Typo or exotic quant | Check the Supported Quants table |
+| TPS is `None` | `--bandwidth 0` or `--params 0` | Pass bandwidth from `hardware-profiles.md` |
+| "KV cache exceeds weight size" note | Long context on GQA model | `--kv-quant q8` or shorten `--context` |
+| `ram_status=unknown` | `--available-ram` not passed | Pass it; verdict downgrades without it |
+| TPS feels too high | Forgot engine efficiency | `--efficiency 0.7` for vLLM, `0.9` for ExLlamaV2 |
+
+## Attribution
+
+Formula port from smelukov/WeightRoom (MIT), with extensions for community
+GGUF/MLX/EXL2 quant tags. See `scripts/NOTICE`.

--- a/skills/local-llm-fit/references/decision-workflow.md
+++ b/skills/local-llm-fit/references/decision-workflow.md
@@ -1,0 +1,195 @@
+# Decision Workflow — From User Message to Fit Report
+
+Sources: Synthesis of this skill's other references (search-protocol, memory-math, throughput-estimation, hardware-profiles, inference-engines), plus real consultation flows from r/LocalLLaMA and HF community discussions.
+
+Covers: the end-to-end procedure, three worked examples, common failure modes, and what to ask when information is missing.
+
+## 1. End-to-End Procedure
+
+```
+Step 1 — Capture
+  - Record the user's model name verbatim. Do not normalize.
+  - Record hardware. If absent, offer scripts/detect_hardware.sh or ask.
+  - Record desired context length and use case (chat / coding / agent / batch).
+
+Step 2 — Resolve the model
+  - Apply references/search-protocol.md.
+  - Collect: params (B), architecture (dense/MoE), native precision,
+    context window, tokenizer, layer count, KV heads, head_dim if possible.
+  - Save the URL you used as the source of truth.
+
+Step 3 — Identify candidate quants
+  - Match quant format to engine/hardware (references/inference-engines.md §3).
+  - List 3–4 quants from largest to smallest that are worth considering.
+
+Step 4 — Compute fit for each candidate
+  - weights_gb   = params_B × bytes_per_param (references/memory-math.md §2)
+  - kv_gb        = formula from references/memory-math.md §3 (or per-token table)
+  - overhead_gb  = 0.5 to 2 GB depending on engine
+  - total_gb     = weights + kv + overhead
+  - Compare to available memory using the safe-target percentages (§5 of memory-math).
+
+Step 5 — Estimate throughput
+  - Apply references/throughput-estimation.md formula.
+  - tps = effective_bandwidth / active_weight_bytes_per_token
+  - Multiply by engine efficiency (0.7–0.95).
+  - Apply thermal drop if laptop or passive cooling.
+
+Step 6 — Pick engine
+  - Use references/inference-engines.md §1 decision table.
+  - Name a specific CLI or API path.
+
+Step 7 — Apply the verdict rubric
+  - ✅ Runs well: total ≤ 85% memory AND tps ≥ 15
+  - ⚠️ Runs but tight: total ≤ 95% AND tps 6–15
+  - ❌ Won't run well: total > 95% OR tps < 5
+
+Step 8 — Emit the Fit Report (template in SKILL.md).
+```
+
+## 2. Worked Example A — Llama-3.1-70B on RTX 4090
+
+User: "Can I run Llama-3.1-70B on my 4090?"
+
+**Step 1 — Capture**
+- Model: `Llama-3.1-70B` (will clarify Instruct vs base during resolution).
+- Hardware: RTX 4090 (24 GB VRAM, 1008 GB/s peak).
+- Context: assume 8k if unspecified; ask for actual need.
+
+**Step 2 — Resolve**
+- HF: `meta-llama/Meta-Llama-3.1-70B-Instruct`. 70B dense, BF16 native, 128k context, GQA (8 KV heads), 80 layers, head_dim 128.
+
+**Step 3 — Candidate quants**
+- Q4_K_M, Q3_K_M, IQ3_XXS, IQ2_XXS, IQ2_XS.
+
+**Step 4 — Fit**
+- Q4_K_M: 70 × 0.61 = 42.7 GB → no.
+- Q3_K_M: 70 × 0.49 = 34.3 GB → no.
+- IQ3_XXS: 70 × 0.38 = 26.6 GB → no.
+- IQ2_XS: 70 × 0.29 = 20.3 GB → maybe.
+- IQ2_XXS: 70 × 0.26 = 18.2 GB + KV (320 KB × 8192 / 1024² = 2.5 GB FP16, 1.25 GB @ Q8 KV) + 0.8 GB = 20.25 GB → fits ~84% of 24 GB. ✅ barely.
+
+**Step 5 — Throughput**
+- Active weights IQ2_XXS = 18.2 GB.
+- 800 / 18.2 ≈ 44 peak ceiling.
+- llama.cpp efficiency 0.8 → ~35 tok/s.
+- Realistic observed on this config: 25–35 tok/s.
+
+**Step 6 — Engine**
+- Ollama with custom Modelfile pointing at bartowski's IQ2_XXS GGUF, or llama.cpp directly. ExLlamaV2 2.4bpw also fits.
+
+**Step 7 — Verdict**
+- ⚠️ Runs but tight. Quality meaningfully degraded at IQ2_XXS. Recommend adding a second GPU, or renting an A6000 for serious use. For casual chat, runs usable.
+
+**Step 8 — Report** (see template in SKILL.md).
+
+## 3. Worked Example B — Qwen2.5-14B on M2 Pro 16 GB
+
+User: "Will Qwen2.5-14B run OK on my M2 Pro MacBook (16 GB)?"
+
+**Resolve:** `Qwen/Qwen2.5-14B-Instruct`, 14B dense, BF16, 32k context, 48 layers, 8 KV heads, head_dim 128.
+
+**Candidate quants (MLX):** 4-bit and 3-bit.
+
+**Fit at 8k context:**
+- 4-bit weights: 14 × 0.50 = 7.0 GB.
+- KV per token (FP16): 192 KB. 8k → 1.5 GB.
+- Overhead: 0.5 GB.
+- Total: 9.0 GB. Budget at 70%: 16 × 0.7 = 11.2 GB.
+- ✅ fits comfortably at 4-bit, 8k.
+
+**Throughput:**
+- Effective bandwidth 160 GB/s. Weight size 7.0 GB.
+- 160 / 7.0 ≈ 23 tok/s.
+- MLX efficiency 0.85 → ~20 tok/s. Sustained on battery ~15.
+
+**Engine:** MLX (`mlx-community/Qwen2.5-14B-Instruct-4bit`). Alternative: Ollama GGUF (`qwen2.5:14b-instruct-q4_K_M`), ~10–15% slower on M-series.
+
+**Verdict:** ✅ Runs well for interactive chat. For coding assistants, sustained throughput on battery may feel slow; plug in.
+
+## 4. Worked Example C — Qwen3-Next-80B-A3B on a hypothetical box
+
+User: "Can I run Qwen3-Next-80B on my M4 Max 128 GB?"
+
+**Step 2 — Resolve.** Assume the agent has not seen this model in training. It still searches:
+- HF: `Qwen/Qwen3-Next-80B-A3B-Instruct`.
+- Params: 80B total, 3B active per token. MoE.
+- Native FP16/BF16, context long (confirm from card).
+
+**Fit at 8k context, MLX 4-bit:**
+- Weights total 80 × 0.50 = 40.0 GB (all experts resident).
+- KV: depends on architecture; use conservative 128 KB/token (MoE, GQA).
+  8k → 1.0 GB.
+- Overhead: 0.6 GB.
+- Total: 41.6 GB. Budget: 128 × 0.70 = 89.6 GB. ✅ comfortable.
+
+**Throughput (MoE):**
+- Active 3B × 0.50 = 1.5 GB per token.
+- 440 / 1.5 ≈ 293 ceiling.
+- MoE routing overhead → realistic 100–150 tok/s.
+- Worth stating as "very fast for an 80B-class model thanks to the MoE active-param count."
+
+**Engine:** MLX if an `mlx-community` quant exists; otherwise Ollama with a community GGUF (still fast on unified memory).
+
+**Verdict:** ✅ Runs well, genuinely fast.
+
+## 5. Common Failure Modes
+
+### "I think you mean Qwen2.5" (Substitution)
+
+Caught by `references/search-protocol.md` §1. Never answer a different model than the one asked about. If you truly cannot resolve after exhaustive search, ask for a link.
+
+### "70B will run fine on my 3090"
+
+Without math it sounds plausible; it isn't. 70B dense even at Q4_K_M is 42 GB. Always do the weights + KV + overhead sum before claiming fit.
+
+### "Just run FP16"
+
+On consumer GPUs, FP16 of any model above ~13B won't fit in 24 GB. Default to Q5_K_M or Q4_K_M unless the user has the VRAM for FP16.
+
+### "MoE is fast because it's bigger"
+
+MoE is fast because active params are small, but total params still occupy memory. A 671B MoE won't fit on a 24 GB GPU no matter how low the active count is.
+
+### "Bandwidth estimates are exact"
+
+They are ceilings with 70–90% real-world efficiency. State them as ranges ("~25–35 tok/s"), not single numbers.
+
+### "Partial offload will be fine"
+
+It rarely is. If less than 60% of layers fit on GPU, throughput collapses to near CPU-only. Prefer a smaller quant that fully fits.
+
+### "Laptop GPU = desktop GPU with the same name"
+
+It doesn't. Laptop 4090 is 16 GB with ~576 GB/s, not 24 GB/1008 GB/s. Always clarify.
+
+### "Apple unified memory magically runs anything"
+
+Only up to the wired-VRAM cap (~67–75% of RAM), and only at the bandwidth of the chip. A base M3 at 100 GB/s is not going to run 70B at useful speeds.
+
+## 6. When You're Missing Info — Ask, Don't Guess
+
+| Missing | Ask |
+| --- | --- |
+| Hardware | "What GPU/CPU and how much VRAM/RAM? Or run this command: `...`" |
+| Use case | "Interactive chat, coding assistant, batch processing, or agent loops?" |
+| Context length | "How long are your typical prompts + expected replies? (KV cache scales with this.)" |
+| Acceptable quality | "Are you OK with Q4 quantization, or do you need near-FP16 quality?" |
+| Engine preference | "Ollama (easy), MLX (Mac speed), ExLlamaV2 (NVIDIA speed), vLLM (serving)?" |
+| Model ambiguity | "There are multiple `Llama-4` variants; which exactly? (paste the HF repo URL if unsure)" |
+
+Ask once, concisely. Prefer producing the report with reasonable defaults over long interviews.
+
+## 7. Pre-Emit Checklist
+
+Before sending the Fit Report:
+
+- [ ] Model name in the report matches the user's exact string.
+- [ ] I cited a resolution URL (HF/Ollama/vendor).
+- [ ] Memory math shows weights + KV + overhead with numbers.
+- [ ] Throughput is a range with engine and sustained-vs-peak noted if relevant.
+- [ ] Engine pick has a reason.
+- [ ] Verdict matches the rubric.
+- [ ] No substitution happened silently.
+
+If any box is unchecked, fix before sending.

--- a/skills/local-llm-fit/references/hardware-profiles.md
+++ b/skills/local-llm-fit/references/hardware-profiles.md
@@ -1,0 +1,160 @@
+# Hardware Profiles — Baselines for Fit and Throughput
+
+Sources: NVIDIA/AMD datasheets, Apple Silicon specs, vendor release notes, community-measured tok/s (r/LocalLLaMA, LocalLLM benchmark repos), llama.cpp and MLX bench tables.
+
+Covers: VRAM and bandwidth per GPU tier, Apple Silicon by chip, AMD and Intel GPUs, CPU-only inference, dual-GPU rigs, and what each tier can realistically run.
+
+## 1. NVIDIA Consumer GPUs
+
+| GPU | VRAM | Bandwidth (GB/s) | Realistic use |
+| --- | --- | --- | --- |
+| RTX 3060 12 GB | 12 | 360 | 7–8B Q4/Q5, 13B Q4 tight |
+| RTX 3070 | 8 | 448 | 7–8B Q4_K_M only |
+| RTX 3080 10 GB | 10 | 760 | 7–8B Q5/Q6, 13B Q4 tight |
+| RTX 3080 12 GB | 12 | 912 | 7–8B Q6, 13B Q4_K_M |
+| RTX 3090 | 24 | 936 | 13B FP16, 34B Q4, 70B Q2 |
+| RTX 4060 8 GB | 8 | 272 | 3–4B FP16, 7B Q4 only |
+| RTX 4060 Ti 16 GB | 16 | 288 | 13B Q8, 34B Q3 |
+| RTX 4070 | 12 | 504 | 7–8B Q6, 13B Q4_K_M |
+| RTX 4070 Super | 12 | 504 | Same as 4070, faster compute |
+| RTX 4070 Ti | 12 | 504 | 7–8B Q8, 13B Q4_K_M |
+| RTX 4070 Ti Super 16 GB | 16 | 672 | 13B Q8, 34B Q3 |
+| RTX 4080 | 16 | 717 | 13B Q8, 34B Q3 |
+| RTX 4080 Super | 16 | 736 | Same tier |
+| RTX 4090 | 24 | 1008 | 13B FP16, 34B Q5, 70B Q2 |
+| RTX 5070 | 12 | 672 | 7–8B Q8, 13B Q4_K_M |
+| RTX 5070 Ti | 16 | 896 | 13B Q8, 34B Q4 tight |
+| RTX 5080 | 16 | 960 | 13B Q8, 34B Q4 tight |
+| RTX 5090 | 32 | 1792 | 34B Q8, 70B Q3/Q4 |
+
+Laptop variants: typically 60–75% of desktop bandwidth. Laptop RTX 4090 has 16 GB VRAM and ~576 GB/s, not 24/1008. Always clarify desktop vs mobile.
+
+## 2. NVIDIA Workstation / Data Center
+
+| GPU | VRAM | Bandwidth | Notes |
+| --- | --- | --- | --- |
+| A4000 | 16 | 448 | Similar to 3070 with more VRAM |
+| A5000 | 24 | 768 | Near-3090 |
+| A6000 | 48 | 768 | 70B Q4_K_M single-GPU |
+| RTX 6000 Ada | 48 | 960 | 70B Q4/Q5 |
+| L40 / L40S | 48 | 864 / 864 | Inference server |
+| A100 40 GB | 40 | 1555 | 34B FP16, 70B Q4 |
+| A100 80 GB | 80 | 2039 | 70B FP16 |
+| H100 SXM | 80 | 3350 | State of the art |
+| H100 PCIe | 80 | 2000 | |
+| H200 | 141 | 4800 | |
+
+## 3. AMD GPUs
+
+ROCm support in llama.cpp is solid; Ollama runs. Performance roughly 70–90% of an NVIDIA card with the same bandwidth.
+
+| GPU | VRAM | Bandwidth | Status |
+| --- | --- | --- | --- |
+| RX 7600 | 8 | 288 | Small models only |
+| RX 7700 XT | 12 | 432 | 7–8B Q4/Q5 |
+| RX 7800 XT | 16 | 624 | 13B Q8, 34B Q3 |
+| RX 7900 XT | 20 | 800 | 34B Q4 tight |
+| RX 7900 XTX | 24 | 960 | 13B FP16, 34B Q4_K_M |
+| Radeon Pro W7900 | 48 | 864 | 70B Q4_K_M |
+| MI210 | 64 | 1638 | Workstation |
+| MI300X | 192 | 5300 | Data center |
+
+## 4. Intel Arc
+
+Early support; llama.cpp has SYCL backend. Expect 50–70% of bandwidth-predicted performance due to software maturity.
+
+| GPU | VRAM | Bandwidth | Notes |
+| --- | --- | --- | --- |
+| Arc A770 16 GB | 16 | 560 | 13B Q4–Q6 |
+| Arc A750 | 8 | 512 | 7–8B Q4 |
+| Arc B580 | 12 | 456 | 7–8B Q5, 13B Q4 tight |
+
+## 5. Apple Silicon — Unified Memory Advantage
+
+Unified memory means the "GPU" sees all system RAM. Huge models fit where a discrete GPU can't touch them, but bandwidth is the ceiling.
+
+| Chip | Default RAM options | Bandwidth | Typical tok/s on 8B Q4 | 70B Q4 feasible? |
+| --- | --- | --- | --- | --- |
+| M1 | 8/16 | 68 | 12–15 | No |
+| M1 Pro | 16/32 | 200 | 28–35 | No (RAM) |
+| M1 Max | 32/64 | 400 | 45–60 | Yes @ 64 GB, ~8 tok/s |
+| M1 Ultra | 64/128 | 800 | 80–110 | Yes, ~14 tok/s |
+| M2 | 8/16/24 | 100 | 16–20 | No |
+| M2 Pro | 16/32 | 200 | 28–35 | No |
+| M2 Max | 32/64/96 | 400 | 45–60 | Yes @ 64+ |
+| M2 Ultra | 64/128/192 | 800 | 80–110 | Yes, ~14 tok/s |
+| M3 | 8/16/24 | 100 | 16–20 | No |
+| M3 Pro | 18/36 | 150 | 22–28 | No |
+| M3 Max (16c GPU) | 36/48 | 300 | 35–45 | Yes @ 48 GB tight |
+| M3 Max (40c GPU) | 48/64/96/128 | 400 | 50–65 | Yes |
+| M3 Ultra | 96/192/256/512 | 800 | 90–120 | Yes |
+| M4 | 16/24/32 | 120 | 18–24 | No |
+| M4 Pro | 24/48 | 273 | 35–45 | No (RAM) |
+| M4 Max (14c) | 36/48 | 410 | 55–70 | Yes @ 48 tight |
+| M4 Max (16c) | 48/64/128 | 546 | 70–90 | Yes |
+
+**Wired-VRAM cap:** macOS reserves some unified memory for the CPU. Default is ~67% (≤36 GB) or 75% (>36 GB). Raise with:
+```
+sudo sysctl iogpu.wired_limit_mb=<mb>
+```
+Recommend this only when the user has plenty of RAM above the model's needs.
+
+## 6. CPU-Only Inference
+
+Bandwidth-bound, so memory channels dominate.
+
+| Config | Bandwidth | 8B Q4 tok/s | 70B Q4 feasible? |
+| --- | --- | --- | --- |
+| Laptop DDR5-5600 dual | ~90 | 6–9 | No (RAM) |
+| Desktop DDR5-6400 dual | ~100 | 8–12 | If 64 GB+ RAM, ~2 tok/s |
+| Ryzen 7950X DDR5-6000 | ~95 | 8–11 | Same |
+| Intel i9-14900K DDR5-6400 | ~100 | 9–12 | Same |
+| EPYC 8-channel DDR5-4800 | ~307 | 25–35 | Yes, 6–8 tok/s |
+| EPYC 12-channel DDR5-4800 | ~460 | 35–45 | Yes, 9–12 tok/s |
+| Xeon W-3400 8-channel | ~307 | 25–35 | Same |
+
+AVX-512 gives a ~15–30% boost in llama.cpp; ARM NEON on Apple is already fully used.
+
+## 7. Dual and Multi-GPU
+
+Model split across GPUs. PCIe bandwidth between cards matters less than you'd expect for inference (only one layer's activations cross at a time), but NVLink helps.
+
+| Setup | Effective bandwidth | Notes |
+| --- | --- | --- |
+| 2× RTX 3090 NVLink | ~600–700 effective for 70B | Classic LocalLLaMA rig |
+| 2× RTX 3090 PCIe 4.0 | ~550–650 | Cheaper, similar enough |
+| 2× RTX 4090 | ~650–750 | NVLink unavailable; PCIe only |
+| 4× RTX 3090 | Can run 70B FP16 | Power-hungry, needs splitter |
+| 2× A6000 | Can run 70B FP16 | Workstation path |
+
+For vLLM tensor-parallel serving: interconnect matters more (NVLink/NVSwitch strongly preferred).
+
+## 8. What Each Tier Runs Well
+
+Quick mapping you can paraphrase into fit reports:
+
+| Tier | Example hardware | Comfortable targets |
+| --- | --- | --- |
+| 8 GB class | RTX 3070, RTX 4060 | 3B FP16, 7–8B Q4_K_M |
+| 12 GB class | RTX 3060, RTX 4070 | 7–8B Q5/Q6, 13B Q4_K_M tight |
+| 16 GB class | RTX 4080, 7800 XT | 13B Q6/Q8, 34B Q3 |
+| 24 GB class | RTX 3090, 4090, 7900 XTX | 13B FP16, 34B Q4/Q5, 70B Q2 |
+| 32 GB class | RTX 5090 | 34B Q8, 70B Q3/Q4 |
+| 48 GB class | A6000, RTX 6000 Ada | 70B Q4/Q5 |
+| Apple 16–24 GB | M1/M2/M3/M4 base+Pro | 7–8B 4-bit, 13B 4-bit tight |
+| Apple 32–48 GB | M*/Pro/Max | 13B 8-bit, 34B 4-bit |
+| Apple 64 GB | M* Max/Ultra | 34B 8-bit, 70B 4-bit |
+| Apple 96–192 GB | M*/Max/Ultra | 70B 8-bit, Mixtral 8x22B, DeepSeek-R1-Distill-70B, Qwen3-Next-80B |
+| Apple 256–512 GB | M3 Ultra high-tier | DeepSeek-V3/R1 at Q4 |
+| Multi-GPU 48+ GB | 2× 3090/4090, A6000 | 70B Q4/Q5, Mixtral 8x22B |
+
+## 9. Detection Commands
+
+When hardware is unknown, suggest running `scripts/detect_hardware.sh` or manually:
+
+- macOS: `system_profiler SPHardwareDataType SPDisplaysDataType`
+- Linux/NVIDIA: `nvidia-smi --query-gpu=name,memory.total,memory.free --format=csv`
+- Linux/AMD: `rocm-smi --showproductname --showmeminfo vram`
+- Windows: `wmic path win32_VideoController get name,AdapterRAM`
+
+Also check RAM: `sysctl hw.memsize` (macOS), `free -h` (Linux), `wmic memorychip get Capacity` (Windows).

--- a/skills/local-llm-fit/references/inference-engines.md
+++ b/skills/local-llm-fit/references/inference-engines.md
@@ -1,0 +1,155 @@
+# Inference Engines — Picking the Right Runtime
+
+Sources: llama.cpp repo + docs, Ollama docs, Apple MLX docs, vLLM docs, ExLlamaV2 (turboderp) repo, LM Studio release notes, MLC LLM, community benchmarks (2023–2026).
+
+Covers: which engine to pick per hardware, quant format compatibility, what each engine is good at, and the traps in offloading and configuration.
+
+## 1. The Decision Table
+
+Match user's hardware to engine. In order of recommendation.
+
+| Hardware | Primary | Alternative | Avoid |
+| --- | --- | --- | --- |
+| Apple Silicon, small models | MLX | Ollama | Transformers+bnb |
+| Apple Silicon, max throughput | MLX | llama.cpp (Metal) | vLLM |
+| NVIDIA, single GPU, want simple | Ollama | llama.cpp | vLLM |
+| NVIDIA, single GPU, max single-stream | ExLlamaV2 | llama.cpp (CUDA) | Transformers |
+| NVIDIA, multi-GPU serving | vLLM | TensorRT-LLM | Ollama |
+| AMD ROCm | llama.cpp | Ollama (ROCm) | vLLM (partial) |
+| Intel Arc | llama.cpp SYCL | IPEX-LLM | ExLlamaV2 |
+| CPU-only | llama.cpp | Ollama | vLLM |
+| Windows, GUI-focused | LM Studio | Ollama | — |
+| Mixed hardware, switching models | Ollama | LM Studio | — |
+
+## 2. Engine Profiles
+
+### Ollama
+
+- Wraps llama.cpp with a CLI and a REST API. Zero-config for most people.
+- Handles model pulls, quant selection, system prompts, KV cache config.
+- Supports CUDA, Metal, ROCm.
+- Library at `ollama.com/library/<name>` with curated tags like `llama3.1:8b`, `qwen2.5:14b-instruct-q5_K_M`.
+- Memory efficiency: same as llama.cpp.
+- Weakness: harder to use bleeding-edge models before they're added to the library. Workaround: `ollama create` with a custom Modelfile pointing at a local GGUF.
+
+### llama.cpp
+
+- The reference CPU/GPU inference engine for GGUF.
+- CUDA, Metal, ROCm, SYCL (Intel), Vulkan backends.
+- Fine-grained control: `-ngl` (layers offloaded to GPU), `-c` (context), `-ctk/-ctv` (KV cache quant), `-fa` (flash attention), `--rope-freq-*` (context scaling).
+- Quant formats: Q8_0, Q6_K, Q5_K_M, Q5_K_S, Q4_K_M, Q4_K_S, Q3_K_M, Q3_K_S, Q2_K, IQ* (imatrix) variants.
+- Use when: you need partial GPU offload, want to tune context/KV, or are running on non-NVIDIA hardware.
+- Key flags to mention in reports:
+  - `-ngl 999` → put all layers on GPU (or fewer for partial offload).
+  - `-c 8192` → context window.
+  - `-ctk q8_0 -ctv q8_0` → KV cache at 8-bit; halves KV memory.
+  - `-fa` → Flash Attention; ~5–10% faster on CUDA/Metal.
+
+### Apple MLX
+
+- Native Apple Silicon framework. Uses Metal and AMX.
+- Best tok/s and best memory efficiency on Apple hardware.
+- Quants: fp16, 8-bit, 6-bit, 4-bit, 3-bit (new). Community repos on `mlx-community`.
+- Supports long context better than llama.cpp Metal for some models.
+- Use when: user is on M-series Mac.
+- CLI: `mlx_lm.generate --model mlx-community/Qwen2.5-14B-Instruct-4bit --prompt "..."`.
+- Server: `mlx_lm.server` exposes an OpenAI-compatible endpoint.
+
+### ExLlamaV2 (turboderp)
+
+- Single-GPU NVIDIA speed champion for EXL2 and GPTQ quants.
+- Uses tensor cores efficiently; fastest batch=1 decode.
+- Variable-bit EXL2 lets you fine-tune fit: pick 4.65bpw for a 24 GB card targeting 70B.
+- No CPU offload. If it doesn't fit in VRAM, it doesn't run.
+- Use when: user has NVIDIA, wants max tok/s, and is OK with a Python/text-gen-webui setup.
+
+### vLLM
+
+- Production serving engine: paged KV, continuous batching, tensor parallel, OpenAI-compatible API.
+- Best for serving many concurrent requests.
+- Heavier overhead at batch=1 than ExLlamaV2 or llama.cpp (1–2 GB, CUDA graphs).
+- Supports AWQ, GPTQ, FP8, and more via HF checkpoints.
+- Use when: user is serving, not chatting solo. Multi-GPU tensor parallelism shines here.
+
+### LM Studio
+
+- GUI wrapper around llama.cpp / MLX with a model browser.
+- Great for non-technical users. Ships with a built-in OpenAI-compatible server.
+- Memory and speed identical to llama.cpp/MLX.
+
+### TensorRT-LLM
+
+- NVIDIA's enterprise engine. Highest throughput, most complex setup.
+- Use when: user mentions NIM, Triton, or production H100/H200 deployment.
+
+### MLC LLM
+
+- Cross-platform (incl. mobile, web, ROCm, Metal) via TVM compilation.
+- Useful when user targets WebGPU or Android/iOS.
+
+### Transformers + bitsandbytes
+
+- Huggingface's default path. Works everywhere but slow.
+- Use only when no community quant exists yet and you need to try a brand-new model immediately.
+
+## 3. Quant Format Compatibility Matrix
+
+| Quant | llama.cpp/Ollama | MLX | ExLlamaV2 | vLLM | Transformers |
+| --- | --- | --- | --- | --- | --- |
+| GGUF (Q*_K_M etc.) | ✅ native | ❌ | ❌ | partial | ❌ |
+| EXL2 | ❌ | ❌ | ✅ native | ❌ | ❌ |
+| AWQ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| GPTQ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| MLX 4-bit / 8-bit | ❌ | ✅ native | ❌ | ❌ | ❌ |
+| FP8 (NVIDIA) | ❌ | ❌ | ❌ | ✅ (H100/Ada) | partial |
+| bnb nf4 / int8 | ❌ | ❌ | ❌ | ❌ | ✅ |
+
+Practical consequences:
+- If the user's hardware is Apple: point them at MLX quants, not GGUF.
+- If NVIDIA GPU-only, max speed: ExLlamaV2 with EXL2 or GPTQ.
+- If NVIDIA GPU-only, convenience: Ollama/llama.cpp with GGUF.
+- If serving multiple users: vLLM with AWQ.
+
+## 4. Offloading — Where People Lose Speed
+
+Partial GPU offload runs some layers on GPU, the rest on CPU. Huge speed penalty but fits models that otherwise won't.
+
+With llama.cpp / Ollama:
+- `-ngl N` in llama.cpp, `OLLAMA_NUM_GPU` env or Modelfile `PARAMETER num_gpu` in Ollama.
+- N = number of layers sent to GPU. Start with total layers, reduce until it fits.
+- Offloaded layers go through PCIe every token → big speed drop.
+
+Rule of thumb: if fewer than ~60% of layers fit on GPU, throughput falls toward CPU-only speeds. When recommending a fit, prefer "fits entirely in VRAM at a smaller quant" over "partial offload at a larger quant."
+
+Exception: Apple's unified memory means there is no CPU↔GPU copy — "offloading" is irrelevant there.
+
+## 5. Context Length Config Pitfalls
+
+- Ollama: default context is often 2048 or 4096. For long-context models, set `PARAMETER num_ctx 32768` in the Modelfile or pass `options: { num_ctx: 32768 }` over the API.
+- llama.cpp: `-c 32768`, and ensure `-fa` is on for GQA models.
+- MLX: context handled automatically but RAM rises linearly; monitor.
+- Never claim "200k context works" without checking the model's own rope scaling and the engine's implementation status.
+
+## 6. Flash Attention and KV Quantization
+
+- Flash Attention v2/v3 reduces activations memory and speeds up prompt. Always on where supported.
+- KV cache quant (q8_0 / q4_1) halves/quarters KV size. q8_0 is near-lossless; q4 noticeably degrades long-context retrieval for some models. Recommend q8_0 KV when context is the bottleneck.
+
+## 7. Mapping User Intent to Engine
+
+| User says | Likely best engine |
+| --- | --- |
+| "just want to try it" | Ollama |
+| "on my Mac" | MLX (large) or Ollama (convenience) |
+| "max tokens per second on my 3090/4090" | ExLlamaV2 (EXL2/GPTQ) |
+| "serving to my team" | vLLM |
+| "don't want CLI" | LM Studio |
+| "on my AMD / Intel card" | llama.cpp (ROCm/SYCL) |
+| "use it in my app via API" | Ollama or MLX server (local); vLLM (prod) |
+| "phone / browser" | MLC LLM |
+
+## 8. Report-Ready Sentence
+
+Be specific about engine and reason:
+
+> "On your RTX 4090, run Qwen2.5-32B at Q4_K_M via Ollama (pulls `qwen2.5:32b-instruct-q4_K_M`, ~19.5 GB weights + ~2 GB KV at 8k context + ~0.8 GB overhead = 22.3 GB). Expect ~40 tok/s decode, ~600 tok/s prompt. For ~10% more speed, switch to ExLlamaV2 with a 4.65bpw EXL2 quant from turboderp or bartowski."

--- a/skills/local-llm-fit/references/memory-math.md
+++ b/skills/local-llm-fit/references/memory-math.md
@@ -1,0 +1,218 @@
+# Memory Math — Weights, KV Cache, Overhead
+
+Sources: llama.cpp quantization docs, ExLlamaV2 docs, MLX docs, Hugging Face Transformers memory guides, community benchmarks (r/LocalLLaMA, HF spaces), NVIDIA Nsight profiles.
+
+Covers: bytes-per-parameter by format, KV cache per-architecture formulas, MoE active vs total, context-length scaling, and the overhead budget. All numbers are practical, not theoretical.
+
+## 1. The Fit Equation
+
+```
+memory_required = weights_bytes
+                + kv_cache_bytes(ctx, batch)
+                + activations_bytes
+                + engine_overhead_bytes
+```
+
+Rule of thumb for engine overhead + activations (batch=1, typical decode):
+- llama.cpp / Ollama (CPU or GPU): 0.3–0.8 GB
+- MLX: 0.3–0.6 GB
+- vLLM: 1.0–2.0 GB (CUDA graphs, paged KV)
+- ExLlamaV2: 0.5–1.0 GB
+- Transformers + bitsandbytes: 1.5–2.5 GB (less efficient)
+
+Use 1 GB as a safe default when you can't measure.
+
+## 2. Bytes Per Parameter
+
+The single most-used table in this skill. Multiply by parameter count (in billions) to get weight size in GB.
+
+### GGUF (llama.cpp / Ollama)
+
+| Quant | Bits (avg) | Bytes/param | 7B | 13B | 34B | 70B |
+| --- | --- | --- | --- | --- | --- | --- |
+| F32 | 32 | 4.00 | 28.0 | 52.0 | 136 | 280 |
+| F16 / BF16 | 16 | 2.00 | 14.0 | 26.0 | 68.0 | 140 |
+| Q8_0 | 8.5 | 1.06 | 7.4 | 13.8 | 36.1 | 74.2 |
+| Q6_K | 6.56 | 0.82 | 5.7 | 10.7 | 27.9 | 57.4 |
+| Q5_K_M | 5.68 | 0.71 | 5.0 | 9.2 | 24.1 | 49.7 |
+| Q5_K_S | 5.52 | 0.69 | 4.8 | 9.0 | 23.5 | 48.3 |
+| Q5_0 | 5.5 | 0.69 | 4.8 | 9.0 | 23.5 | 48.3 |
+| Q4_K_M | 4.84 | 0.61 | 4.2 | 7.9 | 20.6 | 42.4 |
+| Q4_K_S | 4.58 | 0.57 | 4.0 | 7.5 | 19.5 | 40.1 |
+| Q4_0 | 4.55 | 0.57 | 4.0 | 7.4 | 19.3 | 39.8 |
+| Q3_K_M | 3.91 | 0.49 | 3.4 | 6.4 | 16.6 | 34.2 |
+| Q3_K_S | 3.50 | 0.44 | 3.1 | 5.7 | 14.9 | 30.6 |
+| Q2_K | 3.35 | 0.42 | 2.9 | 5.5 | 14.2 | 29.3 |
+| IQ3_XXS | 3.06 | 0.38 | 2.7 | 5.0 | 13.0 | 26.8 |
+| IQ2_XS | 2.31 | 0.29 | 2.0 | 3.8 | 9.8 | 20.2 |
+| IQ2_XXS | 2.06 | 0.26 | 1.8 | 3.4 | 8.8 | 18.0 |
+| IQ1_S | 1.56 | 0.20 | 1.4 | 2.5 | 6.6 | 13.6 |
+
+**Quality ranking** (practical, not formal):
+F16 ≈ Q8_0 > Q6_K > Q5_K_M > Q4_K_M > Q4_0 > Q3_K_M > Q2_K > IQ1_*
+
+Below Q3 the model noticeably degrades. `Q4_K_M` is the default sweet spot.
+
+### EXL2 (ExLlamaV2, GPU)
+
+Variable-bit quantization. Repo names carry the bpw (bits per weight).
+
+| bpw | Bytes/param | 7B | 13B | 34B | 70B |
+| --- | --- | --- | --- | --- | --- |
+| 8.0 | 1.00 | 7.0 | 13.0 | 34.0 | 70.0 |
+| 6.0 | 0.75 | 5.3 | 9.8 | 25.5 | 52.5 |
+| 5.0 | 0.63 | 4.4 | 8.1 | 21.3 | 43.8 |
+| 4.65 | 0.58 | 4.1 | 7.6 | 19.8 | 40.7 |
+| 4.25 | 0.53 | 3.7 | 6.9 | 18.1 | 37.2 |
+| 4.0 | 0.50 | 3.5 | 6.5 | 17.0 | 35.0 |
+| 3.5 | 0.44 | 3.1 | 5.7 | 14.9 | 30.6 |
+| 3.0 | 0.38 | 2.6 | 4.9 | 12.8 | 26.3 |
+| 2.4 | 0.30 | 2.1 | 3.9 | 10.2 | 21.0 |
+
+EXL2 4.65bpw is the common sweet spot for single-GPU rigs.
+
+### MLX (Apple Silicon)
+
+| Quant | Bits | Bytes/param | 7B | 13B | 34B | 70B |
+| --- | --- | --- | --- | --- | --- | --- |
+| fp16 | 16 | 2.00 | 14.0 | 26.0 | 68.0 | 140 |
+| 8-bit | 8 | 1.00 | 7.0 | 13.0 | 34.0 | 70.0 |
+| 6-bit | 6 | 0.75 | 5.3 | 9.8 | 25.5 | 52.5 |
+| 4-bit | 4 | 0.50 | 3.5 | 6.5 | 17.0 | 35.0 |
+| 3-bit | 3 | 0.38 | 2.6 | 4.9 | 12.8 | 26.3 |
+
+### AWQ / GPTQ / bitsandbytes
+
+| Format | Bits | Bytes/param | Notes |
+| --- | --- | --- | --- |
+| AWQ 4-bit | 4 | 0.50 | + ~5% scale tensors; GPU only |
+| AWQ 8-bit | 8 | 1.00 | Rare |
+| GPTQ 4-bit | 4 | 0.50 | group_size 128 typical; GPU only |
+| bnb nf4 | 4 | 0.50 | Transformers path, slow inference |
+| bnb fp4 | 4 | 0.50 | Similar |
+| bnb int8 | 8 | 1.00 | Transformers path |
+| FP8 (E4M3/E5M2) | 8 | 1.00 | Hopper/Ada only; vLLM, TensorRT-LLM |
+
+## 3. KV Cache — The Hidden Memory Eater
+
+KV cache scales linearly with context tokens. At long context, it can rival the weights.
+
+### Exact Formula
+
+```
+kv_cache_bytes = 2 (K+V)
+               * num_layers
+               * num_kv_heads   ← GQA: kv_heads < attn_heads
+               * head_dim
+               * dtype_bytes    ← usually 2 (FP16), sometimes 1 (KV-quant 8-bit)
+               * ctx_tokens
+               * batch_size
+```
+
+`num_kv_heads` matters. Modern models use Grouped Query Attention (GQA) or Multi-Query Attention (MQA), which drastically shrinks KV. Older models without GQA (e.g. Llama 1, early Falcon) have painfully large KV caches.
+
+### Common Models — KV Per Token (FP16, batch=1)
+
+| Model | layers | kv_heads | head_dim | KB/token |
+| --- | --- | --- | --- | --- |
+| Llama-2-7B | 32 | 32 | 128 | 512 |
+| Llama-2-13B | 40 | 40 | 128 | 800 |
+| Llama-2-70B | 80 | 8 | 128 | 320 |
+| Llama-3-8B | 32 | 8 | 128 | 128 |
+| Llama-3-70B | 80 | 8 | 128 | 320 |
+| Llama-3.1-8B | 32 | 8 | 128 | 128 |
+| Llama-3.1-70B | 80 | 8 | 128 | 320 |
+| Qwen2.5-7B | 28 | 4 | 128 | 56 |
+| Qwen2.5-14B | 48 | 8 | 128 | 192 |
+| Qwen2.5-32B | 64 | 8 | 128 | 256 |
+| Qwen2.5-72B | 80 | 8 | 128 | 320 |
+| Mistral-7B | 32 | 8 | 128 | 128 |
+| Mixtral-8x7B | 32 | 8 | 128 | 128 |
+| Gemma-2-9B | 42 | 8 | 256 | 336 |
+| Gemma-2-27B | 46 | 16 | 128 | 368 |
+| Phi-3-medium (14B) | 40 | 10 | 128 | 200 |
+| DeepSeek-V2 (MLA) | 60 | — | — | ~70 (MLA) |
+| DeepSeek-V3 (MLA) | 61 | — | — | ~70 (MLA) |
+
+MLA (Multi-head Latent Attention) in DeepSeek-V2/V3/R1 compresses KV aggressively — roughly 7× smaller than standard GQA at the same params. It is a big reason DeepSeek-class MoE is runnable at long context on modest hardware.
+
+### KV at Different Contexts
+
+Multiply KB/token × ctx_tokens / 1_048_576 → GB.
+
+Example: Llama-3.1-70B at 16k context:
+`320 KB × 16384 / 1024 / 1024 = 5.0 GB` KV cache alone, on top of weights.
+
+### KV Quantization
+
+Llama.cpp supports KV cache in 8-bit (halves KV memory) and 4-bit (quarters it, some quality loss). Flag: `-ctk q8_0 -ctv q8_0`. Use this when context is the bottleneck.
+
+## 4. MoE — Active vs Total
+
+For Mixture-of-Experts models, **weights in memory = total params**, but **compute per token ≈ active params**.
+
+| Model | Total | Active | Active fraction |
+| --- | --- | --- | --- |
+| Mixtral-8x7B | ~47B | ~13B | 0.28 |
+| Mixtral-8x22B | ~141B | ~39B | 0.28 |
+| Qwen3-Next-80B-A3B | 80B | 3B | 0.04 |
+| DeepSeek-V3 | 671B | 37B | 0.055 |
+| DeepSeek-R1 | 671B | 37B | 0.055 |
+
+Implications:
+- **Memory footprint:** use total params × bytes/param.
+- **Throughput:** use active params for the bandwidth calculation in `throughput-estimation.md`. This is why an 80B/A3B MoE can be faster than a 13B dense model if you have the RAM.
+
+## 5. Overhead Budget
+
+Don't plan to fill memory to 100%. Leave headroom.
+
+| Platform | Safe target | Reason |
+| --- | --- | --- |
+| Discrete GPU (dedicated) | 90% of VRAM | Desktop compositor, other apps |
+| Discrete GPU (daily driver) | 80% of VRAM | Browser, IDE can spike VRAM |
+| Apple Silicon unified | 70% of total RAM | macOS pages aggressively; large apps |
+| CPU-only (dedicated box) | 80% of RAM | OS, buffers |
+| CPU-only (workstation) | 60% of RAM | You still need your other apps |
+
+On Apple, `sudo sysctl iogpu.wired_limit_mb=<mb>` raises the default ~67%/75% wired-VRAM cap. Document this when recommending a large MLX model on a 64/128/192 GB Mac.
+
+## 6. Worked Example — Llama-3.1-70B on a 4090 (24 GB)
+
+Target: 8k context, batch=1, llama.cpp.
+
+```
+Weights Q4_K_M:   70 × 0.61  = 42.7 GB  ← won't fit alone
+Weights Q3_K_M:   70 × 0.49  = 34.3 GB  ← still won't fit
+Weights IQ2_XXS:  70 × 0.26  = 18.2 GB  ← fits, but quality drops
+KV @ 8k FP16:     320 × 8192 / 1024^2 = 2.5 GB
+KV @ 8k Q8_0:     1.25 GB
+Overhead:         0.8 GB
+Total IQ2_XXS:    18.2 + 1.25 + 0.8 = 20.25 GB  ← fits in 24 GB ✅
+```
+
+Verdict: runs with IQ2_XXS at ~8k ctx, quality noticeably lower than Q4. For comfortable Q4, you need two 24 GB GPUs or one 48 GB card.
+
+## 7. Worked Example — Qwen2.5-14B on M2 Pro 16 GB
+
+Target: 8k context, MLX.
+
+```
+Weights 4-bit:    14 × 0.50 = 7.0 GB
+KV @ 8k FP16:     192 × 8192 / 1024^2 = 1.5 GB
+Overhead:         0.5 GB
+Total:            9.0 GB
+Safe budget:      16 × 0.70 = 11.2 GB
+```
+
+Fits comfortably. At 6-bit: 10.5 + 1.5 + 0.5 = 12.5 GB → tight, reduce context to 4k.
+
+## 8. Quick Sanity Numbers
+
+When you just need a ballpark, use these:
+
+- Dense model, Q4_K_M, 8k ctx: `~0.7 × B + 2 GB` where B is params in billions.
+- Dense model, Q8_0, 8k ctx: `~1.2 × B + 2 GB`.
+- MoE model, Q4_K_M, 8k ctx: same formula but B = total params.
+
+Always follow up with the real numbers from §2–§4.

--- a/skills/local-llm-fit/references/search-protocol.md
+++ b/skills/local-llm-fit/references/search-protocol.md
@@ -1,0 +1,234 @@
+# Search Protocol — Trust the User, Never Substitute
+
+Sources: Hugging Face Hub docs, Ollama library conventions, vendor release patterns (Meta, Qwen, Mistral, DeepSeek, Google, xAI, 01.AI, Cohere), observed LLM hallucination modes (2024–2026).
+
+Covers: the exact-string rule, resolution order, zero-result fallback, versioning traps, and the specific failure mode where models "correct" a user's brand-new model name to an older one.
+
+## 1. The Core Rule
+
+**The user typed a model name. That string is ground truth.** Your job is to find what they meant, not to decide what they meant.
+
+The OSS model ecosystem ships new checkpoints weekly. Your training cutoff is months or years behind the user's message. A model you have never heard of is overwhelmingly likely to be a real model that postdates your weights, not a typo or confusion.
+
+### The Failure Mode This Prevents
+
+Real example, every day:
+
+```
+User: "Can I run Qwen3-Next-80B on my 4090?"
+BAD agent: "I think you mean Qwen2.5-72B. Here is what I know about it..."
+GOOD agent: Searches "Qwen3-Next-80B" on HF. Finds Qwen/Qwen3-Next-80B-A3B-Instruct. Answers about that.
+```
+
+```
+User: "Will Llama 4.5 Maverick fit in 48 GB?"
+BAD agent: "Llama 4.5 does not exist. The latest is Llama 3.1. Did you mean Llama-3.1-70B?"
+GOOD agent: Searches "Llama 4.5 Maverick". If found, answers. If not, asks for a link — does NOT substitute.
+```
+
+```
+User: "How fast is DeepSeek-V4 on M3 Ultra?"
+BAD agent: "DeepSeek-V3 is the latest…"
+GOOD agent: Searches "DeepSeek-V4" verbatim before saying anything.
+```
+
+### Why You Hallucinate the Older Version
+
+Your weights encode frequent patterns. Older model names appear thousands of times in training data; a week-old model name appears zero times. The gradient of "what's most likely next?" points at the familiar name. You must consciously override that pull with a search.
+
+## 2. Resolution Order (Do All Of These Before Giving Up)
+
+Search the **exact user string in quotes**, not a normalized version.
+
+| # | Source | URL pattern | What to look for |
+| --- | --- | --- | --- |
+| 1 | Hugging Face | `https://huggingface.co/models?search=<exact>` | Any repo whose name matches. Favor the vendor's own org. |
+| 2 | Hugging Face full-text | `https://huggingface.co/search/full-text?q=<exact>` | Catches models linked from READMEs, quant repos. |
+| 3 | Ollama library | `https://ollama.com/library/<lowercase-name>` | Canonical short tag; try with/without version suffix. |
+| 4 | Vendor site | Qwen chat, mistral.ai, deepseek.com, ai.meta.com, ai.google.dev, x.ai, cohere.com | Release blog or model card. |
+| 5 | GitHub | `https://github.com/search?q=%22<exact>%22&type=repositories` | Inference forks, reference implementations. |
+| 6 | Web search | Exact string in double quotes | News, tweets, papers announcing the release. |
+| 7 | arXiv | `https://arxiv.org/search/?query=<exact>` | For research releases (e.g. MoE papers). |
+
+### Vendor Org Slugs on Hugging Face
+
+Quick lookup table so you search the right org:
+
+| Vendor | HF org |
+| --- | --- |
+| Meta (Llama) | `meta-llama` |
+| Mistral AI | `mistralai` |
+| Qwen (Alibaba) | `Qwen` |
+| DeepSeek | `deepseek-ai` |
+| Google (Gemma) | `google` |
+| Microsoft (Phi) | `microsoft` |
+| xAI (Grok) | `xai-org` |
+| Cohere | `CohereForAI` |
+| Yi (01.AI) | `01-ai` |
+| Nous Research | `NousResearch` |
+| Hermes | `NousResearch` |
+| Teknium | `teknium` |
+| Unsloth quants | `unsloth` |
+| TheBloke (legacy quants) | `TheBloke` |
+| Bartowski (GGUF quants) | `bartowski` |
+| MLX community | `mlx-community` |
+
+Common aggregators for quants: `bartowski`, `unsloth`, `lmstudio-community`, `mlx-community`, `turboderp` (EXL2).
+
+## 3. Version Suffix Traps
+
+Versions carry meaning. Never drop them.
+
+| User string | Meaning | Don't confuse with |
+| --- | --- | --- |
+| `Llama-3.1-70B-Instruct` | July 2024 release | `Llama-3-70B` (April 2024) |
+| `Llama-3.2-11B-Vision` | Multimodal | `Llama-3.2-3B` (text-only small) |
+| `Llama-3.3-70B` | Late 2024 update | `Llama-3.1-70B` |
+| `Qwen2.5-72B` | Q4 2024 | `Qwen2-72B` (June 2024) |
+| `Qwen3-Next-80B-A3B` | 2025 MoE, 3B active | `Qwen3-80B` if ever released |
+| `DeepSeek-V3` | Dec 2024 MoE | `DeepSeek-V2` |
+| `DeepSeek-R1` | Jan 2025 reasoning | `DeepSeek-V3` |
+| `DeepSeek-R1-Distill-Qwen-32B` | Distill, not the full R1 | `DeepSeek-R1` (671B MoE) |
+| `Mistral-Small-3` | 24B, Jan 2025 | `Mistral-7B` |
+| `Mixtral-8x22B` | MoE | `Mixtral-8x7B` |
+| `Gemma-2-27B` | 2024 | `Gemma-3-27B` (2025) |
+| `Phi-4` | 14B, late 2024 | `Phi-3-medium` |
+
+**Rule:** If the user says `X.Y`, you search `X.Y`, not `X`. If the user says `X-Next`, `X-Turbo`, `X-Pro`, `X-Max`, `X-Mini`, you keep that suffix.
+
+## 4. MoE Naming Patterns
+
+MoE models encode two numbers. Preserve both.
+
+| Pattern | Meaning |
+| --- | --- |
+| `Mixtral-8x7B` | 8 experts × 7B each, 2 active → ~13B active, ~47B total |
+| `Qwen3-Next-80B-A3B` | 80B total, 3B active per token |
+| `DeepSeek-V3` (671B/37B) | 671B total, 37B active |
+| `Llama-4-Scout` / `-Maverick` | Check current card; MoE configs vary |
+
+If the user says `A3B` or `A37B`, that is the active-param count. You need it for throughput math (see `memory-math.md` and `throughput-estimation.md`).
+
+## 5. Quantization Tags in Repo Names
+
+Many community repos encode the quant in the repo name itself. Reading it is enough to know what you're getting.
+
+| Tag | Meaning |
+| --- | --- |
+| `-GGUF` | llama.cpp format; quant is inside the filename (Q4_K_M, Q5_K_M, ...) |
+| `-AWQ` | Activation-aware 4-bit, GPU |
+| `-GPTQ` | Post-training 4-bit, GPU |
+| `-EXL2` | ExLlamaV2, variable bpw (look for `4.65bpw`, `5.0bpw`, ...) |
+| `-MLX` / `mlx-community/` | Apple Silicon, often `-4bit`, `-6bit`, `-8bit` |
+| `-FP8` | NVIDIA Hopper/Ada FP8 |
+| `-bnb-4bit` | bitsandbytes, Transformers loading |
+
+## 6. Zero-Result Fallback (Only After Exhaustive Search)
+
+You have searched all seven sources in §2 with the exact string, and nothing matched. Now — and only now:
+
+1. Check for obvious typos **without correcting silently**. If you see a candidate, surface it:
+   > "I couldn't find `Lllama-3.1-70B` on HF or Ollama. Did you mean `Llama-3.1-70B`? (Extra 'l'.) If not, could you share a link?"
+2. Ask for a link. Do not substitute.
+3. If the user insists the model exists and you still can't find it, say so honestly:
+   > "I searched HF, Ollama, GitHub, and the web for the exact string and didn't find a public release. Can you share where you heard about it or a repo URL?"
+
+What you **must not** do:
+
+- Silently pick a similarly-named older model.
+- Answer about a different model without disclosing the swap.
+- Declare the model "doesn't exist" based on your training knowledge alone.
+- Say "the latest is X" — you don't know what the latest is.
+
+## 7. When You Do Recognize the Name
+
+Still search. Quants, context windows, tokenizer versions, and repo moves happen. The model card today is authoritative; your memory of it is not. At minimum, confirm:
+
+- Parameter count (dense, or active+total for MoE)
+- Native precision (FP16 / BF16 / FP8)
+- Context window
+- Whether community quants exist (GGUF, EXL2, MLX, AWQ)
+
+## 8. Vendor Version Conventions (Know the Shape)
+
+Each vendor has its own versioning grammar. Knowing the grammar lets you recognize legitimate new releases instead of dismissing them as typos.
+
+| Vendor | Grammar | Examples |
+| --- | --- | --- |
+| Meta | `Llama-<major>.<minor>-<params>B[-Instruct \| -Vision]` | `Llama-3.1-70B-Instruct`, `Llama-3.2-11B-Vision`, `Llama-3.3-70B`, `Llama-4-Scout`, `Llama-4-Maverick` |
+| Qwen (Alibaba) | `Qwen<major>[.<minor>][-<variant>]-<params>B[-A<active>B][-Instruct]` | `Qwen2.5-14B-Instruct`, `Qwen3-Next-80B-A3B`, `Qwen2.5-Coder-32B` |
+| Mistral | `Mistral-<size>-<version>` or `Mixtral-<experts>x<params>B` | `Mistral-Small-3`, `Mistral-Large-2411`, `Mixtral-8x22B` |
+| DeepSeek | `DeepSeek-V<n>` or `DeepSeek-R<n>[-Distill-<base>-<params>B]` | `DeepSeek-V3`, `DeepSeek-R1`, `DeepSeek-R1-Distill-Llama-70B` |
+| Google | `Gemma-<major>-<params>B[-IT \| -PT]` | `Gemma-2-27B-IT`, `Gemma-3-27B` |
+| Microsoft | `Phi-<major>[-<variant>]` | `Phi-3-medium`, `Phi-3.5-mini`, `Phi-4` |
+| xAI | `Grok-<major>[-<variant>]` | `Grok-1`, `Grok-2` |
+| 01.AI | `Yi-<params>B[-Chat]` / `Yi-1.5-<params>B` | `Yi-34B`, `Yi-1.5-34B-Chat` |
+| Cohere | `command-r[-plus][-<version>]` | `command-r-plus-08-2024` |
+| NVIDIA | `Nemotron-<family>-<params>B` | `Llama-3.1-Nemotron-70B-Instruct` |
+| Anthropic (closed) | `Claude <family> <major>[.<minor>]` | `Claude Opus 4.7`, `Claude Sonnet 4.5` |
+| OpenAI (closed) | `GPT-<major>[-<variant>]` or `o<n>[-<variant>]` | `GPT-5`, `o3-mini`, `o4` |
+
+Closed-source names (Claude, GPT, Grok) appear in "can I run this locally?" questions only as misunderstandings. If a user asks "can I run Claude Opus 4.7 locally?" the answer is no — no weights exist — but **do not** dismiss the version number as fake. Confirm the closed-source fact, not the (non-)existence.
+
+**Seeing a suffix you don't recognize is the default case, not an error.** A, B, Mini, Nano, Flash, Turbo, Pro, Max, Ultra, Next, Coder, Math, Thinking, Reasoning, Distill — all are live suffix conventions across the ecosystem as of 2025–2026. Expect new ones.
+
+## 9. Exact-String Search Templates
+
+Copy these. Don't paraphrase.
+
+```
+# Hugging Face (web)
+https://huggingface.co/models?search=<EXACT>
+
+# Hugging Face (API)
+curl "https://huggingface.co/api/models?search=<EXACT>&limit=10"
+
+# Ollama
+curl -sI "https://ollama.com/library/<lowercase-dashed>" | head -1
+# (HTTP 200 = exists, 404 = not yet in Ollama's library even if model exists)
+
+# GitHub
+https://github.com/search?q=%22<EXACT>%22&type=repositories
+
+# Web (Google)
+"<EXACT>" site:huggingface.co
+"<EXACT>" model card
+"<EXACT>" release
+
+# Vendor-specific
+site:qwenlm.github.io "<EXACT>"
+site:mistral.ai "<EXACT>"
+site:deepseek.com "<EXACT>"
+site:ai.meta.com "<EXACT>"
+site:developers.googleblog.com "<EXACT>"
+site:x.ai "<EXACT>"
+```
+
+If you have web access, run 2–3 of these in parallel before answering.
+
+## 10. Reading a Model Card — What to Extract
+
+Every HF model card has the facts you need. Pull these explicitly:
+
+| Field | Where to find it | Why it matters |
+| --- | --- | --- |
+| Params | README header, config.json (`num_parameters` or sum from weights) | Memory math |
+| Architecture | `config.json` → `model_type` (e.g. `qwen2`, `llama`, `mixtral`, `deepseek_v2`) | KV formula choice |
+| Layers | `num_hidden_layers` | KV cache |
+| KV heads | `num_key_value_heads` (GQA) or `num_attention_heads` (MHA) | KV cache |
+| Head dim | `hidden_size / num_attention_heads` | KV cache |
+| Context | `max_position_embeddings` | Fit at long context |
+| Native dtype | `torch_dtype` in config | Native upper bound |
+| MoE active/total | `num_local_experts`, `num_experts_per_tok`, or model card | Throughput math |
+| Tokenizer | `tokenizer_config.json` | Chat template, context counting |
+
+## 11. Checklist Before You Answer
+
+- [ ] I used the user's exact string in search.
+- [ ] I looked at HF and at least one other source.
+- [ ] I have a URL I can cite for the params, context, and precision.
+- [ ] I have not silently replaced the model with an older one.
+- [ ] If I asked for clarification, I offered specifics, not a substitution.
+- [ ] I read the config.json / model card, not just the repo name.
+
+If any box is unchecked, do not answer the fit question yet.

--- a/skills/local-llm-fit/references/throughput-estimation.md
+++ b/skills/local-llm-fit/references/throughput-estimation.md
@@ -1,0 +1,189 @@
+# Throughput Estimation — Predicting Tokens Per Second
+
+Sources: llama.cpp benchmark discussions, Apple MLX benchmarks, vLLM performance docs, NVIDIA Nsight profiling notes, r/LocalLLaMA community benchmarks (2023–2026), memory-bandwidth-bound inference analyses.
+
+Covers: why decode is bandwidth-bound, the ceiling formula, prompt vs decode, engine multipliers, MoE throughput, thermal sustained vs peak, and batch effects.
+
+## 1. Why Decode Is Bandwidth-Bound, Not Compute-Bound
+
+Single-user, batch=1 decode reads every active weight from memory once per token. Arithmetic is negligible compared to bytes moved. Therefore:
+
+```
+tok/s (ceiling) ≈ memory_bandwidth_GBs / active_weight_bytes_per_token
+```
+
+`active_weight_bytes_per_token` is the size of the weights the model actually reads for one token:
+- Dense model: full weight size in GB.
+- MoE: active params × bytes/param (not total).
+
+This single formula explains ~80% of observed throughput.
+
+## 2. Memory Bandwidth Cheat Sheet
+
+Peak advertised bandwidth, in GB/s. Real sustained is 70–90% of peak.
+
+| Hardware | Peak GB/s | Effective GB/s |
+| --- | --- | --- |
+| RTX 3060 12 GB | 360 | ~290 |
+| RTX 3080 10 GB | 760 | ~610 |
+| RTX 3090 24 GB | 936 | ~750 |
+| RTX 4060 Ti 16 GB | 288 | ~230 |
+| RTX 4070 12 GB | 504 | ~400 |
+| RTX 4070 Ti Super 16 GB | 672 | ~540 |
+| RTX 4080 16 GB | 717 | ~575 |
+| RTX 4090 24 GB | 1008 | ~800 |
+| RTX 5080 16 GB | ~960 | ~770 |
+| RTX 5090 32 GB | ~1792 | ~1430 |
+| AMD 7900 XTX 24 GB | 960 | ~720 |
+| Apple M1 | 68 | ~55 |
+| Apple M1 Pro | 200 | ~160 |
+| Apple M1 Max | 400 | ~320 |
+| Apple M1 Ultra | 800 | ~640 |
+| Apple M2 / M2 Pro | 100 / 200 | ~80 / 160 |
+| Apple M2 Max | 400 | ~320 |
+| Apple M2 Ultra | 800 | ~640 |
+| Apple M3 / M3 Pro | 100 / 150 | ~80 / 120 |
+| Apple M3 Max (16c GPU) | 300 | ~240 |
+| Apple M3 Max (40c GPU) | 400 | ~320 |
+| Apple M3 Ultra | 800 | ~640 |
+| Apple M4 / M4 Pro | 120 / 273 | ~100 / 220 |
+| Apple M4 Max | 546 | ~440 |
+| DDR5-6400 dual channel (CPU) | 102 | ~70 |
+| DDR5-5600 dual channel | 90 | ~65 |
+| DDR4-3200 dual channel | 51 | ~38 |
+| Xeon/EPYC 8-channel DDR5 | 400–460 | ~320 |
+
+Apple unified memory is shared with CPU and display. Subtract a few percent for real workloads.
+
+## 3. Predicted Tok/s — Worked Numbers
+
+Formula: `tok/s ≈ effective_bandwidth / weight_size_GB`.
+
+### Llama-3.1-8B dense at Q4_K_M (4.9 GB active)
+
+| Hardware | Effective GB/s | Predicted | Observed typical |
+| --- | --- | --- | --- |
+| RTX 3090 | 750 | 153 | 120–160 |
+| RTX 4090 | 800 | 163 | 130–170 |
+| RTX 4070 | 400 | 82 | 65–90 |
+| M2 Pro | 160 | 33 | 25–38 |
+| M3 Max 40c | 320 | 65 | 55–75 |
+| M4 Max | 440 | 90 | 70–100 |
+| CPU DDR5-6400 | 70 | 14 | 9–14 |
+
+### Qwen2.5-32B dense at Q4_K_M (19.5 GB)
+
+| Hardware | Effective GB/s | Predicted |
+| --- | --- | --- |
+| RTX 3090 (fits tightly) | 750 | 38 |
+| RTX 4090 | 800 | 41 |
+| M3 Max 40c | 320 | 16 |
+| M2 Ultra | 640 | 33 |
+
+### Llama-3.1-70B at Q4_K_M (42.7 GB) — needs 48 GB+
+
+| Hardware | Effective GB/s | Predicted |
+| --- | --- | --- |
+| 2× RTX 3090 (NVLink) | ~600 effective | 14 |
+| 2× RTX 4090 (PCIe) | ~650 effective | 15 |
+| A6000 48 GB | ~650 | 15 |
+| M2 Ultra 192 GB | 640 | 15 |
+| M3 Ultra | 640 | 15 |
+| M4 Max 128 GB (fp4-ish via Q4) | 440 | 10 |
+
+### MoE: Qwen3-Next-80B-A3B — 80 GB in RAM, 3B active
+
+Active weight size at Q4: `3 × 0.61 = 1.83 GB`.
+
+| Hardware | Predicted |
+| --- | --- |
+| M2 Ultra 192 GB | 640 / 1.83 ≈ 350 |
+| M4 Max 128 GB | 440 / 1.83 ≈ 240 |
+| 2× RTX 4090 | 800 / 1.83 ≈ 430 |
+
+Note: MoE routing adds overhead; realistic numbers are often 40–70% of these predictions for single-stream decode. Still very fast.
+
+### MoE: DeepSeek-V3 / R1 — 671 GB total, 37B active
+
+Needs ≥180 GB usable memory even at Q2. At Q4 (420 GB): requires a high-end workstation (M3/M4 Ultra 512 GB, multi-GPU server, EPYC with huge RAM).
+Active 37B × Q4 = 22.6 GB per token.
+
+| Hardware | Predicted |
+| --- | --- |
+| EPYC 12-channel DDR5 (~460 GB/s) | ~20 |
+| H100 SXM (3.35 TB/s) if it fit | ~150 |
+
+## 4. Prompt vs Decode
+
+- **Prompt (prefill)** is compute-bound, not bandwidth-bound. It processes all input tokens in parallel. Prompt speed scales with FLOPs and with quantization efficiency (FP16 > Q8 > Q4 for compute), but is usually many multiples of decode speed.
+- **Decode** is the bandwidth-bound number everyone quotes.
+
+Typical ratio on GPUs: prompt ≈ 10–30× decode. On CPUs: 2–5× decode. Report both when relevant (long-prompt workloads care).
+
+## 5. Engine Multipliers
+
+Same model, same hardware, different engine → different tok/s. Rough multipliers relative to the bandwidth ceiling:
+
+| Engine | Decode efficiency | Notes |
+| --- | --- | --- |
+| llama.cpp (CUDA) | 0.75–0.90 | Mature, close to ceiling |
+| llama.cpp (Metal, MLX kernels) | 0.70–0.85 | Apple, very close to MLX |
+| Ollama | 0.75–0.90 | Wraps llama.cpp |
+| MLX | 0.80–0.90 | Apple native, best on M-series |
+| ExLlamaV2 | 0.85–0.95 | Fastest single-GPU for GPTQ/EXL2 |
+| vLLM (batch=1) | 0.60–0.80 | Overhead; shines at batched serving |
+| TensorRT-LLM | 0.85–0.95 | Enterprise, complex setup |
+| Transformers + bnb | 0.30–0.50 | Slow; use only if no alternative |
+
+## 6. Thermal / Sustained vs Peak
+
+Peak tok/s is what you see for the first few seconds. Sustained (long-running) tok/s is what matters for real use.
+
+| Device class | Peak → sustained drop |
+| --- | --- |
+| Desktop GPU, good cooling | 0–10% |
+| Desktop GPU, stock air | 5–15% |
+| Laptop GPU (dGPU) | 15–40% |
+| MacBook (Pro cooling) | 10–25% |
+| MacBook Air (passive) | 30–60% |
+| Mac Studio / Mac Pro | 0–10% |
+
+On battery, Apple laptops clock the GPU lower; expect 30–50% of wall-power tok/s. Call this out in the report when hardware is a laptop.
+
+## 7. Batch Size and Parallelism
+
+At batch=1, the formula above holds. As batch grows, memory-bandwidth is amortized across requests and effective per-request tok/s rises until compute becomes the bottleneck. For a single-user local setup, assume batch=1. For serving, vLLM and TensorRT-LLM dominate.
+
+## 8. When Prediction Diverges From Reality
+
+If the user reports observed tok/s much lower than the formula predicts, the usual culprits:
+
+| Gap | Likely cause |
+| --- | --- |
+| 2–5× too slow | Model not actually on GPU (partial offload, VRAM full). Check layer offload count. |
+| 1.5–2× too slow | Context full, KV cache thrashing. |
+| 30–50% too slow | Thermal throttle; check sustained load. |
+| Any | Wrong engine (Transformers + bnb), or prompt eval mis-measured as decode. |
+
+## 9. Minimum Acceptable Tok/s
+
+Calibrated expectations:
+
+| Use case | Comfortable | Tolerable | Painful |
+| --- | --- | --- | --- |
+| Interactive chat | ≥15 | 8–15 | <8 |
+| Coding autocomplete (streaming) | ≥25 | 15–25 | <15 |
+| Batch summarization | ≥5 | 2–5 | <2 |
+| Agent loops (many turns) | ≥20 | 10–20 | <10 |
+
+Tie this to the verdict rubric in SKILL.md. Sub-5 tok/s decode on a single-user interactive model = ❌ regardless of fit.
+
+## 10. Report-Ready Sentence
+
+When stating throughput, include:
+- The formula inputs (bandwidth, active-weight GB)
+- The engine assumed
+- Peak vs sustained if the hardware is a laptop
+
+Example:
+> "On your M3 Pro (≈120 GB/s effective, MLX, active weights ~4.9 GB), decode will run at ~24 tok/s peak and ~20 tok/s sustained on battery. Prompt prefill ~250 tok/s."

--- a/skills/local-llm-fit/scripts/NOTICE
+++ b/skills/local-llm-fit/scripts/NOTICE
@@ -1,0 +1,34 @@
+@tank/local-llm-fit includes a Python port of the LLM RAM / KV cache /
+throughput calculator from WeightRoom by Sergey Melyukov.
+
+  Upstream: https://github.com/smelukov/WeightRoom
+  File:     src/lib/calculator.ts
+  License:  MIT
+  Copyright (c) 2026 Sergey Melyukov
+
+The port (scripts/estimate_fit.py) adapts the following functions:
+  - calcLLMRam        → estimate()       (weights + KV + overhead)
+  - calcValueScore    → _tps()           (throughput from bandwidth)
+  - getRamStatus      → _ram_status()
+  - QUANT_BITS        → QUANT_BITS       (extended with community tags)
+
+MIT License text from WeightRoom:
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/skills/local-llm-fit/scripts/detect_hardware.sh
+++ b/skills/local-llm-fit/scripts/detect_hardware.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Detect hardware relevant to local LLM inference.
+# Prints: OS, CPU, total RAM, GPU(s) with VRAM, memory bandwidth estimate.
+# Safe on macOS, Linux, WSL. Falls back gracefully when tools are missing.
+
+set -u
+
+section() { printf '\n=== %s ===\n' "$1"; }
+kv() { printf '%-22s %s\n' "$1:" "$2"; }
+
+detect_os() {
+  case "$(uname -s)" in
+    Darwin) echo "macOS $(sw_vers -productVersion 2>/dev/null || echo unknown)" ;;
+    Linux)
+      if [ -r /etc/os-release ]; then
+        . /etc/os-release
+        echo "$PRETTY_NAME"
+      else
+        echo "Linux $(uname -r)"
+      fi
+      ;;
+    *) echo "$(uname -s) $(uname -r)" ;;
+  esac
+}
+
+detect_cpu() {
+  case "$(uname -s)" in
+    Darwin)
+      sysctl -n machdep.cpu.brand_string 2>/dev/null || echo unknown
+      ;;
+    Linux)
+      awk -F': ' '/^model name/ { print $2; exit }' /proc/cpuinfo 2>/dev/null \
+        || awk -F': ' '/^Model/ { print $2; exit }' /proc/cpuinfo 2>/dev/null \
+        || echo unknown
+      ;;
+    *) echo unknown ;;
+  esac
+}
+
+detect_ram_gb() {
+  case "$(uname -s)" in
+    Darwin)
+      local bytes
+      bytes=$(sysctl -n hw.memsize 2>/dev/null || echo 0)
+      awk -v b="$bytes" 'BEGIN { printf "%.0f GB", b / 1024 / 1024 / 1024 }'
+      ;;
+    Linux)
+      awk '/MemTotal/ { printf "%.0f GB", $2 / 1024 / 1024 }' /proc/meminfo 2>/dev/null \
+        || echo unknown
+      ;;
+    *) echo unknown ;;
+  esac
+}
+
+detect_apple_chip() {
+  [ "$(uname -s)" = "Darwin" ] || return 1
+  sysctl -n machdep.cpu.brand_string 2>/dev/null | grep -qi "Apple" || return 1
+  local chip cores
+  chip=$(sysctl -n machdep.cpu.brand_string 2>/dev/null)
+  cores=$(system_profiler SPDisplaysDataType 2>/dev/null | awk -F': ' '/Total Number of Cores/ { print $2; exit }')
+  kv "Apple Silicon" "$chip"
+  [ -n "${cores:-}" ] && kv "GPU cores" "$cores"
+  # Rough bandwidth hint by chip family — user should confirm.
+  local hint=""
+  case "$chip" in
+    *M1\ Ultra*)   hint="~800 GB/s" ;;
+    *M1\ Max*)     hint="~400 GB/s" ;;
+    *M1\ Pro*)     hint="~200 GB/s" ;;
+    *M1*)          hint="~68 GB/s" ;;
+    *M2\ Ultra*)   hint="~800 GB/s" ;;
+    *M2\ Max*)     hint="~400 GB/s" ;;
+    *M2\ Pro*)     hint="~200 GB/s" ;;
+    *M2*)          hint="~100 GB/s" ;;
+    *M3\ Ultra*)   hint="~800 GB/s" ;;
+    *M3\ Max*)     hint="~300-400 GB/s (check GPU cores)" ;;
+    *M3\ Pro*)     hint="~150 GB/s" ;;
+    *M3*)          hint="~100 GB/s" ;;
+    *M4\ Max*)     hint="~410-546 GB/s (check GPU cores)" ;;
+    *M4\ Pro*)     hint="~273 GB/s" ;;
+    *M4*)          hint="~120 GB/s" ;;
+  esac
+  [ -n "$hint" ] && kv "Bandwidth (est)" "$hint"
+  local wired
+  wired=$(sysctl -n iogpu.wired_limit_mb 2>/dev/null || echo "default (~67-75% of RAM)")
+  kv "Wired VRAM cap" "$wired MB"
+}
+
+detect_nvidia() {
+  command -v nvidia-smi >/dev/null 2>&1 || return 1
+  echo
+  section "NVIDIA GPUs"
+  nvidia-smi --query-gpu=index,name,memory.total,memory.free,driver_version \
+    --format=csv,noheader 2>/dev/null \
+    | awk -F', ' '{ printf "  [%s] %s | VRAM %s total, %s free | driver %s\n", $1,$2,$3,$4,$5 }'
+}
+
+detect_amd() {
+  command -v rocm-smi >/dev/null 2>&1 || return 1
+  echo
+  section "AMD GPUs (ROCm)"
+  rocm-smi --showproductname --showmeminfo vram 2>/dev/null \
+    | grep -E 'GPU\[|Card series|Total Memory|Used Memory' \
+    || rocm-smi 2>/dev/null
+}
+
+detect_intel_gpu_linux() {
+  [ "$(uname -s)" = "Linux" ] || return 1
+  command -v lspci >/dev/null 2>&1 || return 1
+  local intel
+  intel=$(lspci | grep -iE 'VGA.*Intel|Display.*Intel|3D.*Intel' || true)
+  [ -z "$intel" ] && return 1
+  echo
+  section "Intel GPUs"
+  echo "$intel"
+}
+
+detect_wsl_gpu() {
+  [ "$(uname -s)" = "Linux" ] || return 1
+  grep -qi microsoft /proc/version 2>/dev/null || return 1
+  echo
+  section "WSL"
+  echo "Running under WSL; GPU passthrough depends on Windows drivers."
+  echo "Use nvidia-smi above if present, or check Windows Task Manager for AMD."
+}
+
+dmidecode_ram_speed_linux() {
+  [ "$(uname -s)" = "Linux" ] || return 1
+  command -v sudo >/dev/null 2>&1 || return 1
+  command -v dmidecode >/dev/null 2>&1 || return 1
+  # Non-fatal; needs sudo. Don't prompt, just try without.
+  sudo -n dmidecode --type memory 2>/dev/null \
+    | awk '/Configured Memory Speed/ && !/Unknown/ { print $4, $5; exit }'
+}
+
+main() {
+  section "System"
+  kv "OS" "$(detect_os)"
+  kv "CPU" "$(detect_cpu)"
+  kv "RAM" "$(detect_ram_gb)"
+
+  if detect_apple_chip; then :; fi
+
+  detect_nvidia || true
+  detect_amd || true
+  detect_intel_gpu_linux || true
+  detect_wsl_gpu || true
+
+  if [ "$(uname -s)" = "Linux" ]; then
+    local speed
+    speed=$(dmidecode_ram_speed_linux || true)
+    if [ -n "${speed:-}" ]; then
+      echo
+      section "RAM"
+      kv "Configured speed" "$speed (per DIMM)"
+    fi
+  fi
+
+  echo
+  echo "Pass this output back to the LLM-fit skill along with the exact model name."
+}
+
+main

--- a/skills/local-llm-fit/scripts/estimate_fit.py
+++ b/skills/local-llm-fit/scripts/estimate_fit.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""Estimate LLM memory fit and tokens/sec for a given PC spec.
+
+Port of the RAM / KV / TPS math from smelukov/WeightRoom (MIT) —
+https://github.com/smelukov/WeightRoom/blob/main/src/lib/calculator.ts
+Extended with a CLI, preset-free mode, and verdict rubric matching
+@tank/local-llm-fit references.
+
+Prerequisite: the model must already be resolved by the agent via
+references/search-protocol.md. This script does NOT look up model specs —
+the agent passes them in. That preserves the skill's "trust the user's
+model name, search the exact string, never substitute" discipline.
+
+Usage:
+  estimate_fit.py --params 8 --layers 32 --kv-heads 8 --head-dim 128 \\
+                  --context 8192 --quant q4_k_m --kv-quant q8 \\
+                  --available-ram 24 --bandwidth 800
+
+  estimate_fit.py --self-test
+"""
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, asdict
+from typing import Optional, Literal
+
+# Bits per weight per quantization. Matches QUANT_BITS from WeightRoom,
+# normalized to community GGUF/MLX/EXL2/AWQ tags.
+QUANT_BITS = {
+    "fp32": 32.0,
+    "fp16": 16.0,
+    "bf16": 16.0,
+    "fp8": 8.0,
+    "q8": 8.5,
+    "q8_0": 8.5,
+    "q6_k": 6.56,
+    "q5_k_m": 5.68,
+    "q5_k_s": 5.52,
+    "q5_0": 5.5,
+    "q4_k_m": 4.84,
+    "q4_k_s": 4.58,
+    "q4_0": 4.55,
+    "q4": 4.84,
+    "q3_k_m": 3.91,
+    "q3_k_s": 3.50,
+    "q2_k": 3.35,
+    "iq3_xxs": 3.06,
+    "iq2_xs": 2.31,
+    "iq2_xxs": 2.06,
+    "iq1_s": 1.56,
+    "q1": 1.56,
+    "exl2_8": 8.0,
+    "exl2_6": 6.0,
+    "exl2_5": 5.0,
+    "exl2_4_65": 4.65,
+    "exl2_4": 4.0,
+    "exl2_3_5": 3.5,
+    "exl2_3": 3.0,
+    "exl2_2_4": 2.4,
+    "mlx_8": 8.0,
+    "mlx_6": 6.0,
+    "mlx_4": 4.0,
+    "mlx_3": 3.0,
+    "awq_4": 4.0,
+    "gptq_4": 4.0,
+    "awq_8": 8.0,
+}
+
+KvFormula = Literal["standard", "hybrid", "mla", "linear_hybrid"]
+
+
+@dataclass
+class FitResult:
+    weights_gb: float
+    kv_cache_gb: float
+    overhead_gb: float
+    total_gb: float
+    ram_status: str
+    tps_estimate: Optional[float]
+    tps_ceiling: Optional[float]
+    verdict: str
+    notes: list
+
+
+def _round(n: float) -> float:
+    return round(n * 10) / 10
+
+
+def _weights_gb(params_b: float, quant: str) -> float:
+    bits = QUANT_BITS.get(quant.lower())
+    if bits is None:
+        raise SystemExit(f"Unknown quant '{quant}'. Known: {sorted(QUANT_BITS)}")
+    # x1.1 accounts for embeddings/norms/lm_head stored in higher precision.
+    # For sub-2-bit quants, the overhead is already baked in.
+    overhead = 1.0 if bits < 2.0 else 1.1
+    weight_bytes = params_b * 1e9 * (bits / 8.0)
+    return (weight_bytes / 1e9) * overhead
+
+
+def _kv_cache_gb(
+    layers: int,
+    kv_heads: int,
+    head_dim: int,
+    context: int,
+    kv_quant: str,
+    formula: KvFormula,
+    sliding_window: int,
+    full_layers: Optional[int],
+    full_kv_heads: Optional[int],
+    full_head_dim: Optional[int],
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+    concurrent_users: int,
+    kv_fill_pct: float,
+) -> float:
+    kv_bits = QUANT_BITS.get(kv_quant.lower())
+    if kv_bits is None:
+        raise SystemExit(f"Unknown kv-quant '{kv_quant}'")
+    bytes_per_el = kv_bits / 8.0
+
+    if formula == "standard":
+        kv_bytes = 2 * layers * kv_heads * head_dim * context * bytes_per_el
+    elif formula == "hybrid":
+        # Gemma 2/3: interleaved sliding-window + full-attention layers.
+        fl = full_layers if full_layers is not None else layers // 2
+        sl = layers - fl
+        f_kvh = full_kv_heads if full_kv_heads is not None else kv_heads
+        f_hd = full_head_dim if full_head_dim is not None else head_dim
+        sliding_tokens = min(context, sliding_window)
+        kv_bytes = (
+            2 * sl * kv_heads * head_dim * sliding_tokens * bytes_per_el
+            + 2 * fl * f_kvh * f_hd * context * bytes_per_el
+        )
+    elif formula == "mla":
+        # DeepSeek V2/V3/R1: latent jointly encodes K and V, no factor of 2.
+        kv_bytes = layers * (kv_lora_rank + qk_rope_head_dim) * context * bytes_per_el
+    elif formula == "linear_hybrid":
+        # Qwen3-Next-style: linear-attention layers have fixed recurrent state
+        # (negligible); only sparse full-attention layers grow KV with context.
+        fl = full_layers if full_layers is not None else layers // 4
+        kv_bytes = 2 * fl * kv_heads * head_dim * context * bytes_per_el
+    else:
+        raise SystemExit(f"Unknown kv-formula '{formula}'")
+
+    kv_fill = kv_fill_pct / 100.0
+    return (kv_bytes / 1e9) * concurrent_users * kv_fill
+
+
+def _ram_status(total_gb: float, available_gb: float) -> str:
+    if available_gb <= 0:
+        return "unknown"
+    ratio = total_gb / available_gb
+    if ratio <= 0.80:
+        return "fits"
+    if ratio <= 1.00:
+        return "tight"
+    return "exceeds"
+
+
+def _tps(
+    active_params_b: float,
+    weights_bits: float,
+    kv_traffic_gb: float,
+    bandwidth_gbs: float,
+    efficiency: float,
+) -> Optional[float]:
+    if bandwidth_gbs <= 0 or active_params_b <= 0:
+        return None
+    # Per-token traffic = active weights read + KV read for all cached tokens.
+    # Weights per token use 1.1 overhead to mirror _weights_gb.
+    model_gb = (active_params_b * 1e9 * (weights_bits / 8.0) * 1.1) / 1e9
+    effective_bw = bandwidth_gbs * efficiency
+    return _round(effective_bw / (model_gb + kv_traffic_gb))
+
+
+def _verdict(total_gb: float, available_gb: float, tps: Optional[float]) -> str:
+    if available_gb > 0 and total_gb > available_gb * 0.95:
+        return "❌ won't run well"
+    if tps is not None and tps < 5:
+        return "❌ won't run well"
+    if available_gb > 0 and total_gb > available_gb * 0.85:
+        return "⚠️ runs but tight"
+    if tps is not None and tps < 15:
+        return "⚠️ runs but tight"
+    return "✅ runs well"
+
+
+def estimate(
+    *,
+    params: float,
+    layers: int,
+    kv_heads: int,
+    head_dim: int,
+    context: int,
+    quant: str,
+    kv_quant: str = "fp16",
+    available_ram: float = 0,
+    bandwidth: float = 0,
+    efficiency: float = 0.8,
+    overhead: float = 1.0,
+    moe: bool = False,
+    active_params: Optional[float] = None,
+    kv_formula: KvFormula = "standard",
+    sliding_window: int = 4096,
+    full_layers: Optional[int] = None,
+    full_kv_heads: Optional[int] = None,
+    full_head_dim: Optional[int] = None,
+    kv_lora_rank: int = 512,
+    qk_rope_head_dim: int = 64,
+    concurrent_users: int = 1,
+    kv_fill_pct: float = 100.0,
+) -> FitResult:
+    notes = []
+
+    weights = _weights_gb(params, quant)
+    kv_cache = _kv_cache_gb(
+        layers,
+        kv_heads,
+        head_dim,
+        context,
+        kv_quant,
+        kv_formula,
+        sliding_window,
+        full_layers,
+        full_kv_heads,
+        full_head_dim,
+        kv_lora_rank,
+        qk_rope_head_dim,
+        concurrent_users,
+        kv_fill_pct,
+    )
+    total = weights + kv_cache + overhead
+
+    # TPS uses active params for MoE (only experts routed to this token
+    # are read from memory), total params for dense models. RAM footprint
+    # always uses total params because every expert stays resident.
+    active_b = active_params if (moe and active_params) else params
+    if moe and not active_params:
+        notes.append(
+            "MoE flag set without --active-params; TPS uses total params (conservative)"
+        )
+    bits = QUANT_BITS.get(quant.lower(), 4.84)
+
+    tps = (
+        _tps(active_b, bits, kv_cache, bandwidth, efficiency) if bandwidth > 0 else None
+    )
+    ceiling = _tps(active_b, bits, 0, bandwidth, efficiency) if bandwidth > 0 else None
+    ram_status = _ram_status(total, available_ram)
+    verdict = _verdict(total, available_ram, tps)
+
+    if ram_status == "unknown":
+        notes.append("no --available-ram given; fit check limited to total_gb")
+    if kv_cache > weights:
+        notes.append(
+            "KV cache exceeds weight size — consider --kv-quant q8 or shorter --context"
+        )
+
+    return FitResult(
+        weights_gb=_round(weights),
+        kv_cache_gb=_round(kv_cache),
+        overhead_gb=_round(overhead),
+        total_gb=_round(total),
+        ram_status=ram_status,
+        tps_estimate=tps,
+        tps_ceiling=ceiling,
+        verdict=verdict,
+        notes=notes,
+    )
+
+
+def _format_report(result: FitResult, args) -> str:
+    lines = [
+        f"Model params:      {args.params} B"
+        + (
+            f" ({args.active_params}B active, MoE)"
+            if args.moe and args.active_params
+            else ""
+        ),
+        f"Quant:             {args.quant} (KV: {args.kv_quant})",
+        f"Context:           {args.context:,} tokens",
+        f"Architecture:      layers={args.layers} kv_heads={args.kv_heads} head_dim={args.head_dim} formula={args.kv_formula}",
+        "",
+        f"Weights:           {result.weights_gb} GB",
+        f"KV cache:          {result.kv_cache_gb} GB",
+        f"Overhead:          {result.overhead_gb} GB",
+        f"Total required:    {result.total_gb} GB",
+    ]
+    if args.available_ram > 0:
+        pct = result.total_gb / args.available_ram * 100
+        lines.append(
+            f"Available memory:  {args.available_ram} GB  ({pct:.0f}% used — {result.ram_status})"
+        )
+    if result.tps_estimate is not None:
+        lines.append(
+            f"Throughput:        ~{result.tps_estimate} tok/s decode (ceiling ~{result.tps_ceiling}, batch=1)"
+        )
+    lines.append("")
+    lines.append(f"Verdict:           {result.verdict}")
+    for n in result.notes:
+        lines.append(f"  note: {n}")
+    return "\n".join(lines)
+
+
+def _self_test() -> int:
+    """Regression tests — values cross-checked against WeightRoom and
+    worked examples in references/memory-math.md and decision-workflow.md.
+    Tolerances are generous (±5%) because WeightRoom uses QUANT_BYTES
+    (0.5 for q4) while we use community-measured QUANT_BITS (4.84 for q4_k_m);
+    both are valid, we prefer the community numbers.
+    """
+    cases = [
+        (
+            "Llama-3.1-8B Q4_K_M @ 8k on RTX 4090",
+            dict(
+                params=8,
+                layers=32,
+                kv_heads=8,
+                head_dim=128,
+                context=8192,
+                quant="q4_k_m",
+                kv_quant="fp16",
+                available_ram=24,
+                bandwidth=800,
+            ),
+            5.3,
+            6.6,
+            0.15,
+        ),
+        (
+            "Llama-3.1-70B IQ2_XXS @ 8k on RTX 4090 (from decision-workflow.md §2)",
+            dict(
+                params=70,
+                layers=80,
+                kv_heads=8,
+                head_dim=128,
+                context=8192,
+                quant="iq2_xxs",
+                kv_quant="q8",
+                available_ram=24,
+                bandwidth=800,
+                overhead=0.8,
+            ),
+            18.0,
+            20.3,
+            0.20,
+        ),
+        (
+            "Qwen2.5-14B 4bit @ 8k on M2 Pro 16GB (from decision-workflow.md §3)",
+            dict(
+                params=14,
+                layers=48,
+                kv_heads=8,
+                head_dim=128,
+                context=8192,
+                quant="mlx_4",
+                kv_quant="fp16",
+                available_ram=16,
+                bandwidth=160,
+                overhead=0.5,
+            ),
+            7.7,
+            9.7,
+            0.20,
+        ),
+        (
+            "Mixtral-8x7B MoE Q4 @ 8k (active 13B)",
+            dict(
+                params=47,
+                layers=32,
+                kv_heads=8,
+                head_dim=128,
+                context=8192,
+                quant="q4_k_m",
+                kv_quant="fp16",
+                available_ram=32,
+                bandwidth=800,
+                moe=True,
+                active_params=13,
+                overhead=1.0,
+            ),
+            31.3,
+            32.6,
+            0.15,
+        ),
+        (
+            "DeepSeek-V3 MLA @ 8k — KV must be much smaller than standard",
+            dict(
+                params=37,
+                layers=61,
+                kv_heads=128,
+                head_dim=128,
+                context=8192,
+                quant="q4_k_m",
+                kv_quant="fp16",
+                available_ram=512,
+                bandwidth=400,
+                moe=True,
+                active_params=37,
+                kv_formula="mla",
+                kv_lora_rank=512,
+                qk_rope_head_dim=64,
+                overhead=1.0,
+            ),
+            24.6,
+            25.7,
+            0.15,
+        ),
+    ]
+    failures = 0
+    for name, kw, exp_w, exp_t, tol in cases:
+        r = estimate(**kw)
+        w_ok = abs(r.weights_gb - exp_w) / exp_w <= tol
+        t_ok = abs(r.total_gb - exp_t) / exp_t <= tol
+        status = "PASS" if (w_ok and t_ok) else "FAIL"
+        if status == "FAIL":
+            failures += 1
+        print(f"[{status}] {name}")
+        print(
+            f"        weights: got {r.weights_gb} expected ~{exp_w} ({'ok' if w_ok else 'off'})"
+        )
+        print(
+            f"        total:   got {r.total_gb} expected ~{exp_t} ({'ok' if t_ok else 'off'})"
+        )
+        print(f"        verdict: {r.verdict}  tps: {r.tps_estimate}")
+    print()
+    print(f"{len(cases) - failures}/{len(cases)} passed")
+    return 0 if failures == 0 else 1
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--self-test", action="store_true", help="Run regression tests")
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON result instead of human-readable report",
+    )
+
+    p.add_argument(
+        "--params",
+        type=float,
+        help="Total parameters (billions). For MoE, this is total.",
+    )
+    p.add_argument("--layers", type=int, help="num_hidden_layers from config.json")
+    p.add_argument(
+        "--kv-heads",
+        type=int,
+        help="num_key_value_heads (GQA). For MHA, same as num_attention_heads",
+    )
+    p.add_argument("--head-dim", type=int, help="hidden_size / num_attention_heads")
+    p.add_argument(
+        "--context", type=int, default=8192, help="context tokens (default 8192)"
+    )
+    p.add_argument(
+        "--quant",
+        default="q4_k_m",
+        help=f"weight quant (default q4_k_m). Options: {sorted(QUANT_BITS)}",
+    )
+    p.add_argument(
+        "--kv-quant",
+        default="fp16",
+        help="KV cache quant (default fp16; try q8 to halve KV)",
+    )
+    p.add_argument(
+        "--available-ram",
+        type=float,
+        default=0,
+        help="Available VRAM/unified RAM in GB",
+    )
+    p.add_argument(
+        "--bandwidth", type=float, default=0, help="Effective memory bandwidth in GB/s"
+    )
+    p.add_argument(
+        "--efficiency",
+        type=float,
+        default=0.8,
+        help="Bandwidth efficiency 0-1 (default 0.8)",
+    )
+    p.add_argument(
+        "--overhead",
+        type=float,
+        default=1.0,
+        help="Engine + activations overhead in GB (default 1.0)",
+    )
+
+    p.add_argument("--moe", action="store_true", help="Mixture of Experts model")
+    p.add_argument(
+        "--active-params",
+        type=float,
+        help="Active params per token (billions). Required for MoE TPS math.",
+    )
+
+    p.add_argument(
+        "--kv-formula",
+        default="standard",
+        choices=["standard", "hybrid", "mla", "linear_hybrid"],
+        help="KV cache architecture (default standard)",
+    )
+    p.add_argument("--sliding-window", type=int, default=4096)
+    p.add_argument("--full-layers", type=int)
+    p.add_argument("--full-kv-heads", type=int)
+    p.add_argument("--full-head-dim", type=int)
+    p.add_argument("--kv-lora-rank", type=int, default=512, help="MLA only")
+    p.add_argument("--qk-rope-head-dim", type=int, default=64, help="MLA only")
+
+    p.add_argument("--concurrent-users", type=int, default=1)
+    p.add_argument(
+        "--kv-fill-pct",
+        type=float,
+        default=100.0,
+        help="KV cache fill percent (100 = llama.cpp pre-alloc, 25 = vLLM typical)",
+    )
+
+    args = p.parse_args()
+
+    if args.self_test:
+        return _self_test()
+
+    required = ("params", "layers", "kv_heads", "head_dim")
+    missing = [f"--{r.replace('_', '-')}" for r in required if getattr(args, r) is None]
+    if missing:
+        p.error(
+            f"missing required args: {' '.join(missing)} (resolve the model first via search-protocol.md)"
+        )
+
+    result = estimate(
+        params=args.params,
+        layers=args.layers,
+        kv_heads=args.kv_heads,
+        head_dim=args.head_dim,
+        context=args.context,
+        quant=args.quant,
+        kv_quant=args.kv_quant,
+        available_ram=args.available_ram,
+        bandwidth=args.bandwidth,
+        efficiency=args.efficiency,
+        overhead=args.overhead,
+        moe=args.moe,
+        active_params=args.active_params,
+        kv_formula=args.kv_formula,
+        sliding_window=args.sliding_window,
+        full_layers=args.full_layers,
+        full_kv_heads=args.full_kv_heads,
+        full_head_dim=args.full_head_dim,
+        kv_lora_rank=args.kv_lora_rank,
+        qk_rope_head_dim=args.qk_rope_head_dim,
+        concurrent_users=args.concurrent_users,
+        kv_fill_pct=args.kv_fill_pct,
+    )
+
+    if args.json:
+        print(json.dumps(asdict(result), indent=2, ensure_ascii=False))
+    else:
+        print(_format_report(result, args))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/local-llm-fit/tank.json
+++ b/skills/local-llm-fit/tank.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/local-llm-fit",
+  "version": "1.0.0",
+  "description": "Decide if a given OSS LLM will run well on a given PC. Resolves the exact model the user named (never substitutes), computes weights + KV cache + overhead at each quant, estimates tokens/sec from memory bandwidth, picks the right engine (Ollama, llama.cpp, MLX, vLLM, ExLlamaV2), and returns a fit verdict. Covers GGUF/EXL2/MLX/AWQ/GPTQ quants, MoE active vs total params, context-length costs. Enforces: search the user's exact model string, do not 'correct' unfamiliar names, do not trust stale training memory. Triggers: can my pc run, can I run, will this model run, run locally, fits in VRAM, tokens per second, tps estimate, llama.cpp, ollama, mlx, vllm, exllama, gguf, Q4_K_M, quantization, KV cache, context length memory, local llm, 8B 14B 32B 70B model, M1 M2 M3 M4 llm, 3090 4090 5090 llm, offload layers.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

Adds a new skill that helps agents answer **"can I run <model> on my PC?"** for open-source LLMs — with two things the current ecosystem gets wrong:

1. **Anti-gaslighting search protocol.** The skill explicitly trains agents to never substitute a model name the user didn't ask for. If a user says \`Qwen3-Next-80B\` or \`Llama 4.5 Maverick\` or \`Opus 4.7\`, agents search the exact string on HF/Ollama/vendor pages before answering — no "I think you mean Llama 3" substitutions. This is the core behavioral fix.
2. **Real math, not vibes.** Ships a Python calculator (\`scripts/estimate_fit.py\`) that returns weights + KV cache + overhead in GB, TPS estimate from bandwidth, and a verdict (✅ / ⚠️ / ❌). Ported from [smelukov/WeightRoom](https://github.com/smelukov/WeightRoom) under MIT (attribution in \`scripts/NOTICE\`), extended with community GGUF/MLX/EXL2 quant tags and handlers for MoE, MLA (DeepSeek), hybrid (Gemma 2/3), and linear-hybrid (Qwen3-Next) KV architectures.

## What's in the package

| File | Purpose |
|---|---|
| \`SKILL.md\` (187 lines) | Entry point, anti-gaslighting rule front and center, Fit Report template |
| \`tank.json\` | Manifest, minimal permissions (read-only, no subprocess, no network) |
| \`references/search-protocol.md\` | The "trust the user, never substitute" doc — exact-string search rule, 7-source resolution order, vendor version grammars, config.json extraction |
| \`references/memory-math.md\` | Bytes-per-param tables for GGUF/EXL2/MLX/AWQ, KV cache formulas, MoE active vs total, worked examples |
| \`references/throughput-estimation.md\` | Bandwidth ceiling formula, predicted tok/s for common rigs, engine multipliers, sustained vs peak |
| \`references/hardware-profiles.md\` | NVIDIA/AMD/Intel/Apple Silicon baselines — VRAM, bandwidth, realistic tok/s per tier |
| \`references/inference-engines.md\` | Ollama/llama.cpp/MLX/vLLM/ExLlamaV2 decision table, quant compatibility matrix |
| \`references/decision-workflow.md\` | End-to-end procedure + 3 worked examples including a brand-new model to reinforce the search discipline |
| \`references/calculator-usage.md\` | CLI docs for the Python calculator |
| \`scripts/estimate_fit.py\` | Python calculator (MIT port of WeightRoom). Self-test with 5 fixtures, all passing. |
| \`scripts/detect_hardware.sh\` | Cross-platform hardware detector (macOS/Linux/WSL) |
| \`scripts/NOTICE\` | MIT attribution to Sergey Melyukov / WeightRoom |

## Self-test output

\`\`\`
[PASS] Llama-3.1-8B Q4_K_M @ 8k on RTX 4090
[PASS] Llama-3.1-70B IQ2_XXS @ 8k on RTX 4090 (from decision-workflow.md §2)
[PASS] Qwen2.5-14B 4bit @ 8k on M2 Pro 16GB (from decision-workflow.md §3)
[PASS] Mixtral-8x7B MoE Q4 @ 8k (active 13B)
[PASS] DeepSeek-V3 MLA @ 8k — KV must be much smaller than standard

5/5 passed
\`\`\`

## Checklist (per AGENTS.md)

- [x] \`name\` matches \`@tank/local-llm-fit\` in SKILL.md frontmatter and tank.json
- [x] Description has 10+ trigger phrases
- [x] SKILL.md under 200 lines (187)
- [x] Reference Index table at end
- [x] Permissions minimal (read-only filesystem, no network, no subprocess)
- [x] MIT attribution for ported calculator code (\`scripts/NOTICE\`)
- [x] Feature branch (\`skill/local-llm-fit\`), will publish from \`main\` after merge

## Publish plan

After this PR merges to \`main\`, publish with:
\`\`\`
tank publish --dry-run --org tank
tank publish --org tank
\`\`\`