### PR TITLE
feat: add Pulumi and Terraform migration skills

### DIFF
--- a/skills/gcp-to-pulumi/SKILL.md
+++ b/skills/gcp-to-pulumi/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: @tank/gcp-to-pulumi
+description: |
+  Convert or adopt existing Google Cloud infrastructure into Pulumi management
+  without recreating live resources. Inventories GCP assets and IAM, chooses
+  Pulumi GCP resource types and canonical import IDs, distinguishes direct
+  import from Terraform code/state conversion, stages dependency-aware imports,
+  and proves a zero-replacement steady state. Depends on @tank/pulumi and
+  synthesizes current Pulumi and Google Cloud documentation.
+
+  Trigger phrases: "migrate GCP to Pulumi", "convert GCP to Pulumi",
+  "import Google Cloud resources", "adopt GCP infrastructure", "Pulumi import GCP",
+  "existing GCP Pulumi", "GCP infrastructure as code migration",
+  "convert Terraform GCP to Pulumi", "import tfstate to Pulumi",
+  "Cloud Asset Inventory Pulumi", "bulk import GCP", "GCP import IDs",
+  "move Google Cloud to Pulumi", "brownfield GCP Pulumi", "no downtime Pulumi migration"
+---
+
+# GCP to Pulumi
+
+Load `@tank/pulumi` for Pulumi programming, stack, state, provider, testing,
+and delivery fundamentals. This skill adds the brownfield GCP adoption workflow.
+
+## Core Philosophy
+
+1. **Migration changes ownership before architecture** -- first represent the
+   live estate exactly; refactor only after a no-change baseline exists.
+2. **One resource has one writer** -- identify the current owner and freeze its
+   mutations before Pulumi assumes management.
+3. **Inventory beats inference** -- combine Cloud Asset Inventory, service APIs,
+   existing IaC state, IAM policy, and runtime dependencies; no single source is
+   complete enough for a safe migration.
+4. **Provider identity is a migration decision** -- choose `gcp` or
+   `google-native` per supported resource and keep one provider family as the
+   long-term owner of each object.
+5. **Zero destructive operations is the adoption gate** -- imported resources
+   are not complete until refresh and full preview show no unexplained create,
+   replacement, update, or delete.
+
+## Migration Workflow
+
+1. Define scope, owner, outage tolerance, rollback, and the Pulumi project/stack.
+2. Inventory resources, IAM, APIs, dependencies, locations, and current IaC.
+3. Classify each object as import, Terraform state adoption, code conversion,
+   data-source read, intentional exclusion, or later replacement.
+4. Select the Pulumi provider resource type and Registry-documented import ID.
+5. Generate code and an import manifest in dependency-aware waves.
+6. Freeze the prior writer, back up its state, and import into the final Pulumi
+   identity with deletion protection.
+7. Reconcile code with provider-read state without changing live behavior.
+8. Run drift detection and a full detailed preview; accept only the reviewed
+   zero-change baseline.
+9. Transfer CI/CD ownership, monitor, then retire the old writer without running
+   its destroy path.
+10. Refactor in later changes using aliases and ordinary Pulumi review gates.
+
+## Quick-Start: Common Problems
+
+### "What exists in this GCP estate?"
+
+Search Cloud Asset Inventory at the organization, folder, or project scope;
+supplement it with IAM search, service-specific listings, billing/export data,
+and current IaC state. Build a resource ledger before writing Pulumi code.
+
+-> See `references/discovery-and-classification.md`.
+
+### "Should I use import or convert?"
+
+Import manually or externally created resources. For Terraform-owned resources,
+prefer Terraform-aware state adoption and convert HCL separately when it helps;
+conversion alone does not transfer ownership of live resources.
+
+-> See `references/migration-paths.md`.
+
+### "How do I find the right GCP type and import ID?"
+
+Start from the Pulumi Registry page for the exact resource. Confirm package,
+type token, immutable fields, and documented import syntax against the live API.
+
+-> See `references/gcp-provider-and-import-ids.md`.
+
+### "How do I avoid replacement or downtime?"
+
+Import into final names and parents, preserve explicit physical names, protect
+critical resources, align provider defaults, and stop when preview proposes any
+unexplained operation.
+
+-> See `references/adoption-and-cutover.md`.
+
+### "The current estate is Terraform-managed"
+
+Back up code and state, classify provider/resource coverage, use Pulumi's
+Terraform converter and state import intentionally, then remove old ownership
+without `terraform destroy`.
+
+-> See `references/terraform-to-pulumi.md`.
+
+## Decision Trees
+
+### Choose the Migration Path
+
+| Current owner | Path |
+|---|---|
+| Console, `gcloud`, scripts, Deployment Manager, unknown | Direct or program-first Pulumi import |
+| Terraform with reliable state | Terraform state adoption plus code conversion |
+| Terraform code but missing/unreliable state | Inventory live GCP and import directly; use conversion only as a draft |
+| Shared platform object not owned by this stack | Read with a provider function or stack contract |
+| Unsupported resource | Keep current owner or use a reviewed bridge; do not fake ownership |
+
+### Choose Import Scale
+
+| Scope | Default |
+|---|---|
+| One or two independent resources | `pulumi import` with generated code review |
+| Existing target program | Resource `import` option for controlled adoption |
+| Complex graph or component | Program-first `preview --import-file` workflow |
+| Existing Terraform state | `pulumi import --from terraform` where supported |
+
+## Stop Conditions
+
+Stop before mutation if the current writer is unknown, the import ID is guessed,
+the provider package is undecided, state backups are missing, critical IAM is
+not inventoried, or preview shows an unexplained create/replacement/delete.
+Never test a migration by applying a destructive preview to production.
+
+## Reference Index
+
+| File | Contents |
+|---|---|
+| `references/discovery-and-classification.md` | Cloud Asset Inventory, IAM, dependency mapping, ownership ledger, and scope |
+| `references/migration-paths.md` | Direct import, program-first bulk import, Terraform adoption, reads, and exclusions |
+| `references/gcp-provider-and-import-ids.md` | Provider-family choice, type mapping, canonical IDs, defaults, and IAM resources |
+| `references/adoption-and-cutover.md` | Import waves, no-change convergence, protection, cutover, rollback, and handoff |
+| `references/terraform-to-pulumi.md` | Terraform code conversion, tfstate adoption, dual-control prevention, and retirement |

--- a/skills/gcp-to-pulumi/references/adoption-and-cutover.md
+++ b/skills/gcp-to-pulumi/references/adoption-and-cutover.md
@@ -1,0 +1,151 @@
+# Adoption and Cutover
+
+Sources: Pulumi import, preview, refresh, protect, aliases, retainOnDelete, and drift documentation; Google Cloud reliability and asset-management guidance
+
+Covers: import waves, backups, no-change convergence, writer freeze, protection, verification, rollback, handoff, and post-adoption refactoring.
+
+## Preflight Gate
+
+Require these artifacts before any state mutation:
+
+- approved resource ledger
+- current-owner evidence
+- provider/type/import-ID mapping
+- Pulumi project and final stack
+- explicit provider targets
+- old IaC state and code backup
+- Pulumi stack export if the stack already exists
+- rollback owner and procedure
+- service health checks
+- maintenance/change freeze window
+
+Importing is a state mutation even when it does not change the GCP resource.
+
+## Establish the Final Identity
+
+Choose the final project, stack, logical name, parent, provider, and physical
+name before import. Correcting these later requires aliases or state migration.
+
+For critical resources, set `protect: true` during adoption. Use
+`retainOnDelete` only when the explicit desired behavior is to relinquish state
+ownership while leaving the cloud resource unmanaged; it is not a substitute
+for protection.
+
+## Import Waves
+
+Keep waves small enough to diagnose and roll back.
+
+| Wave | Typical content | Gate |
+|---|---|---|
+| 0 | Providers, config, project context, read-only references | Correct targets, no resources created |
+| 1 | Shared network, APIs, DNS/KMS foundations | No destructive diff |
+| 2 | Identity and IAM foundations | Principal and condition parity |
+| 3 | Stateful data and storage | Backup, protection, retention parity |
+| 4 | Compute and managed services | Runtime health parity |
+| 5 | Edge, load balancing, monitoring, fine IAM | End-to-end health |
+
+Adjust order to the actual graph. Importing does not recreate dependencies, but
+provider reads and parent relationships still need a coherent model.
+
+## Per-Wave Procedure
+
+1. Freeze mutations from the current owner for the wave.
+2. Capture fresh inventory and health evidence.
+3. Run import in preview-only mode where supported.
+4. Import canonical IDs into final Pulumi identities.
+5. Save generated code without exposing secrets.
+6. Reconcile declarations with live immutable/defaulted values.
+7. Run `pulumi refresh --preview-only`.
+8. Run full `pulumi preview --diff`.
+9. Require zero unexplained create, update, replace, or delete.
+10. Run service and access health checks.
+11. Record ownership transfer and proceed to the next wave.
+
+## Convergence Triage
+
+| Preview operation | Likely cause | Response |
+|---|---|---|
+| Create | Missing import, wrong stack, wrong logical graph | Stop; do not apply |
+| Replace | Immutable mismatch, wrong type/provider, identity change | Stop; align code/import |
+| Delete | Code omitted imported child or old ownership cleanup leaked in | Stop; restore model |
+| Update | Provider default or desired/live mismatch | Review field and operational impact |
+| Same | Candidate steady state | Confirm drift and health checks |
+
+Do not normalize architecture during convergence. Preserve existing names,
+regions, network links, IAM, retention, scaling, and service settings first.
+
+## Dual-Control Prevention
+
+At cutover, ensure the previous system cannot continue to mutate migrated rows.
+
+For Terraform:
+
+- stop apply jobs
+- preserve state backup
+- remove migrated resources from old state only through reviewed ownership
+  transfer steps
+- do not run `terraform destroy`
+- archive code/state with a migration record
+
+For scripts or console runbooks:
+
+- revoke or narrow mutation credentials
+- update operational documentation
+- point automation to Pulumi workflow
+- monitor audit logs for old writers
+
+## Rollback Model
+
+Rollback means restoring management ownership, not deleting and recreating live
+resources.
+
+Possible rollback:
+
+1. Stop Pulumi writers.
+2. Export Pulumi state and retain migration evidence.
+3. Restore old code/state ownership mapping from backup.
+4. Re-enable the old pipeline only after a no-change plan.
+5. Remove Pulumi ownership without deleting provider resources using the
+   documented state/retention procedure.
+
+Rehearse rollback for high-risk waves. Never improvise by deleting Pulumi state
+entries or running destroy commands.
+
+## Cutover Acceptance
+
+Require all of:
+
+- every in-scope resource has exactly one owner
+- no blocked ledger rows are silently omitted
+- full stack refresh preview is understood
+- full detailed preview is zero-change or contains only approved non-destructive
+  normalization
+- no replacement or delete
+- IAM principals and conditions match
+- service health, data access, DNS, and network paths pass
+- CI uses the intended short-lived identity
+- old writer is disabled and monitored
+- backups and rollback evidence are retained
+
+## Post-Adoption Refactoring
+
+Wait for a stable observation period. Then make one category of change at a
+time:
+
+1. Extract components with aliases for reparented children.
+2. Rename logical resources with aliases.
+3. Replace raw IDs with resource output references.
+4. Normalize configuration and provider instances.
+5. Remove temporary protection only through explicit review.
+6. Redesign or replace infrastructure in separately approved projects.
+
+Keep adoption and modernization in different pull requests and deployment
+events. This preserves an auditable baseline and isolates failures.
+
+## Source Links
+
+- https://www.pulumi.com/docs/iac/guides/migration/import/
+- https://www.pulumi.com/docs/iac/operations/stack-management/drift/
+- https://www.pulumi.com/docs/iac/concepts/resources/options/protect/
+- https://www.pulumi.com/docs/iac/concepts/resources/options/retainondelete/
+- https://www.pulumi.com/docs/iac/concepts/resources/options/aliases/

--- a/skills/gcp-to-pulumi/references/discovery-and-classification.md
+++ b/skills/gcp-to-pulumi/references/discovery-and-classification.md
@@ -1,0 +1,167 @@
+# GCP Discovery and Classification
+
+Sources: Google Cloud Asset Inventory documentation, Google Cloud IAM documentation, Pulumi migration and import documentation, Google Cloud service inventory guidance
+
+Covers: scope, asset and IAM discovery, service-specific enrichment, ownership evidence, dependency mapping, and migration classification.
+
+## Define the Boundary
+
+Record the organization, folders, projects, regions, zones, billing boundary,
+environments, and excluded systems. Inventory at the highest authorized scope;
+project-only discovery misses shared DNS, IAM, networking, organization policy,
+and cross-project service dependencies.
+
+Migration brief:
+
+| Field | Required answer |
+|---|---|
+| Business owner | Who accepts operational risk? |
+| Current writer | Console, script, Terraform, another Pulumi stack, service controller |
+| Target owner | Pulumi organization/project/stack |
+| Change freeze | When does the old writer stop? |
+| Outage tolerance | None, degraded, scheduled window |
+| Rollback | How is state ownership restored without deleting resources? |
+| Success | No-change preview plus service health and ownership transfer |
+
+## Build a Multi-Source Inventory
+
+Cloud Asset Inventory is the broad baseline, not the complete answer.
+
+```bash
+gcloud asset search-all-resources \
+  --scope="organizations/ORG_ID" \
+  --format=json
+
+gcloud asset search-all-iam-policies \
+  --scope="organizations/ORG_ID" \
+  --format=json
+```
+
+Use least-privilege read access and store exports as sensitive operational data.
+IAM bindings, labels, network paths, service account identities, and resource
+names can reveal security architecture.
+
+Supplement with:
+
+| Source | Finds |
+|---|---|
+| Asset Inventory resource search | Broad metadata and ancestry |
+| Asset Inventory IAM search | Policy references and principals |
+| Existing Terraform/Pulumi state | Current IaC ownership and provider IDs |
+| Service-specific APIs | Fields or child resources omitted from broad inventory |
+| Cloud Logging audit logs | Recent writers and mutation paths |
+| CI/CD definitions | Automated owners and credentials |
+| Billing/export data | Active resources missed by initial filters |
+| DNS, certificates, secrets | External dependencies and hidden coupling |
+
+## Resource Ledger
+
+Create one row per independently managed Pulumi resource, not one row per
+application. Include child IAM resources and API enablement where they have a
+separate lifecycle.
+
+| Column | Purpose |
+|---|---|
+| Asset full name | Stable GCP identity |
+| Asset type | Google API type |
+| Project/location | Provider target |
+| Current owner | Tool/state/pipeline |
+| Pulumi package/type | Intended resource mapping |
+| Import ID | Registry-documented canonical form |
+| Dependencies | Parent, API, network, service account, KMS |
+| Immutable fields | Replacement risk |
+| Sensitive/stateful | Protection and backup requirements |
+| Migration path | Import, Terraform adoption, read, exclude, replace later |
+| Wave | Ordered adoption batch |
+| Evidence | Source and timestamp |
+
+An unknown value is a discovery task, not permission to guess.
+
+## Map Dependencies
+
+Build edges from both configuration and runtime behavior.
+
+Common GCP ordering:
+
+1. Project/folder context and required APIs.
+2. Shared VPC, networks, subnetworks, routes, NAT, DNS.
+3. KMS keys, service accounts, workload identity, base IAM.
+4. Data services, buckets, databases, artifact registries.
+5. Compute, GKE, Cloud Run, functions, schedulers.
+6. Load balancing, certificates, DNS records, monitoring.
+7. Fine-grained IAM bindings and policy attachments.
+
+This is a planning order, not a universal create order. Existing resources
+already run; import waves should minimize provider-read and ownership ambiguity.
+
+## Identify Controllers
+
+Some GCP objects are generated or reconciled by another service. Do not import
+controller-owned children independently unless Pulumi is intended to become
+their controller.
+
+Examples:
+
+- GKE-created forwarding rules and service accounts
+- Serverless-managed revisions
+- Google-managed service agents
+- Certificate-manager generated records
+- Organization policy inherited from ancestors
+
+Classify these as observed/read-only, controller-owned, or explicitly migrated.
+
+## Classify Ownership
+
+| Evidence | Classification |
+|---|---|
+| Present in active Terraform state | Terraform-owned |
+| Present in another Pulumi stack | Pulumi-owned elsewhere |
+| Audit logs show deployment service account | Pipeline-owned; locate source |
+| Console-created with no automation | Manual brownfield import |
+| Google-managed service agent/resource | Provider/controller-owned |
+| No evidence | Unknown; investigate before import |
+
+One cloud object must not be managed by two IaC states. Multiple systems may
+read it, but only one may declare mutation ownership.
+
+## IAM Inventory
+
+IAM is often represented at project, folder, organization, and resource levels.
+Determine whether desired Pulumi resources are authoritative policies, bindings,
+or individual members. Mixing authoritative and additive IAM resource forms can
+remove unrelated principals.
+
+Record:
+
+- policy scope
+- role
+- member/principal
+- condition and expression
+- inherited vs direct binding
+- Google-managed principals
+- current authoritative owner
+
+Treat service account keys as secrets and rotate long-lived keys during or
+after migration rather than importing plaintext key material.
+
+## Classification Gate
+
+Every ledger row must end in exactly one class:
+
+| Class | Meaning |
+|---|---|
+| Import | Pulumi assumes lifecycle ownership now |
+| Terraform adoption | Transfer from trusted tfstate and converted program |
+| Read | Pulumi consumes but does not own |
+| Exclude | Out of migration scope with named owner |
+| Controller-owned | Managed by a platform service |
+| Replace later | Imported first, redesigned in a separate approved phase |
+| Blocked | Missing coverage, ID, permissions, or ownership evidence |
+
+## Source Links
+
+- https://docs.cloud.google.com/asset-inventory/docs
+- https://docs.cloud.google.com/asset-inventory/docs/search-resources
+- https://docs.cloud.google.com/sdk/gcloud/reference/asset/search-all-resources
+- https://docs.cloud.google.com/sdk/gcloud/reference/asset/search-all-iam-policies
+- https://www.pulumi.com/docs/iac/guides/migration/import/

