### PR TITLE
feat: add @tank/kueue skill

### DIFF
--- a/skills/kueue/SKILL.md
+++ b/skills/kueue/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: "@tank/kueue"
+description: |
+  Kubernetes-native job queueing for batch, AI/ML, and HPC workloads using
+  Kueue. Covers CRDs, suspend-then-admit scheduling, supported integrations,
+  installation/configuration, observability, quota sharing, and production
+  operations. Synthesizes kueue.sigs.k8s.io, kubernetes-sigs/kueue APIs and
+  KEPs, kueuectl, Prometheus metrics, and cloud autoscaling patterns.
+
+  Trigger phrases: "kueue", "kueuectl", "kubernetes job queue",
+  "ClusterQueue", "LocalQueue", "ResourceFlavor", "Workload", "Cohort",
+  "AdmissionCheck", "MultiKueue", "ProvisioningRequest", "Topology-Aware Scheduling", "Karpenter Kueue", "cluster autoscaler kueue", "GPU quota",
+  "PyTorchJob", "RayJob", "MPIJob", "JobSet", "AppWrapper",
+  "Kubeflow training", "gang scheduling", "fair sharing", "borrowing limit",
+  "lending limit", "nominal quota", "waitForPodsReady", "Kueue metrics"
+---
+
+# Kueue
+
+## Core Philosophy
+
+1. **Suspend first, admit later** — Every supported Job is created in `suspend: true` state by Kueue's mutating webhook. The Workload object is the queueing unit; the Job only unsuspends after the Workload is admitted. Never bypass this by setting `suspend: false` manually.
+2. **Quota lives on the ClusterQueue, naming lives on the LocalQueue** — Users submit Jobs with a `kueue.x-k8s.io/queue-name: <local-queue>` label. The LocalQueue points to a ClusterQueue, which holds the actual quota. This separates tenant identity from capacity policy.
+3. **Cohorts are how slack capacity is shared** — Two ClusterQueues in the same `cohort` can borrow each other's unused `nominalQuota` up to their `borrowingLimit`. Without a cohort, quota is hard-isolated. Set `lendingLimit` to cap how much a queue can be borrowed from.
+4. **Flavors map workloads to hardware** — A `ResourceFlavor` is a tuple of `(nodeLabels, taints, tolerations)`. Quota is per-flavor. The same `cpu` resource can have separate quotas for `spot` and `ondemand` flavors, and `flavorFungibility` controls fall-through behavior.
+5. **AdmissionChecks gate the final unsuspend** — Quota reservation is necessary but not sufficient. AdmissionChecks (e.g., MultiKueue, ProvisioningRequest) must all pass `Ready` before the Workload transitions to `Admitted` and the Job unsuspends.
+
+## Quick-Start: Common Problems
+
+### "My Job is created but no Pods appear"
+
+1. Check the Job has the queue label: `kubectl get job <name> -o jsonpath='{.metadata.labels.kueue\.x-k8s\.io/queue-name}'`
+2. Check the Workload exists: `kubectl get workload -l kueue.x-k8s.io/job-name=<job>`
+3. Read Workload conditions: `kubectl describe workload <wl>` — look at `QuotaReserved`, `Admitted`, `Inadmissible` reasons
+4. If `Inadmissible`: quota is full or no flavor matches the Pod's nodeSelector
+5. If `QuotaReserved` but not `Admitted`: an AdmissionCheck is pending
+-> See `references/operations-and-cli.md`
+
+### "Which Kueue CRD do I create first?"
+
+| Order | CRD | Created by |
+|-------|-----|-----------|
+| 1 | `ResourceFlavor` | Cluster admin |
+| 2 | `ClusterQueue` (references flavors, sets quota, optional cohort) | Cluster admin |
+| 3 | `LocalQueue` in tenant namespace (points to ClusterQueue) | Namespace admin |
+| 4 | `WorkloadPriorityClass` (optional) | Cluster admin |
+| 5 | `Job/RayJob/PyTorchJob` with `kueue.x-k8s.io/queue-name` label | User |
+-> See `references/concepts-and-architecture.md`
+
+### "My framework isn't being managed by Kueue"
+
+1. Check it's enabled in Kueue Configuration: `kubectl -n kueue-system get cm kueue-manager-config -o yaml | grep frameworks`
+2. Restart kueue-controller-manager after editing config: `kubectl -n kueue-system rollout restart deploy/kueue-controller-manager`
+3. For pod integration: `pod` framework must be enabled AND `managedJobsNamespaceSelector` must match the Pod's namespace
+4. For Deployment/StatefulSet: requires the `pod` integration + label `kueue.x-k8s.io/queue-name` on the Pod template
+-> See `references/job-integrations.md`
+
+### "How do I let Cluster Autoscaler scale up GPU nodes for queued workloads?"
+
+1. Add an `AdmissionCheck` of kind `ProvisioningRequest` to the GPU ClusterQueue
+2. Create a `ProvisioningRequestConfig` referencing the autoscaler's provisioning class (`check-capacity.autoscaling.x-k8s.io`, `queued-provisioning.gke.io`, or Karpenter's class)
+3. Pending Workload triggers a ProvisioningRequest → autoscaler scales nodes → Workload admitted → Pods schedule
+-> See `references/advanced-features.md`
+
+### "I want fair sharing between teams"
+
+1. Enable in Configuration: `fairSharing.enable: true`
+2. Put team ClusterQueues in the same `cohort`
+3. Set `fairSharing.weight` per ClusterQueue (default 1)
+4. Choose `preemptionStrategies` (LessThanOrEqualToFinalShare for stable, LessThanInitialShare for aggressive)
+-> See `references/advanced-features.md` and `references/quota-and-tenancy-patterns.md`
+
+## Decision Trees
+
+### Which Queueing Strategy?
+
+| Signal | Strategy |
+|--------|----------|
+| Strict in-order admission (FIFO with head-of-line blocking acceptable) | `StrictFIFO` |
+| Maximize throughput, allow later workloads to admit if head is blocked | `BestEffortFIFO` (default) |
+| Need priority-based ordering | Add `WorkloadPriorityClass` to either |
+
+### Which Preemption Policy?
+
+| Goal | `withinClusterQueue` | `reclaimWithinCohort` |
+|------|---------------------|----------------------|
+| No preemption (hard isolation) | `Never` | `Never` |
+| Higher priority preempts lower | `LowerPriority` | `LowerPriority` |
+| Reclaim borrowed capacity | (own choice) | `Any` |
+| Anything goes (research clusters) | `Any` | `Any` |
+
+### Flavor Fungibility Behavior
+
+| `whenCanBorrow` | `whenCanPreempt` | Behavior |
+|----------------|-----------------|----------|
+| `Borrow` | `TryNextFlavor` | Try borrowing in current flavor before falling through |
+| `TryNextFlavor` | `TryNextFlavor` | Always try next flavor first (e.g., spot before on-demand) |
+| `Borrow` | `Preempt` | Aggressive: borrow or preempt within current flavor before fallback |
+
+### Single ClusterQueue or Many?
+
+| Signal | Topology |
+|--------|----------|
+| Small team, one project | 1 ClusterQueue, no cohort |
+| Multiple teams, want sharing | N ClusterQueues, same cohort, `borrowingLimit` set |
+| Org → Department → Team hierarchy | Hierarchical Cohorts (parent/child) |
+| Strict per-team isolation | N ClusterQueues, no cohort (or `borrowingLimit: 0`) |
+| Multi-cluster federation | MultiKueue with management + worker clusters |
+
+## Reference Index
+
+| File | Contents |
+|------|----------|
+| `references/concepts-and-architecture.md` | Problem positioning, all CRDs (ResourceFlavor, ClusterQueue, LocalQueue, Workload, Cohort, AdmissionCheck, Topology, WorkloadPriorityClass), scheduling lifecycle (suspend → quota check → flavor assignment → admission check → unsuspend), controller architecture (reconcilers, in-memory cache, webhooks), resource model with borrowing/lending semantics, queueing strategies |
+| `references/job-integrations.md` | Universal `kueue.x-k8s.io/queue-name` pattern, full `integrations.frameworks` enablement table, per-framework YAML for batch/v1 Job, JobSet, Kubeflow v1 (PyTorchJob/TFJob/MPIJob/XGBoostJob/PaddleJob/JAXJob), Kubeflow Trainer v2 (TrainJob), KubeRay (RayJob/RayCluster/RayService), AppWrapper, plain Pods (single + groups), Deployment/StatefulSet, LeaderWorkerSet, Spark, custom integrations |
+| `references/installation-and-config.md` | kubectl apply / Helm OCI (`oci://registry.k8s.io/kueue/charts/kueue`) / Kustomize / GitOps install, full `Configuration` kind reference (manageJobsWithoutQueueName, managedJobsNamespaceSelector, integrations, multiKueue, fairSharing, waitForPodsReady, internalCertManagement, leaderElection), feature gates table by maturity, upgrade path, HA + cert-manager + ServiceMonitor production setup |
+| `references/advanced-features.md` | Preemption (withinClusterQueue, reclaimWithinCohort, borrowWithinCohort), Fair Sharing (DRF, weights, preemption strategies, AdmissionFairSharing), MultiKueue (architecture, MultiKueueConfig/Cluster, dispatcherName, supported jobs), Topology-Aware Scheduling (Topology CRD, podset annotations, NCCL locality), ProvisioningRequest (Cluster Autoscaler + Karpenter integration), Hierarchical Cohorts, WorkloadPriorityClass, Partial Admission + Elastic Jobs (workload slices), waitForPodsReady gang scheduling, custom AdmissionCheckController pattern |
+| `references/operations-and-cli.md` | Full `kueuectl` command surface (create/list/get/describe/stop/resume/delete/edit), Workload status interpretation (Pending/QuotaReserved/Admitted/Finished/Evicted + reasons), ClusterQueue status fields, Prometheus metrics catalog (kueue_pending_workloads, kueue_admission_attempt_duration_seconds, etc.), PromQL recipes, log diagnostics, troubleshooting trees for stuck/evicted/never-admitted workloads, performance tuning, drain/migrate procedures |
+| `references/quota-and-tenancy-patterns.md` | Quota semantics (nominalQuota / borrowingLimit / lendingLimit / effectiveQuota), single-tenant pattern, multi-team patterns (equal-share with borrowing, tiered priority, reserved + shared pool, strict isolation), hierarchical cohort design, flavor patterns (spot+on-demand, GPU classes, cross-zone), preemption design, namespace selectors, RBAC, cost allocation, anti-patterns, safe migration playbook |
+| `references/core-batch-ai-recipes.md` | End-to-end YAML recipes for basic batch queueing, multi-team GPU sharing with preemption, distributed PyTorch (Kubeflow), Ray hyperparameter tuning, spot+on-demand fallback, GPU autoscaling with ProvisioningRequest/Karpenter/Cluster Autoscaler, and MultiKueue federated dispatch |
+| `references/operations-services-migration-recipes.md` | Production YAML recipes for MPI/HPC topology-aware scheduling, long-running Deployment quota, Argo/plain Pod queueing, AppWrapper gang admission, elastic jobs, CI/CD runner pools, online-vs-batch LLM inference, staged rollout, verification commands, and gotchas |

