### PR TITLE
docs(AGENTS.md): correct publish workflow for tank v0.16.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,18 +330,45 @@ Covers: brief scope sentence.
 
 1. Create a feature branch for the new or updated skill
 2. Commit all skill files to the branch
-3. Open a PR and merge to `main`
-4. Only after the merge is complete, publish from `main`:
+3. Open a PR and merge to `main` (the `main` branch is protected — direct
+   pushes are rejected, so a PR is required)
+4. Only after the merge is complete, pull `main` locally and publish from
+   the skill directory:
 
 ```bash
-tank publish --org tank
+git checkout main && git pull origin main
+cd skills/<your-skill>/
+tank publish --dry-run    # validate and pack without uploading
+tank publish              # upload to the registry
 ```
 
 Never publish from a feature branch — the source must exist on `main` first.
 
+### Publish target
+
+The publish target is inferred from the `name` field in `tank.json`. As long
+as `name` starts with `@tank/`, the skill publishes under the `tank`
+organization. There is no `--org` flag on `tank publish`.
+
+### Available flags
+
+```
+tank publish [options]
+
+  --dry-run            Validate and pack without uploading
+  --private            Publish skill as private
+  --visibility <mode>  Skill visibility (public|private)
+```
+
+Defaults to public visibility.
+
 ### Rules
 
 - Every skill in this repo belongs to the `@tank` namespace
-- Always publish under the `tank` organization — never a personal account or other org
-- Verify the `name` field in `tank.json` starts with `@tank/` before publishing
-- Use `tank publish --dry-run` first to catch issues
+- The `name` field in `tank.json` MUST start with `@tank/` — this is what
+  routes the publish to the `tank` org. Never use a personal namespace.
+- Run `tank publish --dry-run` first to catch packing or auth issues before
+  uploading
+- Confirm you are on `main` and pulled latest before publishing — publishing
+  packs the current working directory, not a git ref
+- Confirm you are authenticated: `tank whoami` (use `tank login` if not)


### PR DESCRIPTION
## Summary

The Publishing section of AGENTS.md referenced a `tank publish --org tank` flag that does not exist in tank CLI v0.16.2. Discovered while publishing #143 — the publish actually works by inferring the target from the `name` field in `tank.json` (anything starting with `@tank/` routes to the tank org).

## Changes

- **Note that `main` is protected**: PR is required (direct push rejected with GH006). Previously the doc said "open a PR and merge" but did not warn about the protection.
- **Show the full publish flow**: `git checkout main && git pull && cd skills/<name>/ && tank publish --dry-run && tank publish`. Previously it only showed the broken `--org` invocation.
- **Document actual available flags**: `--dry-run`, `--private`, `--visibility`. Removes the imaginary `--org` and adds what really exists.
- **New 'Publish target' section**: explicitly explains that the org is derived from the package name, so there is no flag to pass.
- **Updated Rules**: clarified that the `@tank/` prefix is what does the routing, added reminder to run `tank whoami` to confirm auth, and added reminder that publishing packs the working directory (not a git ref).

## Verification

Ran `tank publish --help` against tank v0.16.2 — confirms the only flags are `--dry-run`, `--private`, `--visibility`. Confirmed the documented flow matches what was actually used to publish #143 successfully.