--- a/skills/gcp-to-pulumi/references/gcp-provider-and-import-ids.md
+++ b/skills/gcp-to-pulumi/references/gcp-provider-and-import-ids.md
@@ -1,0 +1,148 @@
+# GCP Providers and Import IDs
+
+Sources: Pulumi Registry Google Cloud Classic and Google Native provider documentation, provider resource pages, Pulumi import documentation, Google Cloud resource-name documentation
+
+Covers: provider-family selection, explicit providers, resource mapping, canonical import IDs, immutable/defaulted properties, API enablement, and IAM ownership forms.
+
+## Provider Families
+
+Pulumi exposes Google Cloud through provider packages including Google Cloud
+Classic (`gcp`) and Google Native (`google-native`). Their resource types,
+schemas, defaults, import identifiers, maturity, and coverage differ.
+
+Choose per resource using evidence:
+
+| Question | Evidence |
+|---|---|
+| Is the exact resource supported? | Current Registry resource page |
+| Is import documented? | Resource page Import section |
+| Does it model required fields/lifecycle? | Inputs, outputs, replacement notes |
+| Is the team already standardized? | Existing Pulumi estate and components |
+| Does migration source map directly? | Terraform bridge usually aligns with `gcp` |
+
+Do not manage one object through both provider families. Switching families is
+not a package rename; it is a resource-type and state migration.
+
+## Explicit Provider Strategy
+
+Create explicit providers for multi-project or multi-region estates. Record the
+target project, region/zone, credentials source, and provider version.
+
+Avoid relying on ambient `gcloud` defaults in CI. A correct import ID against
+the wrong configured project can fail confusingly or read a different object.
+
+Provider ledger:
+
+| Logical provider | Project | Region/zone | Credential | Resources |
+|---|---|---|---|---|
+| `shared` | shared-prod | global | workload identity A | DNS, VPC |
+| `app` | app-prod | europe-west1 | workload identity B | Cloud Run, SQL |
+
+## Canonical Import IDs
+
+Import IDs are resource-specific. Never derive them from intuition alone.
+Open the exact Registry resource page and copy its documented syntax.
+
+Typical shapes include:
+
+| Resource family | Common shape, verify in Registry |
+|---|---|
+| Storage bucket | bucket name |
+| Service account | `projects/{project}/serviceAccounts/{email}` |
+| Compute network | project/name or full resource path |
+| Regional resource | project/region/name or full path |
+| Zonal resource | project/zone/name or full path |
+| Project service | project/service API name |
+| IAM member/binding | Composite scope/role/member identifier |
+
+The table is orientation only. The Registry's Import section is authoritative
+for the selected package version.
+
+## Type Mapping Procedure
+
+For every Cloud Asset Inventory row:
+
+1. Identify the Google API asset type and full resource name.
+2. Search the Pulumi Registry in the chosen provider family.
+3. Confirm the resource manages the same lifecycle, not a data source or child.
+4. Record the Pulumi type token exactly.
+5. Record import syntax and a redacted example.
+6. List immutable and replacement-triggering inputs.
+7. Map live API fields to Pulumi inputs.
+8. Record provider defaults and fields omitted by the inventory export.
+9. Test read/import in an isolated migration stack when uncertainty remains.
+
+## Physical Names
+
+Existing GCP resources already have physical names. Set name fields explicitly
+where the provider schema expects them so Pulumi does not generate an auto-name
+or infer a different name after import.
+
+Keep logical Pulumi names stable and readable; they do not need to equal the
+physical name, but the mapping must remain documented.
+
+## Immutable and Defaulted Fields
+
+GCP APIs frequently make location, network attachment, database engine, or
+resource name immutable. Provider defaults can also differ from historical API
+defaults.
+
+Convergence procedure:
+
+1. Import/read the live object.
+2. Inspect generated code and detailed state safely.
+3. Add live immutable values explicitly.
+4. Add behaviorally important defaults explicitly.
+5. Preview.
+6. Resolve proposed updates one field at a time.
+7. Reject replacement during adoption unless separately approved.
+
+Do not use broad `ignoreChanges` to hide a mismatch. It can conceal security,
+IAM, retention, or network drift.
+
+## API Enablement
+
+Many resources require a Google API. Determine whether API enablement itself is
+managed by Pulumi, a landing-zone stack, or an external platform.
+
+Changing ownership of project services can be dangerous because disabling an
+API may disrupt dependent resources. Import existing service enablement when it
+belongs in scope, protect it during migration, and avoid disabling dependent
+services during retirement of the old tool.
+
+## IAM Resource Forms
+
+Pulumi GCP providers may expose policy, binding, and member resources with
+different authority:
+
+| Form | Typical ownership |
+|---|---|
+| Policy | Authoritative for the full policy |
+| Binding | Authoritative for members of one role |
+| Member | Additive for one principal/role pair |
+
+Confirm semantics on the exact Registry page. Importing a full authoritative
+binding from an incomplete inventory can remove principals on the next update.
+Preserve conditions and inherited policy boundaries.
+
+## High-Risk Resource Checklist
+
+Apply extra review to:
+
+- Cloud SQL and data stores
+- KMS keys and key rings
+- DNS zones and records
+- shared VPC host/service project links
+- organization/folder/project IAM
+- service account keys
+- GKE clusters and node pools
+- load balancers and certificates
+- buckets with retention or lock policies
+
+## Source Links
+
+- https://www.pulumi.com/registry/packages/gcp/
+- https://www.pulumi.com/registry/packages/google-native/
+- https://www.pulumi.com/registry/packages/gcp/api-docs/provider/
+- https://www.pulumi.com/tutorials/importing-gcp-infrastructure/
+- https://www.pulumi.com/docs/iac/guides/migration/import/

--- a/skills/gcp-to-pulumi/references/migration-paths.md
+++ b/skills/gcp-to-pulumi/references/migration-paths.md
@@ -1,0 +1,159 @@
+# Migration Path Selection
+
+Sources: Pulumi documentation on importing existing infrastructure, CLI import, import resource option, program-first import, migration converters, and Terraform migration
+
+Covers: migration-path decisions, direct and bulk import, Terraform-aware adoption, read-only references, unsupported resources, and generated-code review.
+
+## Separate Code Conversion from Ownership Transfer
+
+Code conversion creates a draft Pulumi program. Import associates existing
+provider objects with Pulumi state. A migration may need either or both.
+
+| Existing situation | Code needed | State action |
+|---|---|---|
+| Manual GCP resources | Write/generate Pulumi declarations | Import provider IDs |
+| Terraform code and reliable state | Convert/rewrite declarations | Adopt from tfstate |
+| Terraform code without reliable state | Use conversion as reference | Directly import live IDs |
+| Deployment Manager or scripts | Translate intent manually | Directly import live IDs |
+| Shared resource owned elsewhere | No managed declaration | Read/invoke or stack contract |
+
+Do not run converted code against an empty Pulumi stack and assume Pulumi will
+discover existing resources. It will plan creates unless resources are imported.
+
+## CLI Import
+
+Use for a small number of resources or for learning the provider's generated
+declaration.
+
+```bash
+pulumi import gcp:storage/bucket:Bucket assets BUCKET_NAME \
+  --stack org/project/production \
+  --preview-only
+```
+
+Then run the actual reviewed import and capture generated code with the CLI's
+output option where appropriate. Check the current CLI help for exact flags.
+
+CLI import normally protects imported resources by default. Preserve protection
+for critical resources until the ownership transfer is proven.
+
+## Resource Import Option
+
+Use program-first import when code structure, logical names, parents, explicit
+providers, and components must be designed before adoption.
+
+TypeScript shape:
+
+```typescript
+const bucket = new gcp.storage.Bucket("assets", {
+  name: "existing-assets",
+  location: "EU",
+}, {
+  import: "existing-assets",
+  protect: true,
+});
+```
+
+Match live immutable and defaulted inputs. An import error often means the code
+does not describe the object the provider read, not that the object is absent.
+
+## Program-First Bulk Import
+
+For a graph, write the target program first and ask preview to generate an
+import file for resources it would otherwise create.
+
+```bash
+pulumi preview --import-file import.json
+```
+
+Review the generated entries, add canonical provider IDs, and import with the
+documented CLI flow. This retains parent and provider relationships from the
+program and reduces flat-import reparenting later.
+
+Bulk import checklist:
+
+1. Program uses final logical names and parents.
+2. Explicit providers target correct GCP projects.
+3. Every import ID comes from the Registry and live API evidence.
+4. Parent/dependency resources appear in a safe wave.
+5. Import file is reviewed as migration data.
+6. Generated code is reconciled into the maintained program.
+7. Full preview reaches steady state.
+
+## Terraform-Aware Adoption
+
+When reliable `.tfstate` exists, use Pulumi's Terraform migration commands to
+preserve the mapping between Terraform addresses and provider IDs. Current
+Pulumi guidance supports `pulumi convert --from terraform` for HCL and
+`pulumi import --from terraform` for state adoption.
+
+Treat converter output as a draft:
+
+- run language formatter and type checks
+- resolve unsupported constructs and diagnostics
+- verify provider versions and aliases
+- compare every state address to a Pulumi resource
+- preserve explicit physical names
+- preview without replacements
+
+See `terraform-to-pulumi.md` for the full sequence.
+
+## Read Instead of Import
+
+Use provider lookup functions when this stack needs metadata but another system
+owns lifecycle. Document the owner and contract.
+
+Reads are appropriate for:
+
+- organization-owned shared VPC
+- centrally managed DNS zone
+- pre-existing project owned by a landing-zone platform
+- externally managed secret version
+- service-generated resource
+
+A read does not protect or control the resource. Runtime dependencies still
+need monitoring and an ownership agreement.
+
+## Unsupported Resources
+
+Do not force an unsupported Google API object into a vaguely similar resource
+type. Options, in order:
+
+1. Keep the existing owner and read outputs.
+2. Check the other official Pulumi Google provider family.
+3. Use a reviewed provider package that accurately models lifecycle.
+4. Build a dynamic/provider bridge only with a clear CRUD and import contract.
+5. Defer the resource from migration.
+
+Using command resources or shell scripts to mutate cloud APIs hides diffs and
+usually cannot provide safe import/update/delete semantics.
+
+## Generated Code Review
+
+Generated declarations capture provider-read properties, not architectural
+intent. Normalize only after import is stable.
+
+Review for:
+
+- plaintext secrets
+- computed/output-only fields copied as inputs
+- provider defaults that should stay explicit during migration
+- obsolete fields
+- unstable generated names
+- missing parent or provider options
+- IAM resources with authoritative semantics
+- references represented as raw strings instead of resource outputs
+
+## Path Gate
+
+Before execution, every resource has one chosen path, one intended Pulumi URN,
+one provider ID, and one current/target owner. Mixed or undecided rows remain
+blocked.
+
+## Source Links
+
+- https://www.pulumi.com/docs/iac/guides/migration/import/
+- https://www.pulumi.com/docs/iac/cli/commands/pulumi_import/
+- https://www.pulumi.com/docs/iac/concepts/resources/options/import/
+- https://www.pulumi.com/docs/iac/guides/migration/migrating-to-pulumi/from-terraform/
+- https://www.pulumi.com/docs/iac/cli/commands/pulumi_convert/