--- a/skills/kueue/references/advanced-features.md
+++ b/skills/kueue/references/advanced-features.md
@@ -1,0 +1,449 @@
+# Advanced Features
+
+Sources: Kueue documentation (kueue.sigs.k8s.io/docs/concepts/preemption/, /fair_sharing/, /multikueue/, /topology_aware_scheduling/, /admission_check/, /elastic_workload/, /tasks/manage/setup_wait_for_pods_ready/), KEPs in kubernetes-sigs/kueue/keps for hierarchical cohorts and lending limits.
+
+Covers: preemption (within-CQ + within-cohort), fair sharing (DRF + AdmissionFairSharing), MultiKueue (federated multi-cluster), Topology-Aware Scheduling, ProvisioningRequest (Cluster Autoscaler/Karpenter integration), hierarchical cohorts, WorkloadPriorityClass, partial admission and elastic jobs (workload slices), gang scheduling via waitForPodsReady, and writing a custom AdmissionCheckController.
+
+## Preemption
+
+Preemption evicts admitted Workloads to make room for a higher-priority pending Workload. Three independent policies on `ClusterQueue.spec.preemption`:
+
+| Policy | Field | Values | What it controls |
+|--------|-------|--------|-----------------|
+| Within-queue | `withinClusterQueue` | `Never`, `LowerPriority`, `LowerOrNewerEqualPriority`, `Any` | Preempt other Workloads in the *same* CQ |
+| Reclaim borrowed | `reclaimWithinCohort` | `Never`, `LowerPriority`, `Any` | Reclaim quota that's been borrowed by cohort siblings |
+| Borrow with preemption | `borrowWithinCohort.policy` | `Never`, `LowerPriority` | While preempting, also borrow from cohort |
+
+```yaml
+preemption:
+  withinClusterQueue: LowerPriority
+  reclaimWithinCohort: Any                # take back nominal quota at any priority
+  borrowWithinCohort:
+    policy: LowerPriority
+    maxPriorityThreshold: 999             # don't preempt anything ≥ 1000
+```
+
+### Two algorithms
+
+**Classic preemption** (default) — fast, lightweight. Conditions: the preempting CQ's usage will be ≤ its `nominalQuota` after admission, OR `borrowWithinCohort` is enabled. Candidates: same-CQ Workloads matching `withinClusterQueue`, or borrowing siblings matching `reclaimWithinCohort`. Tie-break: borrowing siblings first, then lowest priority, then most recently admitted.
+
+**Fair-sharing preemption** (when `fairSharing.enable: true`) — selects victims to equalize the cohort's DRF share. The strategies (`fairSharing.preemptionStrategies`) determine when preemption is allowed:
+- `LessThanOrEqualToFinalShare` — preempt only if preempting CQ's *post-admission* DRF share ≤ target CQ's *post-eviction* share. Stable; no oscillation.
+- `LessThanInitialShare` — preempt only if preempting CQ's *post-admission* share < target's *current* share. More aggressive.
+
+Configure both in order: `[LessThanOrEqualToFinalShare, LessThanInitialShare]` tries the safer first, falls back to aggressive.
+
+### Status after preemption
+
+A preempted Workload's status carries:
+
+```yaml
+status:
+  conditions:
+  - type: Evicted
+    status: "True"
+    reason: Preempted
+    message: 'Preempted to accommodate a workload (UID: ...) due to prioritization in the ClusterQueue'
+  - type: Preempted
+    status: "True"
+    reason: InClusterQueue          # or InCohortReclamation, FairSharing
+```
+
+The Job's `spec.suspend` flips back to `true`, Pods are terminated, and the Workload re-enters the queue (typically with backoff).
+
+## Fair Sharing
+
+Two distinct features, both opt-in via `Configuration.fairSharing` and `Configuration.admissionFairSharing`:
+
+### Cohort-level fair sharing (DRF + preemption)
+
+Distributes borrowable cohort capacity across sibling CQs in proportion to `fairSharing.weight`. Higher weight → larger share entitled.
+
+```yaml
+# Configuration
+fairSharing:
+  enable: true
+  preemptionStrategies: [LessThanOrEqualToFinalShare]
+
+# Per-ClusterQueue
+spec:
+  cohort: shared
+  fairSharing: { weight: "2" }            # this CQ gets 2x share
+```
+
+Share is exposed at `clusterQueue.status.fairSharing.weightedShare` and via the `kueue_cluster_queue_weighted_share` metric. Higher value = "currently using more than fair share". A pending Workload in a CQ with low share can preempt admitted Workloads from siblings with high share.
+
+**Loop-free guarantee**: With `LessThanOrEqualToFinalShare`, if A could preempt B then `share(A_after) ≤ share(B_after)`. Symmetrically B can't preempt A — proves no thrashing.
+
+### AdmissionFairSharing (per-namespace, intra-CQ)
+
+Within a single CQ shared by multiple namespaces, this orders pending Workloads by historical resource usage of their LocalQueue, favoring those that have used less.
+
+```yaml
+admissionFairSharing:
+  usageHalfLifeTime: 15m                 # exponential decay of historical usage
+  usageSamplingInterval: 5m
+  resourceWeights:
+    cpu: 1
+    memory: 1
+    "nvidia.com/gpu": 100                # GPU usage dominates the dominant-resource calc
+```
+
+Use this when one namespace tends to flood the queue and starve others.
+
+## MultiKueue (federated multi-cluster)
+
+Run a *management* cluster that holds quotas + Workloads, dispatching the actual Job to one of N *worker* clusters. The management cluster's kueue-controller-manager keeps remote Workload/Job status in sync.
+
+### Setup
+
+**1. On each worker cluster**: install Kueue normally; create a service account that has cluster-admin (or scoped permissions for the workload kinds you'll dispatch). Export the kubeconfig.
+
+**2. On the management cluster**: store each worker's kubeconfig as a secret in `kueue-system`:
+
+```bash
+kubectl -n kueue-system create secret generic worker1-kubeconfig --from-file=kubeconfig=worker1.kubeconfig
+```
+
+**3. Define the worker registry**:
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: MultiKueueCluster
+metadata: { name: worker1 }
+spec:
+  kubeConfig: { locationType: Secret, location: worker1-kubeconfig }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: MultiKueueConfig
+metadata: { name: multi-prod }
+spec:
+  clusters: [worker1, worker2]
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: AdmissionCheck
+metadata: { name: multikueue-prod }
+spec:
+  controllerName: kueue.x-k8s.io/multikueue
+  parameters: { apiGroup: kueue.x-k8s.io, kind: MultiKueueConfig, name: multi-prod }
+```
+
+**4. Wire the AdmissionCheck into the ClusterQueue** that should federate:
+
+```yaml
+spec:
+  admissionChecks: [multikueue-prod]
+```
+
+### Lifecycle
+
+1. Job submitted on management → Workload created → quota reserved
+2. MultiKueue admission check controller picks targets per `dispatcherName` policy
+3. Workload (and Job copy) created on chosen worker cluster(s)
+4. First worker that admits "wins" — others get the Workload deleted
+5. Manager mirrors `status` back to local Job and Workload
+6. On completion, manager deletes the remote objects
+
+### Dispatcher policies
+
+| `dispatcherName` | Behavior | Trade-off |
+|-----------------|----------|-----------|
+| `kueue.x-k8s.io/multikueue-dispatcher-all-at-once` (default) | Copy to all workers immediately; first to admit wins | Fast, may stress autoscalers |
+| `kueue.x-k8s.io/multikueue-dispatcher-incremental` | Add 3 workers per round; wait 5min before next round | Gentle on autoscalers, slower |
+| Custom | External controller writes `status.nominatedClusterNames` | Full placement control |
+
+### Supported workloads
+
+batch/v1 Job (with `spec.managedBy: kueue.x-k8s.io/multikueue`), JobSet, all Kubeflow training jobs, RayJob, RayCluster, AppWrapper, Deployment, StatefulSet, LeaderWorkerSet, plain Pods, custom externalFrameworks. The `MultiKueueBatchJobWithManagedBy` feature gate (GA in 0.13) handles batch Jobs.
+
+### Limitations
+
+- Management cluster cannot also be a worker cluster (no self-loop)
+- Workloads without `managedBy` (StatefulSet, LWS) get status synced via Kueue's mirror — local readiness may briefly disagree with worker truth
+- A Workload can only run on *one* worker at a time; this is dispatch, not replication
+
+## Topology-Aware Scheduling (TAS)
+
+Place Pods within a network/hardware topology to maximize bandwidth (NVLink, NVSwitch, NCCL all-reduce, InfiniBand) for tightly-coupled training.
+
+### Define the topology
+
+Node labels expose a hierarchy. For example, an NVIDIA GPU rack:
+
+```
+node:    kubernetes.io/hostname=gpu-001
+rack:    cloud.example.com/rack=rack-1
+block:   cloud.example.com/block=block-A
+```
+
+Then a `Topology` CRD names the levels in order from coarsest to finest:
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1alpha1
+kind: Topology
+metadata: { name: gpu-topology }
+spec:
+  levels:
+  - nodeLabel: cloud.example.com/block
+  - nodeLabel: cloud.example.com/rack
+  - nodeLabel: kubernetes.io/hostname
+```
+
+A ResourceFlavor opts in:
+
+```yaml
+spec:
+  nodeLabels: { accelerator: nvidia-h100 }
+  topologyName: gpu-topology
+```
+
+### User-facing PodSet annotations
+
+Applied to the workload's PodTemplate (`spec.template.metadata.annotations`):
+
+| Annotation | Effect |
+|-----------|--------|
+| `kueue.x-k8s.io/podset-required-topology: <level>` | Hard: all Pods in this PodSet must land in one domain at this level. Workload won't admit if no single domain can fit |
+| `kueue.x-k8s.io/podset-preferred-topology: <level>` | Soft: try to fit all in one domain; spread if necessary |
+| `kueue.x-k8s.io/podset-unconstrained-topology: "true"` | Anywhere — TAS ignored, but Workload is still tracked |
+| `kueue.x-k8s.io/podset-group-name: <group>` | Group multiple PodSets together so they all land in the same domain |
+| `kueue.x-k8s.io/podset-slice-required-topology-constraints` (Alpha) | Multi-layer constraints: e.g., 32 pods per block AND 16 per rack |
+
+### Capacity calculation
+
+For each topology domain, TAS computes free capacity = `node-allocatable − usage from other admitted TAS Workloads − usage from non-TAS Pods (DaemonSets, kube-system, Deployments without TAS)`.
+
+### Hot-swap on node failure
+
+Three feature gates (default beta-on in 0.14): `TASFailedNodeReplacement`, `TASReplaceNodeOnPodTermination`, `TASFailedNodeReplacementFailFast`. When a TAS-pinned node fails, Kueue tries to find a replacement node in the same domain without disturbing other Pod-to-node bindings. With FailFast on, a single attempt; otherwise it retries with backoff before evicting the whole Workload.
+
+### Balanced placement (alpha)
+
+`TASBalancedPlacement` distributes Pods evenly across child domains (one level below the requested topology) instead of greedy-packing. Useful for all-to-all collective communication that benefits from uniform distribution.
+
+## ProvisioningRequest (Cluster Autoscaler / Karpenter)
+
+Two-stage admission: quota reservation succeeds → ProvisioningRequest is created → external autoscaler responds → Workload admits.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: AdmissionCheck
+metadata: { name: gpu-provision }
+spec:
+  controllerName: kueue.x-k8s.io/provisioning-request
+  parameters:
+    apiGroup: kueue.x-k8s.io
+    kind: ProvisioningRequestConfig
+    name: gpu-provisioning-config
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ProvisioningRequestConfig
+metadata: { name: gpu-provisioning-config }
+spec:
+  provisioningClassName: queued-provisioning.gke.io   # GKE; or check-capacity.autoscaling.x-k8s.io
+  managedResources: ["nvidia.com/gpu"]
+  retryStrategy:
+    backoffLimitCount: 2
+    backoffBaseSeconds: 60
+    backoffMaxSeconds: 1800
+  podSetMergePolicy: IdenticalWorkloadSchedulingRequirements
+```
+
+Provisioning class names you'll commonly see:
+
+| Class | Provider |
+|-------|----------|
+| `check-capacity.autoscaling.x-k8s.io` | Generic Cluster Autoscaler — only checks if capacity exists |
+| `queued-provisioning.gke.io` | GKE — reserves capacity via flex-start pricing |
+| `karpenter.sh/...` | Karpenter | (consult Karpenter version's docs) |
+
+ProvisioningRequest status flows through `Provisioned: false → true`, `Failed: true`, `BookingExpired: true`, `CapacityRevoked: true`. Kueue's AdmissionCheck mirrors these to its own state (`Pending → Ready → Retry/Rejected`).
+
+### Per-Job overrides via annotations
+
+```yaml
+metadata:
+  annotations:
+    provreq.kueue.x-k8s.io/maxRunDurationSeconds: "3600"
+```
+
+Any annotation prefixed `provreq.kueue.x-k8s.io/` is forwarded as a parameter to the ProvisioningRequest CR.
+
+## Hierarchical Cohorts
+
+Cohort is now a CRD (was just a string). With `parentName`, cohorts form a tree, and capacity flows down.
+
+```yaml
+# Root: org pool
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: Cohort
+metadata: { name: company }
+spec: {}
+---
+# Child: department, gets weighted share
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: Cohort
+metadata: { name: ml-platform }
+spec:
+  parentName: company
+  fairSharing: { weight: "0.6" }            # gets 60% of company-level borrowable pool
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: Cohort
+metadata: { name: data-platform }
+spec:
+  parentName: company
+  fairSharing: { weight: "0.4" }
+---
+# Team CQ joins department cohort
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: team-llm }
+spec:
+  cohort: ml-platform                       # joins the department cohort, can borrow from siblings + parent
+  resourceGroups: [...]
+```
+
+A Cohort can also carry its own `resourceGroups` defining a shared pool (children with `nominalQuota: 0` borrow from it). Use this for "the company has 100 GPUs total, allocate them across departments".
+
+## WorkloadPriorityClass
+
+Decouple Kueue ordering priority from kube-scheduler Pod priority.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata: { name: prod-high }
+value: 10000
+description: "Production training & inference"
+```
+
+Apply via label on the parent Job: `kueue.x-k8s.io/priority-class: prod-high`. Kueue copies it to `Workload.spec.priorityClassRef` and sets `.spec.priority`. The Pod's own `priorityClassName` (if any) is independent and used by kube-scheduler.
+
+| Pod has PriorityClass | Job has WorkloadPriorityClass label | Kueue ordering | Pod scheduling |
+|----------------------|------------------------------------|----------------|----------------|
+| Yes | Yes | WPC value | Pod's PriorityClass |
+| No | Yes | WPC value | (no Pod priority) |
+| Yes | No | Pod's PriorityClass value | Pod's PriorityClass |
+| No | No | 0 | (no Pod priority) |
+
+Mutability: the label and `.spec.priority` are mutable while pending; immutable once `QuotaReserved=True`. Mutating the PriorityClass *value* doesn't propagate retroactively.
+
+## Partial Admission and Elastic Jobs
+
+### Partial admission
+
+For Jobs with `parallelism: N`, allow admission with as few as `M` Pods.
+
+```yaml
+metadata:
+  annotations:
+    kueue.x-k8s.io/job-min-parallelism: "5"     # admit if at least 5 of 20 fit
+spec:
+  parallelism: 20
+  completions: 20
+```
+
+Kueue clamps `spec.parallelism` to whatever fits between min and N at unsuspend time. Useful for Indexed Jobs that can run with degraded width.
+
+### Elastic Jobs (workload slices, alpha)
+
+Behind `ElasticJobsViaWorkloadSlices`. Lets a Job's `parallelism` change *without* eviction/requeue.
+
+```yaml
+metadata:
+  annotations:
+    kueue.x-k8s.io/elastic-job: "true"
+  labels:
+    kueue.x-k8s.io/queue-name: team-a-queue
+spec:
+  parallelism: 3
+  completions: 100
+```
+
+Scaling up creates a new Workload "slice" referencing the same Job; the old slice is marked Finished. Scaling down updates the existing slice. Limited to: batch/v1 Job, RayJob, RayCluster. Not compatible with partial admission, MultiKueue, or TAS.
+
+## Gang Scheduling — waitForPodsReady
+
+All-or-nothing: if all Pods don't become Ready within the timeout, evict and requeue the whole Workload.
+
+```yaml
+# Configuration
+waitForPodsReady:
+  enable: true
+  timeout: 10m
+  recoveryTimeout: 3m
+  blockAdmission: true                      # admit one Workload at a time
+  requeuingStrategy:
+    timestamp: Eviction                     # or Creation (preserves position)
+    backoffLimitCount: 5
+    backoffBaseSeconds: 60
+    backoffMaxSeconds: 3600
+```
+
+Backoff per requeue: `min(backoffBaseSeconds × 2^n, backoffMaxSeconds)`.
+
+`blockAdmission: true` is the standard fix for the "admitted-but-deadlocked" case where two large Workloads each get half their Pods running and starve. Sequential admission costs throughput on healthy clusters; pair with TAS or set `blockAdmission: false` if your physical capacity reliably matches your declared quota.
+
+## AdmissionCheck Framework
+
+`AdmissionCheck` is a generic gate. The built-in checks are MultiKueue and ProvisioningRequest; you can write your own.
+
+### How a CQ uses checks
+
+```yaml
+spec:
+  admissionChecks: [check-a, check-b]              # runs concurrently for every Workload
+# OR per-flavor:
+  admissionChecksStrategy:
+    admissionChecks:
+    - { name: check-a, onFlavors: [gpu-a100] }     # only when a100 is chosen
+    - { name: check-b }                            # always
+```
+
+### State machine
+
+| State | Meaning | Effect on Workload |
+|-------|---------|-------------------|
+| `Pending` | Not yet evaluated | Stay in QuotaReserved |
+| `Ready` | Pass | If all checks Ready → `Admitted=True` |
+| `Retry` | Transient failure | Workload evicted (if Admitted) or quota released; backoff then re-evaluate |
+| `Rejected` | Hard failure | Workload deactivated (`spec.active: false`); event `AdmissionCheckRejected` |
+
+Status carries `podSetUpdates[]` — annotations/labels/tolerations to inject into Pods at unsuspend time. ProvisioningRequest uses this to inject the `cluster-autoscaler.kubernetes.io/consume-provisioning-request` annotation.
+
+### Writing a custom controller
+
+Pattern, in pseudocode:
+
+```go
+// Watch Workload; for each one, find admissionChecks[] entries with our controllerName
+for wl in workloads where check.controllerName == "mycorp.example.com/billing-check":
+    decision := callBillingService(wl.spec.podSets)
+    patchWorkloadStatus(wl, check.name, decision.state, decision.message, decision.podSetUpdates)
+```
+
+Reference implementation: `pkg/controller/admissionchecks/provisioning/` in the Kueue repo. Register the controller's name in your AdmissionCheck:
+
+```yaml
+spec:
+  controllerName: mycorp.example.com/billing-check
+  parameters: { apiGroup: ..., kind: ..., name: ... }
+```
+
+## Sources
+
+- https://kueue.sigs.k8s.io/docs/concepts/preemption/
+- https://kueue.sigs.k8s.io/docs/concepts/fair_sharing/
+- https://kueue.sigs.k8s.io/docs/concepts/multikueue/
+- https://kueue.sigs.k8s.io/docs/tasks/manage/setup_multikueue/
+- https://kueue.sigs.k8s.io/docs/concepts/topology_aware_scheduling/
+- https://kueue.sigs.k8s.io/docs/tasks/manage/setup_topology_aware_scheduling/
+- https://kueue.sigs.k8s.io/docs/concepts/admission_check/
+- https://kueue.sigs.k8s.io/docs/concepts/admission_check/provisioning_request/
+- https://kueue.sigs.k8s.io/docs/tasks/manage/setup_provisioning_request/
+- https://kueue.sigs.k8s.io/docs/concepts/cohort/
+- https://kueue.sigs.k8s.io/docs/concepts/workload_priority_class/
+- https://kueue.sigs.k8s.io/docs/concepts/elastic_workload/
+- https://kueue.sigs.k8s.io/docs/tasks/manage/setup_wait_for_pods_ready/
+- https://github.com/kubernetes-sigs/kueue/tree/main/keps

