### PR TITLE
feat: add @tank/crystal-clear-docs skill

### DIFF
--- a/skills/crystal-clear-docs/SKILL.md
+++ b/skills/crystal-clear-docs/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: "@tank/crystal-clear-docs"
+description: |
+  Create crystal-clear technical documents (HTML + Markdown) with layered
+  explanations, progressive disclosure from TL;DR to deep dive, and SVG
+  diagrams for concepts that need visual explanation. Covers inverted pyramid
+  structure, the Layer Cake Method for multi-resolution explanations, Mermaid
+  diagram-as-code integration, accessible SVG patterns, document formatting for
+  maximum scannability, callout/admonition design, comparison tables, worked
+  examples, and word-level clarity techniques. Synthesizes Minto (The Pyramid
+  Principle), Tufte (Envisioning Information, The Visual Display of Quantitative
+  Information), Krug (Don't Make Me Think), Strunk & White (The Elements of
+  Style), Zinsser (On Writing Well), Google Technical Writing Course, Munroe
+  (Up-Goer Five / Thing Explainer), Mermaid.js, W3C SVG accessibility
+  guidelines, and Cognitive Load Theory (Sweller).
+
+  Trigger phrases: "crystal clear docs", "clear documentation", "write clear docs",
+  "make this document clearer", "technical document", "explain this clearly",
+  "doc needs to be clearer", "improve documentation clarity", "clear explanation",
+  "layered explanation", "TLDR document", "progressive disclosure",
+  "add SVG diagram", "explain with diagram", "visual explanation",
+  "mermaid diagram", "create architecture diagram", "diagram for docs",
+  "structure this document", "format technical doc", "document layout",
+  "make this scannable", "scannable docs", "callout patterns", "admonition design",
+  "how to explain", "explain like", "write a guide", "tutorial structure",
+  "documentation best practices", "technical writing"
+---
+
+# Crystal Clear Docs
+
+Create technical documents people actually read and understand — by layering
+information from TL;DR to deep dive and explaining hard concepts with diagrams.
+
+## Core Philosophy
+
+1. **Lead with the answer.** The reader's first question is "does this matter to
+   me?" — answer it in the first sentence. Everything else supports that answer.
+2. **Layer, don't dump.** Progressive disclosure: TL;DR → Example → Explanation
+   → Deep Dive. Each layer is complete and accurate on its own.
+3. **Show, don't just tell.** Concepts that require the reader to hold multiple
+   relationships in their head get a diagram. Code gets shown before explanation.
+4. **Every word earns its place.** If removing a word changes nothing, remove it.
+   Active voice. Plain language. Short sentences. Scannable structure.
+5. **Respect the reader's time.** They scan, they don't read. Design for scanning:
+   information-dense headings, bold key terms, lists over walls of text, and
+   callouts that surface what matters.
+
+## Quick-Start: Document Anatomy
+
+Every crystal-clear document follows this skeleton:
+
+```
+# [Action-oriented title]
+**TL;DR**: [One sentence — what and why]
+[Quick-start code/command — the answer]
+
+## Overview
+[Layer 1: explanation in plain language, 2-3 paragraphs]
+
+## How It Works
+[Layer 2: mechanism, diagram if helpful, comparisons]
+
+## Configuration / Options
+[Reference table for parameters, options, choices]
+
+## Advanced Usage
+[Layer 3: edge cases, alternatives, deep architecture]
+
+## Related
+[Links to next logical step, tangential topics, support]
+```
+
+→ See `references/layered-writing.md` for the full framework.
+→ See `references/document-structure.md` for formatting patterns.
+→ See `references/writing-clarity.md` for word/sentence-level techniques.
+→ See `references/svg-diagrams.md` for when and how to use diagrams.
+
+## Common Problems
+
+### "This document is a wall of text"
+
+1. Add a one-sentence TL;DR at the very top
+2. Break paragraphs into lists (3+ related items → bullet list)
+3. Add descriptive H2/H3 headings (not "Overview", "Details")
+4. Insert a diagram for any concept spanning more than 2 paragraphs
+5. Move advanced configuration into `<details>` expandable sections
+
+### "I don't know where to add a diagram"
+
+Ask: does the reader need to hold 3+ relationships in their head? If yes, add a
+diagram. Use Mermaid for flowcharts, sequences, state machines, ER diagrams.
+Use hand-coded SVG for simple before/after or architecture comparisons.
+
+### "The explanation is too complex"
+
+1. Write the one-sentence version first (the Compression Ladder exercise)
+2. Then the one-paragraph version
+3. Then the full explanation
+4. Present them in that order — readers self-select depth
+
+### "How do I make this scannable?"
+
+Scan this checklist:
+- Headings are specific and information-dense
+- Bold used only for key terms (not whole sentences)
+- Lists used for any 3+ related items
+- Callouts highlight warnings, tips, and gotchas
+- Code blocks have language annotations and captions
+- Tables used for configuration references and comparisons
+
+## Decision Trees
+
+### Which Diagram Type?
+
+| Concept | Diagram | Syntax |
+|---------|---------|--------|
+| Step-by-step process | Flowchart | `flowchart TD` |
+| Component interactions | Sequence diagram | `sequenceDiagram` |
+| State lifecycle | State diagram | `stateDiagram-v2` |
+| System architecture | Architecture diagram | `architecture-beta` |
+| Data relationships | ER diagram | `erDiagram` |
+| Timeline / roadmap | Gantt chart | `gantt` |
+| A vs B comparison | Side-by-side SVG | Hand-coded or draw.io |
+| Hierarchy / tree | Flowchart with subgraphs | `flowchart TD; subgraph` |
+
+### Which Callout Type?
+
+| Situation | Callout |
+|-----------|---------|
+| Supplementary context | ℹ Note |
+| Better way to do it | 💡 Tip |
+| Potential pitfall | ⚠ Warning |
+| Data loss, security risk | 🚫 Danger |
+| Worked example | Example |
+
+### How Deep to Go?
+
+| Reader wants... | Give them... |
+|----------------|-------------|
+| "Is this relevant?" | TL;DR (1 sentence) |
+| "How do I use it?" | TL;DR + Code example |
+| "Why does it work this way?" | + How It Works section |
+| "What are the edge cases?" | + Advanced Usage section |
+| "I need to contribute/modify" | + Architecture + Deep dive |
+
+## SVGs for Visual Explanation
+
+When a concept spans more than 2 paragraphs and involves relationships,
+structure, flow, or state — add a diagram.
+
+**Use Mermaid inline** (works on GitHub, GitLab, Notion, most Markdown renderers):
+
+```mermaid
+flowchart TD
+    A[User] --> B{Authenticated?}
+    B -->|Yes| C[Grant Access]
+    B -->|No| D[Redirect to Login]
+    C --> E[Return Resource]
+```
+
+**Use inline SVGs** for precise control, annotations, and dark mode support:
+
+```svg
+<svg role="img" aria-label="..." viewBox="0 0 400 200">
+  <title>Short description</title>
+  <desc>Longer description for accessibility</desc>
+  <!-- diagram elements -->
+</svg>
+```
+
+→ Every SVG needs `role="img"`, `<title>`, and `<desc>` elements.
+→ Use `currentColor` so diagrams adapt to light/dark themes.
+→ Color-blind safe: never rely on color alone — always add labels.
+
+## Quality Gate
+
+Before publishing any document, verify:
+
+1. **Can someone get the gist from the TL;DR alone?** If no, rewrite it.
+2. **Can they self-select their depth?** Can they stop at the code example and leave satisfied?
+3. **Do headings predict their content?** No "Overview", "Details" — be specific.
+4. **Is every code block copy-paste runnable?** If it needs invisible setup, add it.
+5. **Are diagrams needed?** Any concept 2+ paragraphs with relationships → add a diagram.
+6. **Did you remove needless words?** Read each sentence. Delete every word. Re-add only what's essential.
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| `references/layered-writing.md` | Inverted pyramid, Layer Cake Method, progressive disclosure, TL;DR patterns, code-first writing, Up-Goer Five technique |
+| `references/svg-diagrams.md` | Diagram type selection, Mermaid syntax and styling, SVG accessibility, dark mode, Tufte's visualization principles, visual explanation patterns |
+| `references/document-structure.md` | Document anatomy, heading hierarchies, callout/admonition patterns, comparison design, scannability, CRAP principles, responsive layout, cognitive load management |
+| `references/writing-clarity.md` | Active voice, jargon elimination, sentence construction, comparison patterns, worked examples, MECE framework, BLUF method |