--- a/skills/gcp-to-pulumi/references/terraform-to-pulumi.md
+++ b/skills/gcp-to-pulumi/references/terraform-to-pulumi.md
@@ -1,0 +1,161 @@
+# Terraform GCP to Pulumi
+
+Sources: Pulumi migration from Terraform documentation, Pulumi convert and import CLI documentation, Terraform state and provider documentation, Pulumi Google Cloud Classic Registry
+
+Covers: source/state assessment, HCL conversion, tfstate adoption, provider mapping, unsupported constructs, dual-control prevention, validation, and Terraform retirement.
+
+## Two Inputs, Two Jobs
+
+Terraform migrations have two independent sources:
+
+| Source | Tells you | Pulumi operation |
+|---|---|---|
+| `.tf` HCL and modules | Intended configuration and abstractions | `pulumi convert --from terraform` or manual rewrite |
+| `.tfstate` | Real provider IDs and current ownership | `pulumi import --from terraform` where supported |
+
+Neither is sufficient alone. Code can be stale; state can omit intent and
+module design. Compare both to live GCP inventory.
+
+## Readiness Assessment
+
+Capture:
+
+- Terraform and provider versions
+- backend and workspace
+- latest state serial and backup
+- selected workspace/environment
+- module sources and versions
+- provider aliases/projects/regions
+- resources excluded by targets or workspaces
+- import blocks, moved blocks, and state moves
+- pending plan and known drift
+- CI apply identity and schedule
+
+Run a read-only Terraform plan before freeze. Resolve unknown drift or document
+why live infrastructure is authoritative.
+
+## Convert the Program
+
+Use Pulumi's Terraform converter as a translation accelerator:
+
+```bash
+pulumi convert --from terraform --language typescript --out pulumi-infra
+```
+
+Check current CLI help and migration docs for supported flags and languages.
+Conversion may emit diagnostics or placeholders for unsupported expressions,
+providers, modules, provisioners, or lifecycle behavior.
+
+Review output for:
+
+- provider aliases and target projects
+- data sources vs managed resources
+- `for_each` keys and resource identity
+- dynamic blocks and conditional resources
+- lifecycle ignore/prevent/replace behavior
+- explicit dependencies
+- secrets and sensitive variables
+- remote-state references
+- module boundaries
+- local-exec/remote-exec provisioners
+
+Rewrite unsupported behavior explicitly; do not retain shell mutation as an
+opaque compatibility layer.
+
+## Adopt Terraform State
+
+Pulumi documents Terraform-aware state adoption with:
+
+```bash
+pulumi import --from terraform /path/to/terraform.tfstate
+```
+
+Use the current official syntax and preview options. Adopt into the final Pulumi
+stack after the converted/maintained program has been reviewed.
+
+State adoption checklist:
+
+1. Freeze Terraform applies.
+2. Pull and back up the exact current state.
+3. Verify state lineage/workspace and GCP identity.
+4. Map every Terraform address to a Pulumi declaration.
+5. Identify provider aliases and module nesting.
+6. Run import preview.
+7. Import in small waves if the estate is large.
+8. Reconcile generated/provider-read inputs.
+9. Run full Pulumi refresh preview and detailed preview.
+10. Require no replacement or delete.
+
+## Address Mapping
+
+Maintain a ledger:
+
+| Terraform address | Provider ID | Pulumi type | Logical name/parent | Status |
+|---|---|---|---|---|
+| `module.net.google_compute_network.main` | project/network | `gcp:compute/network:Network` | network/main | imported |
+
+Account for:
+
+- `count` indexes
+- `for_each` string keys
+- module addresses
+- provider aliases
+- resources moved in state
+- tainted or deposed instances
+- resources present in GCP but absent from state
+
+If state is unreliable, use live GCP direct import for affected resources
+instead of trusting a stale provider ID mapping.
+
+## Terraform/Pulumi Semantic Differences
+
+| Terraform concept | Pulumi direction |
+|---|---|
+| Variables/locals | Stack config and ordinary language values |
+| Resource references | Inputs/Outputs dataflow |
+| Modules | Components or language packages |
+| Data sources | Provider invoke/get functions |
+| `depends_on` | Output edge or `dependsOn` |
+| `prevent_destroy` | `protect` |
+| `ignore_changes` | `ignoreChanges`, only with named external owner |
+| Moved block | Resource aliases/state migration |
+| Workspaces | Pulumi stacks, with boundary review |
+| Remote state output | Stack reference or external contract |
+
+Translate intent, not syntax. Preserve behavior through adoption; improve the
+abstraction after steady state.
+
+## Retire Terraform Safely
+
+Do not prove migration by running `terraform destroy` or removing resources
+from configuration and applying a delete plan.
+
+Retirement sequence:
+
+1. Disable scheduled and merge-triggered Terraform applies.
+2. Preserve code, lockfile, state, plan, and provider versions.
+3. Transfer each resource to Pulumi and verify no-change state.
+4. Remove old mutation credentials or scopes.
+5. Mark the Terraform workspace archived/read-only.
+6. Monitor GCP audit logs for unexpected old writers.
+7. Retain rollback artifacts for the agreed window.
+
+If Terraform must continue managing out-of-scope resources, surgically separate
+ownership and verify its next plan does not change Pulumi-owned objects.
+
+## Acceptance Gate
+
+- Converted code compiles and passes language checks.
+- Every tfstate resource is mapped, excluded with owner, or blocked.
+- Every Pulumi resource has the expected GCP provider ID.
+- Pulumi preview has no unexplained operation.
+- Terraform's next read-only plan cannot mutate migrated resources.
+- CI ownership is singular.
+- Runtime health and IAM parity are verified.
+
+## Source Links
+
+- https://www.pulumi.com/docs/iac/guides/migration/migrating-to-pulumi/from-terraform/
+- https://www.pulumi.com/docs/iac/cli/commands/pulumi_convert/
+- https://www.pulumi.com/docs/iac/cli/commands/pulumi_import/
+- https://www.pulumi.com/registry/packages/gcp/