--- a/skills/kueue/references/concepts-and-architecture.md
+++ b/skills/kueue/references/concepts-and-architecture.md
@@ -1,0 +1,369 @@
+# Kueue Concepts and Architecture
+
+Sources: Kueue official documentation (kueue.sigs.k8s.io/docs/concepts/), kubernetes-sigs/kueue API types (apis/kueue/v1beta1, apis/kueue/v1), Kueue v0.14+ release notes.
+
+Covers: Kueue's positioning as a job-queueing layer above kube-scheduler, the eight core CRDs and their key fields, the suspend → quota → admission-check → admit lifecycle, controller architecture, and the resource/quota/borrowing model.
+
+## What Kueue Is
+
+Kueue is a Kubernetes-native job queueing controller for batch, AI/ML, and HPC workloads. It sits *above* the standard `kube-scheduler` and decides *when* a Job is allowed to start; it never schedules Pods to nodes itself. Once Kueue admits a Workload, it unsuspends the underlying Job and `kube-scheduler` places its Pods normally.
+
+| Layer | Responsibility |
+|-------|----------------|
+| User submits Job with `kueue.x-k8s.io/queue-name` label | LocalQueue routing |
+| Kueue mutating webhook | Sets `spec.suspend: true` on the Job |
+| Kueue Job reconciler | Creates a Workload object representing the queued unit |
+| Kueue Workload reconciler / scheduler | Reserves quota, runs admission checks, assigns flavors |
+| Kueue Job reconciler | Patches `spec.suspend: false` after admission |
+| `kube-scheduler` | Binds Pods to nodes using the assigned flavor's nodeLabels/tolerations |
+
+## Positioning vs Other Schedulers
+
+| System | Role | Relationship to Kueue |
+|--------|------|----------------------|
+| `kube-scheduler` | Pod-to-node binding | Kueue runs above it; both required |
+| Volcano | Custom scheduler with gang scheduling, batch features | Alternative — replaces kube-scheduler |
+| YuniKorn | Standalone scheduler with hierarchical queues | Alternative — replaces kube-scheduler |
+| Cluster Autoscaler / Karpenter | Node provisioning | Kueue triggers provisioning via `ProvisioningRequest` AdmissionCheck |
+
+Kueue's design choice: stay native, do not replace `kube-scheduler`. This means existing workloads keep working and only opt-in via the queue-name label.
+
+## The Eight Core CRDs
+
+All CRDs live under `kueue.x-k8s.io`. The current stable API group is `v1beta1`; `v1` is being introduced incrementally.
+
+### 1. ResourceFlavor
+
+A `(nodeLabels, nodeTaints, tolerations)` tuple — Kueue's name for "this class of hardware". Quotas are denominated per-flavor.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: gpu-a100
+spec:
+  nodeLabels:
+    accelerator: nvidia-a100
+  nodeTaints:
+  - key: nvidia.com/gpu
+    value: "true"
+    effect: NoSchedule
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  topologyName: gpu-rack-topology   # optional, for TAS
+```
+
+Up to 8 nodeLabels and 8 tolerations per flavor. Taints must be `NoSchedule` or `NoExecute` (never `PreferNoSchedule`). When Kueue assigns this flavor to a Workload, it injects the tolerations into the Pod spec at unsuspend time so Pods can land on tainted nodes.
+
+### 2. ClusterQueue
+
+Cluster-wide quota pool. Defines how much of each `(flavor, resource)` pair is available, who can submit (`namespaceSelector`), what queueing strategy applies, and the preemption policy.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: team-a-cq
+spec:
+  cohort: shared-pool                      # join a cohort for borrowing
+  namespaceSelector:                       # restrict who can use this CQ
+    matchLabels: { team: team-a }
+  queueingStrategy: BestEffortFIFO         # or StrictFIFO
+  resourceGroups:
+  - coveredResources: [cpu, memory, "nvidia.com/gpu"]
+    flavors:
+    - name: gpu-a100
+      resources:
+      - name: cpu
+        nominalQuota: "100"
+        borrowingLimit: "50"               # may borrow up to 50 more from cohort
+        lendingLimit:   "80"               # may lend up to 80 to cohort
+      - name: memory
+        nominalQuota: "400Gi"
+      - name: "nvidia.com/gpu"
+        nominalQuota: "8"
+  flavorFungibility:
+    whenCanBorrow: TryNextFlavor           # try cheaper flavor before borrowing
+    whenCanPreempt: TryNextFlavor
+  preemption:
+    reclaimWithinCohort: LowerPriority
+    withinClusterQueue: LowerPriority
+  admissionChecks: [provisioning-request]
+  stopPolicy: None                         # or Hold / HoldAndDrain
+```
+
+Up to 16 resourceGroups per ClusterQueue. Each `resourceGroup.coveredResources` must be a disjoint set; the same resource can never appear in two groups.
+
+### 3. LocalQueue
+
+Namespace-scoped pointer to a ClusterQueue. Users reference LocalQueues by name; admins control which ClusterQueue a LocalQueue maps to.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: team-a-queue
+  namespace: team-a
+spec:
+  clusterQueue: team-a-cq                  # immutable after creation
+  stopPolicy: None
+```
+
+The `LocalQueueDefaulting` feature gate enables auto-creation of a `default` LocalQueue per namespace, eliminating the need for users to specify a queue label on every Job.
+
+### 4. Workload
+
+The unit of queueing. One Workload per Job-like object (one batch Job → one Workload, one PyTorchJob → one Workload). Created and owned by the corresponding Job-controller integration.
+
+Key spec fields:
+- `podSets[]` — homogeneous groups of Pods with `name`, `template`, `count`, optional `minCount` for partial admission
+- `queueName` — target LocalQueue
+- `priorityClassName` + `priority` — for ordering and preemption
+- `active` — set to false to pause the Workload without deleting it
+- `maximumExecutionTimeSeconds` — auto-deactivate after this many seconds running
+
+Key status fields:
+- `conditions[]` — `QuotaReserved`, `Admitted`, `PodsReady`, `Finished`, `Evicted`, `Preempted`
+- `admission.clusterQueue` — which CQ admitted it
+- `admission.podSetAssignments[]` — flavor assignment per podset, with `topologyAssignment` if TAS used
+- `admissionChecks[]` — per-check state: `Pending`, `Ready`, `Retry`, `Rejected`
+- `requeueState` — counter and timestamp for backoff/retry
+
+Users almost never create Workloads directly — they're synthesized by Kueue from the parent Job.
+
+### 5. Cohort
+
+A grouping of ClusterQueues that can borrow each other's unused quota. Originally an implicit string field on ClusterQueue, now also a CRD that supports hierarchy.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: Cohort
+metadata:
+  name: engineering
+spec:
+  parentName: company-root                 # hierarchical cohorts
+  resourceGroups:                          # cohort-level quota pool
+  - coveredResources: [cpu, "nvidia.com/gpu"]
+    flavors:
+    - name: gpu-a100
+      resources:
+      - name: cpu
+        nominalQuota: "200"
+      - name: "nvidia.com/gpu"
+        nominalQuota: "16"
+  fairSharing: { weight: "1" }
+```
+
+A ClusterQueue with `spec.cohort: engineering` becomes a member. With hierarchical cohorts, parent quota cascades to children, and `borrowingLimit` controls how much each level can borrow from its parent.
+
+### 6. AdmissionCheck
+
+A pluggable gate that runs after quota is reserved but before the Workload is fully admitted. Built-in checks include MultiKueue (route to a worker cluster) and ProvisioningRequest (trigger autoscaler). Custom controllers can implement their own checks.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: AdmissionCheck
+metadata:
+  name: provisioning-request
+spec:
+  controllerName: kueue.x-k8s.io/provisioning-request
+  parameters:
+    apiGroup: kueue.x-k8s.io
+    kind: ProvisioningRequestConfig
+    name: gpu-provisioning
+```
+
+ClusterQueues opt into a check by listing it in `spec.admissionChecks`. The check's `controllerName` identifies which controller will set the Ready/Retry/Rejected status on the Workload.
+
+### 7. WorkloadPriorityClass
+
+Like Pod `PriorityClass`, but only affects Workload ordering and preemption inside Kueue — never affects Pod scheduling priority.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata: { name: prod-high }
+value: 1000
+description: "Production training jobs"
+```
+
+A Workload can carry both a Pod `priorityClassName` (for kube-scheduler) and a `kueue.x-k8s.io/priority-class` label (for Kueue ordering). They're independent — use Workload priority for queue ordering without affecting in-cluster Pod priority.
+
+### 8. Topology
+
+Names a hierarchy of node-label keys (e.g., zone → rack → hostname) that Topology-Aware Scheduling can target.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1alpha1
+kind: Topology
+metadata: { name: gpu-rack-topology }
+spec:
+  levels:
+  - nodeLabel: topology.kubernetes.io/zone
+  - nodeLabel: gpu.example.com/rack
+  - nodeLabel: kubernetes.io/hostname
+```
+
+A ResourceFlavor opts in via `spec.topologyName`; Workloads request topology placement via PodSet annotations. See `references/advanced-features.md` for the user-facing annotation API.
+
+### Other CRDs (referenced from advanced features)
+
+| CRD | Purpose | Detail |
+|-----|---------|--------|
+| `MultiKueueConfig` | Lists worker clusters and dispatcher policy | See `advanced-features.md` |
+| `MultiKueueCluster` | Per-worker-cluster config + kubeconfig secret | See `advanced-features.md` |
+| `ProvisioningRequestConfig` | Parameters for ProvisioningRequest AdmissionCheck | See `advanced-features.md` |
+| `AdmissionCheckPolicy` (proposed) | Group of checks applied together | KEP-stage |
+
+## The Scheduling Lifecycle
+
+A 13-step trace from `kubectl apply -f job.yaml` to Pod completion:
+
+| Step | Actor | Action |
+|------|-------|--------|
+| 1 | User | Creates a Job with `kueue.x-k8s.io/queue-name: team-a-queue` |
+| 2 | Mutating webhook | Sets `spec.suspend: true` (the Job creates no Pods) |
+| 3 | Job reconciler | Creates a Workload owned by the Job |
+| 4 | Workload reconciler | Looks up LocalQueue → resolves to ClusterQueue |
+| 5 | Scheduler loop | Iterates pending workloads in queue order |
+| 6 | Scheduler | Quota check: does CQ have enough nominal + borrow capacity? |
+| 7 | Scheduler | Flavor assignment: try flavors per `flavorFungibility`; may invoke preemption |
+| 8 | Workload status | Sets `QuotaReserved=True` with `admission.podSetAssignments` populated |
+| 9 | AdmissionCheck controllers | Each listed check sets state to Ready/Retry/Rejected |
+| 10 | Workload status | When all checks Ready → sets `Admitted=True` |
+| 11 | Job reconciler | Patches Job to `spec.suspend: false` and injects flavor tolerations into Pods |
+| 12 | kube-scheduler | Binds the now-unsuspended Pods to nodes |
+| 13 | Job reconciler | When Job completes, sets `Finished=True` on Workload; quota is released |
+
+State machine summary:
+
+```
+Pending  ──quota OK──▶  QuotaReserved  ──checks Ready──▶  Admitted  ──Pods done──▶  Finished
+   │                          │                              │
+   │                          ▼                              ▼
+   └──Inadmissible───── (Evicted: preempted, check Rejected, queue Held, deactivated) ──┘
+```
+
+## Controller Architecture
+
+Single Deployment: `kueue-controller-manager` in the `kueue-system` namespace, leader-elected for HA. The same binary runs all reconcilers, the scheduler loop, the metrics server, and the webhook server.
+
+### Reconcilers
+
+| Reconciler | Watches | Reconciles |
+|-----------|---------|-----------|
+| Job-integration reconcilers (one per framework) | batch.Job, PyTorchJob, RayJob, ... | Creates/updates the Workload, suspends/unsuspends the Job, injects tolerations |
+| Workload reconciler / scheduler | Workload | Quota reservation, flavor assignment, admission check coordination, eviction |
+| ClusterQueue reconciler | ClusterQueue | Updates `status.flavorsUsage`, pending counts; detects cohort cycles |
+| LocalQueue reconciler | LocalQueue | Mirrors a subset of ClusterQueue stats into the namespace |
+| AdmissionCheck reconciler | AdmissionCheck | Maintains the Active condition |
+| Cohort reconciler | Cohort | Maintains the cohort tree, propagates fair-sharing weight |
+
+### In-Memory Cache (the "snapshot")
+
+The scheduler keeps an in-memory cache of every ClusterQueue's quota usage and every pending Workload's resource needs. Each scheduling cycle works against a *snapshot* of this cache, not the API server, so admission decisions are sub-millisecond. The cache is rebuilt at startup from the API server and incrementally updated by reconcilers.
+
+### Webhooks
+
+| Webhook | Type | Effect |
+|---------|------|--------|
+| Job mutating webhook (one per framework) | Mutating | Sets `spec.suspend: true` on creation; sets default queue name |
+| Workload validating webhook | Validating | Rejects malformed podSets / impossible flavor requests |
+| ClusterQueue / Cohort validating webhook | Validating | Catches cohort cycles, conflicting flavors |
+
+Webhooks require TLS certificates. `internalCertManagement` (default true) auto-generates them; alternatively you can use cert-manager (`internalCertManagement.enable: false`).
+
+## Resource Model
+
+### Quota Math
+
+For each `(ClusterQueue, flavor, resource)` cell:
+- `nominalQuota` — guaranteed amount; cannot be revoked by cohort siblings
+- `borrowingLimit` — max additional amount borrowable from cohort siblings (nil = unlimited within cohort)
+- `lendingLimit` — max amount this CQ exposes for siblings to borrow (nil = all unused)
+- `usage` — sum of resource requests across admitted Workloads
+- `borrowed` — current amount this CQ is borrowing from cohort
+
+The admission check is: `usage + new_workload_request ≤ nominalQuota + min(borrowingLimit, sibling_lendable)`.
+
+### Cohort Borrowing
+
+ClusterQueues in the same cohort form a single borrowing pool per `(flavor, resource)`. A CQ's unused `nominalQuota` (up to its `lendingLimit`) is available for siblings to borrow. Borrowing is symmetric — there's no "owner" of borrowed capacity.
+
+When a sibling's own workload arrives and would normally fit inside its `nominalQuota`, the borrower may be preempted via `preemption.reclaimWithinCohort` (Never / LowerPriority / Any). This is how nominal quota stays guaranteed.
+
+### Flavor Fungibility
+
+When a Workload's resources can be served by multiple flavors (e.g., spot or on-demand), `flavorFungibility` controls fall-through:
+
+| `whenCanBorrow` | Behavior |
+|-----------------|----------|
+| `Borrow` (default) | If borrowing in current flavor works, use it |
+| `TryNextFlavor` | Skip to next flavor before borrowing — useful for "try cheap flavor first" |
+
+| `whenCanPreempt` | Behavior |
+|------------------|----------|
+| `TryNextFlavor` (default) | Try next flavor before resorting to preemption in current |
+| `Preempt` | Preempt within current flavor before falling through |
+
+Real example: list `[spot, ondemand]` with `whenCanBorrow: TryNextFlavor` means "try spot, if spot is full borrow on-demand instead of borrowing more spot from the cohort".
+
+## Queueing Strategies
+
+| Strategy | Behavior | When to use |
+|----------|----------|-------------|
+| `BestEffortFIFO` (default) | Workloads sorted by priority then creation; head-of-line workloads that can't fit are skipped so smaller jobs can admit | Maximize cluster utilization |
+| `StrictFIFO` | Strict FIFO — head of queue blocks all others | Strong fairness when starvation is unacceptable |
+
+Combine with `WorkloadPriorityClass` to get priority-then-FIFO ordering.
+
+## Workload Status Conditions
+
+| Condition | True means |
+|-----------|-----------|
+| `QuotaReserved` | Quota allocated; flavor assignment exists in `status.admission` |
+| `Admitted` | Quota reserved AND all admission checks Ready; Job will be unsuspended |
+| `PodsReady` | All Pods have started and are Ready (only set when `waitForPodsReady` is enabled) |
+| `Finished` | Underlying Job completed (success or failure) |
+| `Evicted` | Workload removed from admission; reason explains why (Preempted, AdmissionCheck, Deactivated, etc.) |
+
+The `Inadmissible` condition is *not* a separate state — it's reported as a reason when scheduling fails. Possible reasons include: `NoFit` (insufficient quota), `Preempted`, `RequeuedByAdmissionCheck`, `Deactivated`.
+
+## Stop Policy
+
+Both ClusterQueue and LocalQueue support `stopPolicy`:
+
+| Value | Behavior |
+|-------|----------|
+| `None` (default) | Normal admission |
+| `Hold` | Stop admitting new Workloads; running Workloads keep running |
+| `HoldAndDrain` | Stop admitting AND evict all admitted Workloads (they re-queue elsewhere or stay pending) |
+
+Use `Hold` for safe drains during maintenance, `HoldAndDrain` for emergencies.
+
+## Where to Look Next
+
+| Topic | Reference |
+|-------|-----------|
+| How to install + the Configuration kind | `installation-and-config.md` |
+| Per-framework wiring (Kubeflow, Ray, Pods, ...) | `job-integrations.md` |
+| Preemption, fair sharing, MultiKueue, TAS, ProvisioningRequest | `advanced-features.md` |
+| kueuectl + Prometheus metrics + troubleshooting | `operations-and-cli.md` |
+| Real-world cohort/flavor topologies | `quota-and-tenancy-patterns.md` |
+| End-to-end recipes | `use-cases-and-recipes.md` |
+
+## Sources
+
+- https://kueue.sigs.k8s.io/docs/concepts/
+- https://kueue.sigs.k8s.io/docs/concepts/cluster_queue/
+- https://kueue.sigs.k8s.io/docs/concepts/local_queue/
+- https://kueue.sigs.k8s.io/docs/concepts/resource_flavor/
+- https://kueue.sigs.k8s.io/docs/concepts/workload/
+- https://kueue.sigs.k8s.io/docs/concepts/cohort/
+- https://kueue.sigs.k8s.io/docs/concepts/admission_check/
+- https://kueue.sigs.k8s.io/docs/concepts/topology_aware_scheduling/
+- https://kueue.sigs.k8s.io/docs/concepts/workload_priority_class/
+- https://github.com/kubernetes-sigs/kueue/tree/main/apis/kueue/v1beta1
+- https://github.com/kubernetes-sigs/kueue/tree/main/apis/kueue/v1

--- a/skills/kueue/references/core-batch-ai-recipes.md
+++ b/skills/kueue/references/core-batch-ai-recipes.md
@@ -1,0 +1,362 @@
+# Core Batch, AI, and Federation Recipes
+
+Sources: Kueue documentation tasks (kueue.sigs.k8s.io/docs/tasks/run/, /tasks/manage/), Google Cloud GKE Kueue tutorials, Karpenter + Kueue integration docs, KubeCon talks 2024-2025.
+
+Covers: copy-paste recipes for basic batch queues, multi-team GPU sharing, Kubeflow PyTorch training, Ray hyperparameter tuning, spot+on-demand fallback, GPU autoscaling with ProvisioningRequest, and MultiKueue federation.
+
+Each recipe states scenario, prerequisites, complete YAML, expected behavior, verification commands, and common gotchas.
+
+## Recipe 1 — Basic batch queue
+
+**Scenario**: 100 parallel batch Pods (4 CPU, 8Gi each), 200-CPU CQ. First 50 admit; the rest queue.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata: { name: default }
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: batch-cq }
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+  - coveredResources: [cpu, memory]
+    flavors:
+    - name: default
+      resources:
+      - { name: cpu, nominalQuota: "200" }
+      - { name: memory, nominalQuota: "400Gi" }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata: { name: default, namespace: default }
+spec: { clusterQueue: batch-cq }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: batch-
+  labels: { kueue.x-k8s.io/queue-name: default }
+spec:
+  parallelism: 100
+  completions: 100
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: w
+        image: busybox
+        command: [sh, -c, "sleep 300"]
+        resources: { requests: { cpu: "4", memory: 8Gi } }
+```
+
+**Verify**: `kueuectl describe cq batch-cq` should show 50 admitted Pods and 1 pending Workload (the rest waiting because Job's PodSet is treated atomically — see partial admission to admit fewer Pods).
+
+**Gotchas**: Without a `kueue.x-k8s.io/queue-name` label, the Job runs immediately, bypassing Kueue. Pod requests >`nominalQuota` → Workload Inadmissible forever.
+
+## Recipe 2 — Multi-team GPU sharing with preemption
+
+**Scenario**: Two teams sharing 8 GPUs in a cohort. Production preempts research when GPUs are full.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata: { name: gpu-a100 }
+spec:
+  nodeLabels: { accelerator: nvidia-a100 }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata: { name: prod-priority }
+value: 1000
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata: { name: research-priority }
+value: 100
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: Cohort
+metadata: { name: shared-gpus }
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: prod-cq }
+spec:
+  cohort: shared-gpus
+  namespaceSelector: { matchLabels: { team: prod } }
+  preemption: { reclaimWithinCohort: Any, withinClusterQueue: LowerPriority }
+  resourceGroups:
+  - coveredResources: ["nvidia.com/gpu"]
+    flavors:
+    - name: gpu-a100
+      resources: [{ name: "nvidia.com/gpu", nominalQuota: "4", borrowingLimit: "4" }]
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: research-cq }
+spec:
+  cohort: shared-gpus
+  namespaceSelector: { matchLabels: { team: research } }
+  preemption: { withinClusterQueue: LowerPriority }     # never preempts prod
+  resourceGroups:
+  - coveredResources: ["nvidia.com/gpu"]
+    flavors:
+    - name: gpu-a100
+      resources: [{ name: "nvidia.com/gpu", nominalQuota: "4", borrowingLimit: "4" }]
+---
+# Submit prod Job (preempts research if needed)
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: prod-inference
+  namespace: prod-ns
+  labels:
+    kueue.x-k8s.io/queue-name: default
+    kueue.x-k8s.io/priority-class: prod-priority
+spec:
+  parallelism: 4
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: c
+        image: nvidia/cuda:12.0-runtime
+        resources: { requests: { "nvidia.com/gpu": "1" } }
+```
+
+**Verify**: When the prod Job is submitted while research is using all 8 GPUs, watch `kueuectl describe workload <research>` — it should transition to `Evicted=True, reason=Preempted`. The prod Workload then admits.
+
+**Gotchas**: Cohort name typo → no sharing. Forgetting `reclaimWithinCohort: Any` on prod-cq → prod can't take GPUs from research.
+
+## Recipe 3 — Distributed PyTorch training (Kubeflow)
+
+**Scenario**: 1 master + 3 workers, gang scheduled, requeued on failure.
+
+```yaml
+# (assumes ResourceFlavor "default" + ClusterQueue "ml-cq" with 4 GPU nominal exist)
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata: { name: default, namespace: default }
+spec: { clusterQueue: ml-cq }
+---
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: pytorch-train
+  labels: { kueue.x-k8s.io/queue-name: default }
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+          - name: pytorch
+            image: pytorch/pytorch:2.0-cuda12.0-runtime
+            resources: { requests: { "nvidia.com/gpu": "1" } }
+    Worker:
+      replicas: 3
+      restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+          - name: pytorch
+            image: pytorch/pytorch:2.0-cuda12.0-runtime
+            resources: { requests: { "nvidia.com/gpu": "1" } }
+```
+
+Pair with `Configuration.waitForPodsReady.enable: true` and `timeout: 10m` so the whole job is requeued if not all 4 Pods come up within the window.
+
+**Verify**: `kueuectl describe workload pytorch-train` shows two PodSets (Master + Worker) and `Admitted=True` + `PodsReady=True`.
+
+**Gotchas**: `PyTorchJob` needs Kueue's `kubeflow.org/pytorchjob` integration enabled. Master and Worker count toward the same Workload's quota — sum the GPUs.
+
+## Recipe 4 — Ray hyperparameter tuning with elastic scaling
+
+**Scenario**: RayJob head + autoscaling worker group, treated as elastic Workload.
+
+```yaml
+# Enable feature gate first: ElasticJobsViaWorkloadSlices=true
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: hp-tune
+  labels: { kueue.x-k8s.io/queue-name: default }
+  annotations: { kueue.x-k8s.io/elastic-job: "true" }
+spec:
+  shutdownAfterJobFinishes: true
+  entrypoint: python /home/ray/tune.py
+  rayClusterSpec:
+    rayVersion: '2.10.0'
+    enableInTreeAutoscaling: true
+    autoscalerOptions: { idleTimeoutSeconds: 30, upscalingMode: Aggressive }
+    headGroupSpec:
+      rayStartParams: { dashboard-host: '0.0.0.0' }
+      template:
+        spec:
+          containers:
+          - { name: ray-head, image: rayproject/ray:2.10.0, resources: { requests: { cpu: "4" } } }
+    workerGroupSpecs:
+    - groupName: workers
+      replicas: 1
+      minReplicas: 1
+      maxReplicas: 5
+      template:
+        spec:
+          containers:
+          - { name: ray-worker, image: rayproject/ray:2.10.0, resources: { requests: { cpu: "2" } } }
+```
+
+**Verify**: As Ray's autoscaler grows the worker group, you'll see new Workload slices and the old slice marked `Finished`. `kueuectl get workload` lists them.
+
+**Gotchas**: Without `ElasticJobsViaWorkloadSlices` feature gate, the Workload is static at the initial replicas. Without `shutdownAfterJobFinishes: true`, Kueue rejects RayJob.
+
+## Recipe 5 — Spot + on-demand fallback
+
+**Scenario**: Workloads admit on spot first; fall through to on-demand when spot is exhausted.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata: { name: spot }
+spec:
+  nodeLabels: { capacity-type: spot }
+  tolerations: [{ key: spot, operator: Equal, value: "true", effect: NoSchedule }]
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata: { name: ondemand }
+spec:
+  nodeLabels: { capacity-type: on-demand }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: cost-optimized }
+spec:
+  resourceGroups:
+  - coveredResources: [cpu]
+    flavors:
+    - { name: spot,     resources: [{ name: cpu, nominalQuota: "100" }] }
+    - { name: ondemand, resources: [{ name: cpu, nominalQuota: "50" }] }
+  flavorFungibility:
+    whenCanBorrow: TryNextFlavor          # do not borrow more spot — go to on-demand
+    whenCanPreempt: TryNextFlavor
+```
+
+Workloads with `tolerations: [{key: spot}]` admit on spot first. Workloads without that toleration skip the spot flavor (its NoSchedule taint excludes them).
+
+**Gotchas**: Without the toleration in the ResourceFlavor, Kueue won't inject it and Pods can't land on tainted spot nodes. Without `flavorFungibility.whenCanBorrow: TryNextFlavor`, Kueue would borrow more spot from the cohort instead of falling through to on-demand.
+
+## Recipe 6 — GPU job with Karpenter / Cluster Autoscaler (ProvisioningRequest)
+
+**Scenario**: GPU Workload pending → ProvisioningRequest created → Karpenter scales up GPU node → Workload admits.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata: { name: gpu-h100 }
+spec:
+  nodeLabels: { accelerator: nvidia-h100 }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ProvisioningRequestConfig
+metadata: { name: gpu-prov }
+spec:
+  provisioningClassName: check-capacity.autoscaling.x-k8s.io   # generic CA class; or karpenter.sh/<class>
+  managedResources: ["nvidia.com/gpu"]
+  retryStrategy: { backoffLimitCount: 3, backoffBaseSeconds: 60, backoffMaxSeconds: 1800 }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: AdmissionCheck
+metadata: { name: gpu-provision }
+spec:
+  controllerName: kueue.x-k8s.io/provisioning-request
+  parameters: { apiGroup: kueue.x-k8s.io, kind: ProvisioningRequestConfig, name: gpu-prov }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: gpu-cq }
+spec:
+  admissionChecks: [gpu-provision]
+  resourceGroups:
+  - coveredResources: ["nvidia.com/gpu"]
+    flavors:
+    - { name: gpu-h100, resources: [{ name: "nvidia.com/gpu", nominalQuota: "8" }] }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: gpu-train-
+  labels: { kueue.x-k8s.io/queue-name: default }
+spec:
+  parallelism: 8
+  template:
+    spec:
+      restartPolicy: Never
+      nodeSelector: { accelerator: nvidia-h100 }
+      containers:
+      - name: trainer
+        image: nvidia/cuda:12.0-runtime
+        resources: { requests: { "nvidia.com/gpu": "1" } }
+```
+
+**Verify**: `kubectl get provisioningrequest -A` shows a request created when the Workload is submitted. After Karpenter or CA provisions nodes, the AdmissionCheck transitions to Ready and the Workload admits.
+
+**Gotchas**: Wrong `provisioningClassName` → no autoscaler picks up the request. Workload Pods need the same nodeSelector as ResourceFlavor's `nodeLabels`.
+
+## Recipe 7 — Multi-cluster federation with MultiKueue
+
+**Scenario**: One management cluster, two worker clusters. Job submitted on management is dispatched to least-loaded worker.
+
+On the **management cluster** (after creating kubeconfig secrets `worker1-kubeconfig` and `worker2-kubeconfig`):
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: MultiKueueCluster
+metadata: { name: worker1 }
+spec: { kubeConfig: { locationType: Secret, location: worker1-kubeconfig } }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: MultiKueueCluster
+metadata: { name: worker2 }
+spec: { kubeConfig: { locationType: Secret, location: worker2-kubeconfig } }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: MultiKueueConfig
+metadata: { name: federation }
+spec: { clusters: [worker1, worker2] }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: AdmissionCheck
+metadata: { name: federate }
+spec:
+  controllerName: kueue.x-k8s.io/multikueue
+  parameters: { apiGroup: kueue.x-k8s.io, kind: MultiKueueConfig, name: federation }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: federated-cq }
+spec:
+  admissionChecks: [federate]
+  resourceGroups:
+  - coveredResources: [cpu]
+    flavors: [{ name: default, resources: [{ name: cpu, nominalQuota: "1000" }] }]
+```
+
+Each worker cluster needs Kueue installed and a ClusterQueue named the same way (`federated-cq`).
+
+**Gotchas**: Worker secret must live in `kueue-system`. The management cluster cannot also be a worker. For batch/v1 Jobs the management Job needs `spec.managedBy: kueue.x-k8s.io/multikueue`.
+
+## Sources
+
+- https://kueue.sigs.k8s.io/docs/tasks/run/
+- https://kueue.sigs.k8s.io/docs/tasks/manage/setup_provisioning_request/
+- https://kueue.sigs.k8s.io/docs/tasks/manage/setup_multikueue/
+- https://kueue.sigs.k8s.io/docs/tasks/run/rayjobs/
+- https://kueue.sigs.k8s.io/docs/tasks/run/kubeflow/
+- https://github.com/kubernetes-sigs/kueue/tree/main/examples

