### PR TITLE
fix(local-llm-fit): trim tank.json description to <=500 chars

### DIFF
--- a/skills/local-llm-fit/tank.json
+++ b/skills/local-llm-fit/tank.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/local-llm-fit",
   "version": "1.0.0",
-  "description": "Decide if a given OSS LLM will run well on a given PC. Resolves the exact model the user named (never substitutes), computes weights + KV cache + overhead at each quant, estimates tokens/sec from memory bandwidth, picks the right engine (Ollama, llama.cpp, MLX, vLLM, ExLlamaV2), and returns a fit verdict. Covers GGUF/EXL2/MLX/AWQ/GPTQ quants, MoE active vs total params, context-length costs. Enforces: search the user's exact model string, do not 'correct' unfamiliar names, do not trust stale training memory. Triggers: can my pc run, can I run, will this model run, run locally, fits in VRAM, tokens per second, tps estimate, llama.cpp, ollama, mlx, vllm, exllama, gguf, Q4_K_M, quantization, KV cache, context length memory, local llm, 8B 14B 32B 70B model, M1 M2 M3 M4 llm, 3090 4090 5090 llm, offload layers.",
+  "description": "Decide if a given OSS LLM runs well on a given PC. Resolves the exact model the user named (never substitutes, never trusts stale training memory), computes weights + KV cache + overhead per quant, estimates tokens/sec from bandwidth, picks engine (Ollama, llama.cpp, MLX, vLLM, ExLlamaV2). Triggers: can my pc run, fits in VRAM, tokens per second, llama.cpp, ollama, mlx, vllm, gguf, Q4_K_M, KV cache, local llm, 8B 14B 32B 70B, M1-M4, 3090 4090 5090, offload layers.",
   "permissions": {
     "network": {
       "outbound": []


### PR DESCRIPTION
## Summary

Tank 0.13.1 rejects `tank.json.description` longer than 500 chars. The initial `@tank/local-llm-fit` publish failed dry-run with:

```
Publish failed: Invalid tank.json:
  - description: Description must be 500 characters or fewer
```

Trimmed from 816 → 468 chars. Preserved:
- The anti-gaslighting hook ("never substitutes, never trusts stale training memory")
- The core capability summary (resolve → compute → estimate → pick engine)
- Key trigger phrases

Full trigger list is in `SKILL.md` frontmatter (which is not subject to the 500-char limit).

No behavioral change — this is purely a manifest size fix to unblock the first publish of #133.