--- a/skills/gcp-to-pulumi/tank.json
+++ b/skills/gcp-to-pulumi/tank.json
@@ -1,0 +1,19 @@
+{
+  "name": "@tank/gcp-to-pulumi",
+  "version": "1.0.0",
+  "description": "Safely adopt existing Google Cloud infrastructure into Pulumi without recreating live resources. Inventories GCP estates, selects Pulumi GCP providers and import IDs, distinguishes direct import from Terraform conversion/state adoption, stages dependency-aware imports, and proves zero-replacement steady state. Triggers: migrate GCP to Pulumi, import Google Cloud resources, adopt GCP infrastructure, convert Terraform GCP to Pulumi, Pulumi import GCP, GCP IaC migration.",
+  "skills": {
+    "@tank/pulumi": "^1.0.0"
+  },
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": ["**/*"],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}

--- a/skills/gcp-to-terraform/SKILL.md
+++ b/skills/gcp-to-terraform/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: @tank/gcp-to-terraform
+description: |
+  Adopt existing Google Cloud infrastructure into Terraform management without
+  recreating live resources. Covers Cloud Asset Inventory and ownership
+  discovery, Google provider types and full import IDs, declarative imports and
+  generated configuration, Google's pre-GA bulk export, IAM authority, remote
+  state, no-change convergence, writer cutover, rollback, and later refactoring.
+  Depends on @tank/terraform and synthesizes current HashiCorp and Google docs.
+
+  Trigger phrases: "migrate GCP to Terraform", "convert GCP to Terraform",
+  "import Google Cloud resources", "existing GCP Terraform", "Terraform import GCP",
+  "GCP to HCL", "adopt Google Cloud infrastructure", "brownfield GCP Terraform",
+  "Cloud Asset Inventory Terraform", "bulk export GCP Terraform",
+  "generate-config-out GCP", "Google provider import ID", "GCP IAM Terraform import",
+  "move Google Cloud to Terraform", "no downtime GCP Terraform migration"
+---
+
+# GCP to Terraform
+
+Load `@tank/terraform` for HCL, providers, modules, state, import, testing, and
+delivery fundamentals. This skill adds the brownfield Google Cloud workflow.
+
+## Core Philosophy
+
+1. **Transfer ownership before redesign** -- first represent live behavior and
+   obtain a no-change plan; modernize only in later reviewed changes.
+2. **One object has one state address and writer** -- freeze scripts, consoles,
+   Config Connector, Deployment Manager, or other IaC before Terraform cutover.
+3. **Inventory is multi-source** -- combine Cloud Asset Inventory, IAM search,
+   service APIs, audit logs, CI definitions, and existing state.
+4. **Provider documentation defines identity** -- use the exact Google provider
+   resource and full import ID format; do not infer IDs from names.
+5. **No destructive plan is the adoption gate** -- stop on unexplained create,
+   update, replacement, or destroy for an ownership-only migration.
+
+## Migration Workflow
+
+1. Define scope, owners, target root/state, freeze, rollback, and success checks.
+2. Inventory resources, IAM, APIs, dependencies, locations, and current writers.
+3. Classify each object as import, data-source read, controller-owned, excluded,
+   unsupported, or later replacement.
+4. Select `hashicorp/google` or `hashicorp/google-beta`, resource type, provider
+   alias, final address, and Registry-documented import ID.
+5. Write reviewed resource and declarative import blocks; use generated config
+   only as a draft.
+6. Initialize a protected remote backend and lock reviewed provider versions.
+7. Freeze the previous writer, back up state/configuration, and import in waves.
+8. Reconcile generated/defaulted fields without changing live behavior.
+9. Require a full no-change plan plus IAM and service health parity.
+10. Transfer CI ownership and retire the prior writer without destroy.
+11. Refactor later with `moved` blocks and ordinary production gates.
+
+## Quick-Start: Common Problems
+
+### "What should be migrated?"
+
+Build an organization/folder/project asset and IAM ledger, then enrich it with
+service-specific details, state, pipelines, and audit-log writer evidence.
+
+-> See `references/discovery-and-classification.md`.
+
+### "Which import workflow should I use?"
+
+Prefer reviewed declarative import blocks. Use generated resource configuration
+when code is missing, CLI import for small legacy cases, and bulk export only
+after accepting its pre-GA and coverage limitations.
+
+-> See `references/import-workflows.md`.
+
+### "What type and ID does this GCP resource use?"
+
+Use the exact Google provider Registry page, prefer a full project-qualified ID
+when supported, and model IAM policy/binding/member authority deliberately.
+
+-> See `references/google-provider-and-iam.md`.
+
+### "How do I prevent downtime or replacement?"
+
+Import into final addresses, preserve immutable/defaulted values, protect
+stateful resources, and stop until the full plan is non-destructive.
+
+-> See `references/convergence-and-cutover.md`.
+
+### "Can Google generate all the Terraform?"
+
+Google's Config Connector-based bulk export is useful discovery/code-generation
+but is pre-GA, platform-limited, and does not support every provider resource.
+Review generated modules/import scripts instead of running them blindly.
+
+-> See `references/bulk-export-and-modernization.md`.
+
+## Decision Trees
+
+### Classify the Resource
+
+| Current condition | Target |
+|---|---|
+| Manually/script-created and supported | Declarative import |
+| Existing Terraform state | Keep or deliberately migrate that state; do not re-import elsewhere |
+| Shared resource owned by platform root | Data source or remote-state contract |
+| Service/controller-generated child | Observe; keep controller ownership |
+| Unsupported provider resource | Exclude or use reviewed alternative; do not fake CRUD |
+
+### Choose Scale
+
+| Scope | Default |
+|---|---|
+| One resource | One import and resource block |
+| Small graph | Multiple reviewed import blocks |
+| Unknown configuration | Import blocks plus `-generate-config-out` |
+| Large supported estate | Inventory-driven waves; optionally compare Google bulk export |
+
+## Stop Conditions
+
+Stop if the current writer is unknown, backend/state ownership is undecided, an
+ID is guessed, provider alias targets are implicit, IAM authority is unclear,
+backup/rollback is missing, or plan proposes unexplained mutation. Never validate
+the migration by applying a destructive production plan.
+
+## Reference Index
+
+| File | Contents |
+|---|---|
+| `references/discovery-and-classification.md` | Asset/IAM inventory, dependencies, controllers, ownership, and migration ledger |
+| `references/import-workflows.md` | Declarative, generated-config, CLI, bulk-query, and module imports |
+| `references/google-provider-and-iam.md` | Google/google-beta choice, aliases, import IDs, API enablement, defaults, and IAM authority |
+| `references/convergence-and-cutover.md` | Remote state, import waves, no-change plan, freeze, rollback, and handoff |
+| `references/bulk-export-and-modernization.md` | Google pre-GA bulk export, generated artifacts, limitations, review, and post-adoption refactoring |

--- a/skills/gcp-to-terraform/references/bulk-export-and-modernization.md
+++ b/skills/gcp-to-terraform/references/bulk-export-and-modernization.md
@@ -1,0 +1,104 @@
+# Google Bulk Export and Modernization
+
+Sources: Google Cloud export/import Terraform documentation, Config Connector CLI references, Cloud Asset Inventory, HashiCorp generated configuration and module guidance
+
+Covers: Google bulk export prerequisites, artifacts, limitations, safe review, comparison with native imports, and post-adoption modernization.
+
+## Status and Purpose
+
+Google's `gcloud beta resource-config bulk-export` path generates Terraform HCL
+from project, folder, or organization resources. Google marks it pre-GA and not
+supported on Windows. Coverage is narrower than the full Google provider.
+
+Use it as discovery and draft generation, not unquestioned source of truth.
+
+## Capability Check
+
+```bash
+gcloud beta resource-config list-resource-types
+```
+
+Compare supported export types with the migration ledger. Unsupported rows still
+need declarative imports or explicit exclusion.
+
+## Export Shape
+
+```bash
+gcloud beta resource-config bulk-export \
+  --path=OUTPUT_DIRECTORY \
+  --project=PROJECT_ID \
+  --resource-format=terraform
+```
+
+The workflow uses Config Connector and Cloud Asset API prerequisites. Review the
+current Google documentation for service-agent permissions before running at
+folder/organization scope; avoid granting broad roles permanently.
+
+## Generated Imports
+
+Google documents:
+
+```bash
+gcloud beta resource-config terraform generate-import OUTPUT_DIRECTORY
+```
+
+This generates module files and an executable import script. Do not execute the
+script before reviewing every address, provider ID, target backend/workspace,
+module source, and ownership classification.
+
+## Review Matrix
+
+| Artifact | Review |
+|---|---|
+| Generated `.tf` | Defaults, computed fields, secrets, names, references |
+| Module tree | Address stability and maintainability |
+| Provider block | Correct project/region and credential source |
+| Import script | Full IDs, shell quoting, exact target state |
+| Coverage list | Missing/unsupported resources |
+| IAM output | Authority and inherited bindings |
+
+Generated modules are often organized by API resource type, not team ownership
+or lifecycle. Preserve addresses through adoption, then redesign with moved
+blocks after a stable baseline.
+
+## Compare Paths
+
+| Need | Better default |
+|---|---|
+| One/small batch | Terraform import blocks |
+| Unknown resource arguments | `-generate-config-out` |
+| Large GCP discovery draft | Google bulk export |
+| Stable maintained architecture | Hand-reviewed modules after adoption |
+
+## Safe Execution
+
+1. Run export with read-oriented, time-bounded permissions.
+2. Store output as sensitive migration material.
+3. Diff against CAI ledger and service inventories.
+4. Review generated HCL and scripts.
+5. Replace broad generated provider configuration with explicit aliases.
+6. Import bounded waves into a locked remote state.
+7. Require no-change plan and health checks.
+8. Remove temporary export privileges.
+
+## Modernization Backlog
+
+Defer these until ownership is stable:
+
+- module boundaries by team/lifecycle
+- root/state decomposition
+- `for_each` stable-key conversion
+- raw-ID replacement with references
+- policy and labels normalization
+- provider version/alias cleanup
+- resource replacement or architecture redesign
+
+Every address change needs a `moved` block or reviewed state migration.
+
+## Source Links
+
+- https://docs.cloud.google.com/docs/terraform/resource-management/export
+- https://docs.cloud.google.com/docs/terraform/resource-management/import
+- https://docs.cloud.google.com/sdk/gcloud/reference/beta/resource-config/bulk-export
+- https://docs.cloud.google.com/sdk/gcloud/reference/beta/resource-config/terraform/generate-import
+- https://developer.hashicorp.com/terraform/language/import/generating-configuration

--- a/skills/gcp-to-terraform/references/convergence-and-cutover.md
+++ b/skills/gcp-to-terraform/references/convergence-and-cutover.md
@@ -1,0 +1,109 @@
+# Convergence and Cutover
+
+Sources: HashiCorp state, import, plan, moved/removed blocks, and backend documentation; Google Cloud Terraform operations, state-storage, and reliability guidance
+
+Covers: backend preflight, import waves, plan triage, writer freeze, verification, rollback, retirement, and post-adoption changes.
+
+## Preflight
+
+Require:
+
+- approved ledger and wave
+- final root/module addresses
+- remote locked backend
+- state/config backups
+- locked provider versions
+- exact provider aliases and identity
+- full import IDs
+- previous-writer freeze
+- rollback owner
+- service/IAM health checks
+
+Import changes state even when the GCP object is unchanged.
+
+## State Bootstrap
+
+Create/protect the state backend separately. For GCS state, enable versioning,
+restrict access, and prevent accidental bucket deletion. Avoid storing state in
+the same unproven root being migrated.
+
+## Waves
+
+| Wave | Content | Gate |
+|---|---|---|
+| 0 | Backend, providers, variables, data reads | Correct targets |
+| 1 | APIs, network, DNS, KMS | No destructive plan |
+| 2 | Identity and IAM foundations | Principal/condition parity |
+| 3 | Stateful storage/data | Backup and lifecycle parity |
+| 4 | Compute and managed services | Runtime health |
+| 5 | Edge, monitoring, fine IAM | End-to-end health |
+
+Keep waves small enough to diagnose and reverse ownership.
+
+## Per-Wave Procedure
+
+1. Freeze old mutation paths.
+2. Capture fresh inventory and state backup.
+3. Run init/validate and import plan.
+4. Apply reviewed import operations.
+5. Reconcile configuration without modernization.
+6. Run full plan.
+7. Stop on unexplained mutation.
+8. Verify service, network, data, and IAM health.
+9. Record ownership and proceed.
+
+## Plan Triage
+
+| Plan | Response |
+|---|---|
+| Create | Missing/wrong import, state, address, or collection key; stop |
+| Replace | Immutable/type/provider/address mismatch; stop |
+| Destroy | Omitted config or wrong ownership; stop |
+| Update | Review default/live/desired difference field by field |
+| No changes | Candidate adoption baseline; verify health and old writer |
+
+## Dual Control
+
+Disable scripts, console runbooks, Config Connector reconciliation, Deployment
+Manager, or alternate IaC for migrated objects. Revoke old mutation credentials
+and monitor audit logs.
+
+If another Terraform state currently owns the object, migrate that state or use
+reviewed moved/state operations; do not import a duplicate binding.
+
+## Rollback
+
+Rollback restores ownership, not infrastructure:
+
+1. Stop Terraform writers.
+2. Preserve current state and evidence.
+3. Restore old owner/state mapping from backup.
+4. Require its no-change plan before re-enabling.
+5. Remove new ownership with a reviewed `removed`/state process that does not
+   destroy the GCP object.
+
+Never improvise rollback with `terraform destroy`.
+
+## Acceptance
+
+- Every in-scope object has one owner/address.
+- Full plan is no-change or only explicitly approved normalization.
+- No replacement/destroy.
+- IAM and runtime checks pass.
+- CI uses short-lived intended identity.
+- Old writer is disabled and monitored.
+- State recovery and rollback evidence are retained.
+
+## Modernize Later
+
+After a stable period, use separate changes for module extraction, address moves,
+references replacing raw IDs, provider normalization, or infrastructure redesign.
+Use `moved` blocks and full plan review.
+
+## Source Links
+
+- https://developer.hashicorp.com/terraform/language/state
+- https://developer.hashicorp.com/terraform/language/import
+- https://developer.hashicorp.com/terraform/language/block/moved
+- https://developer.hashicorp.com/terraform/language/block/removed
+- https://docs.cloud.google.com/docs/terraform/resource-management/store-state

--- a/skills/gcp-to-terraform/references/discovery-and-classification.md
+++ b/skills/gcp-to-terraform/references/discovery-and-classification.md
@@ -1,0 +1,119 @@
+# GCP Discovery and Classification
+
+Sources: Google Cloud Asset Inventory, IAM, audit logging, Terraform on Google Cloud import/export, and HashiCorp import/state documentation
+
+Covers: scope, resource and IAM discovery, ownership evidence, dependency mapping, controller-owned resources, and migration classification.
+
+## Scope Brief
+
+Record organization, folders, projects, regions/zones, environments, billing,
+owners, current writers, target Terraform root/state, outage tolerance, freeze,
+rollback, exclusions, and acceptance tests.
+
+Inventory at the highest authorized scope. Project-only discovery misses shared
+VPC, organization/folder IAM, DNS, policy, and cross-project dependencies.
+
+## Discovery Sources
+
+```bash
+gcloud asset search-all-resources \
+  --scope="organizations/ORG_ID" \
+  --format=json
+
+gcloud asset search-all-iam-policies \
+  --scope="organizations/ORG_ID" \
+  --format=json
+```
+
+Supplement broad inventory:
+
+| Source | Evidence |
+|---|---|
+| Asset resource search | Names, types, ancestry, location |
+| IAM search | Principals, roles, conditions, scopes |
+| Service-specific APIs | Child fields and resources absent from CAI |
+| Audit logs | Recent mutation identities and tools |
+| Existing Terraform/other state | Current lifecycle owner and provider IDs |
+| CI/CD and scripts | Scheduled/merge-triggered writers |
+| Billing/export data | Active costly assets missed by filters |
+
+Treat exports as sensitive architecture data.
+
+## Resource Ledger
+
+| Field | Meaning |
+|---|---|
+| Asset full name/type | GCP identity |
+| Project/location | Provider alias target |
+| Current owner | State/tool/pipeline/person |
+| Terraform type/address | Final binding |
+| Import ID | Registry-documented full form |
+| Dependencies | APIs, network, service account, KMS, parent |
+| Immutable/defaulted fields | Replacement/update risk |
+| IAM semantics | Policy, binding, member, inherited |
+| Classification | Import, read, controller, exclude, blocked |
+| Wave/evidence | Execution order and source timestamp |
+
+Unknown fields remain blocked; do not guess.
+
+## Controllers
+
+Do not independently import children reconciled by GKE, serverless revisions,
+managed load balancing, service agents, or another platform controller unless
+Terraform will become that controller.
+
+## Current Ownership
+
+| Evidence | Classification |
+|---|---|
+| Object in active Terraform state | Already Terraform-owned |
+| Audit log deployment service account | Locate pipeline/source before transfer |
+| Config Connector owner references | Controller-owned |
+| Console creation and no automation | Manual brownfield candidate |
+| Google-managed service agent | Service-owned |
+| No reliable evidence | Blocked |
+
+The same object must not be imported into multiple Terraform states.
+
+## Dependencies and Waves
+
+Typical planning order:
+
+1. Project/provider context and APIs.
+2. Shared VPC, subnetworks, routes, NAT, DNS.
+3. Service accounts, KMS, workload identity, base IAM.
+4. Buckets, databases, artifact repositories, data services.
+5. GKE, compute, Cloud Run, functions, schedulers.
+6. Load balancing, certificates, monitoring, fine IAM.
+
+Existing objects already run, so order imports for ownership clarity and provider
+reads rather than pretending to recreate them.
+
+## IAM Inventory
+
+Record scope, role, principal, condition, inherited/direct status, Google-managed
+principals, and current authority. Incomplete IAM discovery can make an
+authoritative binding remove unrelated members after import.
+
+Do not import service account private key material into source or state. Rotate
+long-lived keys toward workload identity.
+
+## Classification Gate
+
+Every row ends in exactly one state:
+
+- import into this root
+- read through data source
+- already managed in named state
+- controller-owned
+- excluded with named owner
+- unsupported/blocker
+- import now, replace later in separate project
+
+## Source Links
+
+- https://docs.cloud.google.com/asset-inventory/docs
+- https://docs.cloud.google.com/asset-inventory/docs/search-resources
+- https://docs.cloud.google.com/sdk/gcloud/reference/asset/search-all-resources
+- https://docs.cloud.google.com/sdk/gcloud/reference/asset/search-all-iam-policies
+- https://docs.cloud.google.com/docs/terraform/resource-management/import

--- a/skills/gcp-to-terraform/references/google-provider-and-iam.md
+++ b/skills/gcp-to-terraform/references/google-provider-and-iam.md
@@ -1,0 +1,103 @@
+# Google Providers, Import IDs, and IAM
+
+Sources: HashiCorp Google and Google Beta provider Registry documentation, Google Cloud Terraform best practices, IAM documentation, and Google import guidance
+
+Covers: provider choice, aliases, full IDs, immutable/defaulted fields, API enablement, IAM authority, and high-risk resources.
+
+## Provider Choice
+
+Use `hashicorp/google` by default for generally available resources. Use
+`hashicorp/google-beta` only for a required beta field/resource and pin/review
+its version. They share many resource type prefixes, so aliases and explicit
+provider selection must be clear.
+
+Do not import one object through both providers.
+
+## Explicit Targets
+
+```hcl
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+```
+
+Use aliases for multiple projects/regions. Authentication should come from
+Application Default Credentials or workload identity, not committed keys.
+
+Record provider alias, project, region/zone, credential identity, and resources
+for every migration wave.
+
+## Import IDs
+
+The Registry Import section for the exact resource and provider version is
+authoritative. Google recommends full identifiers including project ID when
+supported.
+
+Typical orientation only:
+
+| Resource | Common full shape, verify |
+|---|---|
+| Bucket | `project/name` |
+| VPC network | `projects/PROJECT/global/networks/NAME` |
+| Regional object | `projects/PROJECT/regions/REGION/.../NAME` |
+| Zonal object | `projects/PROJECT/zones/ZONE/.../NAME` |
+| Service account | `projects/PROJECT/serviceAccounts/EMAIL` |
+| API service | `PROJECT/SERVICE` |
+
+Never rely on this summary instead of provider docs.
+
+## Type Mapping
+
+1. Start from CAI asset type/full name.
+2. Find the exact Registry resource.
+3. Verify it owns the same lifecycle.
+4. Record import syntax and full ID.
+5. Record immutable/replacement fields.
+6. Map live API fields to Terraform arguments.
+7. Identify computed/defaulted fields.
+8. Select final provider alias and address.
+
+## Defaults and Immutability
+
+Generated/provider-read configuration can differ from historical defaults.
+Reconcile one field at a time and reject replacement during adoption. Do not use
+broad `ignore_changes` to hide security, retention, IAM, or network differences.
+
+## API Enablement
+
+Determine whether `google_project_service` ownership belongs in this root or a
+landing-zone state. Disabling an API can disrupt dependent resources. Import and
+protect in-scope service enablement; do not let retirement of the old tool
+disable active APIs.
+
+## IAM Forms
+
+| Terraform form | Typical authority |
+|---|---|
+| `*_iam_policy` | Entire policy authoritative |
+| `*_iam_binding` | Members for one role authoritative |
+| `*_iam_member` | One additive principal-role relation |
+
+Confirm exact resource documentation. Do not mix authoritative and additive
+forms over the same scope/role without understanding provider conflict behavior.
+Preserve IAM conditions and inherited policy boundaries.
+
+## High-Risk Review
+
+- organization/folder/project IAM
+- KMS keys and key rings
+- Cloud SQL and data stores
+- bucket retention/locks
+- shared VPC relationships
+- DNS and certificates
+- GKE clusters/node pools
+- load balancers
+- service account keys and service agents
+
+## Source Links
+
+- https://registry.terraform.io/providers/hashicorp/google/latest/docs
+- https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs
+- https://docs.cloud.google.com/docs/terraform/best-practices/working-with-resources
+- https://docs.cloud.google.com/docs/terraform/resource-management/import

--- a/skills/gcp-to-terraform/references/import-workflows.md
+++ b/skills/gcp-to-terraform/references/import-workflows.md
@@ -1,0 +1,109 @@
+# GCP Import Workflows
+
+Sources: HashiCorp declarative and CLI import documentation, generated configuration and bulk import documentation, Google Cloud Terraform import guidance
+
+Covers: import blocks, generated configuration, CLI import, modules, collection instances, bulk discovery, review, and convergence.
+
+## Preferred Declarative Flow
+
+Declare the final resource address and provider-defined ID:
+
+```hcl
+import {
+  to = google_compute_network.main
+  id = "projects/my-project/global/networks/main"
+}
+
+resource "google_compute_network" "main" {
+  project                 = "my-project"
+  name                    = "main"
+  auto_create_subnetworks = false
+}
+```
+
+Run plan, review the import and all subsequent diffs, then apply the reviewed
+plan. Import blocks allow normal code review and can handle batches.
+
+## Generate Missing Configuration
+
+If resource arguments are unknown, write the import block and run:
+
+```bash
+terraform plan -generate-config-out=generated_resources.tf
+```
+
+Generated code is a draft. Remove computed-only fields, preserve immutable and
+behaviorally important defaults, replace plaintext/sensitive values, and fit the
+resource into the final module structure before acceptance.
+
+## CLI Import
+
+Google documents one-at-a-time import as:
+
+```bash
+terraform import google_storage_bucket.assets my-project/assets-bucket
+```
+
+Prefer the provider's full project-qualified ID when supported. CLI import only
+writes state; the destination resource configuration must already exist.
+
+## Module Addresses
+
+Import every concrete child address, for example:
+
+```bash
+terraform import \
+  module.storage.google_storage_bucket.assets \
+  my-project/assets-bucket
+```
+
+Inspect the pinned module source to determine its internal address. Avoid
+importing into a module version whose future upgrade immediately moves/replaces
+the resource.
+
+## Collections
+
+For `for_each` and `count`, target the exact instance address. Use durable keys
+and quote shell addresses correctly. Declarative imports are easier to review
+and less error-prone for collection instances.
+
+## Bulk Options
+
+| Option | Use | Caveat |
+|---|---|---|
+| Multiple import blocks | Reviewed bounded batches | Manual ledger work |
+| Terraform query/bulk import | Provider-supported large discovery | Version/provider support varies |
+| Google bulk export/generate-import | Draft code and script | Pre-GA and incomplete coverage |
+| Generated internal manifest | Deterministic estate-specific waves | Must verify every ID/type |
+
+Do not execute generated import scripts before reviewing addresses, IDs,
+provider aliases, ownership, and state target.
+
+## Steady-State Gate
+
+After import:
+
+1. `terraform state show` confirms ID/address.
+2. Configuration matches immutable/live behavior.
+3. Full plan uses the intended backend and provider aliases.
+4. No unexplained create/update/replace/destroy remains.
+5. Service and IAM health checks pass.
+6. The prior writer is disabled.
+
+## Troubleshooting
+
+| Symptom | Investigate |
+|---|---|
+| Not found | Full ID format, project, alias, permissions |
+| Create remains | Wrong state/address or import not applied |
+| Replacement | Immutable/default/type mismatch |
+| IAM update | Wrong policy/binding/member authority |
+| Module address error | Pinned module's actual child path |
+| Duplicate binding | Existing state ownership |
+
+## Source Links
+
+- https://developer.hashicorp.com/terraform/language/import
+- https://developer.hashicorp.com/terraform/language/import/generating-configuration
+- https://developer.hashicorp.com/terraform/cli/import
+- https://docs.cloud.google.com/docs/terraform/resource-management/import

--- a/skills/gcp-to-terraform/tank.json
+++ b/skills/gcp-to-terraform/tank.json
@@ -1,0 +1,14 @@
+{
+  "name": "@tank/gcp-to-terraform",
+  "version": "1.0.0",
+  "description": "Safely adopt existing Google Cloud infrastructure into Terraform without recreating live resources. Covers Cloud Asset Inventory, Google provider mappings and import IDs, declarative import blocks, generated configuration, pre-GA bulk export, IAM authority, remote state, convergence, and writer cutover. Triggers: migrate GCP to Terraform, import Google Cloud resources, existing GCP Terraform, bulk export GCP Terraform, Terraform import GCP, brownfield Google Cloud IaC.",
+  "skills": {
+    "@tank/terraform": "^1.0.0"
+  },
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}

--- a/skills/pulumi/SKILL.md
+++ b/skills/pulumi/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: @tank/pulumi
+description: |
+  Build, review, operate, and troubleshoot production Pulumi infrastructure as
+  code in TypeScript, Python, Go, .NET, Java, or YAML. Covers projects and
+  stacks, configuration and secrets, Inputs and Outputs, components, providers,
+  state and backends, imports, safe refactoring, testing, policy, CI/CD, drift,
+  and Automation API. Synthesizes current official Pulumi documentation.
+
+  Trigger phrases: "pulumi", "pulumi up", "pulumi preview", "Pulumi.yaml",
+  "Pulumi stack", "pulumi config", "Pulumi secrets", "Input Output apply",
+  "Pulumi component", "Pulumi provider", "Pulumi state", "pulumi import",
+  "Pulumi drift", "Pulumi Automation API", "CrossGuard", "Pulumi CI/CD",
+  "infrastructure as code with TypeScript", "infrastructure as code with Python"
+---
+
+# Pulumi
+
+## Core Philosophy
+
+1. **Preview is a review artifact** -- inspect creates, updates, replacements,
+   and deletes before every update; a syntactically valid program can still
+   propose destructive infrastructure changes.
+2. **Resource identity is durable** -- URNs combine stack, project, type,
+   parent, and logical name. Preserve identity with aliases when reorganizing
+   code so refactors do not become replacements.
+3. **Outputs are deferred values** -- pass `Output` values directly as inputs
+   and transform them with the language SDK. Do not block, stringify, or read
+   them as ordinary values during program evaluation.
+4. **State is sensitive coordination data** -- use a durable backend, protect
+   secrets, avoid manual edits, and use supported stack/state commands only
+   with an export available for recovery.
+5. **Blast radius defines boundaries** -- split projects and stacks by
+   ownership, lifecycle, permissions, and failure domain rather than creating
+   one stack per resource or one stack for an entire organization.
+
+## Default Workflow
+
+1. Inspect `Pulumi.yaml`, stack settings, language dependencies, backend, and
+   selected stack before changing code.
+2. Confirm cloud identity, provider configuration, target account/project,
+   region, and stack configuration without printing secret values.
+3. Make the smallest typed program change that preserves resource identity.
+4. Run language checks and tests, then `pulumi preview --diff` for the exact
+   target stack.
+5. Treat every replacement or delete as a blocker until its cause and blast
+   radius are understood.
+6. Apply through the repository's approval path; verify outputs and provider
+   health after deployment.
+
+## Quick-Start: Common Problems
+
+### "How should I organize this Pulumi estate?"
+
+Choose boundaries from ownership and lifecycle first, then map environments to
+stacks. Connect stacks with explicit outputs or references rather than hidden
+global lookups.
+
+-> See `references/projects-stacks-config.md`.
+
+### "Why can I not use this resource property like a normal string?"
+
+It is probably an `Output`. Pass it directly to another resource input, use
+`apply` only for a derived value, and export only values consumers need.
+
+-> See `references/programming-model.md`.
+
+### "Why does this refactor want to replace infrastructure?"
+
+Compare old and new URNs. A changed logical name, parent, type, project, or
+stack changes identity. Add the appropriate alias before moving code.
+
+-> See `references/resources-components-providers.md`.
+
+### "The cloud and Pulumi disagree"
+
+Run `pulumi refresh --preview-only` to observe drift without changing state.
+Decide whether code or live infrastructure is authoritative before refreshing
+state or reconciling with an update.
+
+-> See `references/state-and-operations.md`.
+
+### "How do I ship Pulumi safely?"
+
+Run static checks and tests, publish the preview for review, authenticate with
+short-lived credentials, serialize updates per stack, and apply only from a
+trusted branch with an approval gate for production.
+
+-> See `references/testing-policy-delivery.md`.
+
+## Decision Trees
+
+### Choose a Language
+
+| Signal | Default |
+|---|---|
+| Existing application team owns infrastructure | Use its primary supported language |
+| TypeScript-heavy platform team | TypeScript for mature package ergonomics |
+| Python-heavy data or backend team | Python with strict type checking |
+| Go platform tooling | Go for explicit control flow and compiled tooling |
+| .NET or Java organization | Use the native ecosystem language |
+| Small declarative composition with little logic | YAML |
+
+### Choose a State Backend
+
+| Need | Direction |
+|---|---|
+| Managed locking, history, RBAC, deployments, drift, policy | Pulumi Cloud |
+| Existing object-storage control requirement | DIY backend with encryption, versioning, and access controls |
+| Disposable local experiment only | Local backend; migrate before collaboration |
+
+### Choose a Resource Abstraction
+
+| Reuse scope | Construct |
+|---|---|
+| One stack, one resource | Custom resource |
+| Repeated architecture inside programs | `ComponentResource` |
+| Versioned multi-language reusable package | Pulumi Package / provider package |
+| Orchestrating Pulumi from an application | Automation API |
+
+## Safety Gates
+
+Pause before applying when a preview contains an unexplained replacement,
+delete, provider change, parent change, secret plaintext, or a target stack that
+does not match the intended environment. Do not use `--yes`, targeted updates,
+state deletion, or manual checkpoint editing to bypass uncertainty.
+
+## Reference Index
+
+| File | Contents |
+|---|---|
+| `references/projects-stacks-config.md` | Project and stack boundaries, config, secrets, environments, and references |
+| `references/programming-model.md` | Inputs, Outputs, dependencies, language choices, and asynchronous value handling |
+| `references/resources-components-providers.md` | Resource identity, options, components, providers, imports, and safe refactoring |
+| `references/state-and-operations.md` | Backends, previews, updates, refresh, drift, recovery, and state safety |
+| `references/testing-policy-delivery.md` | Tests, policy packs, CI/CD, Automation API, and production controls |

--- a/skills/pulumi/references/programming-model.md
+++ b/skills/pulumi/references/programming-model.md
@@ -1,0 +1,180 @@
+# Pulumi Programming Model
+
+Sources: Pulumi documentation on Inputs and Outputs, resource dependencies, functions, language runtimes, and programming model; official language SDK references
+
+Covers: program evaluation, `Input` and `Output`, dependency inference, transformations, invoke functions, language selection, and common asynchronous-value failures.
+
+## Two-Phase Reasoning
+
+A Pulumi program runs as ordinary language code while registering a desired
+resource graph with the deployment engine. Providers then create, read, update,
+or delete resources according to the engine's plan.
+
+Distinguish:
+
+| Time | What is available |
+|---|---|
+| Program evaluation | Config, ordinary values, resource declarations |
+| Deployment | Provider-computed IDs, endpoints, status, and outputs |
+
+Values computed by providers cannot be treated as synchronous values during
+program evaluation. Pulumi represents them as `Output<T>`.
+
+## Input and Output Contract
+
+An input accepts either a known value or an output that will resolve later.
+An output carries a future value plus dependency and secret metadata.
+
+Default rules:
+
+1. Pass an output directly when a resource input accepts it.
+2. Use interpolation helpers for string composition.
+3. Use `apply` only when computation cannot be expressed directly.
+4. Keep resource construction outside `apply` unless the resource truly exists
+   only conditionally on a resolved value.
+5. Never block waiting for an output.
+
+TypeScript example:
+
+```typescript
+const bucket = new gcp.storage.Bucket("assets");
+const url = pulumi.interpolate`gs://${bucket.name}`;
+export const bucketUrl = url;
+```
+
+Python example:
+
+```python
+bucket = gcp.storage.Bucket("assets")
+bucket_url = bucket.name.apply(lambda name: f"gs://{name}")
+pulumi.export("bucket_url", bucket_url)
+```
+
+## Dependency Inference
+
+Passing one resource's output into another resource's input creates an implicit
+dependency. Prefer this dataflow because it is precise and refactor-friendly.
+
+Use `dependsOn` only for a real ordering constraint with no data edge, such as
+an API enablement resource that must complete before another provider call.
+Overusing explicit dependencies serializes updates and hides the actual model.
+
+| Situation | Mechanism |
+|---|---|
+| Consumer needs producer ID | Pass the producer output |
+| Provider lacks a usable data property but order matters | `dependsOn` |
+| Parent should own child lifecycle and URN | `parent` |
+| Separate stack provides value | Stack reference output |
+
+## Known and Unknown Values
+
+During preview, outputs may be unknown because no provider call has created the
+resource. Code inside `apply` may not run during preview. Do not put essential
+registration side effects, file writes, network calls, or validation solely in
+an `apply` callback.
+
+An `apply` callback should be:
+
+- deterministic
+- side-effect free
+- small
+- safe when skipped during preview
+- free of secret logging
+
+## Invoke Functions
+
+Provider functions read data without creating a managed custom resource.
+Choose the output-aware form when arguments contain outputs. Use invokes for
+lookups, not as a substitute for managing infrastructure that Pulumi should own.
+
+| Need | Choice |
+|---|---|
+| Read an existing value only | Provider invoke/get function |
+| Adopt lifecycle ownership | Resource import |
+| Reference another Pulumi resource | Resource output |
+| Read another stack contract | Stack reference |
+
+Provider reads can make preview depend on live API availability and credentials.
+Keep them explicit and avoid repeating the same lookup in loops.
+
+## Language Selection
+
+The infrastructure model is shared, but ergonomics differ.
+
+| Language | Strength | Watch for |
+|---|---|---|
+| TypeScript | Rich package ecosystem, concise output composition | Promise and `Output` confusion |
+| Python | Familiar automation syntax | Runtime type errors without strict checks |
+| Go | Explicit errors and data flow | Verbose output helpers and pointer types |
+| C# | Strong typing and enterprise integration | Async and `Output<T>` distinction |
+| Java | JVM integration | Generated builder conventions |
+| YAML | Small declarative programs | Limited abstraction and complex logic |
+
+Use the team's strongest maintained language. Do not choose a language because
+one migration generator emits it if the owning team cannot operate it.
+
+## Program Purity
+
+Pulumi evaluates the program during preview and update. Uncontrolled side
+effects make those operations diverge.
+
+Avoid:
+
+- current-time resource names
+- random values outside managed random resources
+- unversioned network downloads
+- shell commands that mutate cloud resources
+- filesystem state used as hidden configuration
+- environment variables that are not documented deployment inputs
+
+If external data must affect infrastructure, model and version it as config,
+a provider data source, a dynamic provider with a clear lifecycle, or a separate
+build artifact.
+
+## Conditional Resources and Loops
+
+Use ordinary language control flow only with values known during evaluation,
+usually config. Give loop-created resources stable logical names from durable
+keys rather than list indexes.
+
+```typescript
+for (const [name, spec] of Object.entries(services)) {
+  new ServiceComponent(name, spec);
+}
+```
+
+Changing map keys changes resource identity. If a key must change, add aliases.
+
+## Errors and Diagnostics
+
+Fail early for invalid program inputs. Include the config key or resource role
+in errors without exposing secrets. Provider errors often identify a resource
+URN; trace it to the declaration and inspect the provider inputs shown in the
+detailed preview.
+
+Debug in layers:
+
+1. Language compile/type/lint errors.
+2. Pulumi program registration errors.
+3. Preview diff and unknown values.
+4. Provider schema or authentication errors.
+5. Cloud API operation errors.
+
+## Review Checklist
+
+- Outputs are passed as inputs instead of synchronously unwrapped.
+- `apply` callbacks are pure and preview-safe.
+- Resource names use stable keys.
+- Dataflow expresses dependencies where possible.
+- Explicit dependencies have a documented provider/order reason.
+- Invokes are reads, not accidental unmanaged ownership.
+- Program evaluation has no hidden mutation.
+- Exports form a small consumer contract.
+
+## Source Links
+
+- https://www.pulumi.com/docs/iac/concepts/inputs-outputs/
+- https://www.pulumi.com/docs/iac/concepts/resources/
+- https://www.pulumi.com/docs/iac/concepts/resources/options/dependson/
+- https://www.pulumi.com/docs/iac/concepts/functions/
+- https://www.pulumi.com/docs/iac/languages-sdks/

--- a/skills/pulumi/references/projects-stacks-config.md
+++ b/skills/pulumi/references/projects-stacks-config.md
@@ -1,0 +1,182 @@
+# Projects, Stacks, Configuration, and Secrets
+
+Sources: Pulumi documentation on projects, stacks, configuration, secrets, stack settings, environments, and project organization; Twelve-Factor App configuration principles
+
+Covers: boundary design, `Pulumi.yaml`, stack settings, configuration namespaces, secret handling, stack outputs, and cross-stack contracts.
+
+## Mental Model
+
+| Object | Purpose | Identity |
+|---|---|---|
+| Project | One Pulumi program and its metadata | `name` in `Pulumi.yaml` |
+| Stack | Isolated instance of a project | organization/project/stack |
+| Configuration | Stack-specific program inputs | namespaced key/value entries |
+| Output | Published deployment result | exported by the stack program |
+| Environment | Reusable config/secrets context | imported into stack settings |
+
+A stack is not merely a label. It owns an independent resource graph and state
+checkpoint. An update targets exactly one stack, so stack boundaries are blast
+radius boundaries.
+
+## Design Project Boundaries
+
+Score each candidate boundary against four forces:
+
+| Force | Split when | Keep together when |
+|---|---|---|
+| Ownership | Different teams approve changes | One team owns the lifecycle |
+| Lifecycle | Resources deploy at different rates | Resources change atomically |
+| Privilege | Different deployment identities are required | Permissions are identical |
+| Failure domain | One update must not affect the other | Partial deployment is harmful |
+
+Prefer a small number of coherent projects over either extreme. A monolithic
+organization stack creates a huge blast radius; a project per resource creates
+dependency and coordination overhead.
+
+## Map Environments to Stacks
+
+Use stacks for repeated instances of the same program such as `dev`, `staging`,
+and `production`. Use separate projects when the program shape, owner, or
+deployment permissions differ materially.
+
+Naming checklist:
+
+1. Choose a stable project name before importing resources.
+2. Use organization-qualified stack names in automation.
+3. Avoid ambiguous environment aliases such as `prod2`.
+4. Record cloud account/project and region in stack configuration.
+5. Verify the selected stack before preview and update.
+
+## Project File
+
+`Pulumi.yaml` declares project metadata and runtime. Keep it deterministic and
+reviewable. Use the runtime options supported by the chosen language rather
+than shell wrappers that obscure program execution.
+
+```yaml
+name: payments-platform
+runtime:
+  name: nodejs
+  options:
+    typescript: true
+description: Shared payments infrastructure
+```
+
+Keep provider versions in the language package manager, lock them, and review
+upgrades. The CLI, language SDK, and provider plugin participate in one update;
+unexpected version drift can change schemas or diffs.
+
+## Configuration Contract
+
+Treat config as a typed public interface for the program.
+
+| Value | Store as | Reason |
+|---|---|---|
+| Region, feature flag, resource size | Plain stack config | Non-sensitive deployment input |
+| Password, token, private key | Secret config | Encrypt in state and propagate secrecy |
+| Resource-derived endpoint | Stack output | Produced by deployment, not operator input |
+| Shared organization defaults | Environment or component default | Reuse without duplicating stack files |
+| Cloud identity | Workload identity / environment | Avoid long-lived credential config |
+
+Use namespaced configuration so package and project keys do not collide. Read
+required values with required getters so missing configuration fails early.
+
+```bash
+pulumi config set app:region europe-west1
+pulumi config set --secret app:databasePassword "$VALUE"
+pulumi config set --path app:network.subnetCount 3
+```
+
+Do not place secret plaintext in `Pulumi.<stack>.yaml`, command history, logs,
+preview comments, test fixtures, or exported stack files.
+
+## Secret Semantics
+
+Pulumi records resource inputs and outputs in state. Marking a config value as
+secret encrypts it and normally causes derived Outputs to remain secret. This
+is protection in state and display, not permission to expose the value to an
+unsafe command or third-party process.
+
+Secret review checklist:
+
+1. Obtain credentials through short-lived workload identity where possible.
+2. Use `pulumi config set --secret` for unavoidable static values.
+3. Confirm the stack has the intended secrets provider.
+4. Avoid `apply` callbacks that log values.
+5. Mark derived sensitive values as secret if secrecy is not preserved.
+6. Review exported checkpoints as sensitive material even when encrypted.
+
+Changing secrets providers is a state operation. Back up and follow the
+documented migration command rather than editing ciphertext in YAML.
+
+## Stack Outputs as Contracts
+
+Export stable, consumer-oriented values instead of entire resource objects.
+
+Good outputs:
+
+- Service URL
+- Network or subnet ID
+- Service account email
+- Database instance connection name
+- Artifact repository name
+
+Poor outputs:
+
+- Full provider response objects
+- Secrets a consumer does not need
+- Internal logical names
+- Values that can be derived locally
+
+When one stack consumes another, use a stack reference and version the contract
+operationally. A producer rename can break consumers even if no cloud resource
+changes.
+
+## Cross-Stack Decision
+
+| Relationship | Pattern |
+|---|---|
+| Same lifecycle and owner | Keep resources in one stack |
+| Stable provider/consumer boundary | Export minimal outputs and use stack reference |
+| Runtime application lookup | Publish to service discovery or secret manager |
+| Circular dependency | Redesign ownership; do not create reciprocal stack references |
+
+## Repository Layout
+
+Choose discoverability over ceremony:
+
+```text
+infra/
+  Pulumi.yaml
+  Pulumi.dev.yaml
+  Pulumi.production.yaml
+  src/
+    index.ts
+    network.ts
+    service.ts
+  test/
+```
+
+For multiple projects, give each project its own `Pulumi.yaml` and dependency
+lockfile boundary. Share components through a normal package when multiple
+projects need the same architecture.
+
+## Review Checklist
+
+- Project boundary matches owner and blast radius.
+- Stack name and cloud target are explicit.
+- Required config fails fast.
+- Secrets are encrypted and not logged.
+- Provider and language dependencies are locked.
+- Outputs are minimal and documented.
+- Cross-stack references are acyclic.
+- Stack settings contain no generated resource state.
+
+## Source Links
+
+- https://www.pulumi.com/docs/iac/concepts/projects/
+- https://www.pulumi.com/docs/iac/concepts/stacks/
+- https://www.pulumi.com/docs/iac/concepts/config/
+- https://www.pulumi.com/docs/iac/concepts/secrets/
+- https://www.pulumi.com/docs/iac/concepts/projects/stack-settings-file/
+- https://www.pulumi.com/docs/iac/guides/basics/organizing-projects-stacks/

--- a/skills/pulumi/references/resources-components-providers.md
+++ b/skills/pulumi/references/resources-components-providers.md
@@ -1,0 +1,163 @@
+# Resources, Components, Providers, and Identity
+
+Sources: Pulumi documentation on resources, names, URNs, components, providers, resource options, import, aliases, protect, retainOnDelete, and transformations
+
+Covers: identity, physical naming, components, explicit providers, lifecycle options, imports, and no-replacement refactoring.
+
+## Resource Identity
+
+Pulumi tracks resources by URN, not by source file or variable name. URN inputs
+include stack, project, type, parent path, and logical name.
+
+| Change | Identity impact |
+|---|---|
+| Rename source variable only | None |
+| Move declaration to another file | None |
+| Change logical resource name | New URN unless aliased |
+| Change parent component | New URN unless aliased |
+| Change resource type/provider package | Usually replacement or migration |
+| Move to another project or stack | New state ownership |
+
+Separate the Pulumi logical name from the cloud provider's physical name.
+Auto-naming often prevents collisions and permits create-before-delete. Existing
+resources imported with fixed physical names need extra care around replacement.
+
+## Read Every Preview by Operation
+
+| Symbol/operation | Meaning | Review question |
+|---|---|---|
+| Create | New managed object | Is this intentionally new? |
+| Update | In-place provider change | Is downtime or policy impact acceptable? |
+| Replace | Delete/create or create/delete | Why can this not update in place? |
+| Delete | Remove from provider | Is deletion intended and recoverable? |
+| Same | No desired change | Does drift still need checking? |
+
+An alias solves Pulumi identity movement; it does not make an immutable cloud
+property mutable. After preserving the URN, the provider may still require a
+replacement for a changed physical property.
+
+## Safe Refactoring with Aliases
+
+Add aliases in the same change that renames or reparents a resource. Preview
+must show the existing resource adopting the new identity without create/delete.
+
+Common alias dimensions:
+
+- old logical name
+- old parent
+- old type
+- old project or stack where supported by the migration design
+- prior full URN for exact control
+
+Keep aliases long enough for all active stacks to pass through the migration.
+Removing an alias before a dormant stack updates can cause replacement later.
+
+## Components
+
+Use `ComponentResource` to create a semantic architecture boundary, not merely
+to shorten a file. A component should:
+
+1. Accept a typed, minimal input contract.
+2. Register itself before children.
+3. Parent all child resources to itself.
+4. Propagate relevant resource options.
+5. Register stable outputs.
+6. Hide incidental child implementation details.
+
+Changing an existing resource's parent to a new component changes its URN.
+Supply aliases for the old parent relationship during component extraction.
+
+## Provider Selection
+
+Default providers are convenient for one target account and region. Use an
+explicit provider when the program manages multiple accounts/projects/regions,
+requires distinct credentials, or needs deterministic provider configuration.
+
+| Scenario | Pattern |
+|---|---|
+| One cloud target per stack | Stack config plus default provider |
+| Multiple GCP projects | Explicit provider per project |
+| Component deploys to a supplied target | Accept provider through options |
+| Child package needs provider inheritance | Use provider/provider-map options |
+
+Provider changes can alter defaults, API behavior, and resource identity.
+Preview provider upgrades and provider reassignment as infrastructure changes,
+not package-maintenance noise.
+
+## Lifecycle Options
+
+| Option | Use | Risk |
+|---|---|---|
+| `protect` | Block deletion of critical resources | Must be intentionally removed before legitimate delete |
+| `retainOnDelete` | Remove from Pulumi without deleting provider object | Leaves unmanaged infrastructure and cost |
+| `deleteBeforeReplace` | Force old deletion before replacement | Creates downtime; use only for naming/API constraint |
+| `ignoreChanges` | Delegate selected property ownership externally | Can hide drift and stale desired values |
+| `replaceOnChanges` | Force replacement for selected changes | Expands blast radius |
+| `dependsOn` | Add non-data ordering edge | Can over-serialize graph |
+| `parent` | Establish hierarchy and inherited identity | Reparenting needs aliases |
+| `provider` | Select explicit provider instance | Provider mismatch may propose replacement |
+
+`protect` and `retainOnDelete` solve different problems. Protection blocks a
+Pulumi delete. Retention allows the state entry to be deleted while preserving
+the cloud object.
+
+## Import Existing Resources
+
+Import associates a real provider ID with a Pulumi resource identity. Use the
+CLI for generated code or the resource `import` option for program-first work.
+
+Import invariants:
+
+1. Find the provider-specific canonical import ID in the Registry resource page.
+2. Use the exact provider package and resource type intended for long-term use.
+3. Match immutable and provider-defaulted inputs to the live resource.
+4. Import into the final project, stack, logical name, and parent where possible.
+5. Preview after removing one-time import options from committed code if the
+   selected workflow requires that cleanup.
+6. Require a no-create/no-delete steady-state preview.
+
+Do not import one cloud object into two Pulumi stacks. State ownership must be
+singular even if multiple stacks read the object through data sources.
+
+## Bulk Import
+
+For complex programs, declare the desired graph and run
+`pulumi preview --import-file import.json`. Pulumi fills type, logical name,
+parent, and provider data; supply the real IDs, then execute import using the
+reviewed file.
+
+This program-first path preserves intended hierarchy better than a flat series
+of CLI imports. Import dependencies in provider-valid order when the provider
+requires parent resources or enabled APIs to exist.
+
+## Ignore Changes Carefully
+
+Use `ignoreChanges` only after naming the external controller and authority for
+the property. Pulumi uses prior state for ignored properties; refresh may be
+needed to observe external values before the next update.
+
+Good candidates include controller-managed replica counts. Poor candidates
+include security policy, IAM membership, encryption, or broad resource objects.
+
+## Review Checklist
+
+- Logical names and parent paths are stable.
+- Every rename or reparent includes aliases.
+- Physical names are explicit only when required.
+- Components own and parent their children.
+- Explicit providers match target accounts and regions.
+- Critical resources use deliberate protection.
+- Imports use Registry-documented IDs.
+- Ignore rules identify an external owner.
+- Preview contains no unexplained replacement or delete.
+
+## Source Links
+
+- https://www.pulumi.com/docs/iac/concepts/resources/names/
+- https://www.pulumi.com/docs/iac/concepts/components/
+- https://www.pulumi.com/docs/iac/concepts/resources/providers/
+- https://www.pulumi.com/docs/iac/concepts/resources/options/
+- https://www.pulumi.com/docs/iac/concepts/resources/options/aliases/
+- https://www.pulumi.com/docs/iac/concepts/resources/options/import/
+- https://www.pulumi.com/docs/iac/concepts/resources/options/protect/
+- https://www.pulumi.com/docs/iac/concepts/resources/options/retainondelete/

--- a/skills/pulumi/references/state-and-operations.md
+++ b/skills/pulumi/references/state-and-operations.md
@@ -1,0 +1,177 @@
+# State and Operations
+
+Sources: Pulumi documentation on state and backends, stack management, preview, update, refresh, drift, state export/import, cancellation, and deployment safety
+
+Covers: backend choice, operation lifecycle, drift detection, concurrency, recovery, and last-resort state repair.
+
+## State Contract
+
+State maps Pulumi resource identities to provider IDs and stores inputs,
+outputs, dependencies, provider references, pending operations, and secret
+ciphertext. Losing or corrupting state can turn known resources into apparent
+creates or orphan management relationships.
+
+Protect state as production data:
+
+- durable storage
+- encryption at rest and in transit
+- access control
+- update locking
+- version history or backups
+- auditability
+- tested recovery
+
+Do not commit exported state. Treat exports as sensitive even if secrets remain
+encrypted because metadata, endpoints, IDs, and topology are exposed.
+
+## Backend Decision
+
+| Context | Direction |
+|---|---|
+| Team or production estate | Managed Pulumi Cloud unless policy requires DIY |
+| Regulated self-managed storage | Supported DIY object backend with versioning |
+| Offline local experiment | Local backend only temporarily |
+
+DIY storage moves responsibility for locking behavior, backup, recovery,
+access, secrets-provider compatibility, and operational observability to the
+team. Choose it for a concrete control requirement, not to avoid setup.
+
+## Operation Sequence
+
+Use this sequence for routine changes:
+
+1. Select and display the fully qualified target stack.
+2. Verify cloud identity and provider target.
+3. Run language-level checks.
+4. Run `pulumi preview --diff`.
+5. Review operation counts and detailed property changes.
+6. Obtain approval appropriate to the environment.
+7. Run `pulumi up` through the serialized deployment path.
+8. Verify outputs and service health.
+
+Preview is a prediction. Cloud-side validation, races, quota, policy, or an
+unknown output can still fail during update. Plan rollback and recovery for
+high-risk changes.
+
+## Drift Decision
+
+Start read-only:
+
+```bash
+pulumi refresh --preview-only --stack production
+```
+
+| Finding | Response |
+|---|---|
+| No drift | Continue with code preview |
+| Authorized manual change should remain | Update code, then reconcile state |
+| Unauthorized manual change | Decide whether to revert with `up` or accept via refresh |
+| Resource deleted outside Pulumi | Determine restore vs state acceptance before action |
+| Provider returns normalized defaults | Align code/state only after understanding provider behavior |
+
+`pulumi refresh` writes observed provider values into state. It does not update
+the program. After refresh, run preview to see what the program will attempt to
+change back.
+
+## Concurrency
+
+Only one mutation should run against a stack at a time. Do not run local and CI
+updates concurrently. Managed backends help coordinate locks, but operational
+ownership still matters when canceling or recovering failed deployments.
+
+Use target flags sparingly. A targeted update can violate assumptions in the
+full dependency graph and leave the stack in a state never reviewed as a whole.
+Follow with a complete preview.
+
+## Failed Updates
+
+Classify before acting:
+
+| Failure | First action |
+|---|---|
+| Language/program crash | Fix program; preview again |
+| Authentication/permission | Restore correct short-lived identity |
+| Provider API partial failure | Inspect cloud object and stack pending operation |
+| Interrupted update | Inspect stack history and pending operations |
+| Concurrent update | Identify owner; do not blindly cancel |
+| State mismatch | Export state and investigate before repair |
+
+Canceling the CLI process does not guarantee the provider operation stopped.
+Cloud APIs may complete asynchronously. Observe the provider and stack before
+retrying to avoid duplicate operations.
+
+## Recovery Ladder
+
+Use the least invasive layer that solves the problem:
+
+1. Fix code or configuration and rerun preview.
+2. Refresh read-only to diagnose drift.
+3. Refresh state when live infrastructure is intentionally authoritative.
+4. Import a real but unmanaged resource.
+5. Use supported `pulumi state` commands for a precise identity operation.
+6. Export, review, and re-import state only as a documented last resort.
+
+Before steps 5-6:
+
+- stop writers
+- export the stack
+- record current stack history
+- inspect the exact URN and provider ID
+- rehearse on a non-production copy when feasible
+- define the expected post-repair preview
+
+Never remove a state entry merely to make an error disappear. The cloud object
+will remain and the next program evaluation may try to create a duplicate.
+
+## Resource Protection During Operations
+
+Apply `protect` to resources where accidental deletion is categorically worse
+than a blocked deployment: production databases, root DNS zones, shared KMS
+keys, organization IAM foundations, and state storage.
+
+Protection is not backup. Maintain provider-native recovery controls such as
+database backups, bucket versioning, and retention policies.
+
+## Provider Upgrades
+
+Provider upgrades can change defaults, schemas, diff behavior, import ID
+parsing, and replacement decisions. Upgrade in isolation:
+
+1. Read release notes.
+2. Update lockfiles.
+3. Preview representative non-production stacks.
+4. Inspect normalized/defaulted properties.
+5. Roll through stacks gradually.
+
+## Operational Evidence
+
+Capture without leaking secrets:
+
+- fully qualified stack
+- commit SHA and dependency lockfile
+- CLI and provider versions
+- preview operation counts
+- approval identity
+- update URL/history identifier
+- post-update outputs and health checks
+
+## Review Checklist
+
+- Backend is durable and access-controlled.
+- Production changes have a reviewed detailed preview.
+- Stack mutation is serialized.
+- Drift is observed before it is accepted.
+- Failed operations are classified before retry.
+- State export exists before state surgery.
+- Protection complements provider-native backup.
+- Provider upgrades are isolated from feature changes.
+
+## Source Links
+
+- https://www.pulumi.com/docs/iac/concepts/state-and-backends/
+- https://www.pulumi.com/docs/iac/operations/stack-management/
+- https://www.pulumi.com/docs/iac/operations/stack-management/drift/
+- https://www.pulumi.com/docs/iac/cli/commands/pulumi_preview/
+- https://www.pulumi.com/docs/iac/cli/commands/pulumi_refresh/
+- https://www.pulumi.com/docs/iac/cli/commands/pulumi_stack_export/
+- https://www.pulumi.com/docs/iac/cli/commands/pulumi_stack_import/

--- a/skills/pulumi/references/testing-policy-delivery.md
+++ b/skills/pulumi/references/testing-policy-delivery.md
@@ -1,0 +1,197 @@
+# Testing, Policy, and Delivery
+
+Sources: Pulumi documentation on testing, integration testing, Automation API, policy as code, Pulumi Deployments, CI/CD, and ESC; supply-chain and least-privilege deployment practices
+
+Covers: layered verification, policy packs, preview review, CI authentication, serialized updates, Automation API, and production gates.
+
+## Verification Pyramid
+
+Infrastructure correctness includes program behavior, engine planning, provider
+behavior, and service behavior. No single test layer covers all four.
+
+| Layer | Proves | Does not prove |
+|---|---|---|
+| Language checks | Syntax, types, lint, deterministic tests | Provider acceptance |
+| Program/unit tests | Registered resource shape and invariants | Real cloud behavior |
+| Preview | Planned operations for one stack | Successful provider execution |
+| Policy | Organizational rules on resource inputs | Application health |
+| Integration deployment | Provider creates and updates real resources | Production scale by itself |
+| Post-deploy checks | User-visible behavior | Future drift |
+
+Use the cheapest layer that can catch a failure, but retain real integration
+coverage for provider and lifecycle behavior.
+
+## Program Tests
+
+Test durable invariants rather than generated implementation details.
+
+Good assertions:
+
+- storage is encrypted
+- public access is disabled
+- required labels are present
+- production database deletion protection is enabled
+- component exports the documented contract
+- provider targets the expected project
+
+Brittle assertions:
+
+- exact child registration order
+- every provider default
+- generated auto-name suffix
+- full serialized resource object
+
+Mocks help exercise program registration but cannot prove permissions, quotas,
+eventual consistency, API defaults, or replacement behavior. Label their scope
+honestly and complement them with preview/integration checks.
+
+## Preview as Required Evidence
+
+In pull requests, generate a preview for affected stacks and make these fields
+easy to review:
+
+- stack identity
+- create/update/replace/delete counts
+- detailed changes for IAM, networking, data, and public exposure
+- policy violations
+- provider/version changes
+- unknown values that defer decisions until update
+
+Do not expose secret config or output values in logs. Restrict preview comments
+to trusted repositories and actors.
+
+## Policy as Code
+
+Use policy packs for rules that should apply across projects. Keep local
+program validation for project-specific contracts.
+
+| Rule type | Best home |
+|---|---|
+| Organization forbids public buckets | Mandatory policy pack |
+| All resources require cost-center tag | Policy pack with clear exception path |
+| One component requires exactly two subnets | Component/program validation |
+| Team naming preference | Advisory policy or lint |
+
+Policies evaluate resource inputs during preview/update. They do not replace
+cloud organization policies, IAM boundaries, or runtime security monitoring.
+
+Policy design:
+
+1. Give the violation a remediation-oriented message.
+2. Handle unknown values without silently passing unsafe cases.
+3. Test both compliant and violating resources.
+4. Version policy packs.
+5. Roll new mandatory rules through advisory mode when existing estates need
+   remediation.
+
+## CI Authentication
+
+Prefer workload identity federation or OIDC for Pulumi and cloud access.
+Avoid long-lived service account keys and personal access tokens.
+
+Deployment identity should have:
+
+- read access for preview
+- narrowly scoped mutation access for update
+- backend access only to intended stacks
+- secrets-provider decrypt access only when required
+- no broad organization owner role
+
+Separate preview and update permissions when the platform supports it.
+
+## Pipeline Shape
+
+```text
+pull request
+  -> dependency integrity
+  -> language checks
+  -> program tests
+  -> policy checks
+  -> preview affected stacks
+  -> human review
+trusted merge
+  -> acquire short-lived identity
+  -> update one stack at a time
+  -> post-deploy verification
+  -> record deployment evidence
+```
+
+Serialize updates per stack. Use concurrency groups or the managed deployment
+system so a second merge cannot race the first update.
+
+## Environment Promotion
+
+Promote the same reviewed source and locked dependencies through environments.
+Change stack config, not program branches, for environment-specific values.
+
+Production gate checklist:
+
+1. Non-production update passed.
+2. Detailed production preview is current.
+3. Replacement/delete decisions are approved.
+4. Data backup and rollback controls exist for stateful changes.
+5. Policy checks pass.
+6. Deployment identity and target stack are verified.
+7. Post-deploy health checks are defined.
+
+## Automation API
+
+Use Automation API when a service or tool must orchestrate Pulumi operations
+programmatically. Do not adopt it merely to wrap a CLI call in custom code.
+
+Good fits:
+
+- self-service infrastructure portals
+- per-tenant stack orchestration
+- integration test environments
+- multi-stage application deployments
+- custom workflows requiring structured events and outputs
+
+Automation requirements:
+
+- explicit stack naming and ownership
+- serialized operations
+- durable logs and update events
+- cancellation and timeout handling
+- secret-safe output handling
+- idempotent retry strategy based on observed stack state
+- lifecycle cleanup and retention policy
+
+## Integration Tests
+
+Use ephemeral, isolated stacks with unique cloud naming and budget controls.
+Test create, read/health, update, and destroy for reusable components. If the
+resource is intentionally retained or protected, test the documented cleanup
+path rather than weakening production safeguards.
+
+Record failed cleanup as an operational incident because leaked cloud resources
+cost money and can create security exposure.
+
+## Supply Chain
+
+- Pin provider and SDK versions through lockfiles.
+- Review provider upgrades separately.
+- Verify third-party component/package provenance.
+- Restrict CI actions and images to reviewed versions.
+- Avoid executing untrusted pull-request code with deployment credentials.
+- Keep policy and deployment logs according to audit requirements.
+
+## Review Checklist
+
+- Tests assert infrastructure outcomes, not generated internals.
+- Preview is attached to the exact stack and commit.
+- Policies have actionable messages and tests.
+- CI uses short-lived credentials.
+- Untrusted code cannot access deployment secrets.
+- Updates are serialized per stack.
+- Production has an approval and post-deploy gate.
+- Automation API services handle concurrency and failure explicitly.
+
+## Source Links
+
+- https://www.pulumi.com/docs/iac/guides/testing/
+- https://www.pulumi.com/docs/iac/guides/testing/integration/automation-api/
+- https://www.pulumi.com/docs/iac/concepts/automation-api/
+- https://www.pulumi.com/docs/iac/concepts/policy/
+- https://www.pulumi.com/docs/pulumi-cloud/deployments/
+- https://www.pulumi.com/docs/iac/guides/continuous-delivery/

--- a/skills/pulumi/tank.json
+++ b/skills/pulumi/tank.json
@@ -1,0 +1,16 @@
+{
+  "name": "@tank/pulumi",
+  "version": "1.0.0",
+  "description": "Production Pulumi infrastructure as code using TypeScript, Python, Go, .NET, Java, or YAML. Covers projects, stacks, config and secrets, Inputs and Outputs, components, providers, state, imports, testing, policy, CI/CD, drift, and safe resource refactoring. Triggers: pulumi, pulumi up, pulumi preview, Pulumi.yaml, stack config, Pulumi state, Pulumi import, Pulumi component, Automation API, CrossGuard, infrastructure as code.",
+  "permissions": {
+    "network": {
+      "outbound": []
+    },
+    "filesystem": {
+      "read": ["**/*"],
+      "write": []
+    },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: @tank/terraform
+description: |
+  Build, review, operate, import, and refactor production Terraform. Covers HCL
+  data flow and stable addresses, providers and reusable modules, remote state
+  and locking, declarative import and generated configuration, moved and removed
+  blocks, testing, sensitive data, policy, and reviewed CI/CD. Synthesizes the
+  current official HashiCorp Terraform documentation.
+
+  Trigger phrases: "terraform", "terraform plan", "terraform apply",
+  "terraform import", "Terraform import block", "generate-config-out", "HCL",
+  "Terraform state", "tfstate", "Terraform module", "Terraform provider",
+  "moved block", "removed block", "terraform test", "Terraform CI/CD",
+  "Terraform drift", "infrastructure as code", "Terraform refactor"
+---
+
+# Terraform
+
+## Core Philosophy
+
+1. **Plan is the review contract** -- inspect the complete saved plan before
+   apply; formatting and validation cannot reveal cloud lifecycle changes.
+2. **Addresses are durable identities** -- stable `for_each` keys and explicit
+   `moved` blocks preserve state bindings through refactors.
+3. **State is sensitive coordination data** -- store it remotely with locking,
+   encryption, access control, and recovery; never edit JSON directly.
+4. **Modules expose capabilities, not resource dumps** -- compose small modules
+   through typed variables and minimal outputs while callers own provider setup.
+5. **One remote object has one address** -- import or move ownership explicitly;
+   duplicate bindings and competing states cause destructive plans.
+
+## Default Workflow
+
+1. Inspect the root module, selected workspace/state, backend, provider lockfile,
+   variable sources, and cloud identity.
+2. Run `terraform fmt -check`, `terraform init`, and `terraform validate`.
+3. Run targeted tests, then create a full saved plan for the intended state.
+4. Review creates, updates, replacements, destroys, provider changes, and
+   sensitive/stateful resources.
+5. Apply the reviewed saved plan through a serialized, trusted pipeline.
+6. Verify outputs and service health; retain plan/run evidence without secrets.
+
+## Quick-Start: Common Problems
+
+### "How should I write this configuration?"
+
+Use typed variables with validation, locals for readable derivation, explicit
+resource references for dependencies, stable map keys, and minimal outputs.
+
+-> See `references/configuration-and-addresses.md`.
+
+### "How do I choose providers and modules?"
+
+Declare provider sources and constraints in every module, commit the root lock
+file, configure providers in roots, and pass aliases into child modules.
+
+-> See `references/providers-and-modules.md`.
+
+### "How do I manage or repair state?"
+
+Use a locking remote backend and supported state, `moved`, and `removed` flows.
+Pull a backup before state mutation and define the expected next plan.
+
+-> See `references/state-and-refactoring.md`.
+
+### "How do I adopt existing infrastructure?"
+
+Prefer declarative `import` blocks so adoption appears in plan. Generate draft
+configuration when useful, reconcile it, and require a no-change steady state.
+
+-> See `references/planning-and-imports.md`.
+
+### "How do I ship this safely?"
+
+Layer formatting, validation, tests, policy, a reviewed saved plan, short-lived
+credentials, serialized apply, and post-deployment verification.
+
+-> See `references/testing-security-delivery.md`.
+
+## Decision Trees
+
+### Choose State Boundaries
+
+| Signal | Direction |
+|---|---|
+| Same owner, lifecycle, privilege, and failure domain | One root/state |
+| Different owners or deployment cadence | Separate roots/states |
+| Same configuration, environment-specific values | Separate state/workspace only with explicit targeting |
+| Circular remote-state dependency | Redesign boundaries |
+
+### Choose an Import Workflow
+
+| Scope | Default |
+|---|---|
+| One legacy resource | Declarative `import` block; CLI import only if required |
+| Small reviewed batch | Multiple import blocks |
+| Configuration unknown | Import blocks plus `plan -generate-config-out=...` |
+| Large provider-supported estate | Query/bulk import where stable, otherwise generated manifest reviewed in waves |
+
+### Choose a Collection Meta-Argument
+
+| Identity | Choice |
+|---|---|
+| Durable business keys | `for_each` |
+| Fixed homogeneous count where index identity is acceptable | `count` |
+| Independent named resources | Separate resource blocks |
+
+## Safety Gates
+
+Stop before apply when state identity is uncertain, the workspace/backend is
+wrong, a provider upgrade is mixed into unrelated work, a replacement or destroy
+is unexplained, a saved plan is stale, or credentials target the wrong account.
+Do not use `-target`, `state rm`, refresh-only acceptance, or `-auto-approve` to
+bypass uncertainty.
+
+## Reference Index
+
+| File | Contents |
+|---|---|
+| `references/configuration-and-addresses.md` | HCL values, dependencies, variables, locals, outputs, collections, and stable addresses |
+| `references/providers-and-modules.md` | Provider requirements, lockfiles, aliases, module contracts, and composition |
+| `references/state-and-refactoring.md` | Backends, locking, drift, state commands, moved/removed blocks, and recovery |
+| `references/planning-and-imports.md` | Plan/apply semantics, declarative and CLI import, generated configuration, and convergence |
+| `references/testing-security-delivery.md` | Validation, tests, policies, secrets, CI authentication, saved plans, and production gates |