--- a/skills/kueue/references/installation-and-config.md
+++ b/skills/kueue/references/installation-and-config.md
@@ -1,0 +1,446 @@
+# Installation and Configuration
+
+Sources: Kueue official documentation (kueue.sigs.k8s.io/docs/installation/, /docs/reference/kueue-config.v1beta1/), kubernetes-sigs/kueue Helm chart, GitHub releases, KEPs for feature gates.
+
+Covers: Install methods (kubectl, Helm OCI, Kustomize, GitOps), the `Configuration` kind reference, the feature-gate matrix, upgrade procedure, production hardening (HA, cert-manager, ServiceMonitor, PriorityClass, PDB), and a starter multi-tenant manifest.
+
+## Install Methods
+
+### kubectl apply (release manifests)
+
+The fastest path. One file, no extra tooling.
+
+```bash
+KUEUE_VERSION=v0.14.0
+kubectl apply --server-side -f \
+  https://github.com/kubernetes-sigs/kueue/releases/download/${KUEUE_VERSION}/manifests.yaml
+
+kubectl -n kueue-system wait deploy/kueue-controller-manager \
+  --for=condition=Available --timeout=5m
+```
+
+`--server-side` is required because Kueue's CRDs are large and trip the client-side `Last-Applied-Configuration` annotation size limit.
+
+**Prerequisites**: Kubernetes 1.29+. cert-manager only if you plan to disable Kueue's internal cert management.
+
+### Helm chart (OCI)
+
+The recommended production path. Chart lives in OCI registry `oci://registry.k8s.io/kueue/charts/kueue`.
+
+```bash
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue \
+  --version 0.14.0 \
+  --namespace kueue-system \
+  --create-namespace \
+  --values values.yaml \
+  --wait --timeout 5m
+```
+
+Minimal production `values.yaml`:
+
+```yaml
+controllerManager:
+  replicas: 2
+  manager:
+    resources:
+      requests: { cpu: "1", memory: 1Gi }
+      limits:   { cpu: "2", memory: 2Gi }
+    priorityClassName: system-cluster-critical
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+  featureGates:
+  - name: TopologyAwareScheduling
+    enabled: true
+  - name: MultiKueue
+    enabled: true
+
+enableCertManager: false      # use Kueue's internal cert management
+enablePrometheus: true        # creates ServiceMonitor
+
+managerConfig:                # injected into kueue-manager-config ConfigMap
+  manageJobsWithoutQueueName: false
+  integrations:
+    frameworks:
+    - "batch/job"
+    - "kubeflow.org/pytorchjob"
+    - "ray.io/rayjob"
+```
+
+### Kustomize from source
+
+For developers and CI:
+
+```bash
+git clone https://github.com/kubernetes-sigs/kueue.git
+cd kueue && git checkout v0.14.0
+kubectl apply --server-side -k config/default
+```
+
+The `config/default` overlay enables internal cert management and standard feature gates. Customize via your own overlay.
+
+### GitOps (ArgoCD)
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata: { name: kueue, namespace: argocd }
+spec:
+  project: default
+  destination: { server: https://kubernetes.default.svc, namespace: kueue-system }
+  source:
+    repoURL: https://github.com/kubernetes-sigs/kueue
+    targetRevision: v0.14.0
+    path: charts/kueue
+    helm:
+      valueFiles: [values.yaml]
+  syncPolicy:
+    automated: { prune: true, selfHeal: true }
+    syncOptions: [CreateNamespace=true, ServerSideApply=true]
+```
+
+Pin `targetRevision` to a tag, never `main`. CRDs change between releases and ArgoCD can't safely auto-upgrade them without `ServerSideApply=true`.
+
+## The Configuration Kind
+
+Kueue's runtime configuration lives in a ConfigMap (`kueue-manager-config` in `kueue-system`) holding a serialized `Configuration` object (`config.kueue.x-k8s.io/v1beta1`, with `v1beta2` rolling out).
+
+Edit, then restart the controller: `kubectl -n kueue-system rollout restart deploy/kueue-controller-manager`.
+
+```yaml
+apiVersion: config.kueue.x-k8s.io/v1beta1
+kind: Configuration
+namespace: kueue-system
+
+# --- core controller plumbing ---
+controller:
+  groupKindConcurrency:
+    Workload.kueue.x-k8s.io: 10
+    ClusterQueue.kueue.x-k8s.io: 5
+    LocalQueue.kueue.x-k8s.io: 5
+  cacheSyncTimeout: 2m
+
+clientConnection:
+  qps: 100
+  burst: 200
+
+leaderElection:
+  leaderElect: true
+  resourceName: c1f6bfd2.kueue.x-k8s.io
+  resourceNamespace: kueue-system
+
+# --- network endpoints ---
+metrics:
+  bindAddress: ":8443"
+  enableClusterQueueResources: true
+health:
+  healthProbeBindAddress: ":8081"
+webhook:
+  port: 9443
+
+# --- TLS for webhooks ---
+internalCertManagement:
+  enable: true                                # Kueue self-signs
+  webhookServiceName: kueue-webhook-service
+  webhookSecretName: kueue-webhook-server-cert
+
+# --- which jobs Kueue manages ---
+manageJobsWithoutQueueName: false             # if true, ALL jobs without label are queued
+managedJobsNamespaceSelector:
+  matchLabels:
+    kueue.x-k8s.io/managed: "true"
+integrations:
+  frameworks:
+  - "batch/job"
+  - "kubeflow.org/pytorchjob"
+  - "kubeflow.org/mpijob"
+  - "jobset.x-k8s.io/jobset"
+  - "ray.io/rayjob"
+  - "pod"
+  - "deployment"
+  podOptions:
+    namespaceSelector:
+      matchExpressions:
+      - { key: kubernetes.io/metadata.name, operator: NotIn, values: [kube-system, kueue-system] }
+
+# --- gang scheduling ---
+waitForPodsReady:
+  enable: true
+  timeout: 10m
+  blockAdmission: true
+  requeuingStrategy:
+    timestamp: Eviction
+    backoffLimitCount: 5
+    backoffBaseSeconds: 60
+
+# --- fair sharing ---
+fairSharing:
+  enable: true
+  preemptionStrategies: [LessThanOrEqualToFinalShare]
+admissionFairSharing:
+  usageHalfLifeTime: 15m
+  usageSamplingInterval: 5m
+  resourceWeights:
+    cpu: 1
+    memory: 1
+    "nvidia.com/gpu": 100
+
+# --- multi-cluster ---
+multiKueue:
+  gcInterval: 1h
+  origin: management-cluster
+
+# --- garbage collection ---
+objectRetentionPolicies:
+  workloads:
+    finalStateInactiveTTL: 24h
+
+# --- resource transformations / DRA ---
+resources:
+  excludeResourcePrefixes: ["pod-overhead.kueue.x-k8s.io"]
+  transformations:
+  - input: "memory-fraction"
+    strategy: Replace
+    outputs:
+      memory: "8Gi"
+
+# --- experimental features ---
+featureGates:
+  TopologyAwareScheduling: true
+  ElasticJobsViaWorkloadSlices: true
+```
+
+### Key fields
+
+| Field | Effect |
+|-------|--------|
+| `manageJobsWithoutQueueName` | If `true`, *every* unsuspended Job is wrapped by Kueue. Dangerous on existing clusters — start with `false` and label opt-in jobs |
+| `managedJobsNamespaceSelector` | Restricts the above to namespaces matching the selector. **Required** when any Pod-derived integration (`pod`, `deployment`, `statefulset`) is enabled |
+| `integrations.frameworks` | Enables specific Job-controller integrations. Restart required after change |
+| `integrations.podOptions.namespaceSelector` | Specifically scopes the `pod` integration's webhook |
+| `internalCertManagement.enable: true` | Kueue self-signs the webhook serving cert. Set to `false` to use cert-manager |
+| `clientConnection.qps`/`burst` | API server rate limiting. Raise for clusters with thousands of Workloads |
+| `waitForPodsReady` | All-or-nothing scheduling. See `advanced-features.md` for details |
+| `fairSharing.enable` | Enables DRF-style fair sharing among ClusterQueues in a cohort |
+| `multiKueue.gcInterval` | How often the controller GCs orphaned remote Workloads |
+| `objectRetentionPolicies.workloads.finalStateInactiveTTL` | Auto-delete completed Workloads after this duration |
+| `featureGates` | Per-feature on/off, see table below |
+
+## Feature Gates
+
+Feature gates change frequently. The table below reflects v0.14 (May 2026); always check the current `keps/` directory in the kueue repo and the release notes for accurate state.
+
+| Gate | Default | Stage | Since | What it does |
+|------|---------|-------|-------|--------------|
+| `FlavorFungibility` | true | Beta | 0.5 | Try multiple flavors per resourceGroup |
+| `PartialAdmission` | true | Beta | 0.5 | Admit Jobs with fewer Pods than requested via `job-min-parallelism` |
+| `MultiKueue` | true | Beta | 0.9 | Federated multi-cluster job dispatch |
+| `MultiKueueBatchJobWithManagedBy` | true | GA | 0.13 | batch/v1 Job support in MultiKueue via `managedBy` |
+| `VisibilityOnDemand` | true | Beta | 0.9 | On-demand visibility API for pending Workloads |
+| `TopologyAwareScheduling` | true | Beta | 0.10 | Rack/zone/host topology placement |
+| `LendingLimit` | true | GA | 0.13 | `lendingLimit` field on ClusterQueue resource quota |
+| `LocalQueueDefaulting` | true | Beta | 0.13 | Auto-create `default` LocalQueue per managed namespace |
+| `ObjectRetentionPolicies` | true | Beta | 0.13 | Auto-delete finished Workloads |
+| `HierarchicalCohort` | true | Beta | 0.12 | Parent/child Cohort hierarchy |
+| `AdmissionFairSharing` | true | Beta | 0.13 | Per-namespace fair share within a ClusterQueue |
+| `AdmissionCheckValidationRules` | true | Beta | 0.13 | CEL validation on AdmissionCheck params |
+| `ConfigurableResourceTransformations` | true | Beta | 0.13 | The `resources.transformations` field |
+| `ManagedJobsNamespaceSelector` | true | GA | 0.13 | Honor `managedJobsNamespaceSelector` everywhere |
+| `ElasticJobsViaWorkloadSlices` | false | Alpha | 0.14 | Workload slicing for elastic Jobs |
+| `DynamicResourceAllocation` | false | Alpha | 0.13 | DRA device support in podSets |
+| `TASBalancedPlacement` | false | Alpha | 0.13 | Balanced spread across topology domains |
+| `FailureRecoveryPolicy` | false | Alpha | 0.13 | Auto-requeue on Pod failure |
+| `LocalQueueMetrics` | false | Alpha | 0.10 | Per-LocalQueue metrics (high cardinality) |
+| `AdmissionGatedBy` | false | Alpha | 0.14 | Custom external admission gates |
+
+Set in Configuration:
+
+```yaml
+featureGates:
+  TopologyAwareScheduling: true
+  ElasticJobsViaWorkloadSlices: true
+```
+
+Or via container args:
+
+```yaml
+controllerManager:
+  manager:
+    extraArgs:
+    - --feature-gates=TopologyAwareScheduling=true,ElasticJobsViaWorkloadSlices=true
+```
+
+## Upgrade Path
+
+| Direction | Allowed | Notes |
+|-----------|---------|-------|
+| Patch upgrade (0.14.1 → 0.14.2) | Always | Bug fixes only |
+| Minor upgrade (0.13 → 0.14) | One step at a time | Read EVERY release note between current and target |
+| Skip-version upgrade | Not supported | Walk through each minor |
+| Downgrade | Not supported | Backup CRDs, reinstall older version, restore objects |
+
+Sample procedure:
+
+```bash
+# 1. Backup quota objects
+kubectl get -A clusterqueues,localqueues,resourceflavors,cohorts,admissionchecks \
+  -o yaml > kueue-backup.yaml
+
+# 2. Helm upgrade
+helm upgrade kueue oci://registry.k8s.io/kueue/charts/kueue \
+  --version 0.14.0 -n kueue-system -f values.yaml --wait
+
+# 3. Validate
+kubectl -n kueue-system rollout status deploy/kueue-controller-manager
+kubectl get clusterqueues
+kueuectl version
+```
+
+Common breaking changes to watch for: deprecated feature gates being removed, deprecated config fields (e.g., legacy `queueVisibility` → `VisibilityOnDemand`), CRD schema tightening (validation that previously was lenient).
+
+## Production Hardening
+
+### Resource Sizing
+
+| Cluster size | replicas | requests | limits |
+|-------------|----------|----------|--------|
+| Small (< 100 Workloads) | 1 | 200m CPU / 256Mi | 500m CPU / 512Mi |
+| Medium (< 1k Workloads) | 2 | 500m / 512Mi | 1 / 1Gi |
+| Large (< 10k Workloads) | 2 | 1 / 1Gi | 2 / 2Gi |
+| Very large (10k+) | 2-3 | 2 / 2Gi | 4 / 4Gi |
+
+A single kueue-controller-manager comfortably handles ~10k active Workloads. Above that, look at sharding by tenant cluster.
+
+### High Availability
+
+Two replicas + leader election + PodDisruptionBudget:
+
+```yaml
+controllerManager:
+  replicas: 2
+  podDisruptionBudget: { enabled: true, minAvailable: 1 }
+  manager:
+    priorityClassName: system-cluster-critical
+```
+
+Only the leader does scheduling work; the standby just keeps the lease alive.
+
+### Webhook Certificates
+
+Default: Kueue manages its own webhook serving certs (`internalCertManagement.enable: true`). Cert is regenerated on Pod restart.
+
+For organizations standardizing on cert-manager:
+
+```yaml
+# values.yaml
+enableCertManager: true
+internalCertManagement:
+  enable: false
+```
+
+This creates `Certificate` and `Issuer` resources for the webhook.
+
+### Prometheus Monitoring
+
+If you have prometheus-operator, install with `--set enablePrometheus=true` to get a ServiceMonitor:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata: { name: kueue, namespace: kueue-system }
+spec:
+  selector: { matchLabels: { control-plane: controller-manager, app.kubernetes.io/name: kueue } }
+  endpoints:
+  - port: https
+    scheme: https
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tlsConfig: { insecureSkipVerify: true }
+    interval: 30s
+```
+
+Without prometheus-operator, scrape `kueue-controller-manager-metrics-service:8443` directly. See `operations-and-cli.md` for the metric catalog.
+
+## kueuectl CLI Setup
+
+Install via krew:
+
+```bash
+kubectl krew install kueue
+kubectl kueue version
+```
+
+Or download the binary directly from the GitHub release matching your server version. See `operations-and-cli.md` for the full command surface.
+
+## Multi-Tenancy Starter Manifest
+
+Use this shape for the first real tenant rollout. Keep the full object set in source control, but start with small quotas and explicit namespace labels.
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata: { name: team-research, labels: { kueue.x-k8s.io/managed: "true", department: research } }
+---
+apiVersion: v1
+kind: Namespace
+metadata: { name: team-prod, labels: { kueue.x-k8s.io/managed: "true", department: prod } }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata: { name: gpu-a100 }
+spec:
+  nodeLabels: { accelerator: nvidia-a100 }
+  tolerations: [{ key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }]
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: Cohort
+metadata: { name: company }
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: research-cq }
+spec:
+  cohort: company
+  namespaceSelector: { matchLabels: { department: research } }
+  resourceGroups:
+  - coveredResources: [cpu, memory, "nvidia.com/gpu"]
+    flavors:
+    - name: gpu-a100
+      resources:
+      - { name: cpu, nominalQuota: "32", borrowingLimit: "32" }
+      - { name: memory, nominalQuota: "128Gi", borrowingLimit: "128Gi" }
+      - { name: "nvidia.com/gpu", nominalQuota: "4", borrowingLimit: "4" }
+  flavorFungibility: { whenCanBorrow: TryNextFlavor, whenCanPreempt: TryNextFlavor }
+  preemption: { reclaimWithinCohort: LowerPriority, withinClusterQueue: LowerPriority }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: prod-cq }
+spec:
+  cohort: company
+  namespaceSelector: { matchLabels: { department: prod } }
+  resourceGroups: [{ coveredResources: [cpu, memory, "nvidia.com/gpu"], flavors: [{ name: gpu-a100, resources: [{ name: cpu, nominalQuota: "32", borrowingLimit: "32" }, { name: memory, nominalQuota: "128Gi", borrowingLimit: "128Gi" }, { name: "nvidia.com/gpu", nominalQuota: "4", borrowingLimit: "4" }] }] }]
+  preemption: { reclaimWithinCohort: Any, withinClusterQueue: LowerPriority }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata: { name: default, namespace: team-research }
+spec: { clusterQueue: research-cq }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata: { name: default, namespace: team-prod }
+spec: { clusterQueue: prod-cq }
+```
+
+Apply and verify with `kubectl apply -f starter.yaml`, `kueuectl get clusterqueue`, and `kueuectl get localqueue -A`. Submit jobs with `kueue.x-k8s.io/queue-name: default`; Kueue routes them by namespace labels. Add `WorkloadPriorityClass` objects only after basic admission works.
+
+## Sources
+
+- https://kueue.sigs.k8s.io/docs/installation/
+- https://kueue.sigs.k8s.io/docs/installation/install-via-helm/
+- https://kueue.sigs.k8s.io/docs/installation/upgrade/
+- https://kueue.sigs.k8s.io/docs/reference/kueue-config.v1beta1/
+- https://github.com/kubernetes-sigs/kueue/tree/main/charts/kueue
+- https://github.com/kubernetes-sigs/kueue/tree/main/keps
+- https://github.com/kubernetes-sigs/kueue/releases

--- a/skills/kueue/references/job-integrations.md
+++ b/skills/kueue/references/job-integrations.md
@@ -1,0 +1,440 @@
+# Job Integrations
+
+Sources: Kueue official documentation (kueue.sigs.k8s.io/docs/tasks/run/), Kueue Configuration v1beta1/v1beta2 reference, Kubeflow Training Operator docs, KubeRay docs, JobSet spec, AppWrapper (CodeFlare) docs.
+
+Covers: The universal `queue-name` label pattern, the `integrations.frameworks` enablement table, per-framework wiring (batch Job, JobSet, Kubeflow v1/v2, KubeRay, AppWrapper, plain Pods, Deployment, StatefulSet, LeaderWorkerSet, Spark), the suspend → admit → unsuspend lifecycle, common failure modes, and writing a custom integration.
+
+## The Universal Pattern
+
+Every Kueue-managed workload follows the same shape:
+
+1. **User adds the queue-name label** — `kueue.x-k8s.io/queue-name: <local-queue>` on the workload's `metadata.labels`
+2. **Kueue's framework-specific webhook suspends it** — sets `spec.suspend: true` (Job-like) or injects a scheduling gate (Pods)
+3. **Kueue's framework reconciler creates a Workload** — one per parent object, with `podSets[]` derived from the parent's replica spec
+4. **Workload waits in the queue** — until quota reservation + admission checks succeed
+5. **Kueue unsuspends** — clears `spec.suspend` (Job-like) or removes the scheduling gate (Pods); injects flavor tolerations into Pod templates
+6. **Pods schedule and run** — kube-scheduler binds them; Kueue tracks completion via the parent's status
+
+**The first thing to check when a workload behaves wrong is always: did Kueue suspend it?** `kubectl get <kind> <name> -o jsonpath='{.spec.suspend}'`. If empty/false on a freshly created workload, the integration isn't wired up.
+
+## Enablement Table (per Kueue version)
+
+| Framework | `integrations.frameworks` string | Since | Suspend mechanism | Notes |
+|-----------|---------------------------------|-------|------------------|-------|
+| Kubernetes Job | `batch/job` | v0.1 | `spec.suspend` | The canonical case |
+| JobSet | `jobset.x-k8s.io/jobset` | v0.6 | `spec.suspend` | Multi-job groups |
+| Kubeflow PyTorchJob | `kubeflow.org/pytorchjob` | v0.3 | `spec.suspend` | Master + Workers |
+| Kubeflow TFJob | `kubeflow.org/tfjob` | v0.3 | `spec.suspend` | PS + Worker |
+| Kubeflow XGBoostJob | `kubeflow.org/xgboostjob` | v0.5 | `spec.suspend` | |
+| Kubeflow PaddleJob | `kubeflow.org/paddlejob` | v0.5 | `spec.suspend` | |
+| Kubeflow JAXJob | `kubeflow.org/jaxjob` | v0.13 | `spec.suspend` | |
+| Kubeflow MPIJob (v2beta1) | `kubeflow.org/mpijob` | v0.3 | `spec.suspend` | HPC tightly-coupled |
+| Kubeflow Trainer v2 TrainJob | `trainer.kubeflow.org/trainjob` | v0.14 | `spec.suspend` | Unified training API |
+| KubeRay RayJob | `ray.io/rayjob` | v0.6 | `spec.suspend` | Requires `shutdownAfterJobFinishes: true` |
+| KubeRay RayCluster | `ray.io/raycluster` | v0.6 | `spec.suspend` | Long-running Ray cluster |
+| KubeRay RayService | `ray.io/rayservice` | v0.6 | `spec.suspend` | |
+| AppWrapper | `workload.codeflare.dev/appwrapper` | v0.11 | Workload-level | Wraps any resource |
+| Plain Pod | `pod` | v0.8 | Scheduling gate | Requires namespace selector |
+| Deployment | `deployment` | v0.8 | Pod-level (rolling) | Requires namespace selector |
+| StatefulSet | `statefulset` | v0.8 | Pod-level | Requires namespace selector |
+| LeaderWorkerSet | `leaderworkerset.x-k8s.io/leaderworkerset` | v0.15 | `spec.suspend` | Distributed leader/worker |
+| Spark SparkApplication | `sparkoperator.k8s.io/sparkapplication` | v0.14 | `spec.suspend` | |
+
+The exact string format may include version suffixes (e.g., `batch/job.v1`) depending on Kueue version — check `kubectl get crd <crd> -o yaml` for the current admission webhook config or run `kubectl -n kueue-system describe deploy/kueue-controller-manager`.
+
+## Enabling Integrations in Configuration
+
+```yaml
+apiVersion: config.kueue.x-k8s.io/v1beta1
+kind: Configuration
+integrations:
+  frameworks:
+  - "batch/job"
+  - "jobset.x-k8s.io/jobset"
+  - "kubeflow.org/pytorchjob"
+  - "kubeflow.org/mpijob"
+  - "ray.io/rayjob"
+  - "ray.io/raycluster"
+  - "workload.codeflare.dev/appwrapper"
+  - "pod"
+  - "deployment"
+  - "statefulset"
+  - "leaderworkerset.x-k8s.io/leaderworkerset"
+  externalFrameworks: []                  # for custom integrations
+  podOptions:
+    namespaceSelector:                    # required when "pod" is enabled
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values: [kube-system, kueue-system]
+managedJobsNamespaceSelector:             # gates ALL Pod-derived integrations
+  matchLabels: { kueue-managed: "true" }
+```
+
+After editing the ConfigMap, restart the controller: `kubectl -n kueue-system rollout restart deploy/kueue-controller-manager`. Webhooks re-register on startup.
+
+## Per-Framework Recipes
+
+### batch/v1 Job
+
+The simplest case. Every other integration is a variant of this pattern.
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: trainer-
+  labels: { kueue.x-k8s.io/queue-name: team-a-queue }
+spec:
+  parallelism: 4
+  completions: 4
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: trainer
+        image: alpine:3
+        command: ["sh", "-c", "sleep 60"]
+        resources:
+          requests: { cpu: "1", memory: 200Mi }
+```
+
+**Optional annotations**:
+
+| Annotation | Effect |
+|-----------|--------|
+| `kueue.x-k8s.io/job-min-parallelism: "5"` | Allow partial admission down to 5 of N parallelism |
+| `kueue.x-k8s.io/elastic-job: "true"` | Allow scaling parallelism without restart (with workload slices) |
+| `kueue.x-k8s.io/priority-class: <name>` | Use a Workload-level priority (not Pod priority) |
+| `kueue.x-k8s.io/max-exec-time-seconds: "3600"` | Auto-deactivate after 1 hour of running |
+
+### JobSet
+
+Coordinates multiple replicated Jobs as a single quota unit. Resource calculation: Σ over `replicatedJobs[].replicas * .template.spec.parallelism * pod_request`.
+
+```yaml
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  generateName: training-
+  labels: { kueue.x-k8s.io/queue-name: team-a-queue }
+spec:
+  network: { enableDNSHostnames: true }
+  replicatedJobs:
+  - name: workers
+    replicas: 4
+    template:
+      spec:
+        parallelism: 1
+        template:
+          spec:
+            restartPolicy: Never
+            containers:
+            - name: worker
+              image: trainer:1.0
+              resources: { requests: { cpu: "2", memory: 4Gi, "nvidia.com/gpu": "1" } }
+```
+
+### Kubeflow Trainer v1 — PyTorchJob (and TFJob, MPIJob, etc.)
+
+```yaml
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: distributed-training
+  labels: { kueue.x-k8s.io/queue-name: team-a-queue }
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+          - name: pytorch
+            image: pytorch/pytorch:2.0.0-cuda11.7
+            resources: { requests: { cpu: "4", memory: 16Gi, "nvidia.com/gpu": "1" } }
+    Worker:
+      replicas: 3
+      restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+          - name: pytorch
+            image: pytorch/pytorch:2.0.0-cuda11.7
+            resources: { requests: { cpu: "4", memory: 16Gi, "nvidia.com/gpu": "1" } }
+```
+
+`TFJob`, `XGBoostJob`, `PaddleJob`, `JAXJob`, `MPIJob` all follow the same shape — their replica spec maps to PodSets in the Workload, and Kueue computes total resources by summing across all replica types. For MPIJob, the launcher and worker spec form two PodSets.
+
+### Kubeflow Trainer v2 — TrainJob
+
+The v2 unified API. One CRD for all training frameworks; the algorithm is configured via `trainingRuntime`.
+
+```yaml
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  name: pytorch-train
+  labels: { kueue.x-k8s.io/queue-name: team-a-queue }
+spec:
+  runtimeRef:
+    name: pytorch-distributed
+    apiGroup: trainer.kubeflow.org
+    kind: ClusterTrainingRuntime
+  trainer:
+    numNodes: 4
+    resourcesPerNode:
+      requests: { cpu: "8", memory: 32Gi, "nvidia.com/gpu": "2" }
+```
+
+### KubeRay — RayJob
+
+```yaml
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: ray-batch
+  labels: { kueue.x-k8s.io/queue-name: team-a-queue }
+spec:
+  shutdownAfterJobFinishes: true            # required for Kueue
+  entrypoint: python /home/ray/script.py
+  rayClusterSpec:
+    rayVersion: '2.10.0'
+    headGroupSpec:
+      rayStartParams: { dashboard-host: '0.0.0.0' }
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: rayproject/ray:2.10.0
+            resources: { requests: { cpu: "1", memory: 2Gi } }
+    workerGroupSpecs:
+    - groupName: default
+      replicas: 4
+      minReplicas: 4
+      maxReplicas: 4
+      template:
+        spec:
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.10.0
+            resources: { requests: { cpu: "4", memory: 8Gi, "nvidia.com/gpu": "1" } }
+```
+
+**RayJob limitations**: must be self-contained (creates its own RayCluster); cannot reference an external RayCluster. Maximum 7 worker groups (one PodSet for head + 7 = the Workload PodSet limit of 8).
+
+**RayCluster** (long-running) and **RayService** follow the same suspend/unsuspend pattern but represent persistent allocations.
+
+### AppWrapper — gang-admission for arbitrary workloads
+
+When you need quota gating for a non-natively-supported resource, wrap it in an AppWrapper.
+
+```yaml
+apiVersion: workload.codeflare.dev/v1beta2
+kind: AppWrapper
+metadata:
+  name: wrapped-pytorch
+  labels: { kueue.x-k8s.io/queue-name: team-a-queue }
+spec:
+  components:
+  - template:
+      apiVersion: kubeflow.org/v1
+      kind: PyTorchJob
+      metadata: { name: inner }
+      spec:
+        pytorchReplicaSpecs:
+          Master: { replicas: 1, template: { spec: { containers: [{ name: m, image: pytorch/pytorch, resources: { requests: { cpu: "1" } } }] } } }
+          Worker: { replicas: 3, template: { spec: { containers: [{ name: w, image: pytorch/pytorch, resources: { requests: { cpu: "1" } } }] } } }
+```
+
+The AppWrapper controller (CodeFlare) creates inner resources only after Kueue admits the wrapper. Useful for gang-admitting *combinations* of resources that would otherwise admit independently.
+
+### Plain Pods
+
+Two flavors: single Pod, and pod groups (gang). Both require `pod` in `integrations.frameworks` and a non-empty `managedJobsNamespaceSelector` so system Pods aren't queued.
+
+```yaml
+# single Pod
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: oneshot-
+  labels: { kueue.x-k8s.io/queue-name: team-a-queue }
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - name: c
+    image: busybox
+    command: ["sleep", "30"]
+    resources: { requests: { cpu: "2" } }
+```
+
+Pod groups (multiple Pods admitted together):
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: gang-leader-
+  labels:
+    kueue.x-k8s.io/queue-name: team-a-queue
+    kueue.x-k8s.io/pod-group-name: gang-1
+  annotations:
+    kueue.x-k8s.io/pod-group-total-count: "3"
+    kueue.x-k8s.io/retriable-in-group: "false"   # so failed pods don't waste quota
+spec:
+  containers: [{ name: c, image: busybox, command: ["sleep","60"], resources: { requests: { cpu: "1" } } }]
+  restartPolicy: Never
+# ... two more Pods with same pod-group-name and total-count=3
+```
+
+All Pods in a group must carry the same `pod-group-name` and `pod-group-total-count`. The group is admitted as one Workload; it's complete when all member Pods finish.
+
+### Deployment and StatefulSet
+
+Treats the Deployment/StatefulSet's Pod template as a queueable unit, useful when you want quota for long-running services.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inference-server
+  labels: { kueue.x-k8s.io/queue-name: team-a-queue }
+spec:
+  replicas: 3
+  selector: { matchLabels: { app: inference } }
+  template:
+    metadata:
+      labels: { app: inference }
+    spec:
+      containers:
+      - name: server
+        image: my-inference:1.0
+        resources: { requests: { cpu: "2", memory: 4Gi, "nvidia.com/gpu": "1" } }
+```
+
+The label can also be applied to the Pod template; the Deployment integration is built on top of the `pod` integration. Quota is checked per-Pod, so scaling the Deployment up requests more quota.
+
+### LeaderWorkerSet
+
+For distributed inference / fine-tuning where leader and worker Pods differ.
+
+```yaml
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: lws-train
+  labels: { kueue.x-k8s.io/queue-name: team-a-queue }
+spec:
+  replicas: 2                               # 2 leader-worker groups
+  leaderWorkerTemplate:
+    size: 4                                 # 1 leader + 3 workers per group
+    leaderTemplate:
+      spec:
+        containers:
+        - { name: leader, image: trainer, resources: { requests: { cpu: "4", "nvidia.com/gpu": "1" } } }
+    workerTemplate:
+      spec:
+        containers:
+        - { name: worker, image: trainer, resources: { requests: { cpu: "4", "nvidia.com/gpu": "1" } } }
+```
+
+Total quota = `replicas × size × per-Pod request`. All groups admit together.
+
+### Spark — SparkApplication
+
+```yaml
+apiVersion: sparkoperator.k8s.io/v1beta2
+kind: SparkApplication
+metadata:
+  name: pi
+  labels: { kueue.x-k8s.io/queue-name: team-a-queue }
+spec:
+  type: Scala
+  mode: cluster
+  image: spark:3.5
+  mainClass: org.apache.spark.examples.SparkPi
+  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples.jar
+  driver:   { cores: 1, memory: "1g" }
+  executor: { cores: 2, memory: "2g", instances: 4 }
+```
+
+Driver and executor become two PodSets.
+
+## Common Mistakes
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Job runs immediately, no Workload created | Missing `kueue.x-k8s.io/queue-name` label | Add label to `metadata.labels` |
+| Workload created, stays Pending forever | Quota too low or no flavor matches Pod nodeSelector | `kueuectl describe workload` to read NoFit reason |
+| `kubectl get workload` returns nothing | Framework not in `integrations.frameworks` list | Add string and restart kueue-controller-manager |
+| System pods getting queued | `pod` integration enabled with permissive `managedJobsNamespaceSelector` | Tighten the selector to opt-in namespaces only |
+| Pod group: pods admit individually | Annotation `pod-group-total-count` missing or mismatched | All members must have the same total-count and group-name |
+| RayJob never admits | Missing `shutdownAfterJobFinishes: true` | Set it; Kueue requires self-cleanup |
+| Job unsuspended without admission | Webhook not running (cert-manager issue) | Check `kubectl -n kueue-system get pods` and webhook configuration |
+| Deployment stays at 0 replicas | Pod-level Workload not created because namespace not in `managedJobsNamespaceSelector` | Label the namespace |
+| `MaxPodSets` exceeded error | Workload has > 8 PodSets (e.g., RayCluster with 8 workergroups) | Reduce worker groups to ≤7 (head + 7 = 8) |
+| MPIJob with launcher Pod outside Kueue control | Launcher uses `restartPolicy: OnFailure`, can't be suspended cleanly | Use Job mode for launcher (`launcherCreationPolicy: WaitForWorkersReady`) |
+
+## Lifecycle Summary
+
+For Job-like APIs:
+
+```
+[user creates Job with queue-name label]
+         │
+         ▼
+Mutating webhook sets spec.suspend=true
+         │
+         ▼
+Job reconciler creates Workload (status: Pending)
+         │
+         ▼
+Workload reconciler reserves quota → QuotaReserved
+         │
+         ▼
+Admission checks evaluated → Admitted
+         │
+         ▼
+Job reconciler patches spec.suspend=false (and injects flavor tolerations)
+         │
+         ▼
+kube-scheduler binds Pods → Pods run
+         │
+         ▼
+Job completes → Workload Finished, quota released
+```
+
+For Pod integration: replace "spec.suspend=true" with "scheduling gate `kueue.x-k8s.io/admission` injected" and "patches spec.suspend=false" with "removes scheduling gate".
+
+## Custom Integrations
+
+For workload types not on the table, two paths:
+
+**Path 1: AppWrapper.** Wrap your custom resource in an AppWrapper. No code; Kueue treats the wrapper as the queueing unit.
+
+**Path 2: Implement an integration.** Write a controller that:
+1. Watches your custom resource
+2. Suspends it on creation (whatever your resource's "don't run yet" semantics are)
+3. Creates a Workload with `podSets[]` reflecting your resource's pod requirements
+4. Watches the Workload — when `Admitted=True`, unsuspend
+5. Reports completion / failure to the Workload
+
+Register the type via `integrations.externalFrameworks`. The Kueue codebase has a tutorial `site/content/en/docs/tasks/dev/integrate_a_custom_job/` and the in-tree integrations under `pkg/controller/jobs/` are the best reference implementation.
+
+## Sources
+
+- https://kueue.sigs.k8s.io/docs/tasks/run/
+- https://kueue.sigs.k8s.io/docs/tasks/run/jobs/
+- https://kueue.sigs.k8s.io/docs/tasks/run/jobsets/
+- https://kueue.sigs.k8s.io/docs/tasks/run/kubeflow/
+- https://kueue.sigs.k8s.io/docs/tasks/run/rayjobs/
+- https://kueue.sigs.k8s.io/docs/tasks/run/rayclusters/
+- https://kueue.sigs.k8s.io/docs/tasks/run/plain_pods/
+- https://kueue.sigs.k8s.io/docs/tasks/run/deployment/
+- https://kueue.sigs.k8s.io/docs/tasks/run/statefulset/
+- https://kueue.sigs.k8s.io/docs/tasks/run/appwrappers/
+- https://kueue.sigs.k8s.io/docs/tasks/run/leaderworkerset/
+- https://kueue.sigs.k8s.io/docs/reference/kueue-config.v1beta1/
+- https://github.com/kubernetes-sigs/kueue/tree/main/pkg/controller/jobs

--- a/skills/kueue/references/operations-and-cli.md
+++ b/skills/kueue/references/operations-and-cli.md
@@ -1,0 +1,430 @@
+# Operations, CLI, and Observability
+
+Sources: Kueue documentation (kueue.sigs.k8s.io/docs/reference/kueuectl/, /metrics/, /tasks/manage/observability/, /tasks/troubleshooting/), kubernetes-sigs/kueue source (cmd/kueuectl, pkg/metrics).
+
+Covers: full kueuectl command surface, Workload status interpretation (every condition + reason), ClusterQueue status fields, Prometheus metrics catalog with PromQL recipes, log diagnostics, troubleshooting trees for stuck/evicted/never-admitted workloads, performance tuning, drain/migrate/quota-update procedures.
+
+## kueuectl CLI
+
+### Install
+
+```bash
+# Via krew (recommended)
+kubectl krew install kueue
+kubectl kueue version
+
+# Or download release binary directly
+VERSION=v0.14.0
+curl -L https://github.com/kubernetes-sigs/kueue/releases/download/${VERSION}/kueuectl-linux-amd64 -o kueuectl
+chmod +x kueuectl && sudo mv kueuectl /usr/local/bin/
+```
+
+All kueuectl commands accept the standard kubectl global flags (`--kubeconfig`, `-n`, `-A`, `--context`, `--as`, `--request-timeout`).
+
+### Command surface
+
+| Verb | Resource | Use |
+|------|----------|-----|
+| `version` | — | Print client + controller image versions |
+| `create` | `clusterqueue`, `localqueue`, `resourceflavor` | Bootstrap quota objects from CLI flags |
+| `list` | `workload`, `clusterqueue`, `localqueue`, `resourceflavor`, `pods` | List with filters |
+| `get` | (any) | Retrieve a single object as YAML/JSON |
+| `describe` | `clusterqueue`, `localqueue`, `workload` | Human-readable status with computed fields |
+| `stop` | `workload`, `clusterqueue`, `localqueue` | Hold or HoldAndDrain |
+| `resume` | (same) | Reverse a stop |
+| `delete` | (any) | Delete (CQ must be empty first) |
+| `edit` / `patch` | (any) | In-place modification |
+
+### Common invocations
+
+```bash
+# Create a ClusterQueue with cohort + quota in one shot
+kueuectl create clusterqueue team-a-cq \
+  --cohort=shared --queueing-strategy=BestEffortFIFO \
+  --namespace-selector=matchLabels=team=team-a \
+  --reclaim-within-cohort=LowerPriority \
+  --preemption-within-cluster-queue=LowerPriority \
+  --nominal-quota=cpu:100,memory:400Gi,nvidia.com/gpu:8 \
+  --borrowing-limit=cpu:50,memory:200Gi,nvidia.com/gpu:4
+
+# LocalQueue + ResourceFlavor
+kueuectl create localqueue default --clusterqueue=team-a-cq -n team-a
+kueuectl create resourceflavor gpu-a100 --node-labels=accelerator=nvidia-a100
+
+# List workloads with status filter
+kueuectl list workload -A --status=pending
+kueuectl list workload --clusterqueue=team-a-cq --status=admitted
+kueuectl list workload -n team-a -o wide
+
+# Pods owned by a specific Job through the Workload
+kueuectl list pods --for=job/training-1 -n team-a
+
+# Describe (the most useful diagnostic command)
+kueuectl describe clusterqueue team-a-cq
+kueuectl describe workload <wl-name> -n team-a
+
+# Stop / drain
+kueuectl stop workload <wl> -n team-a                       # cancel reservation, evict
+kueuectl stop clusterqueue team-a-cq --stop-policy=Hold    # no new admissions
+kueuectl stop clusterqueue team-a-cq --stop-policy=HoldAndDrain
+kueuectl resume clusterqueue team-a-cq
+
+# Delete
+kueuectl delete workload <wl> -n team-a
+```
+
+### Sample `describe clusterqueue` output
+
+```
+Name:                  team-a-cq
+Status:                Active
+Cohort:                shared
+Pending Workloads:     3                       # in queue, not yet QuotaReserved
+Reserving Workloads:   2                       # QuotaReserved=True, Admitted=False
+Admitted Workloads:    5                       # actively running
+Flavors Reservation:
+  gpu-a100:
+    cpu:               20/100 (5 borrowed)
+    memory:            80Gi/400Gi
+    nvidia.com/gpu:    4/8
+  cpu:
+    cpu:               50/100
+    memory:            200Gi/400Gi
+Fair Sharing Weight:   1.0   weighted-share=0.25
+```
+
+Use `kubectl get clusterqueue <name> -o yaml` to see the raw `.status.flavorsUsage`, `.status.flavorsReservation`, and `.status.fairSharing.weightedShare` underlying these aggregates.
+
+## Workload Status Reference
+
+`Workload.status.conditions[]` is the source of truth. Each condition has `type`, `status`, `reason`, `message`, `lastTransitionTime`.
+
+| Condition `type` | When True | Common reasons |
+|-----------------|-----------|----------------|
+| `QuotaReserved` | Quota reserved in a CQ; flavor assignment in `status.admission` | `QuotaReserved` |
+| `Admitted` | Quota reserved AND all admission checks Ready; Job is unsuspended | `Admitted` |
+| `PodsReady` | All Pods reached Ready (only set if `waitForPodsReady` enabled) | `Started`, `PodsReady` |
+| `Finished` | Underlying Job reached terminal state | `Succeeded`, `Failed` |
+| `Evicted` | Workload removed from admission | `Preempted`, `PodsReadyTimeout`, `AdmissionCheck`, `ClusterQueueStopped`, `LocalQueueStopped`, `Deactivated`, `NodeFailures` |
+| `Preempted` | (when Evicted=True with reason Preempted) | `InClusterQueue`, `InCohortReclamation`, `FairSharing` |
+| `Inadmissible` | Workload tried but couldn't fit | `NoFit`, `FlavorNotFound`, `Preempted` |
+
+Other status fields:
+
+```yaml
+status:
+  admission:                                # present only while QuotaReserved=True
+    clusterQueue: team-a-cq
+    podSetAssignments:
+    - name: main
+      flavors:
+        cpu: gpu-a100
+        memory: gpu-a100
+        nvidia.com/gpu: gpu-a100
+      resourceUsage: { cpu: "4", memory: "16Gi", "nvidia.com/gpu": "1" }
+      topologyAssignment:                   # only with TAS
+        levels: [block, rack, hostname]
+        domains: [{ values: [block-A, rack-1, gpu-001] }]
+  admissionChecks:
+  - name: provisioning-request
+    state: Ready                            # Pending | Ready | Retry | Rejected
+    podSetUpdates: [...]
+  requeueState:                             # for backoff after eviction
+    count: 2
+    requeueAt: "2026-05-07T12:00:00Z"
+  accumulatedPastExecutionTimeSeconds: 3600
+```
+
+### Common status patterns
+
+| What you see | What it means | First diagnostic |
+|-------------|--------------|------------------|
+| Both `QuotaReserved=False, Admitted=False` | In queue, no quota | `kueuectl describe cq` to see if quota is full |
+| `QuotaReserved=True, Admitted=False` | Quota OK, AdmissionCheck pending | Check `status.admissionChecks[].state` |
+| `Admitted=True, PodsReady=False` (after timeout) | Pods can't all start | Check Pod events; flavor's nodeSelector might exclude available nodes |
+| `Inadmissible=True, reason=NoFit` | No flavor combination fits | Verify Pod requests against ClusterQueue capacity per flavor |
+| `Evicted=True, reason=Preempted` | Higher-priority Workload took resources | Check who preempted in events |
+| `Evicted=True, reason=PodsReadyTimeout` | Gang scheduling failed within timeout | Increase `waitForPodsReady.timeout` or fix Pod startup |
+| `Evicted=True, reason=Deactivated` | `spec.active` was set to false (admin or rejected check) | Re-activate or fix the rejection |
+
+## ClusterQueue Status Reference
+
+```yaml
+status:
+  conditions:
+  - type: Active                            # only condition; True if scheduling enabled
+    status: "True"
+    reason: Ready                           # or FlavorNotFound, ResourceGroupNotFound, Stopped
+  pendingWorkloads: 8                       # waiting in queue
+  reservingWorkloads: 2                     # QuotaReserved=True, not yet Admitted
+  admittedWorkloads: 12                     # actively running
+  flavorsReservation:                       # quota reserved by admitted workloads
+  - name: gpu-a100
+    resources:
+    - { name: cpu,            total: "20", borrowed: "5" }
+    - { name: "nvidia.com/gpu", total: "4", borrowed: "0" }
+  flavorsUsage:                             # actual Pod usage (≤ reservation)
+  - name: gpu-a100
+    resources:
+    - { name: cpu, total: "18" }            # 18 < 20 reserved
+  fairSharing:
+    weightedShare: 0.25                     # for cohort fair sharing
+```
+
+`flavorsReservation - nominalQuota` = currently borrowed amount. `flavorsUsage` lags reservation when Pods are starting up.
+
+## Prometheus Metrics
+
+Endpoint: `kueue-controller-manager-metrics-service:8443/metrics` (TLS). Helm chart with `enablePrometheus: true` creates a ServiceMonitor; otherwise apply `prometheus.yaml` from the release.
+
+### Health metrics
+
+| Metric | Type | Labels | Notes |
+|--------|------|--------|-------|
+| `kueue_admission_attempts_total` | Counter | `result` (success/inadmissible) | Each scheduling attempt |
+| `kueue_admission_attempt_duration_seconds` | Histogram | `result` | Single-cycle scheduler latency |
+| `kueue_build_info` | Gauge | `git_version`, `git_commit`, `build_date`, `go_version` | Always 1; metadata |
+
+### Workload counters per ClusterQueue
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `kueue_pending_workloads` | Gauge | `cluster_queue`, `status` (active/inadmissible) |
+| `kueue_reserving_active_workloads` | Gauge | `cluster_queue` |
+| `kueue_admitted_active_workloads` | Gauge | `cluster_queue` |
+| `kueue_quota_reserved_workloads_total` | Counter | `cluster_queue`, `priority_class` |
+| `kueue_admitted_workloads_total` | Counter | `cluster_queue`, `priority_class` |
+| `kueue_finished_workloads_total` | Counter | `cluster_queue`, `priority_class` |
+| `kueue_evicted_workloads_total` | Counter | `cluster_queue`, `reason`, `underlying_cause`, `priority_class` |
+| `kueue_cluster_queue_status` | Gauge | `cluster_queue`, `status` |
+
+### Latency histograms
+
+| Metric | What it measures |
+|--------|------------------|
+| `kueue_quota_reserved_wait_time_seconds` | Workload creation → QuotaReserved |
+| `kueue_admission_wait_time_seconds` | Workload creation → Admitted (covers checks too) |
+| `kueue_admission_checks_wait_time_seconds` | QuotaReserved → Admitted (just the checks) |
+
+### Quota gauges (require `metrics.enableClusterQueueResources: true`)
+
+| Metric | Labels |
+|--------|--------|
+| `kueue_cluster_queue_nominal_quota` | `cluster_queue`, `flavor`, `resource` |
+| `kueue_cluster_queue_resource_reservation` | (same) |
+| `kueue_cluster_queue_resource_usage` | (same) |
+| `kueue_cluster_queue_borrowing_limit` | (same) |
+| `kueue_cluster_queue_lending_limit` | (same) |
+
+### Cohort metrics
+
+| Metric | Labels |
+|--------|--------|
+| `kueue_cohort_weighted_share` | `cohort` |
+| `kueue_cohort_subtree_quota` | `cohort`, `flavor`, `resource` |
+| `kueue_cohort_subtree_resource_reservations` | (same) |
+
+### LocalQueue metrics (alpha — `LocalQueueMetrics` feature gate)
+
+Same shape as ClusterQueue metrics but with `name` + `namespace` labels and prefix `kueue_local_queue_*`. High cardinality; enable selectively.
+
+## PromQL recipes
+
+```promql
+# Pending workloads per CQ (most useful single-pane chart)
+sum by (cluster_queue) (kueue_pending_workloads{status="active"})
+
+# Quota utilization per (cq, flavor, resource), 0..1
+sum by (cluster_queue, flavor, resource) (kueue_cluster_queue_resource_usage)
+/
+sum by (cluster_queue, flavor, resource) (kueue_cluster_queue_nominal_quota)
+
+# Admission p50/p95/p99
+histogram_quantile(0.50, sum by (le, cluster_queue) (rate(kueue_admission_wait_time_seconds_bucket[5m])))
+histogram_quantile(0.99, sum by (le, cluster_queue) (rate(kueue_admission_wait_time_seconds_bucket[5m])))
+
+# Eviction rate by reason
+sum by (reason) (rate(kueue_evicted_workloads_total[5m]))
+
+# Weighted share per CQ in a cohort (alarm when one CQ dominates)
+kueue_cluster_queue_weighted_share
+
+# Borrowing pressure: amount borrowed / nominal
+sum by (cluster_queue, flavor, resource) (
+  max(0, kueue_cluster_queue_resource_reservation - kueue_cluster_queue_nominal_quota)
+) / sum by (cluster_queue, flavor, resource) (kueue_cluster_queue_nominal_quota)
+```
+
+### Suggested Grafana panels
+
+| Panel | Query template | Use |
+|-------|----------------|-----|
+| Pending workloads (line per CQ) | `sum by (cluster_queue) (kueue_pending_workloads{status="active"})` | Spot queue buildup |
+| Quota utilization stacked area | `sum by (flavor) (kueue_cluster_queue_resource_usage{cluster_queue="$cq"})` | Per-CQ saturation |
+| Eviction rate pie | `sum by (reason) (rate(kueue_evicted_workloads_total[5m]))` | Why are workloads dying? |
+| Admission latency p99 stat | `histogram_quantile(0.99, rate(kueue_admission_wait_time_seconds_bucket[5m]))` | Scheduler health |
+| Cohort weighted share gauge | `kueue_cluster_queue_weighted_share` | Fair sharing fairness |
+
+## Logs and Events
+
+```bash
+# Tail controller logs
+kubectl -n kueue-system logs deploy/kueue-controller-manager -f
+
+# Increase verbosity (edit ConfigMap then rollout restart)
+# Set in Configuration:
+#   logLevel: 4              # 0=info, 1=debug, 2=trace, 4=very verbose
+# Or pass --zap-log-level=debug as a container arg
+
+# Workload events (one of the most useful debug surfaces)
+kubectl describe workload <wl> -n <ns>
+```
+
+| Log line | Means |
+|----------|-------|
+| `Workload admitted to ClusterQueue X` | QuotaReserved + all checks Ready, Job unsuspended |
+| `Workload evicted: Preempted` | A higher-priority Workload took resources |
+| `Could not update Workload status` | Optimistic concurrency conflict; reconciler retries |
+| `Flavor not found` | A ClusterQueue references a ResourceFlavor that doesn't exist |
+| `Admission check Pending → Retry` | External check (ProvisioningRequest, MultiKueue) failed transiently |
+| `couldn't suspend Job` | Webhook race or RBAC denied; check webhook health |
+
+## Troubleshooting Trees
+
+### "Workload stuck Pending"
+
+1. `kueuectl describe workload <wl>` — check the conditions
+2. If `QuotaReserved=False`:
+   - `kueuectl describe cq <cq>` — is `pendingWorkloads` blocking?
+   - Look at `flavorsReservation` vs `nominalQuota` — full?
+   - Workload Pod request fits any flavor? Check `flavors` block under each `resourceGroup`
+   - Is `namespaceSelector` excluding the Workload's namespace?
+3. If `Inadmissible=True, reason=NoFit`:
+   - The Workload's nodeSelector or topology constraints can't be satisfied by any flavor
+   - `kubectl get nodes --show-labels` to verify nodes have the labels referenced by ResourceFlavor
+4. If `QuotaReserved=True, Admitted=False`:
+   - `status.admissionChecks[]` will show which check is `Pending`
+   - For ProvisioningRequest: `kubectl get provisioningrequest -n <ns> -o wide`
+   - For MultiKueue: `kubectl logs -n kueue-system deploy/kueue-controller-manager | grep multikueue`
+
+### "Workload was admitted but evicted"
+
+```bash
+kueuectl describe workload <wl>             # find Evicted reason
+kubectl get events -n <ns> --field-selector involvedObject.name=<wl>
+```
+
+| Reason | Meaning | Fix |
+|--------|---------|-----|
+| `Preempted` | Higher-priority Workload pushed it out | Raise priority, increase quota, change preemption policy |
+| `PodsReadyTimeout` | Gang scheduling didn't complete in `waitForPodsReady.timeout` | Increase timeout; ensure cluster has capacity |
+| `AdmissionCheck` | A check entered Retry state after admission | Check the relevant check controller's logs |
+| `ClusterQueueStopped` / `LocalQueueStopped` | Operator put queue in Hold | `kueuectl resume cq <name>` |
+| `Deactivated` | `spec.active=false` (admin or hard rejection) | Investigate why; may need new submission |
+| `NodeFailures` (TAS) | Nodes the workload was pinned to failed | Check node health |
+
+### "Cluster Autoscaler not scaling for queued GPU workloads"
+
+The autoscaler doesn't see Pods (they're suspended). It only reacts to `ProvisioningRequest`.
+
+```bash
+# Are ProvisioningRequest objects being created?
+kubectl get provisioningrequest -A
+
+# Is the AdmissionCheck wired into the CQ?
+kubectl get clusterqueue <gpu-cq> -o yaml | grep -A2 admissionChecks
+
+# Check autoscaler logs for ProvisioningRequest entries
+kubectl -n kube-system logs deploy/cluster-autoscaler | grep ProvisioningRequest
+```
+
+### "MultiKueue worker won't connect"
+
+```bash
+# Does the secret exist on the manager?
+kubectl -n kueue-system get secret <worker>-kubeconfig
+
+# Can the manager actually reach the worker API server with that kubeconfig?
+KUBECONFIG=<(kubectl -n kueue-system get secret <worker>-kubeconfig -o jsonpath='{.data.kubeconfig}' | base64 -d) \
+  kubectl cluster-info
+
+# Manager logs
+kubectl -n kueue-system logs deploy/kueue-controller-manager | grep -i multikueue
+```
+
+## Operational Procedures
+
+### Drain a ClusterQueue for maintenance
+
+```bash
+kueuectl stop clusterqueue <cq> --stop-policy=Hold        # let running finish
+# wait until kueuectl describe cq shows admittedWorkloads: 0
+# perform maintenance
+kueuectl resume clusterqueue <cq>
+```
+
+For an emergency hard drain: `--stop-policy=HoldAndDrain` evicts admitted Workloads immediately. Pending Workloads either re-admit elsewhere if a sibling CQ has capacity, or stay pending.
+
+### Migrate Workloads to a different ClusterQueue
+
+```bash
+# 1. Create a new LocalQueue pointing at the new CQ
+kueuectl create localqueue migrate-target --clusterqueue=new-cq -n <ns>
+
+# 2. For each Workload, patch the LocalQueue reference (only works while Pending)
+kubectl label workload <wl> -n <ns> kueue.x-k8s.io/queue-name=migrate-target --overwrite
+```
+
+Note: admitted Workloads can't be moved without being evicted first.
+
+### Update quota safely
+
+ClusterQueue `nominalQuota`, `borrowingLimit`, and `lendingLimit` are mutable. Increases are immediately visible to the scheduler — additional pending Workloads will admit on the next cycle. Decreases don't evict already-admitted Workloads; they just prevent further admission until usage drops.
+
+```bash
+kubectl patch clusterqueue team-a-cq --type=merge -p \
+  '{"spec":{"resourceGroups":[{"flavors":[{"name":"gpu-a100","resources":[{"name":"nvidia.com/gpu","nominalQuota":"16"}]}]}]}}'
+```
+
+### Backup / restore
+
+The CRDs are reconcilable from source-of-truth Job objects, but Workload status (admission state, requeue counters) is not. Backup with:
+
+```bash
+kubectl get -A workload,clusterqueue,localqueue,resourceflavor,cohort,admissioncheck,workloadpriorityclass -o yaml > kueue-backup.yaml
+```
+
+On restart, the controller rebuilds quota state from the admitted Workloads it finds — so as long as Workloads are persisted, no quota is lost.
+
+## Performance Tuning
+
+| Knob | Where | Effect |
+|------|-------|--------|
+| `clientConnection.qps` / `burst` | Configuration | API server rate limit; raise for >1k Workloads |
+| `controller.groupKindConcurrency.Workload.kueue.x-k8s.io` | Configuration | Parallel reconcile workers |
+| `webhook.timeoutSeconds` | Configuration | Webhook request budget; raise on slow API servers |
+| `metrics.enableClusterQueueResources` | Configuration | Adds gauges; small CPU cost |
+| `LocalQueueMetrics` feature gate | Configuration | High cardinality; enable selectively |
+
+### Scaling limits
+
+A single kueue-controller-manager comfortably handles ~10k active Workloads. Hard limits in current design:
+
+- 256 flavors per ClusterQueue
+- 16 resource groups per ClusterQueue
+- 8 PodSets per Workload (so 1 head + 7 RayCluster worker groups, etc.)
+- 64 resources per flavor
+
+There is no built-in sharding — for clusters that exceed these limits, run multiple Kueue controllers each managing a subset of ClusterQueues (currently requires custom kustomization).
+
+## Sources
+
+- https://kueue.sigs.k8s.io/docs/reference/kueuectl/
+- https://kueue.sigs.k8s.io/docs/reference/metrics/
+- https://kueue.sigs.k8s.io/docs/tasks/manage/observability/setup_prometheus/
+- https://kueue.sigs.k8s.io/docs/tasks/manage/observability/common_grafana_queries/
+- https://kueue.sigs.k8s.io/docs/tasks/troubleshooting/
+- https://kueue.sigs.k8s.io/docs/tasks/troubleshooting/troubleshooting_jobs/
+- https://kueue.sigs.k8s.io/docs/tasks/troubleshooting/troubleshooting_queues/
+- https://github.com/kubernetes-sigs/kueue/tree/main/cmd/kueuectl
+- https://github.com/kubernetes-sigs/kueue/tree/main/pkg/metrics

