### PR TITLE
fix(browser-polyfills): trim description to ≤500 chars

### DIFF
--- a/skills/browser-polyfills/tank.json
+++ b/skills/browser-polyfills/tank.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/browser-polyfills",
   "version": "1.0.1",
-  "description": "Diagnose and fix browser compatibility issues in Next.js apps. Covers Safari/iOS Safari JavaScript API polyfills, CSS workarounds, Next.js polyfill configuration (App Router + Pages Router), browserslist setup, feature detection patterns, and safe polyfill delivery. Synthesizes caniuse.com (2026), WebKit Bug Tracker, MDN Web Docs, and production Next.js codebase patterns. Triggers: polyfill, Safari broken, works in Chrome not Safari, iOS Safari bug, WebKit issue, browserslist, browser compatibility, cross-browser, caniuse, feature detection, @supports, requestIdleCallback, 100vh Safari, dvh, svh, input zoom iOS, backdrop-filter Safari, Safari date parsing, scroll lock iOS, position sticky Safari, gap flexbox Safari, @next/polyfill, polyfill.io alternative, Safari PWA, smooth scroll Safari.",
+  "description": "Diagnose and fix browser compatibility issues in Next.js apps. Covers Safari/iOS JS polyfills (requestIdleCallback, Promise.withResolvers, Set methods), CSS workarounds (backdrop-filter, dvh, sticky bugs), Next.js polyfill config (App + Pages Router), browserslist, feature detection, polyfill.io alternatives, and Safari React bugs (date parsing, input zoom, 100vh, scroll lock). Triggers: polyfill, Safari broken, iOS Safari bug, browserslist, cross-browser.",
   "permissions": {
     "network": {
       "outbound": []


### PR DESCRIPTION
Description was 800 chars, registry limit is 500. Trimmed to 460.