--- a/skills/terraform/references/configuration-and-addresses.md
+++ b/skills/terraform/references/configuration-and-addresses.md
@@ -1,0 +1,131 @@
+# Configuration and Resource Addresses
+
+Sources: HashiCorp Terraform language, expressions, resource addressing, style, variables, outputs, and meta-argument documentation
+
+Covers: HCL data flow, types, variables, locals, outputs, dependencies, `for_each`, `count`, lifecycle, and stable addresses.
+
+## Configuration Model
+
+Terraform evaluates configuration into a dependency graph. References between
+resources create edges; file order does not. Split files for readability, not
+execution order.
+
+| Construct | Use |
+|---|---|
+| Variable | Typed caller input with description and validation |
+| Local | Named deterministic derivation |
+| Data source | Read an externally owned object |
+| Resource | Declare lifecycle ownership |
+| Output | Publish a minimal root/module contract |
+| Check/precondition | Assert an operational invariant |
+
+## Variables
+
+Declare precise object, map, set, tuple, number, bool, or string types. Add
+nullable/default semantics intentionally and validate domain constraints near
+the input boundary.
+
+```hcl
+variable "environment" {
+  type        = string
+  description = "Deployment environment name."
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "environment must be dev, staging, or production"
+  }
+}
+```
+
+Avoid `type = any` unless the module truly passes opaque data through. Loose
+types move errors into provider execution and make module contracts unclear.
+
+## Dependencies
+
+Prefer expression references:
+
+```hcl
+network = google_compute_network.main.id
+```
+
+Use `depends_on` only when a hidden behavior dependency has no value edge, such
+as API enablement that must precede a provider call. Broad module dependencies
+serialize graphs and produce more unknown values.
+
+## Stable Collection Identity
+
+`for_each` addresses instances by key; `count` addresses by index.
+
+```hcl
+resource "google_service_account" "workload" {
+  for_each   = var.workloads
+  account_id = each.key
+}
+```
+
+Use keys that survive display-name and ordering changes. Renaming a key changes
+the address; add a `moved` block when identity should remain.
+
+| Data shape | Pattern |
+|---|---|
+| Named workloads | `for_each = map` |
+| Unique unordered names | `for_each = toset(...)` |
+| Truly indexed replicas | `count` |
+| Optional singleton | Conditional `for_each` or count with known address tradeoff |
+
+## Outputs
+
+Export consumer capabilities such as IDs, endpoints, and names. Do not expose
+whole resources or sensitive values without a real consumer need.
+
+Mark sensitive outputs, but remember sensitivity hides display; state can still
+contain the value. Protect the backend accordingly.
+
+## Lifecycle
+
+| Setting | Use | Risk |
+|---|---|---|
+| `prevent_destroy` | Block accidental destroy of critical resources | Requires explicit removal for legitimate deletion |
+| `create_before_destroy` | Reduce replacement downtime | Needs parallel-name/quota capacity |
+| `ignore_changes` | External controller owns named fields | Can hide security or configuration drift |
+| `replace_triggered_by` | Couple replacement to explicit dependency | Expands blast radius |
+
+Use `ignore_changes` only with a named external owner and narrow attributes.
+Refreshing state does not make ignored drift harmless.
+
+## Address Changes
+
+These change a resource address:
+
+- resource block label
+- module path
+- `for_each` key
+- `count` index
+- resource type
+
+Moving source between `.tf` files does not. Preserve deliberate identity changes
+with `moved` blocks and review the plan for move rather than destroy/create.
+
+## Determinism
+
+Avoid timestamps, unstable set/list conversions, mutable remote files, and shell
+side effects in configuration. Pin external module/provider versions and make
+environment inputs explicit.
+
+## Review Checklist
+
+- Variables are typed, described, and validated.
+- References express dependencies.
+- Collection keys are durable.
+- Outputs are minimal.
+- Lifecycle rules name the operational reason.
+- Address changes have `moved` blocks.
+- Sensitive values are not printed or committed.
+- Full plan has no unexplained replacement or destroy.
+
+## Source Links
+
+- https://developer.hashicorp.com/terraform/language
+- https://developer.hashicorp.com/terraform/language/values/variables
+- https://developer.hashicorp.com/terraform/language/values/outputs
+- https://developer.hashicorp.com/terraform/language/meta-arguments/for_each
+- https://developer.hashicorp.com/terraform/cli/state/resource-addressing