--- a/skills/crystal-clear-docs/references/document-structure.md
+++ b/skills/crystal-clear-docs/references/document-structure.md
@@ -1,0 +1,272 @@
+# Document Structure and Formatting
+
+Sources: Google Developer Technical Writing Course (One + Two), Steve Krug (Don't Make Me Think, Chapters 1-5), Jakob Nielsen (Nielsen Norman Group, Progressive Disclosure research), Robin Williams (The Non-Designer's Design Book — CRAP principles), Jeff Johnson (Designing with the Mind in Mind), Microsoft UX Guidelines (Inverted Pyramid in UI text).
+
+Covers: How to structure, format, and lay out technical documents for maximum clarity and scannability using HTML and Markdown. Heading hierarchies, callout/admonition patterns, comparison design, responsive layout, and cognitive load management.
+
+## The Golden Rule of Document Structure
+
+**Every page should be self-explanatory within 5 seconds.** The reader should know what this page covers, whether it's relevant to them, and how to proceed — without thinking.
+
+## Document Opening Formula
+
+Every document should open with:
+
+```
+# [Clear, action-oriented title]
+
+**TL;DR**: [One sentence — what this page explains and why you'd read it]
+
+> **Prerequisites**: [What you need to know / have installed]
+> **What this covers**: [Scope — what you'll learn]
+> **What this does NOT cover**: [Non-scope — prevent wasted reading]
+
+[Quick-start code or command — the answer, immediately]
+
+## How It Works [or: Overview]
+[Layered deepening starts here]
+```
+
+## Heading Hierarchy for Progressive Disclosure
+
+Headings must genuinely compress the content below them. A reader scanning only headings should understand the full argument.
+
+| Level | Purpose | Rule |
+|-------|---------|------|
+| H1 | What the entire document is about | One per page, action-oriented |
+| H2 | Major sections supporting H1 | 3-7 per page, answer "what" and "why" |
+| H3 | Subsections detailing H2 | Answer "how", introduce a specific concept or step |
+| H4 | Granular details within H3 | Edge cases, examples, config details |
+
+**The compression test**: If H2 says "Overview" and the content is actually about authentication flow, the heading failed. Rewrite it as "Authentication Flow".
+
+## Callout and Admonition Patterns
+
+Use callouts to surface information that interrupts the linear reading flow. Choose the right type:
+
+| Type | Icon | Color | When to Use |
+|------|------|-------|-------------|
+| **TL;DR** | None or 📌 | Neutral | At the very top of every page. One sentence. |
+| **Info / Note** | ℹ️ | Blue | Supplementary context, "by the way" facts |
+| **Tip** | 💡 | Green | Best practice, "here's a smarter way" |
+| **Warning** | ⚠️ | Yellow/Amber | Potential pitfalls, gotchas, deprecated behavior |
+| **Danger / Critical** | 🚫 | Red | Actions that cause data loss, security issues |
+| **Example** | 📋 | Gray/Neutral | Worked example distinct from explanation |
+
+### HTML Structure for Admonitions
+
+```html
+<div class="admonition note">
+  <strong>ℹ Note:</strong>
+  <p>This operation is idempotent — you can safely retry it.</p>
+</div>
+
+<div class="admonition warning">
+  <strong>⚠ Warning:</strong>
+  <p>This deletes all data. No undo.</p>
+</div>
+```
+
+### Callout Placement Rules
+
+- Before the action they warn about (never after)
+- Never more than one callout per section (diminishing returns)
+- Keep text under 3 lines (if longer, it belongs in the main content)
+
+## Progressive Disclosure with HTML
+
+### `<details>/<summary>` for Optional Depth
+
+```html
+## Configuration Options
+
+<details>
+<summary>Advanced: Custom timeout settings</summary>
+
+The default timeout is 30 seconds. For long-running operations, override with:
+
+```js
+fetch('/api', { timeout: 120000 })
+```
+
+</details>
+```
+
+Use for: advanced configuration, verbose examples, edge cases, verbose error messages, platform-specific differences.
+
+### Tabbed Content for Parallel Paths
+
+```
+### Installation
+
+<div class="tabs">
+  <div class="tab" data-tab="npm">npm install package</div>
+  <div class="tab" data-tab="yarn">yarn add package</div>
+  <div class="tab" data-tab="pnpm">pnpm add package</div>
+</div>
+```
+
+Use for: installation methods, language-specific examples, OS-specific instructions.
+
+## Scannability Techniques
+
+Research shows users scan, they don't read. Design for scanning:
+
+### Visual Hierarchy of Text Elements
+
+Readers process in this order:
+1. Headings (H1-H4)
+2. Bold text within paragraphs
+3. First sentence of each paragraph
+4. Lists (numbered > bulleted)
+5. Code blocks (developers read code before prose)
+6. Body text
+
+### Lists > Paragraphs
+
+When you have 3+ related items, use a list instead of prose:
+
+**Bad (wall of text):**
+The system supports three authentication methods. You can use API keys, which are simple but less secure. You can use OAuth 2.0, which is more secure but requires more setup. You can use JWT tokens, which are stateless and good for microservices.
+
+**Good (scannable list):**
+- **API Keys**: Simple, less secure. Good for server-to-server.
+- **OAuth 2.0**: Secure, requires setup. Good for user-facing apps.
+- **JWT Tokens**: Stateless, no DB lookup. Good for microservices.
+
+### Paragraph Design
+
+- Opening sentence = the paragraph's thesis. Everything after = support.
+- Keep paragraphs to 3-5 sentences.
+- Bold key terms on first use (and define them).
+- Use one paragraph per idea.
+
+## Tables for Comparison and Reference
+
+Tables outperform prose for:
+- Feature comparisons (A vs B vs C)
+- Configuration options (parameter / type / default / description)
+- Error codes (code / meaning / action)
+- Method signatures (method / params / returns / description)
+
+```markdown
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `timeout` | number | 30000 | Request timeout in ms |
+```
+
+## Code Block Best Practices
+
+### Always Include Language Annotation
+
+```python  ← Not ``` alone
+def hello():
+    print("hi")
+```
+
+### Show File Name When Useful
+
+```
+```javascript title="src/auth/login.js"
+```
+```
+
+### Highlight Key Lines
+
+```javascript {3,6-8}
+// The important lines are highlighted for scanning
+function process(data) {       // ← highlighted
+  validate(data)
+  return transform(data)
+}
+```
+
+### Prefer Working Examples
+
+Every code block should be copy-paste runnable. If the reader needs to fill in gaps, you've made them think. Add the boilerplate.
+
+## Cognitive Load Management
+
+From Jeff Johnson's "Designing with the Mind in Mind":
+
+### Principle of Chunking
+
+Break complex information into chunks of 5-9 items (Miller's Law). This applies to:
+- Steps in a procedure
+- Items in a list
+- Sections on a page
+- Options in a decision
+
+### White Space as a Cognitive Tool
+
+Generous spacing between sections gives the reader's brain time to process. Crowded content forces simultaneous processing — the reader must scan, filter, and prioritize all at once.
+
+Rule of thumb: between 30-50% of the visible area should be white space.
+
+### Line Length (Measure)
+
+Optimal line length for readability: 50-75 characters. Longer lines make it harder for the eye to find the next line. Shorter lines break reading rhythm. For code, 80-100 characters is standard.
+
+## Mobile-Responsive Documentation
+
+- SVGs: use `viewBox` (never fixed `width`/`height`)
+- Tables: horizontal scroll wrapper for narrow screens, or collapse to key-value on mobile
+- Code blocks: horizontal scroll, never wrap
+- Callouts: full-width, padding adjusts with viewport
+- Font size: minimum 16px for body text on mobile (prevents iOS zoom on focus)
+
+## CRAP Principles for Document Design
+
+From Robin Williams' "The Non-Designer's Design Book":
+
+| Principle | Meaning | Applied to Docs |
+|-----------|---------|-----------------|
+| **Contrast** | Make different things look very different | Heading sizes clearly distinct; callout colors clearly different from body |
+| **Repetition** | Repeat visual elements for cohesion | Same admonition style throughout; consistent code block styling; consistent link color |
+| **Alignment** | Every element visually connected to something | Left-align body text; consistent indent for code and lists; aligned callout borders |
+| **Proximity** | Related items close together | TL;DR directly below title; code example immediately after its explanation; prerequisites near the top |
+
+## Navigation and Wayfinding
+
+### Table of Contents
+
+For documents longer than 3 scroll-screens, include a TOC after the TL;DR:
+
+```markdown
+- [Quick Start](#quick-start)
+- [How It Works](#how-it-works)
+- [Configuration](#configuration)
+- [Error Handling](#error-handling)
+- [Advanced Usage](#advanced-usage)
+```
+
+### Internal Links
+
+Link to related concepts when the reader might need context. A developer reading about "JWT refresh tokens" might also need to know about "token rotation" — link to it.
+
+### Breadcrumbs (for multi-page docs)
+
+```
+Home > Authentication > JWT Tokens > Refresh Token Flow
+```
+
+Gives the reader spatial context within the documentation system.
+
+### "What's Next" Section
+
+End every page with:
+- Where to go next (logical next step)
+- Related documentation (tangential but relevant)
+- "Still stuck?" → support channels
+
+## Anti-Patterns
+
+| Anti-pattern | Why it fails | Fix |
+|-------------|-------------|-----|
+| Generic headings ("Overview", "Details", "More") | Labels on opaque boxes — no predictive value | Specific, information-dense headings |
+| Walls of text | Readers scan, they don't read | Break into lists, tables, diagrams |
+| No TL;DR | Reader must read to determine relevance | One sentence at the top that captures the essence |
+| Overuse of bold/emphasis | When everything is emphasized, nothing is | Bold only key terms, first-sentence thesis |
+| Code without output | Reader can't verify behavior | Show expected output or screenshot |
+| Unlabeled diagrams | Reader must decode visual without guidance | Every diagram has a caption explaining what it shows |
+| Hiding key info in scroll depth | Mobile users miss content | Critical info above the fold; progressive disclosure for detail |

--- a/skills/crystal-clear-docs/references/layered-writing.md
+++ b/skills/crystal-clear-docs/references/layered-writing.md
@@ -1,0 +1,294 @@
+# Layered Writing for Technical Documents
+
+Sources: Barbara Minto (The Pyramid Principle, 1987), Edward Tufte (Envisioning Information, 1990), Steve Krug (Don't Make Me Think, 2000), William Zinsser (On Writing Well, 1976), Google Technical Writing Course, Randall Munroe (Thing Explainer / Up-Goer Five), Cognitive Load Theory (Sweller, 1988), Wellspoken.me Layer Cake Method.
+
+Covers: Progressive disclosure of information from TL;DR to deep detail. Inverted pyramid structure, layered explanations, and techniques for explaining complex topics at multiple levels of resolution.
+
+## The Inverted Pyramid
+
+Journalists solved this problem long ago: put the most critical information first (who, what, when, where, why), then provide context, background, and nuance in descending order of importance. The structure is designed for skimmers — readers who stop at any point still get something useful.
+
+Applied to technical docs:
+
+| Layer | Position | Content | Reader Type |
+|-------|----------|---------|-------------|
+| TL;DR | Very top | One sentence summary of what this page explains | Everyone |
+| Core | After TL;DR | The answer, command, configuration, step | Skimmers |
+| Detail | Middle | How it works, why this approach | Curious readers |
+| Deep dive | Bottom | Edge cases, alternatives, architecture | Experts |
+
+The key insight: most readers will read the summary and example and leave satisfied. A smaller number will need the deep explanation. Almost none need to read everything.
+
+## The Layer Cake Method
+
+Build understanding in sequential layers where each layer is complete on its own and prepares the reader for the next. Each layer is **accurate** — you're adjusting resolution, not accuracy.
+
+| Layer | Resolution | Length | Example |
+|-------|-----------|--------|---------|
+| Layer 1 | Thumbnail | 1 sentence | "JWT is a compact token that proves who you are without the server storing session state." |
+| Layer 2 | Standard image | 1 paragraph | Mechanism: how it works, plain language. "When you log in, the server creates a signed token with your user ID. Your browser sends this token with every request. The server verifies the signature without a database lookup." |
+| Layer 3 | High-definition | Full section | Nuance: algorithms, expiration, refresh tokens, security considerations, common attack vectors. |
+
+### Honesty Rule
+
+None of the layers oversimplify. If Layer 1 would lead someone to an incorrect conclusion, rewrite it. Accuracy is non-negotiable at every resolution.
+
+## Progressively Disclosing Information
+
+The companion principle to the inverted pyramid: reveal complexity gradually, in layers, rather than all at once.
+
+### Page-level Progressive Disclosure
+
+```
+1. One-paragraph summary at the top
+2. Short code example / quick-start
+3. Deeper explanation below
+4. Advanced usage, edge cases at the bottom
+```
+
+### Document-level Progressive Disclosure
+
+```
+README (one-screen overview and quickstart)
+  → Guides (conceptual explanations organized by task)
+    → API Reference (every parameter, every edge case)
+```
+
+### HTML/Markdown Techniques for Progressive Disclosure
+
+- `<details>/<summary>` for expandable sections. Ideal for optional configurations, advanced settings, verbose examples.
+- Accordion patterns for FAQs or grouped deep-dives.
+- "Read more" links for topics a minority of readers will need.
+- Tooltips for jargon definitions without breaking reading flow.
+- Tabbed content: "Basic" tab vs "Advanced" tab.
+
+## The Compression Ladder Exercise
+
+A training technique for finding the essence of any explanation:
+
+1. Explain a complex topic in 60 seconds. Record yourself.
+2. Explain the same topic in 30 seconds. Record again.
+3. Explain in 15 seconds.
+
+Your 15-second version is the essence. The words you cut between rounds are unnecessary complexity. This works because time pressure forces prioritization.
+
+## The One-Sentence Challenge
+
+Reduce any complex idea to one readable sentence of 15-20 words. If you cannot say it in one sentence, you haven't found the core yet. Every document should start with this sentence.
+
+## Up-Goer Five Technique (Constraint-Based Clarity)
+
+Randall Munroe's method of explaining complex topics using only the 1,000 most common English words forces you to:
+
+1. Find the core idea — you cannot hide behind jargon
+2. Use analogy and metaphor — comparing to everyday experiences
+3. Be creative with description — "space car" for lunar module, "sky bag air" for hydrogen
+
+This extreme constraint is a diagnostic tool. If your explanation breaks when jargon is removed, the underlying concept wasn't clear to begin with. Use it to stress-test your TL;DR and Layer 1.
+
+## Code-First Pattern
+
+For technical documentation, show the code before the explanation. Many developers will read the code, understand it immediately, and never need the explanation. That's not a failure — it's efficiency. The explanation exists for those who need it.
+
+Structure:
+```
+TL;DR (1 sentence)
+Code example (the answer)
+What this code does (1 paragraph)
+Why it works this way (explanation)
+Advanced variations / edge cases
+```
+
+## Anti-Patterns
+
+| Anti-pattern | Why it fails | Fix |
+|-------------|-------------|-----|
+| Burying the answer under context | Readers leave before finding what they need | Lead with the answer |
+| Opening with history/architecture | No one cares before they know how to use it | Quickstart first, architecture later |
+| All detail on one page | Overwhelms, no self-service depth | Layer: summary → example → deep dive |
+| Explaining everything before showing | Developers read code first | Show code, then explain |
+| Equal-weight headings | No visual hierarchy, everything looks equally important | Tiered headings that compress information faithfully |
+| Hiding instead of layering | Information buried too deep to find | Each level must make the next level's contents predictable |
+
+## Quality Gate: Before Publishing
+
+1. Can someone get the gist from the top level alone? (If no, rewrite the TL;DR)
+2. Does each heading make the next section's contents predictable? (If it surprises, the hierarchy leaks)
+3. Can a reader self-select their depth? (Can they stop at Layer 1 and leave satisfied?)
+4. Does the code example work without reading the explanation? (If no, show a simpler example)
+
+## The SCQA Framework (Minto Pyramid Principle)
+
+Structure every introduction with Situation, Complication, Question, Answer. This mirrors how readers naturally process: "What's going on? What's the problem? What question does that raise? What's the answer?"
+
+| Element | Role | Example |
+|---------|------|---------|
+| **S**ituation | Shared context the reader already knows | "Your API handles 10K requests/second with no issues." |
+| **C**omplication | The problem that disrupts the situation | "At 100K requests/second, response times spike to 5+ seconds." |
+| **Q**uestion | The implicit question raised by the complication | "How do we scale to 100K RPS without rewriting the entire API?" |
+| **A**nswer | Your solution (the document's main point) | "Add a Redis cache layer in front of the database — here's how." |
+
+This SCQA structure also works at the paragraph level. A paragraph's first sentence states the situation, the middle describes the complication, and the final sentence provides the answer.
+
+## The Teach-Back Method
+
+A technique for validating that your layered explanation works:
+
+1. Explain a concept to someone
+2. Ask them to explain it back to you
+3. The delta between what you said and what they understood reveals exactly where your explanation broke down
+
+Apply this to documentation:
+- Was there a missing foundation layer? → Add a simpler Layer 1
+- Was a jargon term undefined? → Define on first use
+- Was a logical jump too large? → Add an intermediate layer
+- Did they misunderstand a key concept? → Add a diagram or worked example
+
+## When Layering Goes Wrong
+
+### Hiding Instead of Layering
+
+If information is buried so deep that users cannot find it, that's obscurity, not progressive disclosure. The fix: predictable paths. Every level should make the next level's contents obvious. If someone has to guess where to find something, the structure is broken.
+
+### Compression Without Judgment
+
+Generic headings like "Overview," "Details," "Additional Information" provide structure without hierarchy. Progressive disclosure requires that each level genuinely compresses the level below it. The heading must tell you what is inside AND whether you need to go inside.
+
+### False Confidence from AI Summaries
+
+AI-generated TL;DRs can compress without understanding — producing summaries that sound right but lose critical nuance. An executive summary that omits a key exception clause is worse than no summary at all. Every compression layer must be verified: does the short version preserve what matters?
+
+## Horizontal and Vertical Logic (Minto)
+
+- **Vertical logic**: Every point in the pyramid raises a question in the reader's mind, and the points directly below it answer that question. This is the question-answer dialogue that drives a reader forward.
+- **Horizontal logic**: The ideas within each group must present either a deductive chain (premise → premise → therefore) or an inductive grouping (similar ideas → inference). Every grouping is one or the other — there is no third option.
+
+Test your structure:
+1. Read only the headings. Do they tell a coherent story?
+2. For each heading, ask: "So what?" If the sub-content doesn't compellingly answer, restructure.
+3. For each claim, ask: "Why is that true?" If the sub-content doesn't prove it, add evidence or remove the claim.
+
+## Ordering Ideas in Layers
+
+Present supporting ideas in one of three logical orders:
+
+| Order Type | When to Use | Example |
+|-----------|-------------|---------|
+| **Time order** | Sequence of events with cause-effect | "Step 1: Install → Step 2: Configure → Step 3: Test" |
+| **Structural order** | Parts of a whole, broken down | "The system has three components: frontend, API, and database" |
+| **Degree order** | Ranked by importance | "Most important: security. Next: performance. Last: developer experience" |
+
+## Transition Patterns
+
+Smooth transitions between layers keep the reader oriented. Three techniques:
+
+1. **Referencing backward**: Pick up a key word from the preceding section and carry it into the next. "The JWT token we generated in the previous step now needs to be stored..."
+2. **Summarizing**: Consolidate complex ideas at the end of long sections before moving forward. "To recap: we've set up auth, configured the middleware, and tested the happy path."
+3. **Concluding**: Create appropriate closure or call to action — but only when genuinely needed. "Now that authentication is working, the next step is to add role-based authorization."
+
+## Building the Pyramid: Top-Down vs Bottom-Up
+
+Minto describes two approaches to structuring your document:
+
+### Top-Down (Preferred)
+Start with the conclusion, then ask "What supports this?" The answers become the next level.
+
+1. State your main conclusion (the answer)
+2. Ask: "What questions does this raise in the reader's mind?"
+3. Answer those questions — they become the next level of the pyramid
+4. Repeat until every level is supported
+
+### Bottom-Up (When You Don't Know the Conclusion Yet)
+List all your points, find relationships, draw conclusions upward.
+
+1. Brainstorm all ideas onto a page
+2. Group related ideas together
+3. For each group, write a summary statement that captures the insight
+4. Group the summary statements under a higher-level conclusion
+5. Repeat until you reach a single governing thought
+
+Always try top-down first — it forces you to clarify your thinking before writing.
+
+## The "So What?" and "Why?" Tests
+
+Two questions transform communication:
+
+- **"So what?"** — After writing any point, ask "So what?" If you cannot answer clearly with a consequence, implication, or action, the point doesn't belong. This removes unnecessary content and strengthens cause-effect relationships.
+- **"Why?"** — If you make a claim, ask "Why is that true?" The answer either validates the claim or exposes its weakness. This surfaces hidden assumptions and improves credibility.
+
+Apply these at every level: TL;DR, section headings, paragraphs, individual sentences.
+
+## MECE Framework (Mutually Exclusive, Collectively Exhaustive)
+
+Categories used to organize supporting arguments must be:
+
+1. **Mutually Exclusive**: No overlap. Each item belongs to exactly one category. If a point could fit in two categories, the categories overlap — redefine them.
+2. **Collectively Exhaustive**: Together, the categories cover everything. If something important doesn't fit any category, you have a gap — add a category.
+
+**Example**: Organizing database optimization strategies
+- ❌ Non-MECE: "Indexing, query optimization, caching, read replicas" (caching and read replicas are both scaling strategies — overlapping)
+- ✓ MECE: "Query-level (indexing, rewriting), schema-level (normalization, partitioning), and infrastructure-level (caching, replicas)"
+
+## The Deductive vs Inductive Choice
+
+At the supporting argument level, choose between two reasoning structures:
+
+| Structure | Pattern | Best For | Risk |
+|-----------|---------|----------|------|
+| **Deductive** | General principle → specific case → therefore conclusion | Academic, legal, formal proofs | If the reader rejects the general principle, the whole argument collapses |
+| **Inductive** | Observation A + Observation B + Observation C → therefore pattern exists | Business recommendations, technical decisions | If observations are cherry-picked, the conclusion is invalid |
+
+Minto's recommendation: at the Key Line level (the arguments directly supporting the main conclusion), prefer inductive structure. Executives find it more persuasive because they see evidence before conclusions.
+
+## Writing Summaries That Aren't Intellectually Blank
+
+The most common failure in technical documents: summary statements that restate without adding value.
+
+**Intellectually blank**: "This section covered authentication." (Just restates)
+**Insightful summary**: "JWT authentication eliminates server-side state, but introduces token management complexity — use it when statelessness matters more than revocability."
+
+A good summary must state either:
+- The **effect** of action ideas (what results from doing this)
+- The specific **inference** drawn from situation ideas (the insight the data reveals)
+
+## The Narrative Flow: SCQA in Practice
+
+The introduction tells the reader a story they already know. This pushes aside competing thoughts, establishes shared context, and makes the reader receptive to your argument. A SCQA introduction should take 3-5 sentences total.
+
+**Full example**:
+> Most web APIs authenticate users with session cookies **(Situation)**. But session cookies require server-side state, which doesn't scale well across microservices **(Complication)**. How can we authenticate users across distributed services without shared state? **(Question)**. JSON Web Tokens (JWT) solve this by embedding signed user claims directly in the token — the server verifies without a database lookup **(Answer)**. This document shows you how to implement JWT auth in your Express API in under 10 minutes.
+
+## Testing Your Document Structure
+
+After drafting, run these tests:
+
+1. **Read only the headings and TL;DR.** Does a coherent story emerge? Can someone understand the document's argument from headings alone?
+2. **For each H2, ask its question.** "What is this section answering?" If the heading doesn't imply a question, rewrite it.
+3. **Check the depth gradient.** Is there a clear progression from shallow (TL;DR) to deep (bottom)? Or does it lurch between depths?
+4. **The 5-second test.** Open the page. Look away after 5 seconds. What do you remember? That's the only thing your scanning reader gets.
+
+## Layered Writing Template
+
+For any technical concept, fill this template:
+
+```
+## [Concept Name]
+
+**In one sentence**: [Explain it to a product manager]
+
+**In one paragraph**: [Explain it to a developer who will use it]
+
+**How it works**: [Explain it to a developer who will debug it]
+
+**Diagram**: [Mermaid or SVG showing the flow/architecture/state]
+
+**Code example**: [Minimal, runnable, annotated]
+
+**Common mistakes**: [What goes wrong, why, how to fix]
+
+**When to use / when not to**: [Decision framework — this vs alternatives]
+
+**Deep dive**: [Architecture, tradeoffs, implementation details]
+```
+
+Each section is a self-contained layer. A reader can stop at any layer and have a correct understanding.

--- a/skills/crystal-clear-docs/references/svg-diagrams.md
+++ b/skills/crystal-clear-docs/references/svg-diagrams.md
@@ -1,0 +1,308 @@
+# SVG Diagrams for Technical Explanation
+
+Sources: Edward Tufte (The Visual Display of Quantitative Information, 1983; Envisioning Information, 1990), blobstreaming.org SVG Diagrams for Docs (2024), W3C Writing Accessible SVG (draft), Google Developer Style Guide (Images section), SAP Architecture Center Diagram Best Practices, arivictor/diagram-style-guide (GitHub, 2024), Few/Tufte Design Library.
+
+Covers: When and how to use SVG diagrams to explain concepts that are hard to understand without visual guides. Diagram type selection, SVG accessibility, dark mode compatibility, Mermaid integration, and visual explanation patterns.
+
+## When Diagrams Help (and When They Don't)
+
+SVG diagrams excel at explaining: architecture, data flows, state machines, process flows, relationships (ER, class hierarchies), sequences, comparisons, before/after states.
+
+SVG is NOT the right choice for: photographs or screenshots (use JPEG/WebP), highly complex diagrams with 100+ elements (rendering performance degrades), diagrams requiring pixel-identical browser rendering.
+
+**The test**: If you can explain it clearly in 2-3 sentences, you probably don't need a diagram. If the reader needs to hold multiple relationships in their head simultaneously, a diagram reduces cognitive load.
+
+## Diagram Type Selection
+
+| To Explain | Use | Example Tools |
+|-----------|-----|---------------|
+| How data/control flows through a system | Flowchart | Mermaid flowcharts |
+| Components and their connections | Architecture diagram | Mermaid architecture-beta, Excalidraw |
+| Order of operations between actors | Sequence diagram | Mermaid sequence diagram |
+| Decision logic, conditions | Decision tree | Mermaid flowchart with diamonds |
+| Entity relationships | ER diagram | Mermaid ER, DBML |
+| States and transitions | State diagram | Mermaid state diagram |
+| Comparisons (A vs B) | Side-by-side boxes, Venn | Hand-coded SVG |
+| Timeline / progression | Timeline | Mermaid gantt |
+| Hierarchy / tree | Tree diagram | Mermaid flowchart with subgraphs |
+| Before/After | Paired annotated diagrams | Hand-coded SVG |
+
+## Diagram-As-Code with Mermaid (Preferred Method)
+
+Mermaid is ideal for documentation because:
+- Source is readable Markdown-like text, diffs cleanly in Git
+- Renders to SVG automatically
+- 10x-100x smaller than GUI-generated SVGs
+- Can be embedded directly in Markdown on many platforms (GitHub, GitLab, Notion)
+
+### Essential Mermaid Diagram Types
+
+**Flowchart** — for processes, data flows, logic:
+```mermaid
+flowchart TD
+    A[User Request] --> B{Authenticated?}
+    B -->|Yes| C[Process Request]
+    B -->|No| D[Return 401]
+    C --> E[Return Response]
+```
+
+**Sequence Diagram** — for interactions between components:
+```mermaid
+sequenceDiagram
+    Client->>API: POST /login
+    API->>DB: Verify credentials
+    DB-->>API: User record
+    API-->>Client: JWT token
+```
+
+**State Diagram** — for lifecycle, status:
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Review: submit
+    Review --> Published: approve
+    Review --> Draft: reject
+    Published --> [*]
+```
+
+### Mermaid Styling for Clarity
+
+Four knobs matter most for professional-looking diagrams:
+
+1. **Theme**: `default`, `forest`, `dark`, `neutral`, `base`. `base` if customizing deeply.
+2. **themeVariables**: Only six actually matter: `primaryColor`, `primaryTextColor`, `primaryBorderColor`, `lineColor`, `fontFamily`, `fontSize`.
+3. **Edge curves**: Default `basis` curves look amateur. Switch to `linear` for pipelines, `step` for hierarchies.
+4. **Layout direction**: `TD` (top-down) for hierarchies, `LR` (left-right) for pipelines.
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#f0f0f0','primaryTextColor':'#333','lineColor':'#666','fontSize':'14px'}}}%%
+flowchart LR
+    Input --> Process --> Output
+```
+
+### Declaration Order for Clean Layouts
+
+Tier-based ordering: declare elements in the order they should appear visually, following natural data flow. Declare ALL elements before ANY relationships. Group related elements with `subgraph`.
+
+## Visual Explanation Patterns
+
+### 1. Annotated Architecture
+
+Annotate directly on the diagram rather than using separate legends. Labels near their elements eliminate eye travel. Use callout lines to connect explanatory text to diagram elements.
+
+### 2. Before/After Paired Diagrams
+
+Show the problem ("Before") next to the solution ("After") at the same scale. The reader sees the delta without explanation.
+
+### 3. Zoom-In Details
+
+Show the big picture, then an enlarged detail of the complex part. Circle or highlight the zoom region on the overview.
+
+### 4. Step-By-Step Numbered Progression
+
+Number steps in the order they happen. Readers process numbered sequences faster than trying to decode arrows.
+
+### 5. Comparison Tables with Visual Differentiation
+
+Color-code differences. Use ✓/✗ for feature comparisons. Never rely on color alone — always include text labels.
+
+## SVG Quality Checklist
+
+| Check | How to Verify |
+|-------|---------------|
+| Edge crossings minimized | Count intersection points (not at nodes). Target 0 for simple, <3 for medium |
+| Consistent flow direction | All primary edges flow in one direction (L→R or T→B) |
+| Visual hierarchy clear | System boundary/main container is most prominent element |
+| Color-independent meaning | Diagram is still readable in grayscale |
+| Text legible | Minimum 12px font for digital, adequate contrast |
+| Accessible | `role="img"`, `<title>`, `<desc>` elements present |
+| Groups make sense | Related elements visually proximate and grouped |
+
+## SVG Accessibility
+
+Every SVG diagram must include:
+
+```svg
+<svg role="img" aria-label="Architecture diagram showing client connecting through API gateway to three backend services">
+  <title>System Architecture</title>
+  <desc>Client sends requests to the API gateway which routes to either the auth service, data service, or notification service based on the endpoint.</desc>
+  <!-- diagram elements -->
+</svg>
+```
+
+Rules:
+- Always `role="img"` on root `<svg>`
+- Short label in `aria-label` or `<title>`
+- Longer description in `<desc>` for complex diagrams
+- Color-blind safe: never rely on color alone to convey meaning
+- Sufficient contrast ratios for strokes and text
+
+## Dark Mode Support
+
+Two approaches:
+
+1. **Inline SVGs with `currentColor`** — stroke and fill use `currentColor`, inheriting page color. Most flexible but requires inline embedding.
+2. **Dual SVGs** — light and dark versions, swapped via CSS media query. Simpler but maintenance burden.
+
+Mermaid's `neutral` theme works reasonably well on both light and dark backgrounds without modification.
+
+## Tufte's Principles Applied to Diagrams
+
+| Principle | Application |
+|-----------|-------------|
+| Data-ink ratio | Every pixel serves the data. Remove grid backgrounds, decorative borders, gradient fills, drop shadows, 3D effects |
+| Chartjunk elimination | No moiré patterns, no heavy gridlines, no decorative pictograms. Gridlines in #d8d4ce only if needed |
+| Lie Factor = 1.0 | Every element proportional to what it represents. No area distortions |
+| Direct labels | Label elements directly adjacent. No legends — they force eye travel |
+| Micro/macro readings | Diagram readable as whole gestalt AND inspectable at individual elements |
+| Small multiples | Compare similar structures side-by-side at same scale |
+
+## When to Hand-Code SVG vs Tool-Generated
+
+| Approach | Best For |
+|----------|----------|
+| Mermaid (diagram-as-code) | Flowcharts, sequences, state diagrams, ER — anything that changes often |
+| Hand-coded SVG | Simple diagrams (3-6 boxes, few arrows), diagrams needing precise control, rarely-changed illustrations |
+| Excalidraw export SVG | Architecture diagrams with custom styling, hand-drawn aesthetic |
+| Figma/draw.io export → SVGO | Complex diagrams, diagrams needing visual polish |
+
+## Visual Selection Decision Framework
+
+Adapted from the Few/Tufte Design Library:
+
+| Data Type | Best Visual Encoding | Avoid |
+|-----------|---------------------|-------|
+| Comparisons | Bar chart (length), side-by-side boxes | Pie charts (angle is harder to decode), 3D effects |
+| Change over time | Line chart, sparkline | Stacked area with many series |
+| Relationships / flow | Flowchart, network diagram | Text description of relationships |
+| Part-to-whole | Stacked bar, treemap | Pie chart with many slices |
+| Distribution | Histogram, box plot | Raw data table |
+| Spatial | Map, architecture diagram | List of locations |
+| Process / sequence | Sequence diagram, numbered flowchart | Prose description of steps |
+| Hierarchy | Tree diagram, nested subgraphs | Indented text list |
+
+## Perceptual Encoding Hierarchy
+
+The visual cortex processes encoding types with different speeds and accuracy. Design your diagrams to use the most effective encoding for your primary message:
+
+```
+Position (most accurate)
+  > Length
+    > Angle / Slope
+      > Area
+        > Volume (least accurate)
+          > Color hue / Saturation
+```
+
+Implication: Bar charts (using length/position) are easier to read than pie charts (using angle). For diagrams, this means: position elements by importance, use consistent sizes, and use color for categorization, not for encoding quantitative differences.
+
+## Gestalt Principles for Diagrams
+
+These principles from perceptual psychology govern how viewers unconsciously group elements:
+
+| Principle | Meaning | Diagram Application |
+|-----------|---------|---------------------|
+| **Proximity** | Close elements are perceived as grouped | Group related services in subgraphs or with padding |
+| **Similarity** | Similar elements are perceived as related | Use consistent shapes for same-type components |
+| **Continuity** | The eye follows continuous lines/paths | Avoid crossing lines; prefer straight paths |
+| **Closure** | The mind completes incomplete shapes | Boxes around groups signal containment |
+| **Common Region** | Elements in a bounded area are perceived as a group | Use subgraph blocks, background regions |
+| **Connectedness** | Connected elements are perceived as related | Lines between elements imply relationship |
+
+## Edge Crossing: The Single Biggest Diagram Problem
+
+Research by Purchase et al. found that edge crossings are the strongest negative predictor of diagram comprehension. This matters more than node positioning, symmetry, or even consistent flow direction.
+
+**Crossing reduction strategy**:
+1. Declare elements in visual order (left-to-right, top-to-bottom)
+2. Group related elements with subgraph constraints
+3. Use tier-based ordering: upstream → processing → downstream
+4. If crossings remain, split into multiple diagrams
+
+Targets:
+- Simple (≤6 elements): 0 crossings
+- Medium (7-12 elements): <3 crossings
+- Complex (12+ elements): <5 crossings, or split
+
+## C4 Diagram Levels for Architecture
+
+For architecture documentation, use the C4 model for layered architectural views:
+
+| Level | Scope | Audience | Diagram Content |
+|-------|-------|----------|-----------------|
+| Context | System + external actors | Everyone | The system as a box, external users/systems around it |
+| Container | High-level tech choices | Architects, devs | Web app, API, database, file system |
+| Component | Internal structure | Developers | Controllers, services, repositories within a container |
+| Code | Class-level detail | Developers | UML class diagrams (usually generated, not hand-drawn) |
+
+One diagram per C4 level. Never mix context-level and container-level elements on the same diagram.
+
+## Dark Mode SVG Patterns
+
+### Approach 1: CSS Custom Properties (Inline SVG)
+
+```svg
+<svg viewBox="0 0 200 100" role="img" aria-label="...">
+  <style>
+    .bg { fill: var(--bg-color, #ffffff); }
+    .text { fill: var(--text-color, #333333); stroke: var(--text-color, #333333); }
+    .accent { fill: var(--accent-color, #0066cc); }
+    @media (prefers-color-scheme: dark) {
+      .bg { fill: #1a1a2e; }
+      .text { fill: #e0e0e0; stroke: #e0e0e0; }
+      .accent { fill: #66b3ff; }
+    }
+  </style>
+  ...
+</svg>
+```
+
+### Approach 2: `currentColor` (Simplest)
+
+For monochrome diagrams that should match text color:
+
+```svg
+<svg viewBox="0 0 200 100" role="img" aria-label="...">
+  <rect x="10" y="10" width="80" height="30" fill="none" stroke="currentColor" stroke-width="2"/>
+</svg>
+```
+
+The diagram inherits `currentColor` from the page — automatically dark mode compatible.
+
+### Approach 3: Mermaid Theme Selection
+
+For Mermaid diagrams on sites with dark mode, use the `neutral` theme or `base` with custom variables:
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {
+  'primaryColor':'#bb86fc','primaryTextColor':'#fff','primaryBorderColor':'#bb86fc',
+  'lineColor':'#888','secondaryColor':'#03dac6','tertiaryColor':'#1e1e1e'
+}}}%%
+flowchart TD
+    A --> B
+```
+
+Export at different themes for light/dark and swap via CSS or JavaScript.
+
+## Common SVG Mistakes and Fixes
+
+| Mistake | Fix |
+|---------|-----|
+| Fixed `width`/`height` attributes | Use `viewBox` only; let CSS control display size |
+| `<img src="diagram.svg">` prevents CSS theming | Use inline `<svg>` or `<object>` |
+| Text as paths (from Figma/draw.io export) | Run through SVGO with `convertPathData: false, removeViewBox: false` |
+| Missing `xmlns` | Always include `xmlns="http://www.w3.org/2000/svg"` |
+| Transparent backgrounds | Add explicit background rect; transparent diagrams look broken on dark mode |
+| SVG too large (verbose export) | Run through SVGO: `npx svgo diagram.svg -o diagram.min.svg` |
+
+## When Not to Draw — Let Text Win
+
+A good diagram is worth a thousand words. But a thousand words are sometimes better than a bad diagram. Skip the diagram when:
+
+- The concept takes 1-2 sentences to explain clearly
+- The diagram would have more edge crossings than elements
+- The audience doesn't need the diagram (expert audience, reference doc)
+- The diagram duplicates what's already clear in a table
+- Creating the diagram would take longer than writing a clear paragraph
+
+Remember Tufte: "Simple design, intense content." If the diagram doesn't have intense content, it's decoration.

--- a/skills/crystal-clear-docs/references/writing-clarity.md
+++ b/skills/crystal-clear-docs/references/writing-clarity.md
@@ -1,0 +1,314 @@
+# Writing for Clarity: Words and Comparisons
+
+Sources: Strunk & White (The Elements of Style, 1918), William Zinsser (On Writing Well, 1976), Google Technical Writing Course (One), Steve Krug (Don't Make Me Think — Chapter 5: Omit Needless Words), Robert Horn (Information Mapping).
+
+Covers: Word-level and sentence-level techniques for crystal-clear technical writing. Active voice, eliminating jargon, sentence construction, comparison patterns, worked examples, and the MECE framework for structuring arguments.
+
+## The Core Principle
+
+**Every word must earn its place.** If removing a word changes nothing, remove it. If a simpler word works, use it. Clarity is not about dumbing down — it's about respecting the reader's time and attention.
+
+## Omit Needless Words (Krug + Strunk & White)
+
+Before:
+> "In order to successfully authenticate the user's credentials, it is necessary for the system to verify the provided password against the hashed value that has been previously stored in the database."
+
+After:
+> "The system checks the password against the stored hash."
+
+Technique: Write the sentence. Delete every word. Re-add only what's essential to convey the meaning. You will re-add about 40% of the original.
+
+## Active Voice
+
+Active voice makes actors visible and responsibility clear.
+
+| Passive | Active |
+|---------|--------|
+| "The configuration file should be updated." | "Update the configuration file." |
+| "Errors are logged to the console." | "The server logs errors to the console." |
+| "The token is verified before access is granted." | "The API verifies the token before granting access." |
+
+**When passive voice is acceptable**: The actor is irrelevant or unknown ("The server was compromised"), or you want to emphasize the recipient over the actor.
+
+## Define Terms on First Use
+
+Every new or unfamiliar term gets defined the first time it appears. Definition goes in the same sentence or the very next one.
+
+**Good**:
+> "The system uses JWT (JSON Web Token) — a compact, URL-safe token that proves identity without server-side session storage."
+
+**Bad**:
+> "The system uses JWT."
+> *(reader Googles "JWT" and doesn't come back)*
+
+## Eliminating Jargon
+
+Jargon is domain-specific vocabulary your reader may not know. The test: would your next-door neighbor understand this term?
+
+| Jargon | Plain Alternative |
+|--------|-------------------|
+| "Implement a pub/sub pattern" | "Set up a message system where one service publishes and others subscribe" |
+| "Utilize a monorepo architecture" | "Keep all code in a single repository" |
+| "Leverage horizontal scaling" | "Add more servers instead of bigger servers" |
+| "Idempotent operation" | "Safe to retry — running it twice has the same effect as running it once" |
+
+**Exception for developer docs**: Domain-appropriate jargon is fine IF defined on first use. Developers know "idempotent" — but still define it. Your more junior readers don't know it yet.
+
+## Sentence Construction
+
+### Length
+
+- Core sentences: 15-20 words
+- Limit: 25 words maximum
+- If a sentence runs longer, split it. If splitting loses meaning, use a list.
+
+### Structure
+
+Lead with the subject and verb. Don't make readers hold context while you set up.
+
+**Before**:
+> "After considering the various authentication approaches available, including OAuth 2.0, API keys, and session-based auth, and weighing their respective tradeoffs in terms of security, implementation complexity, and user experience, the team decided to implement JWT-based authentication."
+
+**After**:
+> "The team chose JWT-based authentication. It balances security, implementation simplicity, and user experience better than OAuth 2.0, API keys, or session-based auth."
+
+## Comparison Patterns
+
+### Side-by-Side Table — for multiple options, multiple criteria
+
+| Feature | Method A | Method B | Method C |
+|---------|----------|----------|----------|
+| Speed | Fast | Medium | Slow |
+| Setup | Simple | Complex | Medium |
+| Security | Basic | Enterprise | Standard |
+| **Best for** | Prototypes | Production | Internal tools |
+
+### Pros/Cons List — for evaluating a single option
+
+```
+### JWT Authentication
+
+**Pros**
+- Stateless — no server-side session storage
+- Works across domains (no CORS issues)
+- Compact (URL-safe)
+
+**Cons**
+- Cannot revoke individual tokens
+- Token size grows with claims
+- Requires token refresh mechanism
+```
+
+### When to Use Which
+
+| Situation | Format |
+|-----------|--------|
+| Choosing between 2+ options | Side-by-side table |
+| Evaluating whether to use X | Pros/Cons list |
+| Contrasting old vs new approach | Before/After paired boxes |
+| Showing step-by-step difference | Numbered old flow vs numbered new flow |
+
+## Worked Examples
+
+A worked example takes a realistic scenario (not a contrived toy) and walks through it completely. It includes: the setup, the happy path, common errors, and the final state.
+
+### Structure of a Good Worked Example
+
+```
+### Example: Adding Authentication to a REST API
+
+**The scenario**: You have an existing Express API for a todo app.
+Currently, anyone can read or modify any todo. You need to add
+user-specific authentication.
+
+**Step 1**: Install and configure the auth library.
+[Code block with exactly what to run]
+
+**Step 2**: Add the auth middleware to protected routes.
+[Code block showing before/after]
+
+**Step 3**: Test that unauthenticated requests are rejected.
+[Terminal output showing 401 response]
+
+**Step 4**: Test that authenticated requests succeed.
+[Terminal output showing 200 response]
+
+**What just happened**: [Explanation of the mechanism]
+
+**Common pitfalls**:
+- Forgetting to add the middleware to ALL protected routes → use router-level middleware
+- Storing tokens in localStorage → use httpOnly cookies instead
+```
+
+### Why Worked Examples Work
+
+1. Readers learn by doing, not reading about doing
+2. A realistic example surfaces real-world edge cases
+3. They validate the documentation (if the example doesn't work, the docs are wrong)
+
+## MECE Framework for Structuring Arguments
+
+From Barbara Minto's Pyramid Principle: arguments should be **M**utually **E**xclusive and **C**ollectively **E**xhaustive.
+
+- **Mutually Exclusive**: No overlap between categories. Each item appears in exactly one place.
+- **Collectively Exhaustive**: Together, the categories cover everything. Nothing is left out.
+
+Applied to documentation:
+
+**Non-MECE** (overlap + gaps):
+- Authentication methods: API keys, OAuth, JWT, Bearer tokens
+- Problem: JWT and Bearer tokens overlap
+
+**MECE**:
+- Authentication methods:
+  - Server-side: Session cookies, API keys stored in DB
+  - Client-side: JWT tokens
+  - Delegated: OAuth 2.0
+
+## BLUF: Bottom Line Up Front
+
+Military communication principle: state the conclusion first, then provide supporting reasoning. This is the written equivalent of the inverted pyramid.
+
+In practice:
+- The document's first sentence IS the conclusion
+- Supporting evidence follows
+- The reader never wonders "where is this going?"
+
+## Anticipating Reader Questions
+
+The best technical writing answers questions before they're asked. For every claim, ask:
+
+- **"So what?"** — Why does this matter to the reader? If you can't answer, cut it.
+- **"Why is that true?"** — What's the evidence? If you can't provide it, the claim is weak.
+- **"What could go wrong?"** — What happens if the reader makes the wrong choice? Warn them.
+
+## Quality Checklist for Clarity
+
+- [ ] Every term defined on first use (with a single sentence, in context)
+- [ ] Zero passive voice where active voice would be clearer
+- [ ] Every sentence under 25 words (or split/listed)
+- [ ] No word can be removed without losing meaning
+- [ ] Every code block is copy-paste runnable
+- [ ] Every "why" question the reader might ask is answered (or linked)
+- [ ] First paragraph tells the reader exactly what they'll get
+
+## Information Mapping (Robert Horn)
+
+A framework for breaking content into structured, reusable blocks based on the type of information. Every block of content should be classified as one of these types, and each type should follow a consistent format:
+
+| Block Type | Purpose | Format Pattern |
+|-----------|---------|----------------|
+| **Concept** | Define or explain an idea | Definition → Examples → Non-examples → Related concepts |
+| **Procedure** | Steps to complete a task | Prerequisites → Ordered Steps (numbered) → Expected Result → Troubleshooting |
+| **Process** | How something works (system behavior) | Overview → Stages (sequential) → Feedback at each stage → Output |
+| **Principle** | Rules, guidelines, best practices | Rule statement → Rationale → When to apply → Exceptions |
+| **Fact** | Reference data, specifications | Data point → Context → Source → Caveats |
+
+Each block should be self-contained and labeled so readers can identify the type at a glance. This lets them skip procedure blocks when they want concepts, or skip concepts when they want to execute.
+
+## The Three-Pass Editing Process
+
+From Google's Technical Writing course and Zinsser:
+
+### Pass 1: Structure
+- Does the document open with a TL;DR that answers "what is this about?"
+- Are sections in logical order?
+- Do headings accurately compress their content?
+- Can a reader self-select their depth?
+
+### Pass 2: Clarity
+- Replace every passive voice construction with active (where possible)
+- Split every sentence over 25 words
+- Convert every 3-item prose list to a bulleted or numbered list
+- Define every jargon term on first use
+- Bold every key term exactly once (on first mention)
+
+### Pass 3: Conciseness
+- Read each sentence. Delete every word. Re-add only what's essential.
+- Remove: "It should be noted that", "In order to", "The fact that", "Due to the fact that"
+- Replace: "utilize" → "use", "implement" → "build", "leverage" → "use", "facilitate" → "help"
+- Delete any sentence repeating what the code block already shows
+- Cut adjectives and adverbs that don't add precision (most don't)
+
+## The Curse of Knowledge
+
+The single biggest obstacle to clear technical writing: you know too much. Once you understand something deeply, you cannot imagine what it's like not to understand it. This causes three specific failures:
+
+1. **Unexplained prerequisites**: You assume the reader knows X, but they don't.
+2. **Jargon without context**: You use terms fluently without defining them.
+3. **Skipped steps**: You leap from A to C because B is so obvious to you.
+
+**Counter-measures**:
+- Write the prerequisites section BEFORE the content. Be ruthlessly explicit.
+- Have a non-expert read your draft. Every place they pause or ask "what's that?" — add explanation.
+- Run your TL;DR through the Up-Goer Five test: can you explain the core idea in only common words?
+
+## Handling Different Audience Levels
+
+Most technical documents have a split audience: beginners who need everything explained, and experts who just need the reference. Structure accommodates both:
+
+| Section | Serves | Content |
+|---------|--------|---------|
+| TL;DR + Quickstart | Both | Answer; simplest working example |
+| Overview / Concepts | Beginners | What it is, why it exists, core ideas |
+| How-To Guides | Intermediate | Task-based, realistic workflows |
+| API Reference | Experts | Complete, exhaustive parameter/type docs |
+| Architecture / Internals | Advanced | Design decisions, tradeoffs, implementation details |
+
+The key: a beginner reads top-to-bottom. An expert jumps to API Reference. Neither is forced to wade through content they don't need.
+
+## Error Messages as Documentation
+
+Error messages are the most-read documentation you'll ever write. A good error message:
+
+1. **Says what happened** — in plain language, not error codes
+2. **Says why it happened** — what condition caused it
+3. **Says what to do** — the specific action that fixes it
+
+**Bad**: `Error: EACCES: permission denied`
+**Good**: `Cannot write to /etc/config.json — you don't have permission. Run with sudo or change the file owner: chown $USER /etc/config.json`
+
+### Error Message Template
+
+```
+[What happened]: [plain language description]
+[Symptoms]: [what the user sees]
+[Cause]: [why this happened]
+[Fix]: [specific action to resolve]
+[If that doesn't work]: [fallback / support link]
+```
+
+## Formatting References and Further Reading
+
+Every document should end with clear paths forward. Three levels:
+
+1. **Next logical step**: If the reader completed this document, what should they do next?
+2. **Related topics**: Tangential documentation that provides context or alternatives.
+3. **External references**: Official docs, RFCs, seminal blog posts that informed the content.
+
+Format:
+```markdown
+## What's Next
+
+- **[Next Step: Add Role-Based Authorization](./authorization.md)** — now that authentication works, restrict what each user can do.
+- **[Alternative: OAuth 2.0](./oauth.md)** — if you need delegated auth instead of JWT.
+- **See also**: [JWT RFC 7519](https://tools.ietf.org/html/rfc7519), [jwt.io debugger](https://jwt.io)
+```
+
+## Voice and Tone
+
+Technical documentation is not academic writing. The best docs sound like a knowledgeable colleague explaining something to you directly. The voice is:
+
+- **Confident, not cold**: "Here's how it works" not "The system operates in the following manner"
+- **Direct, not distant**: Use "you" for the reader. "You'll need to install..." not "The user must install..."
+- **Honest about tradeoffs**: "This approach is simpler but slower" not "This approach may have performance implications"
+- **Respectful of the reader's intelligence**: Assume competence. Don't condescend. Don't over-explain the obvious.
+
+## The 30-Second Test
+
+A reader should be able to determine, within 30 seconds of opening your document:
+1. What this page is about
+2. Whether it's relevant to them
+3. What they need to do
+
+If they cannot, the document has failed regardless of how good the deep content is.

--- a/skills/crystal-clear-docs/tank.json
+++ b/skills/crystal-clear-docs/tank.json
@@ -1,0 +1,16 @@
+{
+  "name": "@tank/crystal-clear-docs",
+  "version": "1.0.0",
+  "description": "Create crystal-clear technical documents (HTML + Markdown) with layered explanations (TL;DR to deep dive), progressive disclosure, SVG/Mermaid diagrams, scannable formatting, callout patterns, and word-level clarity. Synthesizes Minto, Tufte, Krug, Strunk & White, Zinsser, Google Tech Writing, Munroe, and Cognitive Load Theory.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": ["**/*"],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary

Adds the `@tank/crystal-clear-docs` skill for creating crystal-clear technical documents (HTML + Markdown) with:

- **Layered explanations** — inverted pyramid, Layer Cake Method, SCQA, MECE, progressive disclosure from TL;DR to deep dive
- **SVG diagrams** — Mermaid diagram-as-code, Tufte's data-ink principles, SVG accessibility, dark mode patterns, C4 architecture levels
- **Document structure** — heading hierarchies, 6 callout types, comparison tables, scannability patterns, CRAP design principles
- **Writing clarity** — active voice, jargon elimination, worked examples, three-pass editing, Information Mapping

### Synthesized from
Minto (Pyramid Principle), Tufte (VDQI, Envisioning Information), Krug (Don't Make Me Think), Strunk & White, Zinsser (On Writing Well), Google Tech Writing Course, Munroe (Up-Goer Five), Cognitive Load Theory, W3C SVG accessibility, Few/Tufte Design Library.

### Files
- `SKILL.md` — 193 lines (within 200 limit)
- `tank.json` — 1.0.0, minimal permissions
- 4 reference files (250-314 lines each): layered-writing, svg-diagrams, document-structure, writing-clarity