--- a/skills/kueue/references/operations-services-migration-recipes.md
+++ b/skills/kueue/references/operations-services-migration-recipes.md
@@ -1,0 +1,294 @@
+# Operations, Services, and Migration Recipes
+
+Sources: Kueue documentation tasks (kueue.sigs.k8s.io/docs/tasks/run/, /tasks/manage/), Google Cloud GKE Kueue tutorials, Karpenter + Kueue integration docs, KubeCon talks 2024-2025.
+
+Covers: production recipes for MPI/HPC topology-aware scheduling, Deployment quota, plain Pod queueing for Argo, AppWrapper gang admission, elastic Jobs, CI/CD runner pools, online-vs-batch LLM inference, staged rollout, verification commands, and gotchas.
+
+## Recipe 8 — HPC MPI with topology-aware scheduling
+
+**Scenario**: 8-process MPIJob requires all Pods on one rack for InfiniBand locality.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1alpha1
+kind: Topology
+metadata: { name: hpc-topology }
+spec:
+  levels:
+  - { nodeLabel: cloud.example.com/rack }
+  - { nodeLabel: kubernetes.io/hostname }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata: { name: hpc }
+spec:
+  nodeLabels: { hpc-capable: "true" }
+  topologyName: hpc-topology
+---
+apiVersion: kubeflow.org/v1
+kind: MPIJob
+metadata:
+  name: hpc-train
+  labels: { kueue.x-k8s.io/queue-name: default }
+spec:
+  slotsPerWorker: 1
+  cleanPodPolicy: Running
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        metadata:
+          annotations: { kueue.x-k8s.io/podset-required-topology: cloud.example.com/rack }
+        spec:
+          containers:
+          - { name: l, image: nvcr.io/nvidia/pytorch:23.04-py3, command: [mpirun, -np, "8", python, train.py], resources: { requests: { cpu: "8", "nvidia.com/gpu": "1" } } }
+          restartPolicy: OnFailure
+    Worker:
+      replicas: 7
+      template:
+        metadata:
+          annotations: { kueue.x-k8s.io/podset-required-topology: cloud.example.com/rack }
+        spec:
+          containers:
+          - { name: w, image: nvcr.io/nvidia/pytorch:23.04-py3, resources: { requests: { cpu: "8", "nvidia.com/gpu": "1" } } }
+          restartPolicy: OnFailure
+```
+
+**Verify**: `kubectl get pods -l mpi-job-name=hpc-train -o wide` — all 8 Pods should land on the same rack.
+
+**Gotchas**: Required topology means the Workload won't admit at all if no rack has 8 free GPUs. Use `podset-preferred-topology` for soft constraints. The TAS feature gate (`TopologyAwareScheduling`) must be enabled.
+
+## Recipe 9 — Long-running service with quota (Deployment)
+
+**Scenario**: An inference Deployment competes for GPU quota alongside batch jobs.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-service
+  labels: { kueue.x-k8s.io/queue-name: default }
+spec:
+  replicas: 10
+  selector: { matchLabels: { app: api } }
+  template:
+    metadata:
+      labels:
+        app: api
+        kueue.x-k8s.io/queue-name: default      # Pod-level label for the pod integration
+    spec:
+      containers:
+      - { name: api, image: myinference:1.0, resources: { requests: { cpu: "2", memory: 4Gi, "nvidia.com/gpu": "1" } } }
+```
+
+Requires `pod` (and `deployment`) in `integrations.frameworks` and the namespace included in `managedJobsNamespaceSelector`. Each Pod is a separate Workload — scaling the Deployment up requests more quota.
+
+**Gotchas**: If quota is full, new replicas stay Pending instead of forcing eviction. To gang-admit replicas atomically, prefer `LeaderWorkerSet` or wrap in an AppWrapper.
+
+## Recipe 10 — Plain Pods for Argo Workflows
+
+**Scenario**: Argo Workflow steps as plain Pods, queued through Kueue.
+
+```yaml
+# Configuration must enable: integrations.frameworks: [pod]
+# and managedJobsNamespaceSelector matching argo namespace
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata: { generateName: pw-, namespace: argo }
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - { name: s1, template: worker }
+    - - { name: s2, template: worker }
+  - name: worker
+    metadata:
+      labels:
+        kueue.x-k8s.io/queue-name: default
+        kueue.x-k8s.io/pod-group-name: pw-group
+      annotations:
+        kueue.x-k8s.io/pod-group-total-count: "2"
+    container:
+      image: busybox
+      command: [sh, -c, "sleep 60"]
+      resources: { requests: { cpu: "2" } }
+```
+
+Pod-group annotations are the key — without them, each step Pod admits independently and you lose gang semantics.
+
+**Gotchas**: `managedJobsNamespaceSelector` must include `argo`. Without `pod-group-total-count`, Kueue can't tell when the group is "complete".
+
+## Recipe 11 — AppWrapper gang-admission for arbitrary workloads
+
+**Scenario**: Atomically admit several resources together that wouldn't otherwise be one Workload.
+
+```yaml
+apiVersion: workload.codeflare.dev/v1beta2
+kind: AppWrapper
+metadata:
+  name: bundled
+  labels: { kueue.x-k8s.io/queue-name: default }
+spec:
+  components:
+  - template:
+      apiVersion: kubeflow.org/v1
+      kind: PyTorchJob
+      metadata: { name: trainer }
+      spec: { ... }
+  - template:
+      apiVersion: v1
+      kind: Service
+      metadata: { name: trainer-svc }
+      spec: { ... }
+```
+
+The PyTorchJob and Service are created together only when the AppWrapper admits.
+
+## Recipe 12 — Elastic Job
+
+**Scenario**: A Job whose `parallelism` changes mid-run, without re-suspension.
+
+```yaml
+# Requires: ElasticJobsViaWorkloadSlices=true feature gate
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elastic
+  labels: { kueue.x-k8s.io/queue-name: default }
+  annotations: { kueue.x-k8s.io/elastic-job: "true" }
+spec:
+  parallelism: 3
+  completions: 100
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - { name: w, image: alpine, command: [sh, -c, "sleep 30"], resources: { requests: { cpu: "1" } } }
+```
+
+`kubectl scale --replicas=10 job/elastic` (or just patching parallelism) creates new slices without requeuing the existing work.
+
+## Recipe 13 — CI/CD test runner pool (priority + cohort)
+
+**Scenario**: GitHub Actions runner Jobs — PR checks low-priority, main-branch high-priority, both bursting from a shared pool.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata: { name: ci-main }
+value: 1000
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata: { name: ci-pr }
+value: 100
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: ci-cq }
+spec:
+  cohort: ci
+  resourceGroups:
+  - coveredResources: [cpu, memory]
+    flavors:
+    - name: default
+      resources:
+      - { name: cpu,    nominalQuota: "32",  borrowingLimit: "32" }
+      - { name: memory, nominalQuota: "128Gi", borrowingLimit: "128Gi" }
+  preemption: { withinClusterQueue: LowerPriority }
+```
+
+Submit each runner Job with `kueue.x-k8s.io/priority-class: ci-pr` (PRs) or `ci-main` (main). When CI is busy, main-branch runners preempt PR runners.
+
+## Recipe 14 — LLM batch inference (online-priority preempts batch)
+
+**Scenario**: Same GPU pool serves online inference (prompt-time critical) and batch inference (latency-tolerant). Online preempts batch.
+
+```yaml
+# Same shape as Recipe 2 (multi-team GPU sharing) — substitute teams with workload classes:
+# - "online-cq" with high-priority WorkloadPriorityClass
+# - "batch-cq" with low-priority, can be preempted by online
+# Use cohort + reclaimWithinCohort: Any on online-cq
+```
+
+In practice, a vLLM serving Deployment with `kueue.x-k8s.io/priority-class: online` admits to the high-priority CQ. Ray batch jobs with `priority-class: batch` get whatever's left and shed when online demand spikes.
+
+## Recipe 15 — Staged Kueue rollout on an existing cluster
+
+A safe migration playbook over 4 weeks:
+
+| Week | Action | Verify |
+|------|--------|--------|
+| 1 | Install Kueue with `manageJobsWithoutQueueName: false`. Create one CQ + LQ. No production Jobs labeled yet. | Controller Pods Healthy; metrics scraping; no behavior change |
+| 2 | Pick one team's namespace. Add namespace label, label their Jobs with `queue-name`. Monitor admission/eviction. | Admission rate matches Job submission rate; no surprise evictions |
+| 3 | Add second team. Put both CQs in a cohort. Set explicit `borrowingLimit`. | Idle quota from one team gets borrowed by the other |
+| 4 | Add `WorkloadPriorityClass` for prod vs research. Enable `preemption.reclaimWithinCohort: LowerPriority` on prod CQ. | Production Jobs preempt research when cohort is full |
+| later | Enable `fairSharing.enable: true`. Add ProvisioningRequest. Add MultiKueue if multi-cluster. | Per phase: confirm `kueue_cluster_queue_weighted_share` evens out; ProvReq flow works end-to-end |
+
+Quota changes are non-destructive: increasing nominalQuota never evicts; decreasing just blocks new admissions. So you can iterate quota numbers safely in production.
+
+## Pattern Selection Cheatsheet
+
+| If your goal is... | Use this recipe |
+|--------------------|-----------------|
+| Just learn Kueue | Recipe 1 (basic batch) |
+| Multi-team GPU isolation | Recipe 2 (cohort + preemption + WorkloadPriorityClass) |
+| Distributed PyTorch / TensorFlow training | Recipe 3 (Kubeflow PyTorchJob) |
+| Hyperparameter sweeps with elastic compute | Recipe 4 (RayJob + elastic) |
+| Cost optimization with spot fallback | Recipe 5 (two flavors + flavorFungibility) |
+| GPU autoscaling | Recipe 6 (ProvisioningRequest + Karpenter/CA) |
+| Multi-region or multi-cluster federation | Recipe 7 (MultiKueue) |
+| Tightly-coupled HPC / NCCL | Recipe 8 (TAS + MPIJob) |
+| Long-running services on quota | Recipe 9 (Deployment integration) |
+| Argo Workflows steps | Recipe 10 (plain Pods + pod-group) |
+| Gang-admit a non-supported workload | Recipe 11 (AppWrapper) |
+| Job that grows/shrinks at runtime | Recipe 12 (elastic via workload slices) |
+| CI/CD runners with bursting | Recipe 13 (priority + cohort) |
+| Mixed online + batch GPU serving | Recipe 14 (preemption hierarchy) |
+| Migrating existing cluster onto Kueue | Recipe 15 (staged rollout) |
+
+## Common Verification Commands
+
+```bash
+# Workload status
+kueuectl describe workload <name>
+kueuectl list workload --status=pending --clusterqueue=<cq>
+
+# Quota state
+kueuectl describe clusterqueue <cq>
+kubectl get clusterqueue <cq> -o jsonpath='{.status.flavorsUsage}' | jq
+
+# Events for a stuck Workload
+kubectl get events --field-selector involvedObject.name=<wl>
+
+# Verify the Job is suspended by Kueue (not running yet)
+kubectl get job <name> -o jsonpath='{.spec.suspend}'
+
+# Check admission check progress
+kubectl get workload <wl> -o jsonpath='{.status.admissionChecks}' | jq
+```
+
+## Common Gotchas (master list)
+
+1. Missing `kueue.x-k8s.io/queue-name` label → Workload never created.
+2. Job runs immediately (not suspended) → integration not enabled, or the framework string mismatch.
+3. Workload Inadmissible forever → Pod requests don't fit any flavor's quota, OR ResourceFlavor `nodeLabels` don't match real nodes.
+4. QuotaReserved=True but Admitted=False → AdmissionCheck stuck in Pending; check the relevant controller.
+5. Pods admit but never become Ready → flavor's nodeSelector / tolerations don't match Pod placement.
+6. Borrowing not happening → `cohort` field missing, or `borrowingLimit: 0` set.
+7. Preemption not happening → wrong priority order, or preemption policy = Never.
+8. ProvisioningRequest never created → AdmissionCheck not listed in CQ's `admissionChecks`.
+9. MultiKueue worker not connecting → kubeconfig secret missing, wrong namespace, or insufficient RBAC.
+10. Pod integration capturing system Pods → tighten `managedJobsNamespaceSelector`.
+
+## Sources
+
+- https://kueue.sigs.k8s.io/docs/tasks/run/
+- https://kueue.sigs.k8s.io/docs/tasks/manage/
+- https://kueue.sigs.k8s.io/docs/tasks/manage/setup_provisioning_request/
+- https://kueue.sigs.k8s.io/docs/tasks/manage/setup_multikueue/
+- https://kueue.sigs.k8s.io/docs/tasks/manage/setup_topology_aware_scheduling/
+- https://kueue.sigs.k8s.io/docs/tasks/run/rayjobs/
+- https://kueue.sigs.k8s.io/docs/tasks/run/kubeflow/
+- https://kueue.sigs.k8s.io/docs/tasks/run/plain_pods/
+- https://github.com/kubernetes-sigs/kueue/tree/main/examples

--- a/skills/kueue/references/quota-and-tenancy-patterns.md
+++ b/skills/kueue/references/quota-and-tenancy-patterns.md
@@ -1,0 +1,445 @@
+# Quota and Tenancy Patterns
+
+Sources: Kueue documentation (kueue.sigs.k8s.io/docs/concepts/cluster_queue/, /cohort/, /tasks/manage/administer_cluster_quotas/, /concepts/fair_sharing/), kubernetes-sigs/kueue v1beta1 + v1beta2 API spec, Kueue KEPs.
+
+Covers: the quota math (nominalQuota / borrowingLimit / lendingLimit / effectiveQuota), single-tenant and multi-tenant topologies (equal-share with borrowing, tiered priority, reserved + shared pool, strict isolation), hierarchical cohorts, flavor patterns (spot+on-demand, GPU classes, cross-zone), preemption design, namespace selectors, RBAC, cost showback, anti-patterns, and a safe migration playbook.
+
+## Quota Math
+
+Three knobs per `(ClusterQueue, flavor, resource)`:
+
+| Field | Meaning | Default |
+|-------|---------|---------|
+| `nominalQuota` | Guaranteed amount this CQ can always use | required |
+| `borrowingLimit` | Max additional amount from cohort siblings | nil = unlimited within cohort |
+| `lendingLimit` | Max amount this CQ exposes for siblings to borrow | nil = all unused nominal |
+
+Effective ceiling at any moment: `nominalQuota + min(borrowingLimit, sum-of-siblings-lendable)`.
+
+Reservation amount = sum of resource requests across admitted Workloads. Borrowed portion = `max(0, reservation - nominalQuota)`.
+
+| Symptom | Likely misconfiguration |
+|---------|------------------------|
+| Workloads admit but consume way more than expected | `borrowingLimit` is nil → unbounded sibling consumption |
+| Sibling CQs starved when this CQ is idle | `lendingLimit` is set too low (or 0) |
+| Big workload never admits despite cohort having capacity | Cohort doesn't have a *single* sibling with enough lendable for the request — cohorts pool but each request needs a single donor's lendable to fit |
+| Workload admits with mixed flavors that wreck NCCL | Resources spread across flavors when they should be in one resourceGroup |
+
+### Resource groups and flavor fungibility
+
+A `resourceGroup` ties resources together so they come from the same flavor. Most useful for GPU + paired CPU + memory:
+
+```yaml
+resourceGroups:
+- coveredResources: [cpu, memory, "nvidia.com/gpu"]
+  flavors:
+  - { name: gpu-h100, resources: [...] }
+  - { name: gpu-a100, resources: [...] }
+```
+
+When admission needs all three resources, they must come from the *same* flavor entry — Kueue won't pick CPU from h100 and GPU from a100. To allow that, put them in separate resourceGroups.
+
+`flavorFungibility` controls fall-through. The defaults (`whenCanBorrow: Borrow`, `whenCanPreempt: TryNextFlavor`) mean: prefer borrowing over fallback, but try next flavor before resorting to preemption.
+
+## Single-Tenant Pattern
+
+Smallest viable setup. One namespace, one team, one CQ, no cohort.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata: { name: default }
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: only-cq }
+spec:
+  namespaceSelector: {}                            # any namespace
+  resourceGroups:
+  - coveredResources: [cpu, memory]
+    flavors:
+    - name: default
+      resources:
+      - { name: cpu,    nominalQuota: "96" }      # ≈ cluster capacity − system overhead
+      - { name: memory, nominalQuota: "384Gi" }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata: { name: default, namespace: default }
+spec: { clusterQueue: only-cq }
+```
+
+Use this on dev clusters or single-team production. No cohort means no borrowing complexity to reason about.
+
+## Multi-Team Patterns
+
+### Pattern A — Equal share with borrowing
+
+Four teams, 100 GPUs total. Each gets 25 nominal, can borrow up to 25 more.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: Cohort
+metadata: { name: teams }
+---
+# repeat for team-b, team-c, team-d with name + namespaceSelector changes
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: team-a-cq }
+spec:
+  cohort: teams
+  namespaceSelector: { matchLabels: { team: a } }
+  resourceGroups:
+  - coveredResources: ["nvidia.com/gpu"]
+    flavors:
+    - name: gpu
+      resources:
+      - { name: "nvidia.com/gpu", nominalQuota: "25", borrowingLimit: "25" }
+```
+
+Net effect: each team is guaranteed 25, can burst to 50 when neighbors are idle. Add `WorkloadPriorityClass` on top if you want intra-team prioritization.
+
+### Pattern B — Tiered priority (production preempts research)
+
+Same cohort, different priorities + preemption policy.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: Cohort
+metadata: { name: prod-research }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: prod-cq }
+spec:
+  cohort: prod-research
+  namespaceSelector: { matchLabels: { tier: production } }
+  resourceGroups:
+  - coveredResources: [cpu]
+    flavors:
+    - { name: default, resources: [{ name: cpu, nominalQuota: "60" }] }
+  preemption:
+    reclaimWithinCohort: Any                # take back nominal from anyone
+    withinClusterQueue: LowerPriority
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: research-cq }
+spec:
+  cohort: prod-research
+  namespaceSelector: { matchLabels: { tier: research } }
+  resourceGroups:
+  - coveredResources: [cpu]
+    flavors:
+    - { name: default, resources: [{ name: cpu, nominalQuota: "40", borrowingLimit: "60" }] }
+  preemption:
+    withinClusterQueue: LowerPriority
+    # no reclaimWithinCohort → research never preempts production
+```
+
+Combine with two `WorkloadPriorityClass` objects (`prod-high: 1000`, `research-low: 100`). Research can borrow up to 60 extra (using prod's idle capacity), but loses it the moment prod has a Workload that can't fit its nominal.
+
+### Pattern C — Reserved + shared burst pool
+
+Each team has a dedicated CQ with small nominal; a separate "shared pool" CQ holds most of the cluster, also in the cohort, that everyone borrows from.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: Cohort
+metadata: { name: with-burst }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: team-a-reserved }
+spec:
+  cohort: with-burst
+  namespaceSelector: { matchLabels: { team: a } }
+  resourceGroups:
+  - coveredResources: [cpu]
+    flavors:
+    - { name: default, resources: [{ name: cpu, nominalQuota: "20", borrowingLimit: "60" }] }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: shared-burst }
+spec:
+  cohort: with-burst
+  namespaceSelector:
+    matchExpressions:
+    - { key: team, operator: DoesNotExist }      # no team can submit directly here
+  resourceGroups:
+  - coveredResources: [cpu]
+    flavors:
+    - { name: default, resources: [{ name: cpu, nominalQuota: "60", lendingLimit: "60" }] }
+```
+
+Why use a "ghost" shared-burst CQ instead of putting capacity directly into a Cohort? Compatibility with older Kueue versions and clearer accounting. With hierarchical cohorts (v0.12+), the same effect can be achieved by setting `Cohort.spec.resourceGroups`.
+
+### Pattern D — Strict isolation (no sharing)
+
+When teams must not affect each other (regulatory, billing isolation):
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: team-a-isolated }
+spec:                                          # no cohort field
+  namespaceSelector: { matchLabels: { team: a } }
+  resourceGroups:
+  - coveredResources: [cpu]
+    flavors:
+    - { name: default, resources: [{ name: cpu, nominalQuota: "25" }] }
+```
+
+Tradeoff: idle quota is wasted. Use only when necessary.
+
+## Hierarchical Cohort Pattern
+
+Org → Department → Team. The Cohort CRD with `parentName` enables capacity to flow down through weighted shares.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: Cohort
+metadata: { name: company-root }
+spec:
+  resourceGroups:                              # root holds the company-wide pool
+  - coveredResources: [cpu, "nvidia.com/gpu"]
+    flavors:
+    - name: default
+      resources:
+      - { name: cpu, nominalQuota: "1000" }
+      - { name: "nvidia.com/gpu", nominalQuota: "64" }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: Cohort
+metadata: { name: ml-platform }
+spec:
+  parentName: company-root
+  fairSharing: { weight: "0.6" }               # 60% of root's borrowable
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: Cohort
+metadata: { name: data-platform }
+spec:
+  parentName: company-root
+  fairSharing: { weight: "0.4" }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: team-llm }
+spec:
+  cohort: ml-platform                          # joins ML dept cohort
+  namespaceSelector: { matchLabels: { team: llm } }
+  resourceGroups:
+  - coveredResources: [cpu, "nvidia.com/gpu"]
+    flavors:
+    - name: default
+      resources:
+      - { name: cpu, nominalQuota: "0" }       # zero nominal — fully borrowing
+      - { name: "nvidia.com/gpu", nominalQuota: "0" }
+```
+
+Quota cascades top-down: company-root holds the pool, ML dept claims 60%, teams within ML dept share that 60% by their own weights. Useful for organizations where capacity is allocated by org chart.
+
+## Flavor Patterns
+
+### Spot + on-demand fallback
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata: { name: spot }
+spec:
+  nodeLabels: { capacity-type: spot }
+  tolerations:
+  - { key: spot, operator: Equal, value: "true", effect: NoSchedule }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata: { name: on-demand }
+spec:
+  nodeLabels: { capacity-type: on-demand }
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: cost-optimized }
+spec:
+  resourceGroups:
+  - coveredResources: [cpu, memory]
+    flavors:
+    - name: spot
+      resources: [{ name: cpu, nominalQuota: "200" }, { name: memory, nominalQuota: "800Gi" }]
+    - name: on-demand
+      resources: [{ name: cpu, nominalQuota: "50" },  { name: memory, nominalQuota: "200Gi" }]
+  flavorFungibility:
+    whenCanBorrow: TryNextFlavor                # don't borrow spot — go to on-demand instead
+```
+
+Workloads tolerating the `spot` taint admit on the spot flavor first. When spot is full, fall through to on-demand. Workloads without the toleration skip the spot flavor entirely and only consider on-demand.
+
+### GPU classes with fallback
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: any-gpu }
+spec:
+  resourceGroups:
+  - coveredResources: [cpu, memory, "nvidia.com/gpu"]
+    flavors:
+    - { name: h100, resources: [{ name: cpu, nominalQuota: "32" }, { name: memory, nominalQuota: "128Gi" }, { name: "nvidia.com/gpu", nominalQuota: "8" }] }
+    - { name: a100, resources: [{ name: cpu, nominalQuota: "64" }, { name: memory, nominalQuota: "256Gi" }, { name: "nvidia.com/gpu", nominalQuota: "16" }] }
+    - { name: t4,   resources: [{ name: cpu, nominalQuota: "32" }, { name: memory, nominalQuota: "128Gi" }, { name: "nvidia.com/gpu", nominalQuota: "32" }] }
+  flavorFungibility:
+    whenCanBorrow: TryNextFlavor
+    whenCanPreempt: TryNextFlavor
+```
+
+Workloads requesting "any GPU" admit on h100 first. Workloads with `nodeSelector: nvidia.com/gpu-product: A100` skip h100 and t4 because of the nodeLabel mismatch. Order the flavors by preference (most expensive/scarce first if you want to use them when available).
+
+### Cross-zone for locality
+
+One flavor per zone enforces zone-locality at admission time:
+
+```yaml
+- { name: zone-a, nodeLabels: { topology.kubernetes.io/zone: us-east-1a } }
+- { name: zone-b, nodeLabels: { topology.kubernetes.io/zone: us-east-1b } }
+- { name: zone-c, nodeLabels: { topology.kubernetes.io/zone: us-east-1c } }
+```
+
+Each ClusterQueue gets quota per zone. Workloads admit into one zone (no cross-zone egress). For finer hardware locality (rack/host), use Topology-Aware Scheduling instead.
+
+## Preemption Design
+
+Two patterns dominate:
+
+**Production preempts research** — `WorkloadPriorityClass(prod=1000) > research(100)`, `prod-cq.preemption.reclaimWithinCohort: Any`. Already covered above in Pattern B.
+
+**Within-team priority** — set `withinClusterQueue: LowerPriority` on each CQ. A team's `prod-online` Workloads (priority 1000) can preempt its own `nightly-batch` Workloads (priority 100) if both submit to the same CQ.
+
+Combine with `borrowWithinCohort: { policy: LowerPriority, maxPriorityThreshold: 999 }` to allow a high-priority Workload to *both* preempt within its CQ *and* borrow from cohort siblings — the threshold prevents borrowing from killing other production work.
+
+## Namespace Selectors and Tenancy
+
+The standard pattern: one ClusterQueue per team, gated by namespace label.
+
+```yaml
+# Namespace setup
+apiVersion: v1
+kind: Namespace
+metadata: { name: team-a, labels: { team: a, kueue.x-k8s.io/managed: "true" } }
+---
+# CQ matches the label
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata: { name: team-a-cq }
+spec:
+  namespaceSelector: { matchLabels: { team: a } }
+  ...
+```
+
+Enable `LocalQueueDefaulting` so users in `team-a` namespace get a `default` LocalQueue auto-created pointing at `team-a-cq`. They no longer need to specify a queue label on every Job (Kueue assigns one by default).
+
+The `managedJobsNamespaceSelector` (in Kueue Configuration) is *separate* — it controls which namespaces Kueue's Pod-derived integrations (`pod`, `deployment`, `statefulset`) operate on. Both should typically include the same set of team namespaces.
+
+## Queue Admin RBAC
+
+Two-tier model:
+
+```yaml
+# Cluster admin — manages quota objects
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: { name: kueue-cluster-admin }
+rules:
+- { apiGroups: [kueue.x-k8s.io], resources: [clusterqueues, resourceflavors, cohorts, workloadpriorityclasses, admissionchecks], verbs: ["*"] }
+---
+# Namespace admin — creates LocalQueues only
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: { name: kueue-namespace-admin, namespace: team-a }
+rules:
+- { apiGroups: [kueue.x-k8s.io], resources: [localqueues], verbs: ["*"] }
+- { apiGroups: [kueue.x-k8s.io], resources: [workloads], verbs: [get, list, watch] }
+```
+
+Regular users only need permission to create their workload kinds (Jobs, RayJobs, etc.). The `kueue.x-k8s.io/queue-name` label is just a label — no special RBAC needed to set it.
+
+## Cost Allocation and Showback
+
+Aggregate Prometheus metrics by namespace:
+
+```promql
+# CPU-hours per namespace
+sum by (namespace) (
+  rate(kueue_cluster_queue_resource_usage{resource="cpu"}[1h])
+) * 3600
+
+# GPU-hours per ClusterQueue
+sum by (cluster_queue) (
+  rate(kueue_cluster_queue_resource_usage{resource="nvidia.com/gpu"}[1h])
+) * 3600
+```
+
+For team-level chargeback, label your ClusterQueues consistently (`team`, `cost-center`) and join with cloud billing data. OpenCost can already attribute Pod-level cost to namespace; layering Kueue's per-CQ usage gives a "what was reserved vs what was spent" view.
+
+## Anti-Patterns
+
+| Anti-pattern | What goes wrong | Fix |
+|--------------|-----------------|-----|
+| Single giant CQ for the whole cluster | Loses per-team accountability and fairness | Split per team; use cohort to keep sharing |
+| No cohort at all | Idle capacity wasted; no bursting | Group team CQs into a cohort |
+| `borrowingLimit: nil` | One CQ can monopolize the whole cohort | Set explicit borrowingLimit |
+| Same flavor for spot + on-demand | Can't differentiate hardware cost | Two ResourceFlavors with `flavorFungibility.whenCanBorrow: TryNextFlavor` |
+| Aggressive preemption everywhere | Production stability suffers | Use `reclaimWithinCohort: LowerPriority` (not `Any`) at minimum |
+| StrictFIFO with one giant Workload | Head-of-line blocks everyone | BestEffortFIFO unless strict ordering is a hard requirement |
+| ResourceFlavor `nodeLabels` don't match any node | Workloads stay Inadmissible forever | Run `kubectl get nodes --show-labels` to verify exact label keys/values |
+| `nominalQuota` exceeds cluster physical capacity | Workloads admit but Pods stay Pending | Set quota to actual schedulable capacity; use ProvisioningRequest for bursting |
+| Mixing `pod` integration with system namespaces in `managedJobsNamespaceSelector` | kube-system Pods get queued; cluster breaks | Tighten selector to opt-in namespaces only |
+| Forgetting `lendingLimit` when one team has 90% nominal | Other teams can't borrow because primary team rarely has unused capacity | Set explicit lendingLimit; rebalance nominal |
+
+## Migration / Rollout Playbook
+
+Adopting Kueue on a running cluster, in stages:
+
+**Phase 1 — Install + observe (week 1)**
+- Install Kueue with `manageJobsWithoutQueueName: false`
+- Create one ResourceFlavor matching your most common node type
+- Create one ClusterQueue with quota = current peak Job usage × 1.2
+- Don't label any Jobs yet — observe scheduler logs
+
+**Phase 2 — Pilot one namespace (week 2)**
+- Pick one team's namespace; add `kueue.x-k8s.io/managed: "true"` label
+- Create LocalQueue in that namespace
+- Add `kueue.x-k8s.io/queue-name` label to that team's Jobs
+- Watch metrics: admission latency, eviction rate, quota utilization
+
+**Phase 3 — Multi-tenant (weeks 3-4)**
+- Add more teams: one ClusterQueue each, all in a cohort
+- Set `borrowingLimit` and `lendingLimit` per CQ
+- Add `WorkloadPriorityClass` for prod vs research
+
+**Phase 4 — Advanced features (later)**
+- Enable `fairSharing` once cohort behavior is understood
+- Add ProvisioningRequest for autoscaler integration
+- Consider TAS for GPU-heavy training
+- Federate with MultiKueue if you have multiple clusters
+
+**Quota change semantics:**
+
+- **Increasing nominalQuota** — immediate; no Workload disruption; new Workloads can admit on next scheduling cycle.
+- **Decreasing nominalQuota** — admitted Workloads keep running; new admissions blocked until usage drops below new quota.
+- **Adding a namespaceSelector restriction** — already-admitted Workloads from now-excluded namespaces keep running; new ones can't submit.
+
+These all-non-destructive operations are why Kueue is safe to adopt incrementally.
+
+## Sources
+
+- https://kueue.sigs.k8s.io/docs/concepts/cluster_queue/
+- https://kueue.sigs.k8s.io/docs/concepts/cohort/
+- https://kueue.sigs.k8s.io/docs/concepts/fair_sharing/
+- https://kueue.sigs.k8s.io/docs/tasks/manage/administer_cluster_quotas/
+- https://kueue.sigs.k8s.io/docs/tasks/manage/setup_sequential_admission_with_priorities/
+- https://kueue.sigs.k8s.io/docs/tasks/manage/setup_consumable_resources/
+- https://github.com/kubernetes-sigs/kueue/tree/main/keps

--- a/skills/kueue/tank.json
+++ b/skills/kueue/tank.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tank/kueue",
+  "version": "1.0.0",
+  "description": "Kubernetes-native queueing and quota management for batch, AI/ML, and HPC workloads with Kueue. Covers ClusterQueue, LocalQueue, ResourceFlavor, Workload, cohorts, admission checks, supported integrations, installation, kueuectl, metrics, preemption, fair sharing, MultiKueue, topology-aware scheduling, ProvisioningRequest autoscaling, tenancy patterns, and production recipes.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": [
+        "**/*"
+      ],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary
- Add the `@tank/kueue` Tank skill for Kubernetes-native batch, AI/ML, and HPC queueing.
- Cover Kueue concepts, integrations, installation/configuration, advanced features, operations, tenancy, and production recipes.
- Include eight reference files with validated line counts and matching reference index entries.

## Validation
- `python3 -m json.tool skills/kueue/tank.json`
- `python3 skills/skill-creator/scripts/quick_validate.py skills/kueue`
- Custom validation for frontmatter, line counts, reference index, and reference formatting