--- a/skills/terraform/references/planning-and-imports.md
+++ b/skills/terraform/references/planning-and-imports.md
@@ -1,0 +1,119 @@
+# Planning and Imports
+
+Sources: HashiCorp Terraform plan/apply, import overview, import block, single and bulk import, configuration generation, and CLI import documentation
+
+Covers: plan review, saved plans, declarative imports, CLI import, generated configuration, bulk workflows, identity, and no-change convergence.
+
+## Plan Semantics
+
+Plan compares configuration, prior state, and refreshed remote objects using the
+selected providers and variables. Review the exact root, workspace/backend,
+credentials, lockfile, and variable inputs.
+
+| Operation | Question |
+|---|---|
+| Create | Is this intentionally new rather than missing import? |
+| Update | Is provider-side impact acceptable? |
+| Replace | Which immutable/address/lifecycle change caused it? |
+| Destroy | Is deletion intended, backed up, and approved? |
+| Import | Does this ID map to exactly this address? |
+| Move | Does old identity map to new identity? |
+
+For production, save the reviewed plan and apply that file. Do not regenerate an
+unreviewed plan inside the apply step.
+
+## Declarative Import
+
+Use import blocks so adoption participates in normal plan/apply review:
+
+```hcl
+import {
+  to = google_storage_bucket.assets
+  id = "project-id/assets-bucket"
+}
+```
+
+Also declare the destination resource. The provider documentation defines the
+accepted ID/identity format.
+
+Each remote object must bind to one resource address. Never import the same
+object into two addresses or states.
+
+## Generated Configuration
+
+When the destination block is unknown, declare import and run:
+
+```bash
+terraform plan -generate-config-out=generated_resources.tf
+```
+
+Generated configuration is a draft based on provider-read data. Review computed
+fields, defaults, sensitive values, immutable properties, naming, dependencies,
+and module boundaries before treating it as maintained code.
+
+## CLI Import
+
+`terraform import ADDRESS ID` writes the state binding but does not generate
+configuration. Use it for a small legacy case when the resource block already
+exists and declarative import is impractical.
+
+CLI import can require local equivalents of remote workspace variables because
+the command runs locally in some HCP Terraform workflows.
+
+## Bulk Import
+
+Modern Terraform supports provider-backed search/query and bulk import where
+the provider implements it. Verify current Terraform/provider support and review
+all discovered identities; broad discovery can include objects owned elsewhere.
+
+For providers without suitable bulk query support, generate a reviewed import
+manifest from inventory and create import blocks in small waves.
+
+## Convergence
+
+Import is complete only when:
+
+1. State shows the intended provider ID at the intended address.
+2. Configuration represents live immutable and behaviorally important values.
+3. A full plan proposes no unexplained create/update/replace/destroy.
+4. The prior writer is disabled.
+5. Runtime health and access checks pass.
+
+Do not hide mismatches with broad `ignore_changes` or apply replacement during
+an ownership-only migration.
+
+## Import Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| ID not found | Wrong ID format, project, provider alias, or permissions |
+| Address missing | Destination resource/module instance not declared |
+| Create still planned | Import targeted wrong state/address or did not execute |
+| Replacement planned | Immutable field/default/type mismatch |
+| Duplicate-object error | Same object already bound or import omitted |
+| IAM change after import | Authoritative resource form does not match ownership |
+
+## Import Block Lifecycle
+
+Import blocks are idempotent after the object is bound and can remain as history.
+Follow repository policy consistently; never remove them before the successful
+import is committed and the stable plan is recorded.
+
+## Review Checklist
+
+- Plan target, inputs, providers, and state are explicit.
+- Production applies the reviewed saved plan.
+- Import ID comes from provider docs.
+- Destination address is final and unique.
+- Generated config is reviewed, not blindly committed.
+- Imports run in bounded waves.
+- Steady-state plan is non-destructive.
+- Previous writers are retired without destroy.
+
+## Source Links
+
+- https://developer.hashicorp.com/terraform/cli/commands/plan
+- https://developer.hashicorp.com/terraform/language/import
+- https://developer.hashicorp.com/terraform/language/import/single-resource
+- https://developer.hashicorp.com/terraform/language/import/generating-configuration
+- https://developer.hashicorp.com/terraform/cli/import

--- a/skills/terraform/references/providers-and-modules.md
+++ b/skills/terraform/references/providers-and-modules.md
@@ -1,0 +1,129 @@
+# Providers and Modules
+
+Sources: HashiCorp provider requirements, dependency lockfile, provider configuration, standard module structure, composition, and module-development documentation
+
+Covers: provider source/version declarations, lockfiles, aliases, authentication, module contracts, composition, and publishing boundaries.
+
+## Provider Contract
+
+Every module declares required provider source and compatible minimum version.
+The root module also constrains operational compatibility and commits the lock
+file so installations select reviewed provider builds.
+
+```hcl
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+  }
+}
+```
+
+Run `terraform init -upgrade` only in an isolated dependency-upgrade change.
+Provider upgrades can alter defaults, schemas, import parsing, and replacement
+behavior.
+
+## Lockfile
+
+Commit `.terraform.lock.hcl` for root configurations. Review version and checksum
+changes. Reusable modules declare compatible constraints but do not own the
+caller's selected build.
+
+Do not commit `.terraform/`; it contains downloaded plugins and local metadata.
+
+## Provider Configuration
+
+Configure credentials and target account/project/region in root modules. Child
+modules receive provider configurations from callers and declare aliases they
+accept.
+
+| Scenario | Pattern |
+|---|---|
+| One target | Default provider in root |
+| Multiple GCP projects | Aliased provider per project |
+| Reusable module | Declare requirement; caller passes provider |
+| CI | Workload identity/OIDC, not static keys |
+
+Do not hide target project selection in ambient CLI defaults. Plans and imports
+must identify the intended provider configuration.
+
+## Module Contract
+
+A module should model one deployable capability with:
+
+- typed, validated inputs
+- sensible but non-surprising defaults
+- minimal outputs
+- no embedded provider credentials
+- explicit provider requirements
+- stable internal addresses
+- tests for durable behavior
+
+Prefer composition at the root over deep modules calling sibling modules.
+Callers can wire outputs to inputs and retain control over architecture.
+
+## Structure
+
+```text
+module/
+  main.tf
+  variables.tf
+  outputs.tf
+  versions.tf
+  README.md
+  tests/
+  examples/
+```
+
+The root is the public module. Nested modules under `modules/` should remain
+composable; document any intended public nested modules.
+
+## Versioning
+
+Pin published module versions in callers. Use semantic releases and explain
+state/address migrations. A source ref such as a moving branch makes the same
+configuration resolve to different infrastructure logic over time.
+
+## Provider Aliases
+
+Aliases are part of module wiring. Declare `configuration_aliases` in reusable
+modules, then pass explicit mappings from the root. Import commands and blocks
+must resolve the same alias that will manage the object afterward.
+
+## Module Refactoring
+
+Moving resources into or between modules changes addresses. Add `moved` blocks
+from old to new addresses in the configuration version that performs the move.
+Keep migration blocks until all states using the module have upgraded.
+
+## Anti-Patterns
+
+| Pattern | Failure |
+|---|---|
+| Provider block inside reusable child | Callers cannot safely alias/override targets |
+| One module wrapping one resource without policy | Adds indirection without capability |
+| Mega-module with dozens of switches | Huge state/blast radius and invalid combinations |
+| Outputs exposing every attribute | Couples callers to implementation |
+| Broad version ranges in root | Surprise upgrades |
+| Credentials in variables/tfvars | Leak into files, logs, or state |
+
+## Review Checklist
+
+- Every provider has an explicit source and constraint.
+- Root lockfile is committed.
+- Provider upgrade is isolated.
+- Root owns authentication and aliases.
+- Modules expose capabilities and minimal outputs.
+- Module sources are immutable/versioned.
+- Address moves have migration blocks.
+- Provider targets are explicit in plan and import workflows.
+
+## Source Links
+
+- https://developer.hashicorp.com/terraform/language/providers/requirements
+- https://developer.hashicorp.com/terraform/language/files/dependency-lock
+- https://developer.hashicorp.com/terraform/language/modules/develop/structure
+- https://developer.hashicorp.com/terraform/language/modules/develop/composition
+- https://developer.hashicorp.com/terraform/language/modules/develop/providers

--- a/skills/terraform/references/state-and-refactoring.md
+++ b/skills/terraform/references/state-and-refactoring.md
@@ -1,0 +1,125 @@
+# State and Refactoring
+
+Sources: HashiCorp Terraform state, backends, locking, refactoring, moved blocks, removed blocks, state command, and workspace documentation
+
+Covers: state safety, backend choice, locking, drift, state inspection, supported refactors, ownership removal, and recovery.
+
+## State Invariant
+
+Terraform state stores the one-to-one binding between a resource instance
+address and a remote object. It also contains provider metadata, dependencies,
+outputs, and potentially secrets.
+
+Protect it with:
+
+- remote durable storage
+- locking
+- encryption
+- least-privilege access
+- versioning/backups
+- serialized writers
+- auditable runs
+
+Never commit state or edit its JSON directly.
+
+## Backend Boundary
+
+State boundaries should follow owner, lifecycle, privilege, and blast radius.
+Too-large state makes every plan risky; too-small state creates remote-state
+coupling and orchestration overhead.
+
+Backend configuration is bootstrap-sensitive. Migrate with `terraform init
+-migrate-state`, a backup, exclusive access, and post-migration verification.
+
+## Locking and Concurrency
+
+Only one mutation may operate on a state at a time. Investigate lock ownership
+before force-unlock; a still-running apply can corrupt coordination.
+
+Saved plans embed prior state and input decisions. Regenerate a plan after state,
+configuration, variables, credentials, or provider versions change.
+
+## Drift
+
+Normal plan refreshes remote objects before diffing unless configured otherwise.
+Use refresh-only planning to review externally made changes without immediately
+accepting or reverting them.
+
+| Drift intent | Action |
+|---|---|
+| External change should be reverted | Normal reviewed plan/apply |
+| External change should become desired | Update config, then plan |
+| State must accept observed change first | Refresh-only plan/apply with explicit review |
+| Object deleted externally | Decide recreate vs remove ownership before apply |
+
+## Refactoring
+
+Use declarative `moved` blocks for address changes:
+
+```hcl
+moved {
+  from = google_storage_bucket.assets
+  to   = module.storage.google_storage_bucket.assets
+}
+```
+
+This documents the migration and lets every state pass through it. Prefer it to
+ad hoc `terraform state mv` for versioned configuration refactors.
+
+## Removing Ownership
+
+Use a `removed` block with destroy disabled when Terraform should forget an
+object while leaving it live. Review current version syntax and plan output.
+This intentionally creates unmanaged infrastructure, so record the new owner.
+
+`terraform state rm` is an imperative last resort. If configuration still
+declares the resource, the next plan proposes a create.
+
+## State Command Safety
+
+Before `state mv`, `state rm`, `state replace-provider`, or state push:
+
+1. Stop all writers.
+2. Pull a state backup.
+3. Record lineage/serial and exact addresses.
+4. Define the expected post-command plan.
+5. Rehearse on a copy when production risk is high.
+6. Run a complete plan afterward.
+
+## Recovery Ladder
+
+1. Fix configuration or variables.
+2. Reinitialize providers/backend.
+3. Review refresh-only plan.
+4. Import an unmanaged live object.
+5. Use moved/removed blocks.
+6. Use precise state commands with backup.
+7. Restore a versioned state snapshot only through documented backend process.
+
+Do not remove state bindings merely to silence an error.
+
+## Workspaces
+
+CLI workspaces provide multiple state instances for one configuration but do not
+create strong permission or code boundaries. Use separate roots/backends when
+environments have different owners, credentials, or infrastructure shapes.
+
+## Review Checklist
+
+- Backend is remote, locked, encrypted, and recoverable.
+- State boundary matches blast radius.
+- Writers are serialized.
+- Refactors use moved blocks.
+- Ownership removal names the next owner.
+- State commands have backup and expected-plan evidence.
+- Full plan follows every state operation.
+- State artifacts and outputs do not leak secrets.
+
+## Source Links
+
+- https://developer.hashicorp.com/terraform/language/state
+- https://developer.hashicorp.com/terraform/language/state/locking
+- https://developer.hashicorp.com/terraform/language/state/refactor
+- https://developer.hashicorp.com/terraform/language/state/remove
+- https://developer.hashicorp.com/terraform/language/block/moved
+- https://developer.hashicorp.com/terraform/language/block/removed

--- a/skills/terraform/references/testing-security-delivery.md
+++ b/skills/terraform/references/testing-security-delivery.md
@@ -1,0 +1,104 @@
+# Testing, Security, and Delivery
+
+Sources: HashiCorp Terraform validate, test framework, sensitive data, automation, HCP Terraform, policy, and dependency lockfile documentation; workload identity practices
+
+Covers: formatting, validation, native tests, real integration tests, policy, secrets, CI authentication, plan review, serialized apply, and post-deploy evidence.
+
+## Verification Layers
+
+| Layer | Proves |
+|---|---|
+| `fmt -check` | Canonical formatting |
+| `validate` | Internal syntax/schema consistency |
+| `test` with plan | Module logic and assertions without apply |
+| `test` with apply | Real provider lifecycle against test resources |
+| Policy/static analysis | Organization rules and known misconfiguration |
+| Full environment plan | Exact proposed operations |
+| Post-apply checks | Runtime service behavior |
+
+Mocks cannot prove cloud permissions, quotas, defaults, eventual consistency, or
+real replacement behavior. Keep real, isolated lifecycle tests for reusable
+modules and high-risk provider behavior.
+
+## Native Tests
+
+Terraform discovers `.tftest.hcl` and `.tftest.json`. Default run blocks apply
+real infrastructure; set `command = plan` deliberately for non-creating tests.
+
+Assert durable outcomes such as encryption, network exposure, labels, retention,
+and output contracts. Avoid exact snapshots of every provider default.
+
+Test cleanup failure is an incident: leaked resources create cost and exposure.
+
+## Sensitive Data
+
+Sensitive markings redact CLI/UI display but values may remain in state and plan
+files. Secure backend, plan artifacts, logs, variable files, and CI caches.
+
+Prefer short-lived workload identity and secret managers. Do not commit `.tfvars`
+containing credentials or pass secrets on command lines that enter shell history.
+
+## CI Pipeline
+
+```text
+pull request
+  -> fmt and validate
+  -> provider/module integrity
+  -> tests and policy
+  -> full plan
+  -> review
+trusted merge
+  -> acquire short-lived identity
+  -> apply reviewed plan, one state at a time
+  -> health checks and evidence
+```
+
+Untrusted pull-request code must not receive cloud or state credentials.
+
+## Plan Evidence
+
+Record state/workspace, commit, Terraform/provider versions, plan operation
+counts, policy results, approval, apply result, and health checks. Restrict saved
+plan access because it can contain sensitive values.
+
+## Concurrency
+
+Serialize apply per state with backend locking and CI concurrency controls. Do
+not run local emergency applies concurrently with automation.
+
+Targeted plans/applies are diagnostic or recovery tools, not normal delivery;
+follow them with a complete plan to restore graph-wide confidence.
+
+## Provider Upgrades
+
+Upgrade separately, review lockfile checksums, plan representative states, and
+roll out gradually. Do not combine provider upgrades with imports or refactors.
+
+## Production Gate
+
+- Correct state/backend and cloud identity.
+- Checks and tests pass.
+- Full saved plan is current and reviewed.
+- No unexplained replacement or destroy.
+- Stateful changes have provider-native backup/recovery.
+- Short-lived least-privilege credentials are active.
+- Apply is serialized.
+- Health checks and rollback ownership are defined.
+
+## Review Checklist
+
+- Tests match their real-vs-mocked scope.
+- Secrets are protected beyond display redaction.
+- Untrusted code has no deployment credentials.
+- Plans are exact, reviewable, and access-controlled.
+- Applies use reviewed saved plans.
+- Provider upgrades are isolated.
+- Production verification covers user-visible behavior.
+
+## Source Links
+
+- https://developer.hashicorp.com/terraform/language/validate
+- https://developer.hashicorp.com/terraform/language/tests
+- https://developer.hashicorp.com/terraform/language/manage-sensitive-data
+- https://developer.hashicorp.com/terraform/tutorials/automation/automate-terraform
+- https://developer.hashicorp.com/terraform/cloud-docs/policy-enforcement

--- a/skills/terraform/tank.json
+++ b/skills/terraform/tank.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tank/terraform",
+  "version": "1.0.0",
+  "description": "Operate production Terraform with safe HCL, stable resource addressing, providers and modules, remote state, declarative imports, refactoring, tests, security, and reviewed plan/apply delivery. Triggers: terraform, terraform plan, terraform apply, terraform import, import block, HCL, tfstate, Terraform module, Terraform provider, moved block, removed block, terraform test, infrastructure as code.",
+  "permissions": {
+    "network": { "outbound": [] },
+    "filesystem": { "read": ["**/*"], "write": [] },
+    "subprocess": false
+  },
+  "repository": "https://github.com/tankpkg/skills"
+}


### PR DESCRIPTION
## Summary
- add @tank/pulumi and @tank/terraform foundation skills
- add @tank/gcp-to-pulumi with an install-time dependency on @tank/pulumi ^1.0.0
- add @tank/gcp-to-terraform with an install-time dependency on @tank/terraform ^1.0.0
- document safe brownfield GCP adoption, no-replacement convergence, and writer cutover

## Validation
- quick_validate.py passes for all four packages
- tank publish --dry-run passes for all four packages
- manifest dependency assertions pass for both GCP migration skills