### PR TITLE
feat: deepen crystal clear docs learning design

### DIFF
--- a/skills/crystal-clear-docs/SKILL.md
+++ b/skills/crystal-clear-docs/SKILL.md
@@ -1,193 +1,203 @@
 ---
 name: "@tank/crystal-clear-docs"
 description: |
-  Create crystal-clear technical documents (HTML + Markdown) with layered
-  explanations, progressive disclosure from TL;DR to deep dive, and SVG
-  diagrams for concepts that need visual explanation. Covers inverted pyramid
-  structure, the Layer Cake Method for multi-resolution explanations, Mermaid
-  diagram-as-code integration, accessible SVG patterns, document formatting for
-  maximum scannability, callout/admonition design, comparison tables, worked
-  examples, and word-level clarity techniques. Synthesizes Minto (The Pyramid
-  Principle), Tufte (Envisioning Information, The Visual Display of Quantitative
-  Information), Krug (Don't Make Me Think), Strunk & White (The Elements of
-  Style), Zinsser (On Writing Well), Google Technical Writing Course, Munroe
-  (Up-Goer Five / Thing Explainer), Mermaid.js, W3C SVG accessibility
-  guidelines, and Cognitive Load Theory (Sweller).
+  Design technical documentation that readers can find, understand, use, and
+  transfer to new situations. Covers outcome-driven document design, reader and
+  mental-model analysis, prior knowledge and misconceptions, cognitive load,
+  worked examples, multimedia learning, behavioral writing, navigation, and
+  evidence-informed validation. Synthesizes Mayer, Lovett et al., How People Learn
+  II, Wiggins and McTighe, Neelen and Kirschner, Dunlosky and Rawson, Rogers and
+  Lasky-Fink, and Pinker.
 
-  Trigger phrases: "crystal clear docs", "clear documentation", "write clear docs",
-  "make this document clearer", "technical document", "explain this clearly",
-  "doc needs to be clearer", "improve documentation clarity", "clear explanation",
-  "layered explanation", "TLDR document", "progressive disclosure",
-  "add SVG diagram", "explain with diagram", "visual explanation",
-  "mermaid diagram", "create architecture diagram", "diagram for docs",
-  "structure this document", "format technical doc", "document layout",
-  "make this scannable", "scannable docs", "callout patterns", "admonition design",
-  "how to explain", "explain like", "write a guide", "tutorial structure",
-  "documentation best practices", "technical writing"
+  Trigger phrases: "crystal clear docs", "clear documentation",
+  "explain this clearly", "teach this concept", "help readers understand",
+  "improve this guide", "technical writing", "write a tutorial",
+  "write a how-to guide", "documentation psychology", "fix confusing docs",
+  "reader mental model", "add a diagram", "documentation usability",
+  "make this easier to learn", "write a runbook", "safety-critical docs",
+  "architecture page", "retry boundaries"
 ---
 
 # Crystal Clear Docs
 
-Create technical documents people actually read and understand — by layering
-information from TL;DR to deep dive and explaining hard concepts with diagrams.
+Create documentation that produces the intended reader outcome, not merely a
+polished page.
 
 ## Core Philosophy
 
-1. **Lead with the answer.** The reader's first question is "does this matter to
-   me?" — answer it in the first sentence. Everything else supports that answer.
-2. **Layer, don't dump.** Progressive disclosure: TL;DR → Example → Explanation
-   → Deep Dive. Each layer is complete and accurate on its own.
-3. **Show, don't just tell.** Concepts that require the reader to hold multiple
-   relationships in their head get a diagram. Code gets shown before explanation.
-4. **Every word earns its place.** If removing a word changes nothing, remove it.
-   Active voice. Plain language. Short sentences. Scannable structure.
-5. **Respect the reader's time.** They scan, they don't read. Design for scanning:
-   information-dense headings, bold key terms, lists over walls of text, and
-   callouts that surface what matters.
+1. **Define the change before the content.** State what readers must find,
+   decide, explain, or do and what evidence would demonstrate success.
+2. **Design for the reader's current model.** New information is interpreted
+   through prior knowledge, misconceptions, goals, language, and context.
+3. **Expose structure, not just facts.** Make entities, relationships, causes,
+   constraints, decisions, and applicability conditions visible.
+4. **Match support to expertise.** Give novices explicit guidance and
+   experienced readers direct access to dense reference and boundary cases.
+   Fade support only in adaptive, facilitated, or multi-attempt experiences.
+5. **Validate performance, not polish.** "Looks clear" is weak evidence. Ask
+   representative readers to find, explain, predict, execute, or adapt.
 
-## Quick-Start: Document Anatomy
+Learning research supplies mechanisms and design hypotheses, not universal
+page rules. Much of the evidence comes from instruction and controlled studies;
+validate each application with the actual audience, task, medium, and delay.
 
-Every crystal-clear document follows this skeleton:
+## Task Router
 
-```
-# [Action-oriented title]
-**TL;DR**: [One sentence — what and why]
-[Quick-start code/command — the answer]
+| Request | Start with |
+| --- | --- |
+| Diagnose or design a document system | `references/outcome-driven-design.md` |
+| Teach a concept or correct a misconception | `references/reader-mental-models.md`, then `references/layered-writing.md` |
+| Write a runbook or safety-critical procedure | `references/document-structure.md`, then `references/reader-mental-models.md` |
+| Design an architecture or process diagram | `references/svg-diagrams.md` |
+| Rewrite confusing prose | `references/writing-clarity.md` |
+| Repair navigation or layout | `references/document-structure.md` |
 
-## Overview
-[Layer 1: explanation in plain language, 2-3 paragraphs]
+## Workflow
 
-## How It Works
-[Layer 2: mechanism, diagram if helpful, comparisons]
+### 1. Diagnose the Need
 
-## Configuration / Options
-[Reference table for parameters, options, choices]
+Identify the observed performance gap before accepting "write documentation"
+as the solution.
 
-## Advanced Usage
-[Layer 3: edge cases, alternatives, deep architecture]
+- Fix tools, permissions, incentives, or workflow when information is not the
+  blocker.
+- Use reference or point-of-work support when readers only need retrieval.
+- Use instruction when readers must retain, reason, judge, or transfer.
 
-## Related
-[Links to next logical step, tangential topics, support]
-```
+See `references/outcome-driven-design.md`.
 
-→ See `references/layered-writing.md` for the full framework.
-→ See `references/document-structure.md` for formatting patterns.
-→ See `references/writing-clarity.md` for word/sentence-level techniques.
-→ See `references/svg-diagrams.md` for when and how to use diagrams.
+### 2. Define Outcome and Evidence
+
+Write an observable outcome:
+
+> Given [situation and resources], the reader can [task or judgment] to
+> [quality criteria], including [important variation].
+
+Define the proof before outlining the page. Match evidence to the goal: lookup,
+execution, explanation, diagnosis, adaptation, or transfer.
+
+### 3. Model the Reader
+
+Record only dimensions that change a design decision:
+
+- Domain and task knowledge
+- Knowledge organization and likely misconceptions
+- Goals, value, confidence, and agency
+- Language, tools, environment, access, risk, and culture
+- What novices need exposed and experts can safely skip
+
+See `references/reader-mental-models.md`.
+
+### 4. Choose the Documentation Job
+
+| Reader need | Primary form | Optimize for |
+| --- | --- | --- |
+| Find an exact fact | Reference | Search, stable labels, completeness |
+| Complete a known task | How-to | Actions, decisions, checks, recovery |
+| Learn an end-to-end capability | Tutorial | Guided task, feedback, fading |
+| Explain behavior | Concept page | Causal model, examples, prediction |
+| Choose among options | Decision guide | Criteria, contrasts, boundaries |
+| Recover from failure | Troubleshooting guide | Evidence, causes, tests, remedies |
+| Respond under pressure | Runbook | Safe sequence, stop conditions, escalation |
+
+Split incompatible jobs instead of forcing one page to serve all of them.
+
+### 5. Build Understanding
+
+When understanding or transfer matters:
+
+1. Activate or supply prerequisites.
+2. State the governing question or useful idea.
+3. Explain the causal or structural model.
+4. Show a worked example with decisions and reasons.
+5. Contrast an example, nonexample, near miss, or boundary case.
+6. Prompt prediction or self-explanation where it exposes the model.
+7. Fade guidance and vary the case when independent use matters.
+8. Provide answer criteria, automated checks, or human feedback where the
+   delivery medium supports them.
+
+A static page cannot observe competence or personalize feedback. It can offer
+worked, partial, and independent variants, but the reader or an external system
+must choose the appropriate stage and evaluate the result.
+
+See `references/layered-writing.md`.
+
+### 6. Select Representations by Cognitive Job
+
+| Relationship | Useful representation |
+| --- | --- |
+| Cause, qualification, argument | Prose |
+| Ordered action | Numbered procedure |
+| Exact executable form | Code |
+| Aligned comparison or lookup | Table |
+| Flow, state, hierarchy, space, interaction | Diagram |
+| Change over time or quantity | Appropriate chart |
+
+Add words and visuals when they complement each other. Signal structure, keep
+corresponding elements close, segment meaningful complexity, pretrain notation
+when needed, and provide accessible alternatives.
+
+See `references/svg-diagrams.md`.
+
+### 7. Write and Arrange for Use
+
+- Put the topic, point, action, or consequence where readers encounter it early.
+- Use concrete actors, verbs, objects, conditions, and outcomes.
+- Shape sentences around clear relationships, not word-count quotas.
+- Move from familiar information to new information.
+- Use headings, lists, tables, callouts, links, and emphasis only when they
+  expose meaning or reduce action friction.
+- Preserve coherent prose when causality or qualification matters.
+- Test the rendered document on the media readers actually use.
+
+See `references/writing-clarity.md` and `references/document-structure.md`.
 
 ## Common Problems
 
-### "This document is a wall of text"
+### "Readers can copy the example but cannot adapt it"
 
-1. Add a one-sentence TL;DR at the very top
-2. Break paragraphs into lists (3+ related items → bullet list)
-3. Add descriptive H2/H3 headings (not "Overview", "Details")
-4. Insert a diagram for any concept spanning more than 2 paragraphs
-5. Move advanced configuration into `<details>` expandable sections
+Expose the governing principle and decision cues. Add a near miss, a changed
+case, and an explanation prompt. Fade copied steps before testing transfer.
 
-### "I don't know where to add a diagram"
+### "Beginners are lost but experts find it tedious"
 
-Ask: does the reader need to hold 3+ relationships in their head? If yes, add a
-diagram. Use Mermaid for flowcharts, sequences, state machines, ER diagrams.
-Use hand-coded SVG for simple before/after or architecture comparisons.
+Keep one source of truth but provide different entry paths: concise reference
+for experienced readers and skippable prerequisites, reasoning, and worked
+examples for novices. Never hide safety conditions in the novice path.
 
-### "The explanation is too complex"
+### "The page is easy to scan but nobody understands it"
 
-1. Write the one-sentence version first (the Compression Ladder exercise)
-2. Then the one-paragraph version
-3. Then the full explanation
-4. Present them in that order — readers self-select depth
+Restore coherent relationships. Lists and headings help navigation; they do not
+replace causal explanation, examples, contrasts, and integration with prior
+knowledge.
 
-### "How do I make this scannable?"
+### "The explanation feels clear, but we cannot tell if it worked"
 
-Scan this checklist:
-- Headings are specific and information-dense
-- Bold used only for key terms (not whole sentences)
-- Lists used for any 3+ related items
-- Callouts highlight warnings, tips, and gotchas
-- Code blocks have language annotations and captions
-- Tables used for configuration references and comparisons
-
-## Decision Trees
-
-### Which Diagram Type?
-
-| Concept | Diagram | Syntax |
-|---------|---------|--------|
-| Step-by-step process | Flowchart | `flowchart TD` |
-| Component interactions | Sequence diagram | `sequenceDiagram` |
-| State lifecycle | State diagram | `stateDiagram-v2` |
-| System architecture | Architecture diagram | `architecture-beta` |
-| Data relationships | ER diagram | `erDiagram` |
-| Timeline / roadmap | Gantt chart | `gantt` |
-| A vs B comparison | Side-by-side SVG | Hand-coded or draw.io |
-| Hierarchy / tree | Flowchart with subgraphs | `flowchart TD; subgraph` |
-
-### Which Callout Type?
-
-| Situation | Callout |
-|-----------|---------|
-| Supplementary context | ℹ Note |
-| Better way to do it | 💡 Tip |
-| Potential pitfall | ⚠ Warning |
-| Data loss, security risk | 🚫 Danger |
-| Worked example | Example |
-
-### How Deep to Go?
-
-| Reader wants... | Give them... |
-|----------------|-------------|
-| "Is this relevant?" | TL;DR (1 sentence) |
-| "How do I use it?" | TL;DR + Code example |
-| "Why does it work this way?" | + How It Works section |
-| "What are the edge cases?" | + Advanced Usage section |
-| "I need to contribute/modify" | + Architecture + Deep dive |
-
-## SVGs for Visual Explanation
-
-When a concept spans more than 2 paragraphs and involves relationships,
-structure, flow, or state — add a diagram.
-
-**Use Mermaid inline** (works on GitHub, GitLab, Notion, most Markdown renderers):
-
-```mermaid
-flowchart TD
-    A[User] --> B{Authenticated?}
-    B -->|Yes| C[Grant Access]
-    B -->|No| D[Redirect to Login]
-    C --> E[Return Resource]
-```
-
-**Use inline SVGs** for precise control, annotations, and dark mode support:
-
-```svg
-<svg role="img" aria-label="..." viewBox="0 0 400 200">
-  <title>Short description</title>
-  <desc>Longer description for accessibility</desc>
-  <!-- diagram elements -->
-</svg>
-```
-
-→ Every SVG needs `role="img"`, `<title>`, and `<desc>` elements.
-→ Use `currentColor` so diagrams adapt to light/dark themes.
-→ Color-blind safe: never rely on color alone — always add labels.
+Test the target performance. Ask readers to paraphrase the model, predict a
+result, complete the task, diagnose a fresh failure, or choose under changed
+constraints. Observe errors and revise where understanding breaks.
 
 ## Quality Gate
 
-Before publishing any document, verify:
+- [ ] Confirm documentation can address the actual problem.
+- [ ] State an observable reader outcome and matching evidence.
+- [ ] Identify required prior knowledge and likely misconceptions.
+- [ ] Choose structure and representation from the reader's task.
+- [ ] Preserve conditions, boundaries, and safety-critical nuance.
+- [ ] Distinguish lookup, execution, and durable understanding.
+- [ ] Distinguish immediate comprehension, supported execution, durable
+  learning, and transfer; one successful attempt does not prove all four.
+- [ ] Make success and recovery observable.
+- [ ] Support access across relevant devices and assistive technologies.
+- [ ] Validate with representative readers and realistic tasks.
 
-1. **Can someone get the gist from the TL;DR alone?** If no, rewrite it.
-2. **Can they self-select their depth?** Can they stop at the code example and leave satisfied?
-3. **Do headings predict their content?** No "Overview", "Details" — be specific.
-4. **Is every code block copy-paste runnable?** If it needs invisible setup, add it.
-5. **Are diagrams needed?** Any concept 2+ paragraphs with relationships → add a diagram.
-6. **Did you remove needless words?** Read each sentence. Delete every word. Re-add only what's essential.
-
-## Reference Files
+## Reference Index
 
 | File | Contents |
-|------|----------|
-| `references/layered-writing.md` | Inverted pyramid, Layer Cake Method, progressive disclosure, TL;DR patterns, code-first writing, Up-Goer Five technique |
-| `references/svg-diagrams.md` | Diagram type selection, Mermaid syntax and styling, SVG accessibility, dark mode, Tufte's visualization principles, visual explanation patterns |
-| `references/document-structure.md` | Document anatomy, heading hierarchies, callout/admonition patterns, comparison design, scannability, CRAP principles, responsive layout, cognitive load management |
-| `references/writing-clarity.md` | Active voice, jargon elimination, sentence construction, comparison patterns, worked examples, MECE framework, BLUF method |
+| --- | --- |
+| `references/outcome-driven-design.md` | Performance diagnosis, backward design, transfer, evidence, document types, alignment, evaluation |
+| `references/reader-mental-models.md` | Prior knowledge, mental models, misconceptions, expertise, motivation, culture, metacognition |
+| `references/layered-writing.md` | Explanation sequencing, worked examples, contrasts, scaffolding, retrieval, feedback, transfer |
+| `references/svg-diagrams.md` | Multimedia learning, diagram selection, signaling, integration, accessibility, Mermaid, SVG |
+| `references/writing-clarity.md` | Attention, concrete prose, sentence geometry, coherence, action friction, behavioral editing |
+| `references/document-structure.md` | Document types, reading modes, semantic chunks, navigation, code, responsive and accessible layout |

--- a/skills/crystal-clear-docs/references/document-structure.md
+++ b/skills/crystal-clear-docs/references/document-structure.md
@@ -1,272 +1,423 @@
-# Document Structure and Formatting
+# Document Navigation and Layout
 
-Sources: Google Developer Technical Writing Course (One + Two), Steve Krug (Don't Make Me Think, Chapters 1-5), Jakob Nielsen (Nielsen Norman Group, Progressive Disclosure research), Robin Williams (The Non-Designer's Design Book — CRAP principles), Jeff Johnson (Designing with the Mind in Mind), Microsoft UX Guidelines (Inverted Pyramid in UI text).
+Sources: Google Technical Writing Courses, Steve Krug (Don't Make Me Think), Jeff Johnson (Designing with the Mind in Mind), Robin Williams (The Non-Designer's Design Book), W3C Web Content Accessibility Guidelines, and task-centered documentation practice.
 
-Covers: How to structure, format, and lay out technical documents for maximum clarity and scannability using HTML and Markdown. Heading hierarchies, callout/admonition patterns, comparison design, responsive layout, and cognitive load management.
+Covers: Arrange technical content after its purpose is defined. Choose structures by document type, support scanning, close reading, and lookup, create semantic chunks, select headings and content forms, and test navigation, responsive behavior, accessibility, and task completion.
 
-## The Golden Rule of Document Structure
+## Structure Follows Purpose
 
-**Every page should be self-explanatory within 5 seconds.** The reader should know what this page covers, whether it's relevant to them, and how to proceed — without thinking.
+Define the reader, situation, and outcome before arranging the page. Structure cannot compensate for an unclear purpose.
 
-## Document Opening Formula
+Write a one-sentence contract:
 
-Every document should open with:
+> This runbook helps an on-call engineer restore queue processing without duplicating jobs.
 
-```
-# [Clear, action-oriented title]
+Use that contract to choose the document type, opening, sequence, navigation, and depth. Do not begin with a universal page template.
 
-**TL;DR**: [One sentence — what this page explains and why you'd read it]
+Ask:
 
-> **Prerequisites**: [What you need to know / have installed]
-> **What this covers**: [Scope — what you'll learn]
-> **What this does NOT cover**: [Non-scope — prevent wasted reading]
+- What brought the reader here?
+- Will they scan, learn, decide, execute, or look up a fact?
+- Must they follow a sequence?
+- Which information is safety-critical?
+- Which paths apply only to some readers?
+- Will they return repeatedly or read once?
+- Where and on what device will they use the document?
 
-[Quick-start code or command — the answer, immediately]
+Let the strongest use case govern the primary path. Support secondary use cases without making every reader traverse them.
 
-## How It Works [or: Overview]
-[Layered deepening starts here]
-```
+## Choose a Structure by Document Type
 
-## Heading Hierarchy for Progressive Disclosure
+Different documents create different reading contracts.
 
-Headings must genuinely compress the content below them. A reader scanning only headings should understand the full argument.
+| Document type | Primary reader intent | Useful structure |
+| --- | --- | --- |
+| Tutorial | Learn by completing a guided experience | Goal, setup, staged actions, checkpoints, reflection |
+| How-to guide | Complete a known task | Preconditions, task steps, verification, recovery |
+| Concept explanation | Build a mental model | Governing idea, parts, relationships, example, implications |
+| Reference | Retrieve exact facts | Scope, stable categories, searchable entries, constraints |
+| Decision record | Understand a choice | Context, decision, alternatives, consequences, status |
+| Proposal | Decide whether to act | Recommendation, value, evidence, tradeoffs, requested decision |
+| Runbook | Respond safely under pressure | Trigger, diagnosis, safe actions, checks, escalation, rollback |
+| Troubleshooting guide | Recover from a symptom | Symptom, discriminating checks, causes, fixes, verification |
+| Release note | Learn what changed and what to do | Change, affected users, impact, required action, references |
+| API guide | Integrate correctly | Mental model, authentication, common flow, errors, linked reference |
 
-| Level | Purpose | Rule |
-|-------|---------|------|
-| H1 | What the entire document is about | One per page, action-oriented |
-| H2 | Major sections supporting H1 | 3-7 per page, answer "what" and "why" |
-| H3 | Subsections detailing H2 | Answer "how", introduce a specific concept or step |
-| H4 | Granular details within H3 | Edge cases, examples, config details |
+Do not force one document to serve incompatible intents. Split a tutorial from exhaustive reference when the combined page makes both harder to use. Keep related documents connected with explicit links and shared terminology.
 
-**The compression test**: If H2 says "Overview" and the content is actually about authentication flow, the heading failed. Rewrite it as "Authentication Flow".
+### Safety-Critical Runbook Blueprint
 
-## Callout and Admonition Patterns
+Use one visible operational spine:
 
-Use callouts to surface information that interrupts the linear reading flow. Choose the right type:
+1. State purpose, authority, roles, and the exact trigger.
+2. Put the irreversible hazard and governing safety invariant first.
+3. List prerequisites, required evidence, and explicit stop conditions.
+4. Separate phases with decision gates and named approvers.
+5. For every consequential action, show expected state and failure response.
+6. Distinguish rollback before commitment from recovery or failback afterward.
+7. Define escalation thresholds and who owns the decision.
+8. Verify the system invariant, user-visible result, monitoring, and follow-up state.
 
-| Type | Icon | Color | When to Use |
-|------|------|-------|-------------|
-| **TL;DR** | None or 📌 | Neutral | At the very top of every page. One sentence. |
-| **Info / Note** | ℹ️ | Blue | Supplementary context, "by the way" facts |
-| **Tip** | 💡 | Green | Best practice, "here's a smarter way" |
-| **Warning** | ⚠️ | Yellow/Amber | Potential pitfalls, gotchas, deprecated behavior |
-| **Danger / Critical** | 🚫 | Red | Actions that cause data loss, security issues |
-| **Example** | 📋 | Gray/Neutral | Worked example distinct from explanation |
+Provide a concise fast path and an expanded path when expertise varies. Keep hazards, stop conditions, authority, and verification identical in both.
 
-### HTML Structure for Admonitions
+## Support Three Reading Modes
+
+Design for movement between scanning, close reading, and lookup.
+
+### Scan Mode
+
+Help readers decide relevance and locate a path. Expose descriptive headings, meaningful lead sentences, visible steps, and recognizable terms.
+
+### Close-Read Mode
+
+Preserve coherent prose, reasoning, examples, and qualifications. Avoid fragmenting every thought into labels and bullets.
+
+### Lookup Mode
+
+Provide stable names, predictable categories, searchable literal strings, anchors, and compact reference forms.
+
+Readers switch modes within one session. An engineer may scan for the right error, close-read its explanation, then look up a parameter. Keep those transitions easy.
+
+Test each mode separately. A page can scan well but fail to explain, or explain well but make a known fact difficult to retrieve.
+
+## Design the First View
+
+Use the first view to establish orientation, relevance, and a plausible next move.
+
+Include only what this document needs:
+
+- A specific title
+- A concise statement of purpose or result
+- A critical prerequisite or warning
+- The main action, recommendation, or navigation choice
+- Context needed to interpret what follows
+
+Do not require a summary block on every page. A short reference entry may need only a precise title and signature. A proposal may need its recommendation first. A tutorial may need a goal and setup. A runbook may need an emergency warning before context.
+
+Avoid ceremonial openings such as "This document will discuss." Use the space to clarify scope or help the reader begin.
+
+## Create Semantic Chunks
+
+Group content by meaning and task, not by a fixed item count.
+
+A chunk should answer one recognizable question or support one coherent action. Its boundaries should help readers predict what belongs together.
+
+Useful chunk boundaries include:
+
+- A change in reader goal
+- A new stage in a process
+- A switch from rule to exception
+- A distinct option or platform path
+- A move from explanation to execution
+- A new lookup category
+
+Keep tightly coupled information together even when the section becomes long. Split a section when readers need different labels, can skip one part independently, or would benefit from a direct link to one part.
+
+Do not treat memory research as a mandate for a universal number of sections or list items. Complexity, familiarity, and task context determine useful grouping.
+
+## Make Headings Carry Information Scent
+
+Write headings that predict the content and help readers choose a path.
+
+Weak headings:
+
+- Overview
+- Details
+- Other
+- Advanced
+
+Stronger headings:
+
+- How Lease Revocation Prevents Duplicate Writes
+- Rotate Credentials Without Interrupting Traffic
+- Errors Caused by an Expired Signing Key
+- Optional Controls for Regulated Workloads
+
+Use a consistent hierarchy. Do not skip levels for visual styling. Let heading levels express containment, then use CSS to control appearance.
+
+Prefer headings that match reader vocabulary. Include literal product names, error text, commands, or concepts when readers are likely to search for them.
+
+Apply the heading-only test: scan the headings in order and determine whether they reveal the page's scope and path. Do not demand that headings reproduce the entire argument; require them to make navigation predictable.
+
+## Select Prose, Lists, or Tables Deliberately
+
+Choose the form that matches the relationship among ideas.
+
+| Content relationship | Preferred form |
+| --- | --- |
+| Reasoning, causality, or narrative | Prose |
+| Ordered actions or ranked sequence | Numbered list |
+| Parallel choices or attributes | Bulleted list |
+| Comparison across shared dimensions | Table |
+| Term-to-definition lookup | Definition list or compact reference entries |
+| Branching decision | Decision table, flowchart, or conditional subsections |
+| Spatial or system relationship | Diagram with text alternative |
+
+Keep connected reasoning in prose. Lists expose parallelism but can hide causality and qualification.
+
+Use numbered lists only when order matters or when readers must refer to step numbers. Use bullets when items are peers and sequence is irrelevant.
+
+Use tables when readers compare cells across rows or columns. Avoid tables for long narrative text, sequential procedures, or content that becomes unusable on narrow screens.
+
+Give each list a grammatical lead-in. Keep list items parallel enough that readers can compare them without reinterpreting the syntax.
+
+## Sequence Procedures Around the Task
+
+Place prerequisites before the first step, but include only conditions that must be true before the reader begins.
+
+Distinguish prerequisite types:
+
+| Type | Example |
+| --- | --- |
+| Access | Permission to deploy the service |
+| Environment | CLI connected to the production project |
+| State | Migration completed in the primary region |
+| Knowledge | Familiarity with the service's traffic model |
+| Input | Revision name and rollback target |
+
+Move optional preparation into the relevant branch instead of blocking all readers with it.
+
+For each consequential step, consider four elements:
+
+1. Action: what the reader does.
+2. Context: where or under which condition.
+3. Result: what should become visible.
+4. Recovery: what to do when the result differs.
+
+Place verification near the action it verifies. Do not collect all expected results at the distant end of a long procedure.
+
+Separate alternative paths before their steps diverge. Label the choice with the condition that determines it, such as "If traffic is already split" rather than "Option B."
+
+## Use Callouts for Interruptions With Consequence
+
+Reserve callouts for content that must stand apart from the main flow.
+
+| Callout purpose | Use when |
+| --- | --- |
+| Note | Context helps interpretation but does not alter the action |
+| Tip | An optional technique improves efficiency or quality |
+| Warning | A plausible action can cause loss, exposure, or difficult recovery |
+| Important | A condition changes whether the procedure succeeds |
+| Example | A concrete case benefits from visual separation |
+
+Label callouts with words, not color or icons alone. State the consequence before elaboration in warnings.
+
+Place a warning before the hazardous action. Keep a prerequisite in the prerequisite flow rather than disguising it as a callout.
+
+Avoid stacking callouts. If several adjacent notices are essential, revise the main structure so the information becomes part of the task path.
+
+Use this accessible HTML pattern when custom markup is appropriate:
 
 ```html
-<div class="admonition note">
-  <strong>ℹ Note:</strong>
-  <p>This operation is idempotent — you can safely retry it.</p>
-</div>
-
-<div class="admonition warning">
-  <strong>⚠ Warning:</strong>
-  <p>This deletes all data. No undo.</p>
-</div>
+<aside class="callout callout-warning" aria-labelledby="delete-warning">
+  <h3 id="delete-warning">Warning: deletion cannot be undone</h3>
+  <p>Export the audit records before removing the workspace.</p>
+</aside>
 ```
 
-### Callout Placement Rules
+## Present Code Samples According to Purpose
 
-- Before the action they warn about (never after)
-- Never more than one callout per section (diminishing returns)
-- Keep text under 3 lines (if longer, it belongs in the main content)
+Decide what each sample demonstrates.
 
-## Progressive Disclosure with HTML
+| Sample purpose | Include |
+| --- | --- |
+| Command to execute | Exact command, required substitutions, expected signal |
+| Focused API pattern | Relevant context and omitted-code markers |
+| Complete starter | Imports, setup, execution, and dependency versions |
+| Configuration fragment | File location, surrounding key path, valid syntax |
+| Diagnostic output | Command that produced it and lines that matter |
+| Concept illustration | Minimal code plus an explicit non-production label |
 
-### `<details>/<summary>` for Optional Depth
+Do not require every code block to run independently. A focused fragment can explain an idea more clearly than a complete application. Mark omissions and dependencies so readers understand the boundary.
+
+Annotate fenced blocks with the language when supported. Identify the file or shell context when ambiguity is likely.
+
+Keep explanations beside the relevant lines. Highlight sparingly and provide a text explanation; do not depend on color alone.
+
+Show expected output when it helps readers verify success or distinguish states. Omit predictable output that adds noise.
+
+Test executable samples in the environment they claim to support. Treat illustrative pseudocode as illustration, not as a tested command.
+
+## Add Tables of Contents Conditionally
+
+Use a table of contents when it reduces navigation cost.
+
+Add one when readers are likely to:
+
+- Jump among independent sections
+- Revisit the page as reference
+- Share links to subsections
+- Encounter a long or branching page
+- Need a quick map of unfamiliar territory
+
+Omit one when the page is short, strictly sequential, or already has a compact local navigation system.
+
+Keep TOC labels synchronized with headings. Link only to destinations worth choosing independently. Avoid a TOC that is nearly as long as the content it precedes.
+
+Use a local mini-TOC for a dense section when a page-level TOC would not help.
+
+## Build Links That Preserve Context
+
+Write link text that predicts the destination or action.
+
+Prefer:
+
+> Review the `Token rotation failure modes` section in the product documentation.
+
+Avoid:
+
+> For more information, open the related page.
+
+Link at the point of need. Do not interrupt every term with a link if the destination is optional and the repeated visual noise harms reading.
+
+Distinguish related purposes:
+
+- Prerequisite link: read or complete before proceeding
+- Supporting link: consult for deeper explanation
+- Reference link: verify exact syntax or values
+- Next-step link: continue a workflow
+
+Preserve stable anchors for frequently shared sections. Check internal and external links as part of maintenance.
+
+## Apply Progressive Disclosure Carefully
+
+Keep the primary path visible. Hide only optional depth that readers can identify accurately from its label.
+
+Good candidates for disclosure controls include verbose traces, platform-specific variants, background derivations, and uncommon edge cases.
+
+Poor candidates include safety warnings, required steps, core definitions, and information readers do not know they need.
+
+Use native controls when possible:
 
 ```html
-## Configuration Options
-
 <details>
-<summary>Advanced: Custom timeout settings</summary>
-
-The default timeout is 30 seconds. For long-running operations, override with:
-
-```js
-fetch('/api', { timeout: 120000 })
-```
-
+  <summary>Show the full timeout trace</summary>
+  <pre><code>...</code></pre>
 </details>
 ```
 
-Use for: advanced configuration, verbose examples, edge cases, verbose error messages, platform-specific differences.
+Make the summary describe the hidden content. Ensure controls work by keyboard, expose state to assistive technology, and remain understandable when printing or exporting.
 
-### Tabbed Content for Parallel Paths
+Use tabs only for genuinely parallel paths. Keep shared steps outside tabs, use persistent labels, and ensure each path can be linked and copied without losing context.
 
-```
-### Installation
+## Use Visual Design to Reinforce Relationships
 
-<div class="tabs">
-  <div class="tab" data-tab="npm">npm install package</div>
-  <div class="tab" data-tab="yarn">yarn add package</div>
-  <div class="tab" data-tab="pnpm">pnpm add package</div>
-</div>
-```
+Retain four adaptable principles from Robin Williams:
 
-Use for: installation methods, language-specific examples, OS-specific instructions.
+| Principle | Apply it by |
+| --- | --- |
+| Contrast | Making heading, body, code, and warning roles visibly distinct |
+| Repetition | Reusing patterns for the same semantic role |
+| Alignment | Placing elements on a coherent visual axis |
+| Proximity | Keeping labels, examples, captions, and consequences near what they describe |
 
-## Scannability Techniques
+Do not convert these principles into fixed whitespace percentages or decorative rules. Evaluate whether the layout reveals grouping, priority, and sequence.
 
-Research shows users scan, they don't read. Design for scanning:
+Use whitespace to separate semantic groups. Reduce spacing inside a group and increase it across a boundary. Maintain enough density for lookup-heavy pages without turning them into an undifferentiated wall.
 
-### Visual Hierarchy of Text Elements
+Keep emphasis scarce and consistent. If bold, color, borders, and callouts all compete, simplify the hierarchy.
 
-Readers process in this order:
-1. Headings (H1-H4)
-2. Bold text within paragraphs
-3. First sentence of each paragraph
-4. Lists (numbered > bulleted)
-5. Code blocks (developers read code before prose)
-6. Body text
+## Design for Responsive Reading
 
-### Lists > Paragraphs
+Test the actual document at narrow and wide widths, with zoom, and with increased text size.
 
-When you have 3+ related items, use a list instead of prose:
+Use flexible patterns:
 
-**Bad (wall of text):**
-The system supports three authentication methods. You can use API keys, which are simple but less secure. You can use OAuth 2.0, which is more secure but requires more setup. You can use JWT tokens, which are stateless and good for microservices.
+- Set media with responsive dimensions and preserve aspect ratios.
+- Give SVGs a `viewBox` and meaningful text alternatives.
+- Allow code blocks to scroll without shrinking text into illegibility.
+- Wrap wide tables in a labeled scroll region or provide a stacked alternative.
+- Keep controls large enough to operate by touch and keyboard.
+- Avoid layouts that depend on hover or precise pointing.
+- Prevent side navigation from obscuring the main reading path.
 
-**Good (scannable list):**
-- **API Keys**: Simple, less secure. Good for server-to-server.
-- **OAuth 2.0**: Secure, requires setup. Good for user-facing apps.
-- **JWT Tokens**: Stateless, no DB lookup. Good for microservices.
+Do not assume wrapping code is always wrong or always right. Preserve significant whitespace and long tokens where wrapping would alter meaning; offer line wrapping where it improves reading without corrupting the sample.
 
-### Paragraph Design
+Ensure anchor navigation does not hide headings beneath sticky headers.
 
-- Opening sentence = the paragraph's thesis. Everything after = support.
-- Keep paragraphs to 3-5 sentences.
-- Bold key terms on first use (and define them).
-- Use one paragraph per idea.
+## Build Accessibility Into Structure
 
-## Tables for Comparison and Reference
+Use semantic HTML before adding ARIA.
 
-Tables outperform prose for:
-- Feature comparisons (A vs B vs C)
-- Configuration options (parameter / type / default / description)
-- Error codes (code / meaning / action)
-- Method signatures (method / params / returns / description)
+- Provide one descriptive page title and a logical heading hierarchy.
+- Use real lists for lists and real tables for tabular relationships.
+- Associate table headers with their data cells.
+- Give images and diagrams alternatives that convey their purpose.
+- Keep link text meaningful outside its surrounding sentence.
+- Preserve visible keyboard focus.
+- Avoid conveying meaning through color, position, or shape alone.
+- Identify the language of the page and unusual language changes.
+- Support reflow and text enlargement without loss of content or function.
 
-```markdown
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `timeout` | number | 30000 | Request timeout in ms |
-```
+Write diagram alternatives at the level the task requires. A decorative image may need empty alternative text. A system diagram may need a concise summary plus a structured description of nodes, direction, and exceptions.
 
-## Code Block Best Practices
+Check exported PDF and print views when readers rely on them. Interactive disclosure, sticky navigation, and color-coded states may disappear outside the browser.
 
-### Always Include Language Annotation
+## Strengthen Information Scent
 
-```python  ← Not ``` alone
-def hello():
-    print("hi")
-```
+Give readers cues that accurately predict where a path leads.
 
-### Show File Name When Useful
+Use task language in navigation labels. Distinguish "Configure retries" from "Retry behavior" when one destination is procedural and the other conceptual.
 
-```
-```javascript title="src/auth/login.js"
-```
-```
+Place high-value choices where readers expect them. Keep terminology aligned across page titles, navigation, search results, and in-page headings.
 
-### Highlight Key Lines
+Avoid vague clusters such as "Resources," "Learn more," and "Miscellaneous" when specific labels are possible.
 
-```javascript {3,6-8}
-// The important lines are highlighted for scanning
-function process(data) {       // ← highlighted
-  validate(data)
-  return transform(data)
-}
-```
+Cross-link sibling paths when readers commonly arrive at the wrong one. Explain the distinction briefly:
 
-### Prefer Working Examples
+> To retry a failed job, use this runbook. To change automatic retry policy, open the `Configure retry limits` guide.
 
-Every code block should be copy-paste runnable. If the reader needs to fill in gaps, you've made them think. Add the boilerplate.
+## Test the First View
 
-## Cognitive Load Management
+Show representative readers only the initial viewport or rendered opening, without explaining it.
 
-From Jeff Johnson's "Designing with the Mind in Mind":
+Ask:
 
-### Principle of Chunking
+- What is this document for?
+- Who is it for?
+- What would you do next?
+- What risk or prerequisite is visible?
+- Where would you go for your specific case?
 
-Break complex information into chunks of 5-9 items (Miller's Law). This applies to:
-- Steps in a procedure
-- Items in a list
-- Sections on a page
-- Options in a decision
+Do not impose a universal time limit. Observe whether readers orient confidently under realistic conditions. Record incorrect interpretations, not merely speed.
 
-### White Space as a Cognitive Tool
+Revise the title, lead, labels, or priority when readers choose the wrong path. Do not add more elements automatically; often the fix is to remove competing signals.
 
-Generous spacing between sections gives the reader's brain time to process. Crowded content forces simultaneous processing — the reader must scan, filter, and prioritize all at once.
+## Run Task and Retrieval Tests
 
-Rule of thumb: between 30-50% of the visible area should be white space.
+Give readers realistic goals and let the document carry the interaction.
 
-### Line Length (Measure)
+For a task test, observe whether they can:
 
-Optimal line length for readability: 50-75 characters. Longer lines make it harder for the eye to find the next line. Shorter lines break reading rhythm. For code, 80-100 characters is standard.
+1. Choose the correct path.
+2. Satisfy the prerequisites.
+3. Complete the actions in order.
+4. Recognize success or failure.
+5. Recover from a plausible problem.
 
-## Mobile-Responsive Documentation
+For a lookup test, ask them to find a known parameter, limit, error, or exception. Note where they begin, which labels they follow, and whether the answer includes enough context to use safely.
 
-- SVGs: use `viewBox` (never fixed `width`/`height`)
-- Tables: horizontal scroll wrapper for narrow screens, or collapse to key-value on mobile
-- Code blocks: horizontal scroll, never wrap
-- Callouts: full-width, padding adjusts with viewport
-- Font size: minimum 16px for body text on mobile (prevents iOS zoom on focus)
+For a scan test, ask them to identify which sections apply without reading every paragraph.
 
-## CRAP Principles for Document Design
+Test on the target medium. Include mobile, keyboard-only, screen reader, print, or constrained operational contexts when those surfaces matter.
 
-From Robin Williams' "The Non-Designer's Design Book":
+Distinguish structural failures from prose failures. If readers cannot find the right paragraph, change navigation or grouping. If they find it but misunderstand it, revise the writing using `writing-clarity.md`.
 
-| Principle | Meaning | Applied to Docs |
-|-----------|---------|-----------------|
-| **Contrast** | Make different things look very different | Heading sizes clearly distinct; callout colors clearly different from body |
-| **Repetition** | Repeat visual elements for cohesion | Same admonition style throughout; consistent code block styling; consistent link color |
-| **Alignment** | Every element visually connected to something | Left-align body text; consistent indent for code and lists; aligned callout borders |
-| **Proximity** | Related items close together | TL;DR directly below title; code example immediately after its explanation; prerequisites near the top |
+## Review Structural Quality
 
-## Navigation and Wayfinding
+- [ ] Define the page purpose and primary reader path before arranging it.
+- [ ] Match the organization to the document type and reader intent.
+- [ ] Support scanning, close reading, and lookup where each is needed.
+- [ ] Make the first view establish orientation and a useful next move.
+- [ ] Group content by semantic relationship rather than fixed quotas.
+- [ ] Use headings with accurate information scent and logical hierarchy.
+- [ ] Choose prose, lists, tables, and diagrams by relationship.
+- [ ] Put prerequisites, warnings, verification, and recovery near the action.
+- [ ] Scope code samples according to what they teach or enable.
+- [ ] Add TOCs, links, and disclosure controls only when they reduce effort.
+- [ ] Preserve responsive behavior, semantic HTML, and accessible alternatives.
+- [ ] Test first-view orientation, task completion, scanning, and retrieval.
 
-### Table of Contents
+## Relationship to Writing Clarity
 
-For documents longer than 3 scroll-screens, include a TOC after the TL;DR:
-
-```markdown
-- [Quick Start](#quick-start)
-- [How It Works](#how-it-works)
-- [Configuration](#configuration)
-- [Error Handling](#error-handling)
-- [Advanced Usage](#advanced-usage)
-```
-
-### Internal Links
-
-Link to related concepts when the reader might need context. A developer reading about "JWT refresh tokens" might also need to know about "token rotation" — link to it.
-
-### Breadcrumbs (for multi-page docs)
-
-```
-Home > Authentication > JWT Tokens > Refresh Token Flow
-```
-
-Gives the reader spatial context within the documentation system.
-
-### "What's Next" Section
-
-End every page with:
-- Where to go next (logical next step)
-- Related documentation (tangential but relevant)
-- "Still stuck?" → support channels
-
-## Anti-Patterns
-
-| Anti-pattern | Why it fails | Fix |
-|-------------|-------------|-----|
-| Generic headings ("Overview", "Details", "More") | Labels on opaque boxes — no predictive value | Specific, information-dense headings |
-| Walls of text | Readers scan, they don't read | Break into lists, tables, diagrams |
-| No TL;DR | Reader must read to determine relevance | One sentence at the top that captures the essence |
-| Overuse of bold/emphasis | When everything is emphasized, nothing is | Bold only key terms, first-sentence thesis |
-| Code without output | Reader can't verify behavior | Show expected output or screenshot |
-| Unlabeled diagrams | Reader must decode visual without guidance | Every diagram has a caption explaining what it shows |
-| Hiding key info in scroll depth | Mobile users miss content | Critical info above the fold; progressive disclosure for detail |
+Use this reference after defining what the reader should achieve and drafting the necessary ideas. Use `writing-clarity.md` to improve reader outcomes, sentence geometry, coherence, concrete language, action friction, and behavioral testing within each structural unit.

--- a/skills/crystal-clear-docs/references/layered-writing.md
+++ b/skills/crystal-clear-docs/references/layered-writing.md
@@ -1,294 +1,449 @@
-# Layered Writing for Technical Documents
+# Evidence-Informed Explanation Design
 
-Sources: Barbara Minto (The Pyramid Principle, 1987), Edward Tufte (Envisioning Information, 1990), Steve Krug (Don't Make Me Think, 2000), William Zinsser (On Writing Well, 1976), Google Technical Writing Course, Randall Munroe (Thing Explainer / Up-Goer Five), Cognitive Load Theory (Sweller, 1988), Wellspoken.me Layer Cake Method.
+Sources: Richard E. Mayer (Multimedia Learning), Dunlosky and Rawson (The Cambridge Handbook of Cognition and Education), Lovett et al. (How Learning Works), National Academies (How People Learn II), Mirjam Neelen and Paul A. Kirschner (Evidence-Informed Learning Design), Grant Wiggins and Jay McTighe (Understanding by Design), Barbara Minto (The Pyramid Principle, where useful).
 
-Covers: Progressive disclosure of information from TL;DR to deep detail. Inverted pyramid structure, layered explanations, and techniques for explaining complex topics at multiple levels of resolution.
+Covers: Design explanations for lookup, execution, and durable understanding; sequence prerequisite knowledge and causal models; use worked examples, contrasts, scaffolding, retrieval, feedback, and transfer checks to support outcomes that can be evaluated.
 
-## The Inverted Pyramid
+Evidence boundary: Treat these principles as evidence-informed adaptations. Most source studies concern instruction, training, or controlled learning tasks. A static document cannot diagnose mastery, schedule practice, or deliver personalized feedback unless another person or system supplies those functions.
 
-Journalists solved this problem long ago: put the most critical information first (who, what, when, where, why), then provide context, background, and nuance in descending order of importance. The structure is designed for skimmers — readers who stop at any point still get something useful.
+## Start with the Reader's Intended Performance
 
-Applied to technical docs:
+Define what the reader must do after reading before deciding how to organize the page.
 
-| Layer | Position | Content | Reader Type |
-|-------|----------|---------|-------------|
-| TL;DR | Very top | One sentence summary of what this page explains | Everyone |
-| Core | After TL;DR | The answer, command, configuration, step | Skimmers |
-| Detail | Middle | How it works, why this approach | Curious readers |
-| Deep dive | Bottom | Edge cases, alternatives, architecture | Experts |
+Replace broad goals such as "understand caching" with observable performances:
 
-The key insight: most readers will read the summary and example and leave satisfied. A smaller number will need the deep explanation. Almost none need to read everything.
+- Identify when a cache can return stale data.
+- Configure a cache safely for one endpoint.
+- Predict what happens after invalidation fails.
+- Diagnose a low hit rate from logs and request patterns.
+- Choose between local and distributed caching for a new service.
 
-## The Layer Cake Method
+Use backward design:
 
-Build understanding in sequential layers where each layer is complete on its own and prepares the reader for the next. Each layer is **accurate** — you're adjusting resolution, not accuracy.
+1. Specify the desired performance.
+2. Decide what evidence would demonstrate that performance.
+3. Identify the knowledge and reasoning required.
+4. Design explanation, practice, and feedback around that evidence.
+5. Remove content that does not support the performance.
 
-| Layer | Resolution | Length | Example |
-|-------|-----------|--------|---------|
-| Layer 1 | Thumbnail | 1 sentence | "JWT is a compact token that proves who you are without the server storing session state." |
-| Layer 2 | Standard image | 1 paragraph | Mechanism: how it works, plain language. "When you log in, the server creates a signed token with your user ID. Your browser sends this token with every request. The server verifies the signature without a database lookup." |
-| Layer 3 | High-definition | Full section | Nuance: algorithms, expiration, refresh tokens, security considerations, common attack vectors. |
+Do not equate content coverage with learning; the presence of a definition, example, or diagram does not show that a reader can use it.
 
-### Honesty Rule
+## Distinguish Three Documentation Jobs
 
-None of the layers oversimplify. If Layer 1 would lead someone to an incorrect conclusion, rewrite it. Accuracy is non-negotiable at every resolution.
+Choose the dominant job of each page or section.
+Do not force every reader through the same instructional sequence.
 
-## Progressively Disclosing Information
+| Job | Reader question | Primary design | Evidence of success |
+| --- | --- | --- | --- |
+| Lookup | "What is the exact value or syntax?" | Searchable, concise, stable reference | Reader finds the correct fact quickly |
+| Execution | "How do I complete this task?" | Goal-oriented procedure with checks | Reader completes the task correctly |
+| Understanding | "Why does this behave this way?" | Prerequisites, causal model, examples, practice | Reader explains, predicts, and transfers |
 
-The companion principle to the inverted pyramid: reveal complexity gradually, in layers, rather than all at once.
+### Design Lookup Content
 
-### Page-level Progressive Disclosure
+Optimize lookup content for retrieval from the document, not memorization.
 
-```
-1. One-paragraph summary at the top
-2. Short code example / quick-start
-3. Deeper explanation below
-4. Advanced usage, edge cases at the bottom
-```
+- Use specific headings that match likely search terms.
+- Put exact syntax, defaults, constraints, and return values near each other.
+- Use tables when readers compare fields across a stable schema.
+- Keep examples adjacent to the referenced option.
+- Link to explanatory material instead of embedding a lesson in every entry.
+- Preserve canonical terminology so search remains reliable.
 
-### Document-level Progressive Disclosure
+Test lookup content by asking a representative reader to find a fact under time pressure, then measure whether the answer is found and interpreted correctly.
 
-```
-README (one-screen overview and quickstart)
-  → Guides (conceptual explanations organized by task)
-    → API Reference (every parameter, every edge case)
-```
+### Design Execution Content
 
-### HTML/Markdown Techniques for Progressive Disclosure
+Organize procedures around a concrete outcome.
 
-- `<details>/<summary>` for expandable sections. Ideal for optional configurations, advanced settings, verbose examples.
-- Accordion patterns for FAQs or grouped deep-dives.
-- "Read more" links for topics a minority of readers will need.
-- Tooltips for jargon definitions without breaking reading flow.
-- Tabbed content: "Basic" tab vs "Advanced" tab.
+- State the end state and prerequisites before the first action.
+- Use action-oriented steps in the order the system requires.
+- Show expected output at consequential checkpoints.
+- Explain decisions where different inputs require different actions.
+- Put recovery guidance beside failure-prone steps.
+- End with a verification that tests the real outcome.
 
-## The Compression Ladder Exercise
+Do not interrupt an execution path with long conceptual digressions.
+Link or defer deeper explanations unless the concept is required to choose the next action safely.
 
-A training technique for finding the essence of any explanation:
+### Design Understanding Content
 
-1. Explain a complex topic in 60 seconds. Record yourself.
-2. Explain the same topic in 30 seconds. Record again.
-3. Explain in 15 seconds.
+Build a model the reader can reason with.
 
-Your 15-second version is the essence. The words you cut between rounds are unnecessary complexity. This works because time pressure forces prioritization.
+- Activate relevant prior knowledge.
+- Supply missing prerequisites.
+- Explain entities, relations, mechanisms, and constraints.
+- Demonstrate reasoning through worked examples.
+- Contrast cases that differ on a decisive feature.
+- Prompt the reader to explain and predict.
+- Test application in a changed context.
 
-## The One-Sentence Challenge
+Treat understanding as a family of usable capabilities, such as explaining, interpreting, applying, predicting, diagnosing, adapting, or taking a relevant perspective. Select evidence from the intended outcome; repeating vocabulary alone is insufficient.
 
-Reduce any complex idea to one readable sentence of 15-20 words. If you cannot say it in one sentence, you haven't found the core yet. Every document should start with this sentence.
+## Diagnose Prior Knowledge Before Adding Detail
 
-## Up-Goer Five Technique (Constraint-Based Clarity)
+Prior knowledge shapes what readers notice, how they organize new information, and what they infer.
+It can help, remain inert, or actively mislead.
 
-Randall Munroe's method of explaining complex topics using only the 1,000 most common English words forces you to:
+Audit the intended audience:
 
-1. Find the core idea — you cannot hide behind jargon
-2. Use analogy and metaphor — comparing to everyday experiences
-3. Be creative with description — "space car" for lunar module, "sky bag air" for hydrogen
+| Prior-knowledge state | Evidence | Design response |
+| --- | --- | --- |
+| Missing | Reader cannot interpret foundational terms | Teach or link the prerequisite first |
+| Inactive | Reader knows the idea but does not apply it | Prompt recall and connect it explicitly |
+| Fragmented | Reader knows isolated facts without relations | Organize facts into a causal or structural model |
+| Inaccurate | Reader predicts the wrong outcome consistently | Expose the misconception with a discriminating case |
+| Sufficient | Reader can explain prerequisite relationships | Compress review and move to application |
 
-This extreme constraint is a diagnostic tool. If your explanation breaks when jargon is removed, the underlying concept wasn't clear to begin with. Use it to stress-test your TL;DR and Layer 1.
+Avoid the expert blind spot: experts compress familiar steps into chunks and may omit decisions novices still need to make.
 
-## Code-First Pattern
+Run a prerequisite audit:
 
-For technical documentation, show the code before the explanation. Many developers will read the code, understand it immediately, and never need the explanation. That's not a failure — it's efficiency. The explanation exists for those who need it.
+1. Write the target performance.
+2. List every decision required to perform it.
+3. For each decision, list the facts, concepts, and cues it depends on.
+4. Mark likely novice gaps and misconceptions.
+5. Teach only the prerequisites that the target performance requires.
 
-Structure:
-```
-TL;DR (1 sentence)
-Code example (the answer)
-What this code does (1 paragraph)
-Why it works this way (explanation)
-Advanced variations / edge cases
-```
+## Sequence for Meaning, Not Merely Simplicity
 
-## Anti-Patterns
+Sequence content so each part enables the next act of reasoning.
 
-| Anti-pattern | Why it fails | Fix |
-|-------------|-------------|-----|
-| Burying the answer under context | Readers leave before finding what they need | Lead with the answer |
-| Opening with history/architecture | No one cares before they know how to use it | Quickstart first, architecture later |
-| All detail on one page | Overwhelms, no self-service depth | Layer: summary → example → deep dive |
-| Explaining everything before showing | Developers read code first | Show code, then explain |
-| Equal-weight headings | No visual hierarchy, everything looks equally important | Tiered headings that compress information faithfully |
-| Hiding instead of layering | Information buried too deep to find | Each level must make the next level's contents predictable |
+Use these relationships deliberately:
 
-## Quality Gate: Before Publishing
+| Relationship | Sequence | Example |
+| --- | --- | --- |
+| Prerequisite | Foundation before dependent concept | Identity before authorization rules |
+| Causal | Cause, mechanism, consequence | Retry load before retry storms |
+| Procedural | Required action order | Create key, configure client, verify signature |
+| Structural | Whole, parts, relations | Request lifecycle before middleware internals |
+| Comparative | Shared frame before differences | Common queue semantics before provider tradeoffs |
+| Increasing variability | Stable case before changed conditions | Single process before distributed coordination |
 
-1. Can someone get the gist from the top level alone? (If no, rewrite the TL;DR)
-2. Does each heading make the next section's contents predictable? (If it surprises, the hierarchy leaks)
-3. Can a reader self-select their depth? (Can they stop at Layer 1 and leave satisfied?)
-4. Does the code example work without reading the explanation? (If no, show a simpler example)
+Do not assume "simple to complex" identifies the correct order.
+A simple fact can be useless until the reader sees the problem it explains.
 
-## The SCQA Framework (Minto Pyramid Principle)
+## Build a Causal Model
 
-Structure every introduction with Situation, Complication, Question, Answer. This mirrors how readers naturally process: "What's going on? What's the problem? What question does that raise? What's the answer?"
+Name the parts of the system and explain how they interact over time.
 
-| Element | Role | Example |
-|---------|------|---------|
-| **S**ituation | Shared context the reader already knows | "Your API handles 10K requests/second with no issues." |
-| **C**omplication | The problem that disrupts the situation | "At 100K requests/second, response times spike to 5+ seconds." |
-| **Q**uestion | The implicit question raised by the complication | "How do we scale to 100K RPS without rewriting the entire API?" |
-| **A**nswer | Your solution (the document's main point) | "Add a Redis cache layer in front of the database — here's how." |
+A useful causal explanation answers:
 
-This SCQA structure also works at the paragraph level. A paragraph's first sentence states the situation, the middle describes the complication, and the final sentence provides the answer.
+1. What entities participate?
+2. What state does each entity hold?
+3. What event initiates change?
+4. What mechanism transforms the state?
+5. What constraint limits the mechanism?
+6. What observable consequence follows?
+7. Under what conditions does the explanation stop applying?
 
-## The Teach-Back Method
+Prefer mechanism statements over labels.
 
-A technique for validating that your layered explanation works:
+Weak:
 
-1. Explain a concept to someone
-2. Ask them to explain it back to you
-3. The delta between what you said and what they understood reveals exactly where your explanation broke down
+> The service experiences cache stampede.
 
-Apply this to documentation:
-- Was there a missing foundation layer? → Add a simpler Layer 1
-- Was a jargon term undefined? → Define on first use
-- Was a logical jump too large? → Add an intermediate layer
-- Did they misunderstand a key concept? → Add a diagram or worked example
+Stronger:
 
-## When Layering Goes Wrong
+> When a popular key expires, concurrent requests all miss before any request repopulates the value. Each request then starts the same expensive database query, multiplying load during the expiry window.
 
-### Hiding Instead of Layering
+The stronger explanation supports prediction.
+A reader can infer that request coalescing or staggered expiry changes the outcome.
 
-If information is buried so deep that users cannot find it, that's obscurity, not progressive disclosure. The fix: predictable paths. Every level should make the next level's contents obvious. If someone has to guess where to find something, the structure is broken.
+## Use Progressive Disclosure by Purpose
 
-### Compression Without Judgment
+Preserve progressive disclosure when it helps readers enter at the right depth.
+Do not treat it as a universal top-to-bottom gradient.
 
-Generic headings like "Overview," "Details," "Additional Information" provide structure without hierarchy. Progressive disclosure requires that each level genuinely compresses the level below it. The heading must tell you what is inside AND whether you need to go inside.
+Provide separate paths when readers have different goals:
 
-### False Confidence from AI Summaries
-
-AI-generated TL;DRs can compress without understanding — producing summaries that sound right but lose critical nuance. An executive summary that omits a key exception clause is worse than no summary at all. Every compression layer must be verified: does the short version preserve what matters?
-
-## Horizontal and Vertical Logic (Minto)
-
-- **Vertical logic**: Every point in the pyramid raises a question in the reader's mind, and the points directly below it answer that question. This is the question-answer dialogue that drives a reader forward.
-- **Horizontal logic**: The ideas within each group must present either a deductive chain (premise → premise → therefore) or an inductive grouping (similar ideas → inference). Every grouping is one or the other — there is no third option.
-
-Test your structure:
-1. Read only the headings. Do they tell a coherent story?
-2. For each heading, ask: "So what?" If the sub-content doesn't compellingly answer, restructure.
-3. For each claim, ask: "Why is that true?" If the sub-content doesn't prove it, add evidence or remove the claim.
-
-## Ordering Ideas in Layers
-
-Present supporting ideas in one of three logical orders:
-
-| Order Type | When to Use | Example |
-|-----------|-------------|---------|
-| **Time order** | Sequence of events with cause-effect | "Step 1: Install → Step 2: Configure → Step 3: Test" |
-| **Structural order** | Parts of a whole, broken down | "The system has three components: frontend, API, and database" |
-| **Degree order** | Ranked by importance | "Most important: security. Next: performance. Last: developer experience" |
-
-## Transition Patterns
-
-Smooth transitions between layers keep the reader oriented. Three techniques:
-
-1. **Referencing backward**: Pick up a key word from the preceding section and carry it into the next. "The JWT token we generated in the previous step now needs to be stored..."
-2. **Summarizing**: Consolidate complex ideas at the end of long sections before moving forward. "To recap: we've set up auth, configured the middleware, and tested the happy path."
-3. **Concluding**: Create appropriate closure or call to action — but only when genuinely needed. "Now that authentication is working, the next step is to add role-based authorization."
-
-## Building the Pyramid: Top-Down vs Bottom-Up
-
-Minto describes two approaches to structuring your document:
-
-### Top-Down (Preferred)
-Start with the conclusion, then ask "What supports this?" The answers become the next level.
-
-1. State your main conclusion (the answer)
-2. Ask: "What questions does this raise in the reader's mind?"
-3. Answer those questions — they become the next level of the pyramid
-4. Repeat until every level is supported
-
-### Bottom-Up (When You Don't Know the Conclusion Yet)
-List all your points, find relationships, draw conclusions upward.
-
-1. Brainstorm all ideas onto a page
-2. Group related ideas together
-3. For each group, write a summary statement that captures the insight
-4. Group the summary statements under a higher-level conclusion
-5. Repeat until you reach a single governing thought
-
-Always try top-down first — it forces you to clarify your thinking before writing.
-
-## The "So What?" and "Why?" Tests
-
-Two questions transform communication:
-
-- **"So what?"** — After writing any point, ask "So what?" If you cannot answer clearly with a consequence, implication, or action, the point doesn't belong. This removes unnecessary content and strengthens cause-effect relationships.
-- **"Why?"** — If you make a claim, ask "Why is that true?" The answer either validates the claim or exposes its weakness. This surfaces hidden assumptions and improves credibility.
-
-Apply these at every level: TL;DR, section headings, paragraphs, individual sentences.
-
-## MECE Framework (Mutually Exclusive, Collectively Exhaustive)
-
-Categories used to organize supporting arguments must be:
-
-1. **Mutually Exclusive**: No overlap. Each item belongs to exactly one category. If a point could fit in two categories, the categories overlap — redefine them.
-2. **Collectively Exhaustive**: Together, the categories cover everything. If something important doesn't fit any category, you have a gap — add a category.
-
-**Example**: Organizing database optimization strategies
-- ❌ Non-MECE: "Indexing, query optimization, caching, read replicas" (caching and read replicas are both scaling strategies — overlapping)
-- ✓ MECE: "Query-level (indexing, rewriting), schema-level (normalization, partitioning), and infrastructure-level (caching, replicas)"
-
-## The Deductive vs Inductive Choice
-
-At the supporting argument level, choose between two reasoning structures:
-
-| Structure | Pattern | Best For | Risk |
-|-----------|---------|----------|------|
-| **Deductive** | General principle → specific case → therefore conclusion | Academic, legal, formal proofs | If the reader rejects the general principle, the whole argument collapses |
-| **Inductive** | Observation A + Observation B + Observation C → therefore pattern exists | Business recommendations, technical decisions | If observations are cherry-picked, the conclusion is invalid |
-
-Minto's recommendation: at the Key Line level (the arguments directly supporting the main conclusion), prefer inductive structure. Executives find it more persuasive because they see evidence before conclusions.
-
-## Writing Summaries That Aren't Intellectually Blank
-
-The most common failure in technical documents: summary statements that restate without adding value.
-
-**Intellectually blank**: "This section covered authentication." (Just restates)
-**Insightful summary**: "JWT authentication eliminates server-side state, but introduces token management complexity — use it when statelessness matters more than revocability."
-
-A good summary must state either:
-- The **effect** of action ideas (what results from doing this)
-- The specific **inference** drawn from situation ideas (the insight the data reveals)
-
-## The Narrative Flow: SCQA in Practice
-
-The introduction tells the reader a story they already know. This pushes aside competing thoughts, establishes shared context, and makes the reader receptive to your argument. A SCQA introduction should take 3-5 sentences total.
-
-**Full example**:
-> Most web APIs authenticate users with session cookies **(Situation)**. But session cookies require server-side state, which doesn't scale well across microservices **(Complication)**. How can we authenticate users across distributed services without shared state? **(Question)**. JSON Web Tokens (JWT) solve this by embedding signed user claims directly in the token — the server verifies without a database lookup **(Answer)**. This document shows you how to implement JWT auth in your Express API in under 10 minutes.
-
-## Testing Your Document Structure
-
-After drafting, run these tests:
-
-1. **Read only the headings and TL;DR.** Does a coherent story emerge? Can someone understand the document's argument from headings alone?
-2. **For each H2, ask its question.** "What is this section answering?" If the heading doesn't imply a question, rewrite it.
-3. **Check the depth gradient.** Is there a clear progression from shallow (TL;DR) to deep (bottom)? Or does it lurch between depths?
-4. **The 5-second test.** Open the page. Look away after 5 seconds. What do you remember? That's the only thing your scanning reader gets.
-
-## Layered Writing Template
-
-For any technical concept, fill this template:
-
-```
-## [Concept Name]
-
-**In one sentence**: [Explain it to a product manager]
-
-**In one paragraph**: [Explain it to a developer who will use it]
-
-**How it works**: [Explain it to a developer who will debug it]
-
-**Diagram**: [Mermaid or SVG showing the flow/architecture/state]
-
-**Code example**: [Minimal, runnable, annotated]
-
-**Common mistakes**: [What goes wrong, why, how to fix]
-
-**When to use / when not to**: [Decision framework — this vs alternatives]
-
-**Deep dive**: [Architecture, tradeoffs, implementation details]
+```text
+Concept page: model, mechanism, examples, transfer
+Task guide: prerequisites, actions, checks, recovery
+Reference: exact syntax, constraints, defaults
 ```
 
-Each section is a self-contained layer. A reader can stop at any layer and have a correct understanding.
+Within an understanding page, disclose complexity in model-preserving layers:
+
+1. State the phenomenon and useful governing idea.
+2. Introduce the minimum entities and relationships.
+3. Demonstrate the mechanism in a representative case.
+4. Add boundary conditions and exceptions.
+5. Ask the reader to apply the model to a varied case.
+
+Keep each shorter layer accurate; do not omit an exception when the omission would produce unsafe action or a false prediction.
+
+Use expandable sections for optional evidence, derivations, or environment-specific details.
+Do not hide prerequisites, decision criteria, or verification steps.
+
+## Design Worked Examples Around Reasoning
+
+Use worked examples when a task contains interacting steps or unfamiliar decisions.
+Show not only what to do, but how to decide.
+
+A complete worked example includes:
+
+- The goal and initial state.
+- The cues that matter.
+- The rule or principle selected.
+- Each action or inference.
+- The reason for consequential steps.
+- The resulting state.
+- A check against the goal.
+
+### Worked Example: Diagnose a Retry Storm
+
+**Scenario:** A client retries failed requests three times with no delay. A dependency slows down but remains available.
+
+**Reasoning:**
+
+1. Observe that failures are transient and concurrent across many clients.
+2. Identify immediate retries as additional demand during the same degraded period.
+3. Predict that each original request can create three more requests.
+4. Infer that increased demand further reduces dependency capacity.
+5. Choose exponential backoff with jitter to spread retries over time.
+6. Verify by comparing request amplification and dependency latency before and after the change.
+
+**Governing principle:** A retry policy must reduce synchronized load, not merely repeat an operation.
+
+**Boundary:** Do not retry non-idempotent operations without a deduplication strategy.
+
+This example exposes decisions and constraints rather than presenting configuration as magic.
+
+## Pair Examples with Nonexamples and Contrasts
+
+One positive example often leaves the category boundary unclear.
+Use contrasts to reveal which feature controls the outcome.
+
+| Pattern | Purpose | Prompt |
+| --- | --- | --- |
+| Example | Demonstrate a valid application | "Why does this satisfy the rule?" |
+| Nonexample | Expose a violation | "Which condition fails?" |
+| Near miss | Isolate one decisive difference | "What single change would make it valid?" |
+| Counterexample | Limit an overgeneralized claim | "Where does the rule stop applying?" |
+| Varied example | Show surface changes with deep structure preserved | "What remains the same?" |
+
+Keep irrelevant differences low when teaching a new distinction.
+Increase surface variation later to support transfer.
+
+Example for idempotency:
+
+- Example: `PUT /users/42` sets the complete user representation; repeating it leaves the same state.
+- Nonexample: `POST /charges` creates a new charge on every successful repetition.
+- Near miss: `POST /charges` with a stable idempotency key can return the prior result instead of creating another charge.
+- Contrast question: Which property matters, the HTTP verb or the effect of repetition?
+
+Use the answer to correct shallow rules such as "POST is never idempotent."
+
+## Scaffold Performance, Then Fade Support
+
+Supply temporary support that lets readers perform reasoning they cannot yet complete independently.
+
+Use scaffolds such as:
+
+- A decision checklist.
+- A partially completed example.
+- Labeled reasoning steps.
+- A diagnostic question sequence.
+- A template with prompts.
+- Immediate feedback on a first attempt.
+
+In an adaptive tutorial, course, or facilitated sequence, fade support as competence grows:
+
+| Stage | Reader activity | Support |
+| --- | --- | --- |
+| Model | Study a fully worked example | All decisions and reasons shown |
+| Complete | Fill selected missing steps | Critical cues remain visible |
+| Practice | Solve a similar case | Short checklist available |
+| Vary | Solve a changed case | Only the goal and constraints remain |
+| Transfer | Solve an unfamiliar case | No procedural prompts |
+
+Do not remove support according to a fixed page count or schedule.
+Fade when performance shows that the support is no longer needed.
+
+In a static document, provide clearly labeled worked, completion, and independent variants. Let readers choose a path and include answer criteria; do not claim that the page itself detected competence or adapted guidance.
+
+Avoid permanent scaffolds that prevent independent judgment.
+A template is harmful when readers fill fields without understanding why they exist.
+
+## Prompt Self-Explanation
+
+Ask readers to explain relationships, choices, and errors in their own words.
+Self-explanation helps integrate new information with prior knowledge and exposes gaps.
+
+Use focused prompts:
+
+- Why is this step necessary?
+- Which evidence supports this diagnosis?
+- What would change if this assumption were false?
+- How does this result follow from the mechanism?
+- Which part of the example maps to the governing principle?
+- Why is the tempting alternative wrong here?
+
+Place prompts after meaningful chunks, not after every sentence.
+Require an explanation that can be checked against criteria.
+
+Avoid vague prompts such as "Do you understand?" Recognition and confidence are weak evidence of understanding.
+
+## Add Retrieval, Not Just Rereading
+
+Prompt readers to recall or reconstruct important ideas without looking at the answer.
+Retrieval strengthens access to knowledge and reveals what remains unavailable.
+
+Use low-cost retrieval in documentation:
+
+- Ask for a prediction before revealing the outcome.
+- End a section with two or three recall questions.
+- Ask readers to recreate a decision rule from a new scenario.
+- Provide troubleshooting symptoms and require a likely cause.
+- Insert a delayed checkpoint after related material.
+
+Separate retrieval from lookup; do not require memorization of values that readers should safely retrieve from reference material.
+
+Retrieve durable structures instead:
+
+- Mechanisms.
+- Decision criteria.
+- Failure signatures.
+- Safety constraints.
+- Relationships among concepts.
+
+Provide the answer after an honest attempt and explain why it is correct.
+
+## Design for Transfer
+
+Test whether the reader can apply the underlying principle when surface details change.
+
+Move through increasing distance:
+
+1. Repeat the same structure with different values.
+2. Change irrelevant surface features.
+3. Combine the principle with another constraint.
+4. Present a context where the principle competes with another goal.
+5. Ask the reader to identify when the principle does not apply.
+
+Example transfer sequence for rate limiting:
+
+- Configure a fixed limit for one public endpoint.
+- Choose a key for limits shared across multiple instances.
+- Protect a costly operation where requests have unequal cost.
+- Balance abuse prevention against bursty legitimate traffic.
+- Explain why client-side throttling alone does not enforce a server limit.
+
+Do not label a near-copy as transfer.
+Change the cues enough that the reader must recognize deep structure.
+
+## Provide Feedback That Advances the Model
+
+Make feedback timely enough to connect with the reader's decision when the medium supports feedback.
+Explain the gap between the response and the target, then identify a next action.
+
+| Feedback type | Useful content | Avoid |
+| --- | --- | --- |
+| Outcome | Whether the result met the criterion | Praise without evidence |
+| Process | Which reasoning step succeeded or failed | Restating the answer only |
+| Cue | Which signal the reader missed | Giving away every later step |
+| Strategy | A better approach for the next attempt | General advice such as "be careful" |
+| Self-regulation | How to check work independently | Dependence on an expert grader |
+
+Use automated validation, answer explanations, peer review, or instructor feedback according to the delivery context. A static page can provide criteria and model answers but cannot identify a reader's actual error without an external response mechanism.
+
+For an incorrect diagnosis, explain which observation contradicts it.
+For a correct guess, still ask for the mechanism or evidence.
+
+Do not overload feedback with every possible improvement.
+Prioritize the misconception or decision that most affects future performance.
+
+## Verify Learning and Document Quality
+
+Align verification with the intended performance.
+
+| Intended outcome | Weak check | Stronger check |
+| --- | --- | --- |
+| Recall a constraint | Reread the warning | State the constraint without looking |
+| Execute a task | Confirm steps were read | Inspect the resulting system behavior |
+| Explain a mechanism | Repeat the definition | Predict an outcome and justify it |
+| Diagnose a failure | Recognize a shown answer | Diagnose a fresh case from evidence |
+| Choose an approach | List options | Select under constraints and defend the tradeoff |
+| Transfer a principle | Repeat the example | Apply it in a structurally similar new domain |
+
+Use teach-back as evidence only when the explanation includes relationships and predictions.
+Verbatim repetition does not demonstrate a usable model.
+
+Collect evidence from real readers where practical:
+
+- Search success for lookup pages.
+- Task completion and error recovery for procedures.
+- Prediction accuracy and justification for conceptual explanations.
+- Performance on varied cases for transfer.
+- Recurring support questions after publication.
+
+Revise the explanation at the point where evidence shows a breakdown.
+Do not add general detail when the failure is a missing cue, prerequisite, or feedback loop.
+
+## Review for Coherence and Cognitive Demand
+
+Keep the reader's effort directed toward the target model.
+
+Remove or relocate content that introduces terms, stories, or edge cases without supporting the intended performance.
+Chunk information around meaningful decisions rather than arbitrary length.
+Use consistent names for the same entity.
+Signal causal connectors such as "because," "therefore," and "only when."
+
+Review each section with these questions:
+
+1. What must the reader do after this section?
+2. Which prerequisite does that performance require?
+3. Which relationship or mechanism should the reader build?
+4. Where does the explanation model expert reasoning?
+5. Which contrast clarifies the boundary?
+6. Where does support fade?
+7. What must the reader retrieve or explain?
+8. How does a varied case test transfer?
+9. What feedback follows an error?
+10. What observable evidence verifies success?
+
+## Explanation Design Blueprint
+
+Use this blueprint for a concept intended to support durable understanding:
+
+```text
+Target performance
+  State what the reader will explain, predict, choose, or diagnose.
+
+Prior knowledge
+  Name required prerequisites and likely misconceptions.
+
+Organizing question
+  Frame the problem the model resolves.
+
+Governing idea
+  Give an accurate, useful answer at entry depth.
+
+Causal or structural model
+  Explain entities, relations, mechanisms, constraints, and boundaries.
+
+Worked example
+  Demonstrate decisions and reasons, then verify the result.
+
+Contrast set
+  Add an example, nonexample, near miss, or counterexample.
+
+Guided attempt
+  Provide a partial solution, prompts, and targeted feedback.
+
+Independent attempt
+  Fade support and vary the context.
+
+Retrieval and self-explanation
+  Ask the reader to reconstruct and justify the model.
+
+Transfer check
+  Require application under changed surface conditions.
+
+Verification
+  Compare observable performance with explicit criteria.
+```
+
+Use only the parts required by the intended performance.
+Keep lookup and execution paths direct when durable learning is not the reader's goal.

--- a/skills/crystal-clear-docs/references/outcome-driven-design.md
+++ b/skills/crystal-clear-docs/references/outcome-driven-design.md
@@ -1,0 +1,351 @@
+# Outcome-Driven Documentation Design
+
+Sources: Wiggins and McTighe (Understanding by Design), Lovett et al. (How Learning Works), National Academies (How People Learn II), Neelen and Kirschner (Evidence-Informed Learning Design), Dunlosky and Rawson (The Cambridge Handbook of Cognition and Education), Pinker (The Sense of Style)
+Covers: Diagnose the need, define task and transfer outcomes, design backward from evidence, select an appropriate document type, align content with authentic use, and evaluate results.
+
+Evidence boundary: Apply learning and instructional-design findings as mechanisms and design hypotheses. Much of the research comes from courses, training, or controlled studies rather than static technical pages. Validate transfer to the actual audience, task, medium, and time horizon.
+
+## Start With the Performance Need
+
+Treat documentation as an intervention, not as an automatic response to every problem.
+
+Ask what people must do differently, where they must do it, and what currently prevents them.
+
+Do not begin with a topic list, a requested format, or an inventory of available material.
+
+Begin with the gap between current and desired performance.
+
+Separate four commonly conflated needs:
+
+| Observed need | Diagnostic question | Likely response |
+| --- | --- | --- |
+| Access | Do readers know enough but fail to find facts at the moment of use? | Improve retrieval, navigation, labels, search, or point-of-work support |
+| Execution | Do readers know what to do but face missing tools, permissions, time, incentives, or coordination? | Repair the environment or workflow; do not prescribe more explanation |
+| Learning | Must readers build knowledge or skill that persists beyond the document? | Design explanation, guided practice, feedback, and later application |
+| Judgment | Must readers choose among cases where no fixed procedure is sufficient? | Teach principles, contrasts, criteria, and decision practice |
+
+Diagnose before writing because a polished learning document cannot fix a missing permission, broken interface, contradictory policy, or absent incentive.
+
+Use evidence from actual work when possible:
+
+- Observe representative tasks and failure points.
+- Inspect support requests, error patterns, search terms, and abandoned workflows.
+- Ask performers what cues they use and where uncertainty begins.
+- Compare successful and unsuccessful outputs against real criteria.
+- Confirm whether the problem persists when information is available at the point of need.
+
+Treat stakeholder requests as hypotheses.
+
+Translate "we need a guide" into a testable performance statement before accepting the format.
+
+### Distinguish Performance Support From Learning
+
+Choose performance support when readers can consult the document during work and do not need fluent recall.
+
+Choose learning support when delay, risk, workload, or context makes consultation impractical, or when readers must recognize situations independently.
+
+Combine both when readers need a durable model plus precise operational details.
+
+| Situation | Favor point-of-work support | Favor durable learning |
+| --- | --- | --- |
+| Rare, stable procedure | Checklist or runbook | Only if failure has severe consequences |
+| Frequent recurring task | Concise reference may remain useful | Build fluency and exception handling |
+| High-stakes response | Add an executable protocol | Rehearse recognition, judgment, and recovery |
+| Rapidly changing facts | Keep facts external and maintainable | Teach stable principles and update detection |
+| Novel troubleshooting | Provide diagnostic trees and telemetry references | Build causal models and case comparison |
+| Policy compliance | Surface required actions at decision points | Explain rationale when interpretation is required |
+
+Do not equate memorization with learning value.
+
+Externalize details that are cheap and safe to look up.
+
+Develop internal knowledge when it enables recognition, inference, speed, or transfer.
+
+## Define the Intended Change
+
+Define learning as a durable change in knowledge or capability, inferred cautiously from later behavior rather than from exposure to content.
+
+Infer that change from later performance rather than from page views or self-reported familiarity alone.
+
+Write the outcome from the reader's point of view:
+
+> Given [realistic situation and available resources], the reader can [observable task or judgment] to [quality criteria], including [important variation or exception].
+
+Make the conditions explicit.
+
+Specify whether readers may search, use tools, consult teammates, or follow a checklist.
+
+Avoid testing unaided recall if real performance permits reference use.
+
+Specify the product or consequence that demonstrates success.
+
+Avoid weak outcomes such as "understand the system," "know the policy," or "be aware of the feature" unless you define what that understanding enables.
+
+Keep four outcomes distinct:
+
+| Outcome | Appropriate evidence | Do not infer automatically |
+| --- | --- | --- |
+| Immediate comprehension | Accurate paraphrase, inference, or prediction now | Durable retention |
+| Supported performance | Correct task completion with the document and normal tools | Unaided capability |
+| Durable learning | Relevant knowledge or capability remains available after delay | Broad transfer |
+| Transfer | Correct performance under a meaningfully changed case | Reliability in every context |
+
+Treat one observation as evidence under its tested conditions, not proof of every outcome.
+
+### Define Task, Knowledge, and Judgment
+
+Decompose an outcome only far enough to expose what the document must support.
+
+| Outcome component | Ask | Documentation implication |
+| --- | --- | --- |
+| Whole task | What meaningful result must the reader produce? | Anchor the document in the complete workflow |
+| Constituent actions | Which steps must be coordinated? | Show sequence, dependencies, and handoffs |
+| Concepts | What relationships must make sense? | Explain a model, not a glossary alone |
+| Recognition cues | What tells the reader which action applies? | Include symptoms, thresholds, and contrasts |
+| Quality criteria | What distinguishes acceptable from unsafe or incomplete? | Show standards, examples, and nonexamples |
+| Exceptions | Where does the normal path fail? | Integrate branches near the relevant decision |
+| Recovery | How can the reader detect and correct failure? | Add verification and rollback guidance |
+
+Keep the whole task visible while teaching parts.
+
+Avoid fragmenting a complex performance into disconnected pages that never show coordination.
+
+## Specify Transfer Deliberately
+
+Treat transfer as a design target, not an automatic by-product of clear explanation.
+
+Define the distance between the documented example and the future use.
+
+| Transfer dimension | Near transfer | Farther transfer |
+| --- | --- | --- |
+| Context | Same tool and environment | Different tool, team, or environment |
+| Time | Immediate use | Delayed use |
+| Function | Same task | Related but structurally different task |
+| Representation | Same labels and interface | Different terminology or surface features |
+| Support | Same prompts available | Fewer prompts or independent recognition |
+
+Do not claim broad transfer from success on a copied example.
+
+Expect transfer to weaken as surface cues, time, function, and support diverge.
+
+Design for the actual transfer distance:
+
+- State the underlying principle after grounding it in a concrete case.
+- Compare cases that share structure but differ in surface details.
+- Contrast similar-looking cases that require different actions.
+- Name the cues that determine applicability.
+- Explain where an analogy breaks.
+- Ask readers to predict, decide, or diagnose before revealing the answer.
+- Fade prompts only when independent performance is required.
+
+Do not teach a supposedly generic skill without the domain knowledge that makes the skill usable.
+
+Critical thinking, troubleshooting, and judgment depend on relevant knowledge structures.
+
+## Design Backward From Evidence
+
+Use three linked stages:
+
+| Stage | Design question | Required artifact |
+| --- | --- | --- |
+| Desired result | What should readers be able to do or decide later? | Outcome statement with conditions and criteria |
+| Acceptable evidence | What performance would justify confidence? | Authentic task, checks, and scoring criteria |
+| Learning and support | What document experience makes that evidence likely? | Content, examples, practice, navigation, and support |
+
+Do not write content and invent evaluation afterward.
+
+Define acceptable evidence before deciding sections, visuals, or media.
+
+Use the evidence target to remove attractive but irrelevant material.
+
+Reject both coverage-driven and activity-driven design.
+
+Coverage-driven design asks, "What information can we include?"
+
+Activity-driven design asks, "What interactive or visual element can we add?"
+
+Outcome-driven design asks, "What change must occur, and what experience is necessary for it?"
+
+### Define Evidence of Understanding
+
+Distinguish recall from usable understanding.
+
+| Evidence | What it supports | What it does not establish alone |
+| --- | --- | --- |
+| Recognition | Reader can identify a presented fact or option | Independent recall or application |
+| Recall | Reader can reproduce information | Appropriate use in context |
+| Explanation | Reader can connect causes, mechanisms, or rationale | Reliable execution under variation |
+| Application | Reader can use knowledge in a familiar case | Transfer to materially different cases |
+| Diagnosis | Reader can infer causes from evidence | Ability to implement a remedy |
+| Adaptation | Reader can modify an approach under new constraints | Consistency across future situations |
+| Self-correction | Reader can detect and repair an error | Prevention of all initial errors |
+
+Match evidence to the intended outcome.
+
+Use multiple forms of evidence when the task combines knowledge, execution, and judgment.
+
+Do not use satisfaction, completion, engagement, or perceived learning as substitutes for performance evidence.
+
+Treat those measures as implementation signals, not proof of learning.
+
+## Build Authentic Tasks
+
+Define authenticity by correspondence to consequential work, not by visual realism alone.
+
+Consider five dimensions:
+
+| Dimension | Design question |
+| --- | --- |
+| Task | Does the reader perform the same kind of thinking and action used in practice? |
+| Physical or technical context | Are the relevant tools, constraints, noise, and interfaces represented? |
+| Social context | Are collaboration, approval, communication, and handoffs represented? |
+| Output | Does the task produce the artifact or consequence expected in practice? |
+| Criteria | Is performance judged by standards that matter in the real setting? |
+
+Simplify an authentic task without stripping away the decisions that make it authentic.
+
+Remove incidental complexity first.
+
+Retain consequential cues, tradeoffs, and failure modes.
+
+For learning experiences that support multiple attempts, use worked examples for unfamiliar tasks, then offer partially completed and independent cases when independent action matters.
+
+Use scenarios when context changes the correct response.
+
+Use nonexamples when common outputs look plausible but violate an important criterion.
+
+Do not make practice artificially difficult merely to appear rigorous.
+
+Preserve the difficulty inherent in the target judgment while removing difficulty caused by unclear wording or irrelevant detail.
+
+## Select the Document Type From the Outcome
+
+Choose the smallest document system that supports the real task.
+
+| Reader need | Primary document type | Essential design feature |
+| --- | --- | --- |
+| Complete a known procedure now | How-to guide | Ordered actions, prerequisites, verification, recovery |
+| Look up an exact fact | Reference | Stable labels, exhaustive definitions, searchability |
+| Build a causal or conceptual model | Explanation | Relationships, mechanisms, diagrams, examples |
+| Choose among alternatives | Decision guide | Criteria, tradeoffs, branches, boundary cases |
+| Respond consistently under pressure | Checklist or runbook | Short executable steps, stop conditions, escalation |
+| Learn a new end-to-end capability | Tutorial or guided walkthrough | Coherent task, scaffolding, feedback, transfer prompt |
+| Diagnose a failure | Troubleshooting guide | Symptoms, evidence collection, causal branches, recovery |
+| Adopt a changed policy or behavior | Change guide | Rationale, changed actions, migration path, consequences |
+
+Split document types when their reading modes conflict.
+
+Do not bury lookup material inside a narrative tutorial.
+
+Do not force conceptual explanation into terse procedural steps when readers need a model to handle exceptions.
+
+Link layers through task language so readers can move from action to explanation without losing context.
+
+## Align Every Element
+
+Build an alignment matrix before drafting or during revision.
+
+| Outcome | Evidence | Content or support | Authentic variation | Evaluation signal |
+| --- | --- | --- | --- | --- |
+| State one observable capability | Name the proving performance | Include only enabling knowledge and guidance | Add a relevant change in context | Record a behavior tied to the outcome |
+
+Check alignment in both directions.
+
+For every content block, identify the outcome it enables.
+
+For every outcome, identify sufficient content, support, and evidence.
+
+Remove orphan content that serves no outcome.
+
+Repair orphan outcomes that have no path to mastery.
+
+Avoid decorative interactivity, diagrams, or examples that attract attention without helping readers select, organize, integrate, or apply information.
+
+Treat media as a means, never as the strategy itself.
+
+## Write for Use, Not Display
+
+Present the subject as something the reader can inspect, reason about, and act on.
+
+Follow Pinker's practical implication of classic style: direct attention to the thing being explained rather than to the author's process of explaining it.
+
+Make actors, actions, objects, and causal relations explicit.
+
+Do not hide uncertainty behind nominalizations or institutional abstractions.
+
+State assumptions and boundaries where they change the decision.
+
+Prefer a concrete case before a compressed abstraction when the abstraction depends on expert knowledge.
+
+Name the principle after the case so readers can recognize it elsewhere.
+
+## Evaluate the Document as an Intervention
+
+Evaluate at several levels without conflating them.
+
+| Level | Question | Useful evidence |
+| --- | --- | --- |
+| Reach | Did the intended readers encounter the document? | Search discovery, entry paths, audience coverage |
+| Usability | Could readers find and interpret what they needed? | Task observation, findability failures, comprehension checks |
+| Learning | Did readers build durable knowledge or skill? | Delayed explanation, application, or retrieval |
+| Transfer | Could readers perform under realistic variation? | Novel cases, workplace outputs, reduced assistance |
+| Performance | Did the target result improve? | Error rate, cycle time, quality, escalation, rework |
+| System effect | Did the intervention create new costs or risks? | Maintenance burden, misuse, inequitable access, downstream failures |
+
+Use baseline evidence when available.
+
+Compare performance against explicit criteria rather than against impressions of polish.
+
+Inspect failures for design information:
+
+- If readers cannot find the right page, repair information architecture.
+- If readers find it but misread it, repair wording, representation, or assumed knowledge.
+- If readers explain it but cannot act, add authentic application and decision cues.
+- If readers act in the example but fail elsewhere, strengthen transfer design.
+- If readers can act but do not, investigate incentives, access, workflow, or trust.
+- If successful readers stop using the document, determine whether they learned or merely abandoned it.
+
+Do not interpret lower page views as failure when the intended performance requires fewer visits.
+
+Do not interpret high page views as success when repeated visits signal poor retrieval or unresolved confusion.
+
+### Use Evidence-Informed Iteration
+
+Combine three sources of evidence:
+
+| Evidence source | Contribution | Limitation |
+| --- | --- | --- |
+| Research | Supplies mechanisms, tested principles, and boundary conditions | May not match the exact audience or environment |
+| Local data | Reveals real behavior, constraints, and outcomes | Can be noisy, incomplete, or confounded |
+| Practitioner judgment | Integrates context and feasibility | Can preserve habit, bias, or fashionable myths |
+
+Require the three sources to challenge one another.
+
+Do not copy a technique solely because it worked elsewhere.
+
+Ask what mechanism it relies on and whether the relevant conditions hold here.
+
+Document uncertainty when evidence is indirect.
+
+Run a small, consequential test before scaling a costly design.
+
+Revise the outcome, evidence, or intervention when results expose a faulty assumption.
+
+## Outcome Design Review
+
+Use this review before publication:
+
+- Confirm that the problem is actually addressable through documentation.
+- State the desired performance in observable terms.
+- Define the conditions and resources available during real use.
+- Specify required transfer distance instead of assuming transfer.
+- Choose evidence that matches the intended capability.
+- Represent an authentic task, output, context, and quality standard.
+- Select the document type from the reader's need.
+- Align every section and medium with an outcome.
+- Separate implementation signals from learning and performance evidence.
+- Plan evaluation across usability, learning, transfer, and system effects.
+- Record boundary conditions and unresolved assumptions.
+- Remove content that exists only because it was available.
+
+Treat publication as the start of evidence collection, not the end of design.

--- a/skills/crystal-clear-docs/references/reader-mental-models.md
+++ b/skills/crystal-clear-docs/references/reader-mental-models.md
@@ -1,0 +1,414 @@
+# Reader Mental Models
+
+Sources: Lovett et al. (How Learning Works), National Academies (How People Learn II), Dunlosky and Rawson (The Cambridge Handbook of Cognition and Education), Neelen and Kirschner (Evidence-Informed Learning Design), Pinker (The Sense of Style)
+Covers: Model readers across relevant dimensions, activate and repair prior knowledge, support coherent knowledge organization, address misconceptions and expertise reversal, and account for motivation, culture, context, and metacognition.
+
+## Model the Reader as a System
+
+Reject the idea of a single average reader.
+
+Model variation that changes how the document will be interpreted or used.
+
+Do not reduce readers to job titles, generations, personality types, or preferred "learning styles."
+
+Treat reader characteristics as interacting conditions, not fixed labels.
+
+| Dimension | Diagnostic question | Possible design consequence |
+| --- | --- | --- |
+| Domain knowledge | What concepts, facts, and patterns can readers already use? | Adjust explanation, examples, and assumed vocabulary |
+| Task experience | Have readers performed this task in real conditions? | Adjust scaffolding, exception coverage, and verification |
+| Knowledge organization | Are facts connected into a usable model? | Add structure, causal relations, comparisons, or maps |
+| Beliefs and misconceptions | Which existing explanations compete with the intended one? | Elicit, contrast, refute, and replace |
+| Language and discourse | Which terms, genres, and conventions are familiar? | Define local language and expose tacit conventions |
+| Goals and value | Why would readers invest effort here? | Lead with relevant stakes and useful outcomes |
+| Expectancy and agency | Do readers believe success is possible and controllable? | Add achievable entry points, feedback, and choices |
+| Social position and identity | Does the document signal belonging, authority, or exclusion? | Revise examples, voice, assumptions, and access |
+| Physical and technical context | Where, when, and on what device will reading occur? | Adjust navigation, density, format, and offline support |
+| Metacognitive skill | Can readers judge whether they understand and select a strategy? | Add checks, criteria, and recovery prompts |
+
+Build personas only when they encode evidence about these consequential dimensions.
+
+Discard decorative persona details that do not alter a design decision.
+
+### Gather Reader Evidence
+
+Prefer behavior over speculation.
+
+Use multiple signals:
+
+- Observe readers attempting representative tasks.
+- Ask readers to explain what they think is happening before correcting them.
+- Collect terms readers search for rather than only terms experts prefer.
+- Inspect recurring errors for underlying rules or beliefs.
+- Compare novice and expert navigation paths.
+- Identify where readers seek reassurance, stop, or escalate.
+- Note environmental constraints such as interruptions, device size, latency, or privacy.
+- Ask what a successful result looks like in the reader's own context.
+
+Do not infer understanding from fluent conversation alone.
+
+Ask for prediction, explanation, classification, or application that reveals the underlying model.
+
+Treat user preference as one input, not as proof of learning effectiveness.
+
+Readers can accurately report friction and goals while misjudging which presentation produces durable understanding.
+
+## Diagnose Prior Knowledge
+
+Treat prior knowledge as the foundation on which readers interpret every sentence.
+
+Classify its state before deciding how much context to add.
+
+| Prior-knowledge state | Reader behavior | Documentation response |
+| --- | --- | --- |
+| Accurate and activated | Applies relevant concepts at the right moment | Build directly and avoid redundant scaffolding |
+| Accurate but inert | Knows the fact but does not recognize when it applies | Add cues, scenarios, and applicability conditions |
+| Insufficient | Lacks prerequisites needed to interpret the explanation | Provide pretraining or link a prerequisite path |
+| Inappropriate | Activates a familiar but irrelevant analogy or procedure | Contrast contexts and mark the boundary |
+| Inaccurate | Uses a flawed rule or causal account | Elicit, challenge, and replace the model |
+| Fragmented | Recalls pieces without relationships | Supply an organizing structure and integration prompts |
+
+Do not treat all gaps as missing facts.
+
+A reader may possess the facts yet organize them in a way that blocks application.
+
+### Activate Relevant Knowledge
+
+Use activation when readers already have a useful foundation but may not retrieve it spontaneously.
+
+Choose a cue that matches the future use:
+
+- Ask a short prediction before the explanation.
+- Name a familiar situation that shares the target structure.
+- Present a diagnostic question that exposes the relevant distinction.
+- Briefly recap prerequisites in the language used on this page.
+- Link the new concept to an existing workflow or artifact.
+- Show where the new item fits in a familiar system.
+
+Keep activation focused.
+
+Do not invite a broad brainstorm that activates irrelevant associations.
+
+Do not assume a hyperlink activates knowledge; state the minimum prerequisite relation at the point of use.
+
+### Supply Missing Prerequisites
+
+Pretrain the names, roles, and relationships of essential components before explaining a complex process.
+
+Use prerequisite links when readers can pause and learn separately.
+
+Use inline reminders when switching pages would break the task.
+
+Make prerequisite status visible:
+
+| Prerequisite type | Best support |
+| --- | --- |
+| Term needed to parse the next sentence | Define inline |
+| Small relationship needed throughout | Add a compact model or recap |
+| Independent foundational skill | Link a distinct prerequisite guide |
+| Tool setup required before action | Put in prerequisites and verify explicitly |
+| Optional depth for advanced reasoning | Place in a linked explanation |
+
+Avoid recursive prerequisite chains with no clear starting point.
+
+Offer a stable entry route for readers who lack the assumed base.
+
+## Design the Intended Knowledge Organization
+
+Do not present information as a pile of facts and expect readers to infer expert structure.
+
+Experts tend to organize knowledge around deep principles, causal relations, and conditions of use.
+
+Novices tend to rely more on surface features, literal labels, and the order in which information appeared.
+
+Expose the structure that supports the target reasoning.
+
+| Target reasoning | Useful organization |
+| --- | --- |
+| Explain why something happens | Cause-and-effect chain or mechanism |
+| Execute a process | Sequence with states, decisions, and feedback loops |
+| Compare alternatives | Matrix using decision-relevant dimensions |
+| Classify a case | Hierarchy with defining and distinguishing features |
+| Understand a system | Components, relations, flows, and boundaries |
+| Diagnose failure | Symptom-to-cause network with disconfirming evidence |
+| Apply a principle | Principle linked to varied cases and limits |
+| Plan work | Goal, dependencies, constraints, and checkpoints |
+
+Choose one primary organization for the main explanation.
+
+Add secondary views only when readers must transform between them.
+
+Keep labels and relations consistent across prose, diagrams, examples, and navigation.
+
+Do not use a diagram merely to repeat nearby prose.
+
+Use it when spatial arrangement makes relationships easier to inspect.
+
+### Support Mental Model Construction
+
+Treat comprehension as active model building.
+
+Help readers select relevant elements, organize them, and integrate them with prior knowledge.
+
+Signal what matters without turning every sentence into emphasis.
+
+Make causal links explicit when experts might silently infer them.
+
+Use examples to instantiate a model, not to substitute for one.
+
+Pair a principle with more than one meaningfully varied case when transfer matters.
+
+Use a contrast case to reveal which features are structural and which are incidental.
+
+Ask readers to explain why a step or decision follows when that inference is central.
+
+Do not overload the model with every exception during first construction.
+
+Establish the normal structure, then attach exceptions at the point they modify it.
+
+### Detect Fragmented Models
+
+Look for these signals:
+
+- Readers can repeat definitions but cannot predict consequences.
+- Readers execute steps but cannot recover when the interface changes.
+- Readers recognize examples but cannot classify a new case.
+- Readers mention many components but omit relations among them.
+- Readers use the correct rule only when the page uses identical wording.
+- Readers cannot explain why a prohibited action is unsafe.
+
+Respond by repairing organization, not by adding more disconnected facts.
+
+## Address Misconceptions as Competing Models
+
+Treat a durable misconception as an explanatory model that may be coherent and useful in some familiar situations.
+
+Do not assume that stating the correct fact will erase it.
+
+Avoid foregrounding a misconception without making the correction and replacement model more prominent.
+
+Use a replacement sequence:
+
+1. Elicit or name the reader's likely prediction.
+2. Show a case where that prediction fails or becomes incomplete.
+3. Explain the mechanism behind the discrepancy.
+4. Present the replacement model clearly.
+5. Apply the replacement to a new case.
+6. Mark situations where the old shortcut still appears plausible.
+
+Keep the correction respectful.
+
+Attack the model, not the reader's intelligence or identity.
+
+### Classify the Error Before Correcting It
+
+| Error type | Example pattern | Repair strategy |
+| --- | --- | --- |
+| Missing distinction | Treats two related terms as interchangeable | Compare them on a consequential case |
+| Overgeneralization | Applies a valid rule outside its boundary | State conditions and show a boundary case |
+| Faulty causality | Attributes an outcome to the wrong mechanism | Trace causal evidence and competing predictions |
+| Surface analogy | Maps visible similarities while missing structural differences | Compare relation-by-relation and mark the break |
+| Procedural habit | Repeats an obsolete sequence despite changed conditions | Interrupt with recognition cues and replacement practice |
+| Identity-linked belief | Treats correction as a threat to group or self | Reduce threat, establish shared goals, and preserve agency |
+
+Use examples of actual errors when privacy and safety permit.
+
+Explain why the wrong answer feels reasonable.
+
+That explanation helps readers notice the same trap later.
+
+Do not promise instant correction for deeply rehearsed beliefs.
+
+Provide repeated opportunities to choose the replacement model in relevant contexts.
+
+## Adapt for Expertise Without Creating Two Truths
+
+Treat expertise as domain-specific and uneven.
+
+A reader may be expert in the business domain and novice in the tool, or the reverse.
+
+Do not infer broad expertise from seniority or title.
+
+Account for expertise reversal: guidance that supports novices can become redundant, slow, or distracting for knowledgeable readers.
+
+| Design element | Novice value | Expert risk | Adaptive response |
+| --- | --- | --- | --- |
+| Worked example | Reduces unguided search | Repeats an automated procedure | Make it skippable and link from the concise path |
+| Definitions | Establishes shared vocabulary | Interrupts fluent reading | Define inline once and provide reference access |
+| Step-by-step instructions | Supports coordination | Obscures exceptions and intent | Offer a compact checklist plus expanded steps |
+| Explanatory diagram | Builds a system model | Restates a familiar model | Lead with the decision or delta for experts |
+| Frequent prompts | Directs attention | Creates friction and loss of agency | Fade or collapse prompts by experience level |
+| Basic examples | Ground abstraction | Fail to challenge judgment | Add advanced boundary and failure cases |
+
+Layer by reader need rather than duplicating entire manuals.
+
+Provide a fast path that preserves safety-critical conditions.
+
+Provide an expanded path that explains rationale, prerequisites, and examples.
+
+Keep canonical facts and policy in one maintained location.
+
+Do not hide essential warnings in beginner-only material.
+
+For safety-critical documents, validate both paths separately:
+
+- Ask a representative novice to execute the expanded path without coaching.
+- Ask an experienced operator to use the fast path under realistic pressure.
+- Confirm both paths preserve the same hazards, stop conditions, authority, and verification criteria.
+- Treat any safety condition missed by either audience as a structural failure.
+
+### Avoid the Curse of Knowledge
+
+Apply Pinker's warning that writers struggle to imagine what readers do not know.
+
+Audit expert drafts for invisible assumptions:
+
+- Undefined actors, objects, states, or acronyms.
+- Causal steps compressed into "therefore," "simply," or "obviously."
+- Procedures that begin after an unmentioned setup step.
+- Categories whose distinguishing features remain tacit.
+- Examples that require insider history to make sense.
+- References such as "this," "it," or "the process" with ambiguous antecedents.
+- Nominalized actions that conceal who does what.
+
+Ask a representative reader to paraphrase, not merely approve, the draft.
+
+Ask experts to state what they noticed that a novice might not notice.
+
+Use those cues as explicit teaching targets.
+
+## Design for Motivation and Agency
+
+Treat motivation as a dynamic interaction among value, expectancy, goals, identity, and environment.
+
+Do not label readers as motivated or unmotivated without examining the task and context.
+
+| Motivation condition | Reader interpretation | Documentation response |
+| --- | --- | --- |
+| Low value | "This does not help a goal I care about." | Connect the content to a credible consequence or task |
+| Low expectancy | "Even with effort, I cannot succeed." | Clarify prerequisites, reduce initial complexity, and show progress |
+| Low agency | "The outcome is controlled by others." | Expose choices, escalation paths, and controllable actions |
+| Goal conflict | "Other work matters more right now." | Support scanning, defer optional depth, and respect time constraints |
+| Threat or non-belonging | "This system was not made for people like me." | Remove deficit framing and signal legitimate participation |
+| Distrust | "The source or policy is not credible." | State authority, evidence, rationale, limits, and update history |
+
+Lead with relevance, not hype.
+
+Explain why the task matters to the reader's work or decision.
+
+Make success criteria visible so effort feels directed.
+
+Provide meaningful choices where multiple valid routes exist.
+
+Do not manufacture engagement with decorative stories, jokes, or images unrelated to the model.
+
+Interesting but extraneous details can compete with essential processing.
+
+## Account for Culture and Context
+
+Treat learning and interpretation as culturally situated.
+
+Do not frame cultural difference as a deficit inside the reader.
+
+Examine both the reader and the document's own assumptions.
+
+| Context factor | Audit question |
+| --- | --- |
+| Language | Does fluency in the document language differ from domain competence? |
+| Authority | Are readers expected to question, comply, negotiate, or seek approval? |
+| Collaboration | Is the task individual in the document but collective in practice? |
+| Risk | What social, legal, financial, or physical cost accompanies a mistake? |
+| Access | Can readers reach the document, tools, links, and examples in their environment? |
+| Time | Are readers studying, scanning during work, or responding under pressure? |
+| Local practice | Do examples assume one region, organization, or technical stack? |
+| Identity | Do examples and labels imply who belongs or who is competent? |
+
+Separate universal claims from local conventions.
+
+Label organization-specific policy as policy, not as an inherent property of the domain.
+
+Explain unfamiliar discourse practices such as how to read a log, interpret a standard, or challenge a decision.
+
+Use asset framing: connect new material to knowledge readers developed in work, community, language, or adjacent domains.
+
+Test translations and localized examples for conceptual equivalence, not word substitution alone.
+
+Preserve reader dignity in error messages, warnings, and prerequisite guidance.
+
+## Support Metacognition
+
+Do not assume that readers accurately know whether they understand.
+
+Fluent prose and familiar examples can create confidence without transferable knowledge.
+
+Support a self-regulation cycle:
+
+| Phase | Reader question | Documentation support |
+| --- | --- | --- |
+| Plan | What am I trying to accomplish, and what do I need? | Outcomes, prerequisites, route choices |
+| Monitor | Am I following and producing the expected result? | Predictions, checkpoints, observable states |
+| Evaluate | Does my result meet the criteria? | Verification, examples, rubrics, tests |
+| Adjust | What should I do if it does not? | Diagnosis, recovery, alternate explanations, escalation |
+
+Use checks that reveal the quality of the mental model.
+
+Prefer "What would happen if this input changed, and why?" over "Does this make sense?"
+
+Ask readers to compare their output with explicit criteria.
+
+Provide feedback that identifies the gap and the next useful action.
+
+Distinguish confidence from evidence.
+
+Encourage readers to predict before checking the answer when prediction is safe and relevant.
+
+Make stopping rules explicit so readers know when to seek help rather than persist with a faulty model.
+
+Avoid turning every page into a quiz.
+
+Add metacognitive support where miscalibration would cause meaningful error or block transfer.
+
+## Validate the Reader Model
+
+Treat the reader model as a revisable hypothesis.
+
+Test it with representative people and authentic tasks.
+
+Look for mismatches between assumed and observed behavior.
+
+| Observation | Likely model error | Revision direction |
+| --- | --- | --- |
+| Readers skip background and fail later | Prerequisites are invisible or poorly placed | Surface a concise dependency at the decision point |
+| Readers reread but cannot explain | Structure is fragmented | Add relations, mechanism, or a coherent overview |
+| Readers follow steps but choose the wrong branch | Recognition cues are underspecified | Add contrasts and conditions of applicability |
+| Experts abandon the page | Scaffolding dominates the fast path | Layer detail and foreground expert decisions |
+| Novices copy without adapting | Example surface features dominate | Extract the principle and vary the next case |
+| Readers reject a correction | Misconception carries value, identity, or trust | Address threat, evidence, and replacement model |
+| Readers report clarity but fail a new case | Fluency was mistaken for understanding | Add prediction, application, and delayed checks |
+
+Segment findings by consequential dimensions rather than by demographics alone.
+
+Do not generalize from one vocal reader when evidence shows meaningful variation.
+
+Preserve alternate paths when different reader states genuinely require different support.
+
+## Reader Model Review
+
+Use this review before publication:
+
+- Identify the reader dimensions that alter design decisions.
+- Verify prior knowledge rather than assuming it from title or tenure.
+- Distinguish accurate, inert, insufficient, inappropriate, inaccurate, and fragmented knowledge.
+- Activate only knowledge relevant to the target model.
+- Expose deep structure, causal relations, and conditions of use.
+- Pair principles with varied cases when transfer matters.
+- Treat misconceptions as competing models that require replacement.
+- Layer novice support and expert access without duplicating truth.
+- Audit the draft for the curse of knowledge.
+- Connect effort to value, expectancy, agency, and meaningful goals.
+- Inspect cultural, linguistic, social, and environmental assumptions.
+- Add metacognitive checks where confidence can diverge from performance.
+- Validate the model through paraphrase, prediction, application, and observed use.
+- Revise the reader model when behavior contradicts it.
+
+Design for readers as active sense-makers whose knowledge, goals, identities, and contexts shape what the document becomes in use.

--- a/skills/crystal-clear-docs/references/svg-diagrams.md
+++ b/skills/crystal-clear-docs/references/svg-diagrams.md
@@ -1,308 +1,434 @@
-# SVG Diagrams for Technical Explanation
+# Visual and Multimedia Explanation
 
-Sources: Edward Tufte (The Visual Display of Quantitative Information, 1983; Envisioning Information, 1990), blobstreaming.org SVG Diagrams for Docs (2024), W3C Writing Accessible SVG (draft), Google Developer Style Guide (Images section), SAP Architecture Center Diagram Best Practices, arivictor/diagram-style-guide (GitHub, 2024), Few/Tufte Design Library.
+Sources: Richard E. Mayer (Multimedia Learning), Dunlosky and Rawson (The Cambridge Handbook of Cognition and Education), Edward Tufte (Envisioning Information; The Visual Display of Quantitative Information), W3C Web Accessibility Initiative guidance, and Mermaid documentation.
 
-Covers: When and how to use SVG diagrams to explain concepts that are hard to understand without visual guides. Diagram type selection, SVG accessibility, dark mode compatibility, Mermaid integration, and visual explanation patterns.
+Covers: Design visual and multimedia explanations with selecting-organizing-integrating principles; manage dual channels and limited capacity; select, integrate, implement, accessibly describe, and visually validate Mermaid and SVG diagrams for different audiences.
 
-## When Diagrams Help (and When They Don't)
+## Design for Active Processing
 
-SVG diagrams excel at explaining: architecture, data flows, state machines, process flows, relationships (ER, class hierarchies), sequences, comparisons, before/after states.
+Treat a visual explanation as support for three learner activities:
 
-SVG is NOT the right choice for: photographs or screenshots (use JPEG/WebP), highly complex diagrams with 100+ elements (rendering performance degrades), diagrams requiring pixel-identical browser rendering.
+1. Select relevant words and visual elements.
+2. Organize selected material into coherent verbal and pictorial models.
+3. Integrate those models with each other and with prior knowledge.
 
-**The test**: If you can explain it clearly in 2-3 sentences, you probably don't need a diagram. If the reader needs to hold multiple relationships in their head simultaneously, a diagram reduces cognitive load.
+Do not add a diagram merely to decorate prose.
+Give the visual a cognitive job that the reader can state.
 
-## Diagram Type Selection
+Define the job as an observable interpretation, trace, comparison, prediction, or decision.
+Engagement can support attention and effort, but it is not evidence of understanding. Keep an engaging visual when it supports motivation without competing with the explanatory goal; otherwise remove or redesign it.
 
-| To Explain | Use | Example Tools |
-|-----------|-----|---------------|
-| How data/control flows through a system | Flowchart | Mermaid flowcharts |
-| Components and their connections | Architecture diagram | Mermaid architecture-beta, Excalidraw |
-| Order of operations between actors | Sequence diagram | Mermaid sequence diagram |
-| Decision logic, conditions | Decision tree | Mermaid flowchart with diamonds |
-| Entity relationships | ER diagram | Mermaid ER, DBML |
-| States and transitions | State diagram | Mermaid state diagram |
-| Comparisons (A vs B) | Side-by-side boxes, Venn | Hand-coded SVG |
-| Timeline / progression | Timeline | Mermaid gantt |
-| Hierarchy / tree | Tree diagram | Mermaid flowchart with subgraphs |
-| Before/After | Paired annotated diagrams | Hand-coded SVG |
+## Respect Dual Channels and Limited Capacity
 
-## Diagram-As-Code with Mermaid (Preferred Method)
+People receive material through the eyes and ears, then process selected material in limited-capacity visual/pictorial and auditory/verbal working-memory channels. Printed words enter visually before the learner represents them verbally, so sensory route and representational mode are related but not identical.
+Meaningful learning requires active selection, organization, and integration.
 
-Mermaid is ideal for documentation because:
-- Source is readable Markdown-like text, diffs cleanly in Git
-- Renders to SVG automatically
-- 10x-100x smaller than GUI-generated SVGs
-- Can be embedded directly in Markdown on many platforms (GitHub, GitLab, Notion)
+Apply these implications:
 
-### Essential Mermaid Diagram Types
+- Use words and visuals when they contribute complementary information.
+- Reduce simultaneous elements that compete for the same channel.
+- Group material into meaningful units.
+- Pace dynamic explanations so readers can complete one integration before the next.
+- Reuse visual conventions so readers spend less capacity decoding notation.
+- Make the relationship between representations explicit.
 
-**Flowchart** — for processes, data flows, logic:
+Do not interpret dual channels as permission to duplicate every sentence as narration, labels, and captions.
+Duplication can overload rather than reinforce.
+
+## Select the Representation from the Relationship
+
+Choose a representation based on what the reader must perceive or infer.
+
+| Explanatory need | Useful representation | Reader action |
+| --- | --- | --- |
+| Ordered actions with branching | Flowchart or decision tree | Follow a path and evaluate conditions |
+| Messages among actors over time | Sequence diagram | Trace order, ownership, and response |
+| Valid states and transitions | State diagram | Predict legal and illegal transitions |
+| Components and boundaries | Architecture or containment diagram | Locate responsibility and dependency |
+| Data entities and cardinality | Entity-relationship diagram | Infer allowed associations |
+| Causal mechanism | Causal chain or process model | Explain how a change produces an effect |
+| Comparison under common dimensions | Aligned small multiples or table | Detect similarities and differences |
+| Quantitative magnitude | Position or length encoding | Compare values accurately |
+| Trend over time | Line chart | Detect direction, rate, and exceptions |
+| Distribution | Histogram, dot plot, or box plot | Inspect spread, clusters, and outliers |
+| Spatial arrangement | Map or spatial schematic | Relate location to behavior |
+| Exact values | Table | Retrieve precise entries |
+
+Use prose when sequence, space, quantity, or relationship is not central.
+Use code when the exact executable form is the target.
+Use a table when readers need systematic comparison or precise lookup.
+
+Do not default to a flowchart for every concept.
+A poor representation can make the relevant relationship harder to see.
+
+## Apply Coherence Selectively
+
+Exclude material that does not support the explanatory goal.
+
+Remove decorative illustrations, unrelated icons, background textures, gratuitous animation, ornamental frames, and labels that repeat obvious shapes.
+Retain context that prevents a false inference or supports orientation.
+
+Do not reduce coherence to visual minimalism.
+A sparse diagram can still be incoherent if it omits the relationship the reader needs.
+
+## Signal Structure and Attention
+
+Guide attention toward organization and consequential changes.
+
+Use signaling through:
+
+- Descriptive titles that state the diagram's claim or question.
+- Consistent shape semantics.
+- Typographic hierarchy.
+- Direct labels.
+- Numbered phases.
+- Selective emphasis.
+- Boundary boxes.
+- Aligned lanes.
+- Highlighted paths tied to the current explanation.
+
+Maintain a restrained visual vocabulary.
+Use one emphasis treatment for the same semantic purpose.
+
+Do not signal everything.
+When every node is bold, colored, or boxed, nothing receives priority.
+
+## Keep Related Words and Visuals Contiguous
+
+Place explanatory words near the corresponding visual element in space and time.
+
+For static visuals:
+
+- Put short labels on or beside the relevant object.
+- Position captions immediately before or after the visual.
+- Align callouts with the element they explain.
+- Avoid legends when direct labels remain legible.
+- Keep a code excerpt near the diagram state it implements.
+
+Avoid forcing readers to alternate between distant prose and an unlabeled diagram.
+Eye travel and memory load can prevent integration.
+
+## Set Redundancy Boundaries
+
+Avoid presenting identical, information-dense words simultaneously as narration and on-screen text when both compete for verbal processing.
+
+Use on-screen text when:
+
+- The content is a name, value, formula, command, or exact phrase.
+- The reader must inspect it at their own pace.
+- Audio is unavailable or undesirable.
+- Accessibility requires a textual alternative.
+- The audience may not understand the narration language or accent reliably.
+
+Use narration with visuals when:
+
+- Animation changes too quickly for extended labels.
+- Spoken explanation can offload visual attention.
+- The visual itself already occupies substantial visual capacity.
+- Playback controls let the reader pause and replay.
+
+Use concise labels plus narration when exact terms must remain visible.
+Do not remove essential text merely to comply with a redundancy slogan.
+
+Distinguish visible duplication from accessible alternatives.
+Captions, transcripts, and descriptions remain necessary even when they repeat spoken content for users who need them.
+
+## Segment Complex Explanations
+
+Break a complex visual process into learner-controlled, meaningful segments.
+
+Segment by:
+
+- Phase of a process.
+- Decision point.
+- System boundary.
+- Layer of abstraction.
+- Actor interaction.
+- Before and after state.
+- Stable subproblem.
+
+Give readers controls to advance, pause, return, or inspect.
+For static documents, use a sequence of small multiples or progressive panels.
+
+Do not animate a complete architecture diagram one arrow at a time without preserving orientation.
+Keep stable landmarks visible across segments.
+
+Split a visual when the reader must answer unrelated questions.
+Keep it unified when separating it would hide a critical relationship.
+
+## Pretrain Names, Roles, and Notation
+
+Introduce essential components and conventions before asking readers to follow a complex interaction.
+
+Pretrain:
+
+- Component names.
+- Shape meanings.
+- Arrow semantics.
+- Units and scales.
+- Actor roles.
+- Required domain terms.
+- Color or line-style categories.
+
+Use a compact orientation panel or an initial labeled state.
+Then reuse the same names and encodings throughout.
+
+Do not pretrain incidental details.
+Teach only what reduces decoding effort during the main explanation.
+
+## Use Modality with Context
+
+Choose spoken or written words according to task, medium, and audience.
+
+Prefer spoken explanation alongside a visually dense animation when the learner can control playback and hear clearly.
+Prefer written explanation for searchable reference, code, formulas, unfamiliar terminology, multilingual access, noisy environments, or self-paced inspection.
+
+Do not declare one modality universally superior.
+Prototype against the actual task and delivery environment.
+
+## Integrate Visuals with Prose
+
+Make prose and visual perform complementary roles.
+
+Use an integration sequence:
+
+1. State what the reader should determine.
+2. Orient the reader to the visual's entities and encoding.
+3. Direct attention through the relevant relationship.
+4. Explain the inference.
+5. Ask the reader to use the visual on a new case.
+
+Do not write "see diagram below" without stating what to look for.
+
+Example:
+
+> Trace the solid path from the client to storage. Authorization occurs after routing but before the transaction begins, so rejected requests never acquire a database connection.
+
+This sentence coordinates attention and inference.
+
+## Show Processing and Retry Boundaries
+
+For asynchronous architecture, label more than components and arrows:
+
+| Boundary | Make explicit |
+| --- | --- |
+| Acceptance | What acknowledgement guarantees and what remains incomplete |
+| Processing | Which component owns the work and terminal state |
+| Retry | Owner, repeated operation, attempt scope, backoff, and limit |
+| Delivery | At-most-once or at-least-once behavior and deduplication duty |
+| Failure | Retryable versus terminal failure and dead-letter or escalation path |
+
+Keep processing retries separate from notification or delivery retries. Show whether duplicate execution is possible and where idempotency is enforced. Validate success, transient failure, retry exhaustion, duplicate delivery, and non-retryable failure as distinct traces.
+
+## Integrate Visuals with Code
+
+Connect conceptual structure to executable details without pretending they are identical.
+
+Use these patterns:
+
+- Match component names to module or function names where practical.
+- Number diagram phases and code excerpts consistently.
+- Highlight the path implemented by the adjacent snippet.
+- State which implementation details the diagram intentionally omits.
+- Link each failure path to the handling branch in code.
+- Show a state transition beside the operation that triggers it.
+- State what an acknowledgement proves, such as `202` meaning accepted rather than completed.
+
+Avoid diagrams that reproduce source code as boxes and arrows.
+Abstract implementation only enough to expose the target relationship.
+State which implementation details were intentionally omitted.
+
+## Account for Expertise Differences
+
+Adjust visual support to the reader's existing schemas.
+
+For novices:
+
+- Pretrain notation and component roles.
+- Reduce simultaneous relations.
+- Use direct labels and guided paths.
+- Show representative concrete cases.
+- Keep explanatory support close to the visual.
+
+For experienced readers:
+
+- Preserve information density when it supports rapid pattern recognition.
+- Remove guidance that obscures the full structure.
+- Expose exceptions, tradeoffs, and implementation boundaries.
+- Provide navigable overview and detail views.
+
+Do not assume that simplified visuals always help novices or that dense visuals always help experts.
+Validate whether the representation matches their knowledge and task.
+
+Provide alternate entry points when one document serves mixed expertise:
+
+- Orientation view for unfamiliar readers.
+- Full system view for experienced readers.
+- Focused detail views for specific questions.
+
+## Design Accessible Visual Explanations
+
+Provide equivalent access to the visual's purpose and information.
+
+For simple informative images, write concise alternative text that communicates the relevant relationship.
+For complex diagrams, provide a short alternative plus a nearby structured description or equivalent data.
+For decorative images, use an empty alternative so assistive technology can skip them.
+
+Also:
+
+- Preserve meaningful reading order in the DOM.
+- Meet contrast requirements for text and meaningful graphics.
+- Do not encode meaning through color alone.
+- Pair color with labels, shape, line style, or pattern.
+- Keep text selectable when practical.
+- Support zoom and responsive resizing.
+- Avoid flashing or uncontrolled motion.
+- Provide pause controls for animation.
+- Caption and transcribe narrated media.
+
+Do not assume `<title>` and `<desc>` alone explain a complex diagram adequately.
+Write a nearby text explanation when relationships, sequences, or data require detail.
+
+## Implement Maintainable Mermaid Diagrams
+
+Use Mermaid for diagrams whose semantics fit its supported forms and whose source will change with the system.
+
+Prefer Mermaid when:
+
+- Text diffs matter.
+- Contributors need to edit without design software.
+- Automatic layout is acceptable.
+- The target renderer supports the required diagram type.
+
+Keep source semantic:
+
 ```mermaid
-flowchart TD
-    A[User Request] --> B{Authenticated?}
-    B -->|Yes| C[Process Request]
-    B -->|No| D[Return 401]
-    C --> E[Return Response]
-```
-
-**Sequence Diagram** — for interactions between components:
-```mermaid
-sequenceDiagram
-    Client->>API: POST /login
-    API->>DB: Verify credentials
-    DB-->>API: User record
-    API-->>Client: JWT token
-```
-
-**State Diagram** — for lifecycle, status:
-```mermaid
-stateDiagram-v2
-    [*] --> Draft
-    Draft --> Review: submit
-    Review --> Published: approve
-    Review --> Draft: reject
-    Published --> [*]
-```
-
-### Mermaid Styling for Clarity
-
-Four knobs matter most for professional-looking diagrams:
-
-1. **Theme**: `default`, `forest`, `dark`, `neutral`, `base`. `base` if customizing deeply.
-2. **themeVariables**: Only six actually matter: `primaryColor`, `primaryTextColor`, `primaryBorderColor`, `lineColor`, `fontFamily`, `fontSize`.
-3. **Edge curves**: Default `basis` curves look amateur. Switch to `linear` for pipelines, `step` for hierarchies.
-4. **Layout direction**: `TD` (top-down) for hierarchies, `LR` (left-right) for pipelines.
-
-```mermaid
-%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#f0f0f0','primaryTextColor':'#333','lineColor':'#666','fontSize':'14px'}}}%%
 flowchart LR
-    Input --> Process --> Output
+    request[Client request] --> validate{Valid?}
+    validate -->|No| reject[Return 400]
+    validate -->|Yes| enqueue[Enqueue job]
+    enqueue --> accept[Return 202]
 ```
 
-### Declaration Order for Clean Layouts
+Use stable identifiers separate from visible labels.
+Keep labels concise and explain details in surrounding prose.
+Group related nodes only when containment carries meaning.
+Choose layout direction from the relationship and available page width.
 
-Tier-based ordering: declare elements in the order they should appear visually, following natural data flow. Declare ALL elements before ANY relationships. Group related elements with `subgraph`.
+Do not depend on declaration order as a guarantee of exact placement.
+Renderer versions and layout engines can change output.
 
-## Visual Explanation Patterns
+Pin or record the Mermaid version used for generated artifacts.
+Render diagrams in CI or documentation previews when appearance matters.
 
-### 1. Annotated Architecture
+## Implement Robust SVG
 
-Annotate directly on the diagram rather than using separate legends. Labels near their elements eliminate eye travel. Use callout lines to connect explanatory text to diagram elements.
+Use hand-authored or tool-generated SVG when precise composition, custom illustration, interaction, or stable placement is required.
 
-### 2. Before/After Paired Diagrams
-
-Show the problem ("Before") next to the solution ("After") at the same scale. The reader sees the delta without explanation.
-
-### 3. Zoom-In Details
-
-Show the big picture, then an enlarged detail of the complex part. Circle or highlight the zoom region on the overview.
-
-### 4. Step-By-Step Numbered Progression
-
-Number steps in the order they happen. Readers process numbered sequences faster than trying to decode arrows.
-
-### 5. Comparison Tables with Visual Differentiation
-
-Color-code differences. Use ✓/✗ for feature comparisons. Never rely on color alone — always include text labels.
-
-## SVG Quality Checklist
-
-| Check | How to Verify |
-|-------|---------------|
-| Edge crossings minimized | Count intersection points (not at nodes). Target 0 for simple, <3 for medium |
-| Consistent flow direction | All primary edges flow in one direction (L→R or T→B) |
-| Visual hierarchy clear | System boundary/main container is most prominent element |
-| Color-independent meaning | Diagram is still readable in grayscale |
-| Text legible | Minimum 12px font for digital, adequate contrast |
-| Accessible | `role="img"`, `<title>`, `<desc>` elements present |
-| Groups make sense | Related elements visually proximate and grouped |
-
-## SVG Accessibility
-
-Every SVG diagram must include:
+Start with a responsive root:
 
 ```svg
-<svg role="img" aria-label="Architecture diagram showing client connecting through API gateway to three backend services">
-  <title>System Architecture</title>
-  <desc>Client sends requests to the API gateway which routes to either the auth service, data service, or notification service based on the endpoint.</desc>
-  <!-- diagram elements -->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 800 450"
+  role="img"
+  aria-labelledby="ccdocs-write-title ccdocs-write-description"
+>
+  <title id="ccdocs-write-title">Validated write path</title>
+  <desc id="ccdocs-write-description">
+    Requests pass from the API through validation and authorization before storage.
+  </desc>
 </svg>
 ```
 
-Rules:
-- Always `role="img"` on root `<svg>`
-- Short label in `aria-label` or `<title>`
-- Longer description in `<desc>` for complex diagrams
-- Color-blind safe: never rely on color alone to convey meaning
-- Sufficient contrast ratios for strokes and text
+Use unique IDs for every inline SVG in the document.
 
-## Dark Mode Support
+Implementation guidance:
 
-Two approaches:
+- Preserve `viewBox` during optimization.
+- Let CSS constrain display width and height.
+- Use reusable classes or CSS custom properties for themes.
+- Keep stroke widths legible at intended sizes.
+- Prefer real text over outlined glyph paths when portability permits.
+- Define markers and repeated symbols once in `<defs>`.
+- Remove editor metadata and unused definitions.
+- Sanitize externally sourced SVG before inline embedding.
+- Test inline, `<img>`, and generated-file behavior according to the chosen delivery path.
 
-1. **Inline SVGs with `currentColor`** — stroke and fill use `currentColor`, inheriting page color. Most flexible but requires inline embedding.
-2. **Dual SVGs** — light and dark versions, swapped via CSS media query. Simpler but maintenance burden.
-
-Mermaid's `neutral` theme works reasonably well on both light and dark backgrounds without modification.
-
-## Tufte's Principles Applied to Diagrams
-
-| Principle | Application |
-|-----------|-------------|
-| Data-ink ratio | Every pixel serves the data. Remove grid backgrounds, decorative borders, gradient fills, drop shadows, 3D effects |
-| Chartjunk elimination | No moiré patterns, no heavy gridlines, no decorative pictograms. Gridlines in #d8d4ce only if needed |
-| Lie Factor = 1.0 | Every element proportional to what it represents. No area distortions |
-| Direct labels | Label elements directly adjacent. No legends — they force eye travel |
-| Micro/macro readings | Diagram readable as whole gestalt AND inspectable at individual elements |
-| Small multiples | Compare similar structures side-by-side at same scale |
-
-## When to Hand-Code SVG vs Tool-Generated
-
-| Approach | Best For |
-|----------|----------|
-| Mermaid (diagram-as-code) | Flowcharts, sequences, state diagrams, ER — anything that changes often |
-| Hand-coded SVG | Simple diagrams (3-6 boxes, few arrows), diagrams needing precise control, rarely-changed illustrations |
-| Excalidraw export SVG | Architecture diagrams with custom styling, hand-drawn aesthetic |
-| Figma/draw.io export → SVGO | Complex diagrams, diagrams needing visual polish |
-
-## Visual Selection Decision Framework
-
-Adapted from the Few/Tufte Design Library:
-
-| Data Type | Best Visual Encoding | Avoid |
-|-----------|---------------------|-------|
-| Comparisons | Bar chart (length), side-by-side boxes | Pie charts (angle is harder to decode), 3D effects |
-| Change over time | Line chart, sparkline | Stacked area with many series |
-| Relationships / flow | Flowchart, network diagram | Text description of relationships |
-| Part-to-whole | Stacked bar, treemap | Pie chart with many slices |
-| Distribution | Histogram, box plot | Raw data table |
-| Spatial | Map, architecture diagram | List of locations |
-| Process / sequence | Sequence diagram, numbered flowchart | Prose description of steps |
-| Hierarchy | Tree diagram, nested subgraphs | Indented text list |
-
-## Perceptual Encoding Hierarchy
-
-The visual cortex processes encoding types with different speeds and accuracy. Design your diagrams to use the most effective encoding for your primary message:
-
-```
-Position (most accurate)
-  > Length
-    > Angle / Slope
-      > Area
-        > Volume (least accurate)
-          > Color hue / Saturation
-```
-
-Implication: Bar charts (using length/position) are easier to read than pie charts (using angle). For diagrams, this means: position elements by importance, use consistent sizes, and use color for categorization, not for encoding quantitative differences.
-
-## Gestalt Principles for Diagrams
-
-These principles from perceptual psychology govern how viewers unconsciously group elements:
-
-| Principle | Meaning | Diagram Application |
-|-----------|---------|---------------------|
-| **Proximity** | Close elements are perceived as grouped | Group related services in subgraphs or with padding |
-| **Similarity** | Similar elements are perceived as related | Use consistent shapes for same-type components |
-| **Continuity** | The eye follows continuous lines/paths | Avoid crossing lines; prefer straight paths |
-| **Closure** | The mind completes incomplete shapes | Boxes around groups signal containment |
-| **Common Region** | Elements in a bounded area are perceived as a group | Use subgraph blocks, background regions |
-| **Connectedness** | Connected elements are perceived as related | Lines between elements imply relationship |
-
-## Edge Crossing: The Single Biggest Diagram Problem
-
-Research by Purchase et al. found that edge crossings are the strongest negative predictor of diagram comprehension. This matters more than node positioning, symmetry, or even consistent flow direction.
-
-**Crossing reduction strategy**:
-1. Declare elements in visual order (left-to-right, top-to-bottom)
-2. Group related elements with subgraph constraints
-3. Use tier-based ordering: upstream → processing → downstream
-4. If crossings remain, split into multiple diagrams
-
-Targets:
-- Simple (≤6 elements): 0 crossings
-- Medium (7-12 elements): <3 crossings
-- Complex (12+ elements): <5 crossings, or split
-
-## C4 Diagram Levels for Architecture
-
-For architecture documentation, use the C4 model for layered architectural views:
-
-| Level | Scope | Audience | Diagram Content |
-|-------|-------|----------|-----------------|
-| Context | System + external actors | Everyone | The system as a box, external users/systems around it |
-| Container | High-level tech choices | Architects, devs | Web app, API, database, file system |
-| Component | Internal structure | Developers | Controllers, services, repositories within a container |
-| Code | Class-level detail | Developers | UML class diagrams (usually generated, not hand-drawn) |
-
-One diagram per C4 level. Never mix context-level and container-level elements on the same diagram.
-
-## Dark Mode SVG Patterns
-
-### Approach 1: CSS Custom Properties (Inline SVG)
+Use `currentColor` for monochrome elements that should inherit surrounding text color:
 
 ```svg
-<svg viewBox="0 0 200 100" role="img" aria-label="...">
-  <style>
-    .bg { fill: var(--bg-color, #ffffff); }
-    .text { fill: var(--text-color, #333333); stroke: var(--text-color, #333333); }
-    .accent { fill: var(--accent-color, #0066cc); }
-    @media (prefers-color-scheme: dark) {
-      .bg { fill: #1a1a2e; }
-      .text { fill: #e0e0e0; stroke: #e0e0e0; }
-      .accent { fill: #66b3ff; }
-    }
-  </style>
-  ...
-</svg>
+<path d="M20 40 H180" fill="none" stroke="currentColor" stroke-width="2" />
 ```
 
-### Approach 2: `currentColor` (Simplest)
+Use explicit semantic colors when categories must remain stable across contexts.
+Test those colors in light mode, dark mode, forced colors, and grayscale.
 
-For monochrome diagrams that should match text color:
+Do not prescribe transparent or opaque backgrounds universally.
+Choose deliberately based on embedding context and test both expected themes.
 
-```svg
-<svg viewBox="0 0 200 100" role="img" aria-label="...">
-  <rect x="10" y="10" width="80" height="30" fill="none" stroke="currentColor" stroke-width="2"/>
-</svg>
-```
+## Validate the Visual, Not Just the Source
 
-The diagram inherits `currentColor` from the page — automatically dark mode compatible.
+Render every diagram in its actual documentation environment.
+Source validity does not guarantee usable output.
 
-### Approach 3: Mermaid Theme Selection
+Inspect at:
 
-For Mermaid diagrams on sites with dark mode, use the `neutral` theme or `base` with custom variables:
+- Expected desktop width.
+- Narrow mobile width.
+- Browser zoom.
+- Light and dark themes.
+- High-contrast or forced-color mode where supported.
+- The exported or printed format.
+- The minimum intended resolution.
 
-```mermaid
-%%{init: {'theme':'base', 'themeVariables': {
-  'primaryColor':'#bb86fc','primaryTextColor':'#fff','primaryBorderColor':'#bb86fc',
-  'lineColor':'#888','secondaryColor':'#03dac6','tertiaryColor':'#1e1e1e'
-}}}%%
-flowchart TD
-    A --> B
-```
+Verify:
 
-Export at different themes for light/dark and swap via CSS or JavaScript.
+| Check | Question |
+| --- | --- |
+| Explanatory purpose | Can readers state the intended relationship or inference? |
+| Selection | Do important elements attract attention before decoration? |
+| Organization | Can readers group parts and follow the intended structure? |
+| Integration | Can readers connect labels, prose, and prior concepts? |
+| Legibility | Are text, lines, markers, and distinctions readable at target size? |
+| Semantics | Do shape, color, and line conventions remain consistent? |
+| Accessibility | Is equivalent information available without vision, color, motion, or audio? |
+| Responsiveness | Does resizing preserve meaning and usable text size? |
+| Fidelity | Does the diagram match the current system or data? |
+| Robustness | Does it render correctly in every supported renderer? |
 
-## Common SVG Mistakes and Fixes
+Use representative reader tasks rather than aesthetic preference alone:
 
-| Mistake | Fix |
-|---------|-----|
-| Fixed `width`/`height` attributes | Use `viewBox` only; let CSS control display size |
-| `<img src="diagram.svg">` prevents CSS theming | Use inline `<svg>` or `<object>` |
-| Text as paths (from Figma/draw.io export) | Run through SVGO with `convertPathData: false, removeViewBox: false` |
-| Missing `xmlns` | Always include `xmlns="http://www.w3.org/2000/svg"` |
-| Transparent backgrounds | Add explicit background rect; transparent diagrams look broken on dark mode |
-| SVG too large (verbose export) | Run through SVGO: `npx svgo diagram.svg -o diagram.min.svg` |
+- Ask a reader to trace one path.
+- Ask where a decision occurs.
+- Ask what changes between two states.
+- Ask for a prediction from the visual.
+- Ask which element supports the stated conclusion.
+- Trace success, transient failure, retry exhaustion, duplicate delivery, and terminal failure when retries are part of the system.
 
-## When Not to Draw — Let Text Win
+Record errors and hesitation.
+Revise labels, grouping, segmentation, or representation according to observed failures.
 
-A good diagram is worth a thousand words. But a thousand words are sometimes better than a bad diagram. Skip the diagram when:
+## Avoid Universal Layout Rules
 
-- The concept takes 1-2 sentences to explain clearly
-- The diagram would have more edge crossings than elements
-- The audience doesn't need the diagram (expert audience, reference doc)
-- The diagram duplicates what's already clear in a table
-- Creating the diagram would take longer than writing a clear paragraph
+Treat layout principles as content-dependent tradeoffs.
+Reduce crossings when they impair tracing, preserve feedback loops when they matter, split only separable questions, and choose direct labels or legends according to legibility.
+Judge the result by whether the intended reader can find elements, follow relationships, make the intended inference, and explain omissions.
+Do not enforce fixed node, crossing, paragraph, or font-size quotas without reference to medium and audience.
 
-Remember Tufte: "Simple design, intense content." If the diagram doesn't have intense content, it's decoration.
+## Visual Explanation Review
+
+Run this review before publication:
+
+1. State the visual's cognitive job in one sentence.
+2. Confirm that the chosen representation exposes the target relationship.
+3. Remove unrelated material and preserve necessary context.
+4. Signal the organization and consequential path.
+5. Place labels and explanation close to corresponding elements.
+6. Check whether simultaneous words duplicate or complement one another.
+7. Segment complexity and pretrain notation where needed.
+8. Align prose, visual, and code terminology.
+9. Provide accessible alternatives and interaction controls.
+10. Render in every supported theme, width, and output format.
+11. Test a representative interpretation or prediction task.
+12. Revise from observed comprehension failures, not taste alone.

--- a/skills/crystal-clear-docs/references/writing-clarity.md
+++ b/skills/crystal-clear-docs/references/writing-clarity.md
@@ -1,314 +1,353 @@
-# Writing for Clarity: Words and Comparisons
+# Behavioral Writing and Cognitive Prose
 
-Sources: Strunk & White (The Elements of Style, 1918), William Zinsser (On Writing Well, 1976), Google Technical Writing Course (One), Steve Krug (Don't Make Me Think — Chapter 5: Omit Needless Words), Robert Horn (Information Mapping).
+Sources: Todd Rogers and Jessica Lasky-Fink (Writing for Busy Readers), Steven Pinker (The Sense of Style), Google Technical Writing Courses, and Steve Krug (Don't Make Me Think).
 
-Covers: Word-level and sentence-level techniques for crystal-clear technical writing. Active voice, eliminating jargon, sentence construction, comparison patterns, worked examples, and the MECE framework for structuring arguments.
+Covers: Shape prose around the reader's desired action and limited attention. State the topic and point early, write concrete and coherent sentences, reduce action friction, edit without rigid word quotas, and test whether readers understand and act.
 
-## The Core Principle
+## Begin With the Reader Outcome
 
-**Every word must earn its place.** If removing a word changes nothing, remove it. If a simpler word works, use it. Clarity is not about dumbing down — it's about respecting the reader's time and attention.
+Define what the reader should know, decide, feel, or do after reading.
 
-## Omit Needless Words (Krug + Strunk & White)
+Write the outcome as an observable result:
 
-Before:
-> "In order to successfully authenticate the user's credentials, it is necessary for the system to verify the provided password against the hashed value that has been previously stored in the database."
+> After reading, an on-call engineer can identify the failing dependency and choose the safe recovery command.
 
-After:
-> "The system checks the password against the stored hash."
+Avoid outcomes that describe only the document:
 
-Technique: Write the sentence. Delete every word. Re-add only what's essential to convey the meaning. You will re-add about 40% of the original.
+> This page provides an overview of incident recovery.
 
-## Active Voice
+Use the outcome to decide what belongs. Keep information that changes the reader's understanding, choice, or action. Remove information that serves only the writer's wish to appear complete.
 
-Active voice makes actors visible and responsibility clear.
+Ask these questions before drafting:
 
-| Passive | Active |
-|---------|--------|
-| "The configuration file should be updated." | "Update the configuration file." |
-| "Errors are logged to the console." | "The server logs errors to the console." |
-| "The token is verified before access is granted." | "The API verifies the token before granting access." |
+- Who will read this in the moment that matters?
+- What prompted them to open it?
+- What do they already know?
+- What uncertainty blocks them?
+- What action or judgment should become easier?
+- What could they misunderstand with serious consequences?
 
-**When passive voice is acceptable**: The actor is irrelevant or unknown ("The server was compromised"), or you want to emphasize the recipient over the actor.
+Treat the reader's situation as part of the writing problem. A calm learner, an executive choosing an option, and an engineer responding to an outage need different prose even when the facts are identical.
 
-## Define Terms on First Use
+## Respect the Attention Budget
 
-Every new or unfamiliar term gets defined the first time it appears. Definition goes in the same sentence or the very next one.
+For operational, workplace, and action-oriented documents, assume attention may be scarce, interrupted, and goal-directed. Deliberate study and specification review permit deeper reading but still benefit from visible structure.
 
-**Good**:
-> "The system uses JWT (JSON Web Token) — a compact, URL-safe token that proves identity without server-side session storage."
+Do not demand attention before delivering value. Put the information that helps the reader orient or act where they can encounter it early.
 
-**Bad**:
-> "The system uses JWT."
-> *(reader Googles "JWT" and doesn't come back)*
+Spend attention deliberately:
 
-## Eliminating Jargon
+| Reader cost | Justify it with |
+| --- | --- |
+| A new term | Greater precision or a reusable concept |
+| A long explanation | A decision that depends on the reasoning |
+| An exception | A likely or costly failure it prevents |
+| A cross-reference | Useful depth that would distract from the current task |
+| A qualification | Accuracy that materially changes interpretation |
 
-Jargon is domain-specific vocabulary your reader may not know. The test: would your next-door neighbor understand this term?
+Formatting supports prose; it does not rescue weak prose. Use short sections, descriptive labels, and selective emphasis to expose meaning, not to decorate the page.
 
-| Jargon | Plain Alternative |
-|--------|-------------------|
-| "Implement a pub/sub pattern" | "Set up a message system where one service publishes and others subscribe" |
-| "Utilize a monorepo architecture" | "Keep all code in a single repository" |
-| "Leverage horizontal scaling" | "Add more servers instead of bigger servers" |
-| "Idempotent operation" | "Safe to retry — running it twice has the same effect as running it once" |
+Make the first visible text earn continued attention. Tell readers what subject they have reached, why it matters to them, and what the central point is.
 
-**Exception for developer docs**: Domain-appropriate jargon is fine IF defined on first use. Developers know "idempotent" — but still define it. Your more junior readers don't know it yet.
+## Put the Topic and Point Early
 
-## Sentence Construction
+Name the topic before discussing its attributes. State the point before presenting the trail of reasoning when readers need the conclusion to interpret the evidence.
 
-### Length
+Weak opening:
 
-- Core sentences: 15-20 words
-- Limit: 25 words maximum
-- If a sentence runs longer, split it. If splitting loses meaning, use a list.
+> After several weeks of analysis across teams, during which we reviewed latency, cost, and operational burden, a number of findings emerged about the current queue design.
 
-### Structure
+Stronger opening:
 
-Lead with the subject and verb. Don't make readers hold context while you set up.
+> The current queue design cannot meet the recovery target. It loses too much time retrying permanent failures. The analysis below explains the evidence and the replacement options.
 
-**Before**:
-> "After considering the various authentication approaches available, including OAuth 2.0, API keys, and session-based auth, and weighing their respective tradeoffs in terms of security, implementation complexity, and user experience, the team decided to implement JWT-based authentication."
+Use an early point to create a frame, not to erase nuance. Add the most important condition in the same opening when it changes the recommendation.
 
-**After**:
-> "The team chose JWT-based authentication. It balances security, implementation simplicity, and user experience better than OAuth 2.0, API keys, or session-based auth."
+For a request, lead with the requested action:
 
-## Comparison Patterns
+> Approve the database maintenance window by Thursday so the migration can run before the release freeze.
 
-### Side-by-Side Table — for multiple options, multiple criteria
+For an explanation, lead with the governing idea:
 
-| Feature | Method A | Method B | Method C |
-|---------|----------|----------|----------|
-| Speed | Fast | Medium | Slow |
-| Setup | Simple | Complex | Medium |
-| Security | Basic | Enterprise | Standard |
-| **Best for** | Prototypes | Production | Internal tools |
+> Token rotation limits the damage from a stolen refresh token by invalidating its predecessor after use.
 
-### Pros/Cons List — for evaluating a single option
+For a warning, lead with the consequence:
 
-```
-### JWT Authentication
+> Do not retry this command after a timeout; the first request may still be deleting records.
 
-**Pros**
-- Stateless — no server-side session storage
-- Works across domains (no CORS issues)
-- Compact (URL-safe)
+Delay the point only when discovery is the intended experience or when readers must inspect evidence without being anchored by a conclusion. Treat that choice as deliberate, not habitual.
 
-**Cons**
-- Cannot revoke individual tokens
-- Token size grows with claims
-- Requires token refresh mechanism
-```
+## Make Value Truthful and Visible
 
-### When to Use Which
+Describe the value the document actually provides. Do not inflate convenience into certainty, imply safety without evidence, or promise simplicity while hiding necessary work.
 
-| Situation | Format |
-|-----------|--------|
-| Choosing between 2+ options | Side-by-side table |
-| Evaluating whether to use X | Pros/Cons list |
-| Contrasting old vs new approach | Before/After paired boxes |
-| Showing step-by-step difference | Numbered old flow vs numbered new flow |
+Replace promotional claims with useful specifics:
 
-## Worked Examples
+| Vague claim | Truthful value |
+| --- | --- |
+| "Seamlessly integrates" | "Uses the existing OAuth connection; no second login is required" |
+| "Instant results" | "Returns cached results in under a second in the common path" |
+| "Easy to configure" | "Requires one environment variable and no code changes" |
+| "Production ready" | "Supports retries, idempotency, and regional failover tested in staging" |
 
-A worked example takes a realistic scenario (not a contrived toy) and walks through it completely. It includes: the setup, the happy path, common errors, and the final state.
+State tradeoffs beside benefits. Readers trust guidance that identifies where it stops being useful.
 
-### Structure of a Good Worked Example
+Prefer evidence over intensifiers. Replace "very reliable" with the observed failure rate, tested condition, or recovery behavior that supports the claim.
 
-```
-### Example: Adding Authentication to a REST API
+## Use Concrete Language
 
-**The scenario**: You have an existing Express API for a todo app.
-Currently, anyone can read or modify any todo. You need to add
-user-specific authentication.
+Make actors, actions, objects, and conditions visible.
 
-**Step 1**: Install and configure the auth library.
-[Code block with exactly what to run]
+Abstract:
 
-**Step 2**: Add the auth middleware to protected routes.
-[Code block showing before/after]
+> Appropriate optimization of resource utilization should be undertaken.
 
-**Step 3**: Test that unauthenticated requests are rejected.
-[Terminal output showing 401 response]
+Concrete:
 
-**Step 4**: Test that authenticated requests succeed.
-[Terminal output showing 200 response]
+> Reduce each worker from 2 GB to 1 GB after its peak memory stays below 700 MB for seven days.
 
-**What just happened**: [Explanation of the mechanism]
+Prefer verbs that show what changes: `delete`, `compare`, `encrypt`, `retry`, `approve`, and `measure`. Question noun-heavy phrases such as "implementation of," "facilitation of," and "performance of."
 
-**Common pitfalls**:
-- Forgetting to add the middleware to ALL protected routes → use router-level middleware
-- Storing tokens in localStorage → use httpOnly cookies instead
-```
+Name the actor when responsibility matters:
 
-### Why Worked Examples Work
+> The deployment workflow creates the revision. The service owner approves traffic migration.
 
-1. Readers learn by doing, not reading about doing
-2. A realistic example surfaces real-world edge cases
-3. They validate the documentation (if the example doesn't work, the docs are wrong)
+Use passive voice when the actor is unknown, irrelevant, or intentionally backgrounded:
 
-## MECE Framework for Structuring Arguments
+> The signing key was exposed in a public log.
 
-From Barbara Minto's Pyramid Principle: arguments should be **M**utually **E**xclusive and **C**ollectively **E**xhaustive.
+Choose examples with realistic names, values, constraints, and consequences. A concrete example should illuminate the rule rather than introduce accidental complexity.
 
-- **Mutually Exclusive**: No overlap between categories. Each item appears in exactly one place.
-- **Collectively Exhaustive**: Together, the categories cover everything. Nothing is left out.
+Define unfamiliar terms in the context where the reader needs them. Do not interrupt experts with definitions of ordinary domain language, but do not make newcomers leave the page to decode a critical instruction.
 
-Applied to documentation:
+## Counter the Curse of Knowledge
 
-**Non-MECE** (overlap + gaps):
-- Authentication methods: API keys, OAuth, JWT, Bearer tokens
-- Problem: JWT and Bearer tokens overlap
+Assume expertise has hidden steps from you.
 
-**MECE**:
-- Authentication methods:
-  - Server-side: Session cookies, API keys stored in DB
-  - Client-side: JWT tokens
-  - Delegated: OAuth 2.0
+Look for knowledge that became invisible through repetition:
 
-## BLUF: Bottom Line Up Front
+- A tool the reader may not have installed
+- A permission the writer already possesses
+- A state transition omitted between two commands
+- A term used differently across teams
+- A reason an apparently simpler option is unsafe
+- A cue experts notice but novices do not
 
-Military communication principle: state the conclusion first, then provide supporting reasoning. This is the written equivalent of the inverted pyramid.
+Do not solve the curse of knowledge by explaining everything. Identify the minimum background required for this reader outcome, then supply or link that background at the point of need.
 
-In practice:
-- The document's first sentence IS the conclusion
-- Supporting evidence follows
-- The reader never wonders "where is this going?"
+Use a fresh reader to reveal hidden assumptions. Ask them to mark every point where they guess, reread, search elsewhere, or wonder whether a step succeeded.
 
-## Anticipating Reader Questions
+When no representative reader is available, simulate their path:
 
-The best technical writing answers questions before they're asked. For every claim, ask:
+1. Start from the stated prerequisites, not your own environment.
+2. Follow each reference and command in order.
+3. Record every unstated choice.
+4. Check whether the visible result confirms progress.
+5. Rewrite assumptions as prerequisites, instructions, or verification cues.
 
-- **"So what?"** — Why does this matter to the reader? If you can't answer, cut it.
-- **"Why is that true?"** — What's the evidence? If you can't provide it, the claim is weak.
-- **"What could go wrong?"** — What happens if the reader makes the wrong choice? Warn them.
+## Shape Sentence Geometry
 
-## Quality Checklist for Clarity
+Judge sentences by how their parts fit, not by a universal word limit.
 
-- [ ] Every term defined on first use (with a single sentence, in context)
-- [ ] Zero passive voice where active voice would be clearer
-- [ ] Every sentence under 25 words (or split/listed)
-- [ ] No word can be removed without losing meaning
-- [ ] Every code block is copy-paste runnable
-- [ ] Every "why" question the reader might ask is answered (or linked)
-- [ ] First paragraph tells the reader exactly what they'll get
+Let a sentence carry one governing relationship that readers can hold in working memory. Add detail when it remains attached to a clear subject and verb. Split the sentence when qualifications compete, the subject disappears, or the reader must retain one clause while decoding another.
 
-## Information Mapping (Robert Horn)
+Overloaded:
 
-A framework for breaking content into structured, reusable blocks based on the type of information. Every block of content should be classified as one of these types, and each type should follow a consistent format:
+> Because the migration, which was designed before regional replicas were available and therefore assumes a single writer, can replay events while traffic remains live, operators who begin the cutover before replication catches up may create duplicate records that are not removed automatically.
 
-| Block Type | Purpose | Format Pattern |
-|-----------|---------|----------------|
-| **Concept** | Define or explain an idea | Definition → Examples → Non-examples → Related concepts |
-| **Procedure** | Steps to complete a task | Prerequisites → Ordered Steps (numbered) → Expected Result → Troubleshooting |
-| **Process** | How something works (system behavior) | Overview → Stages (sequential) → Feedback at each stage → Output |
-| **Principle** | Rules, guidelines, best practices | Rule statement → Rationale → When to apply → Exceptions |
-| **Fact** | Reference data, specifications | Data point → Context → Source → Caveats |
+Reshaped:
 
-Each block should be self-contained and labeled so readers can identify the type at a glance. This lets them skip procedure blocks when they want concepts, or skip concepts when they want to execute.
+> The migration assumes a single writer because it predates regional replicas. It can replay events while traffic remains live. If operators start the cutover before replication catches up, the replay may create duplicate records. Cleanup is not automatic.
 
-## The Three-Pass Editing Process
+Vary sentence length to match thought. Use a short sentence for a decision, warning, or transition. Use a longer sentence when its internal structure makes a relationship easier to understand than several disconnected statements would.
 
-From Google's Technical Writing course and Zinsser:
+Keep modifiers near what they modify. Put conditions before an instruction when readers must know the condition before acting. Put secondary qualifications after the main clause when they should not delay comprehension.
 
-### Pass 1: Structure
-- Does the document open with a TL;DR that answers "what is this about?"
-- Are sections in logical order?
-- Do headings accurately compress their content?
-- Can a reader self-select their depth?
+## Manage Given and New Information
 
-### Pass 2: Clarity
-- Replace every passive voice construction with active (where possible)
-- Split every sentence over 25 words
-- Convert every 3-item prose list to a bulleted or numbered list
-- Define every jargon term on first use
-- Bold every key term exactly once (on first mention)
+Begin a sentence with information readers already recognize, then move toward what is new or important.
 
-### Pass 3: Conciseness
-- Read each sentence. Delete every word. Re-add only what's essential.
-- Remove: "It should be noted that", "In order to", "The fact that", "Due to the fact that"
-- Replace: "utilize" → "use", "implement" → "build", "leverage" → "use", "facilitate" → "help"
-- Delete any sentence repeating what the code block already shows
-- Cut adjectives and adverbs that don't add precision (most don't)
+Disconnected:
 
-## The Curse of Knowledge
+> A regional lease protects each write. The recovery controller may revoke it. Split-brain writes are prevented by the lease token.
 
-The single biggest obstacle to clear technical writing: you know too much. Once you understand something deeply, you cannot imagine what it's like not to understand it. This causes three specific failures:
+Coherent:
 
-1. **Unexplained prerequisites**: You assume the reader knows X, but they don't.
-2. **Jargon without context**: You use terms fluently without defining them.
-3. **Skipped steps**: You leap from A to C because B is so obvious to you.
+> Each write carries a regional lease token. The recovery controller can revoke that token during failover. This revocation prevents split-brain writes.
 
-**Counter-measures**:
-- Write the prerequisites section BEFORE the content. Be ruthlessly explicit.
-- Have a non-expert read your draft. Every place they pause or ask "what's that?" — add explanation.
-- Run your TL;DR through the Up-Goer Five test: can you explain the core idea in only common words?
+Use familiar information as a handhold. Repeat a key noun when a pronoun could point to several things. Avoid unnecessary synonym changes that make one concept look like several concepts.
 
-## Handling Different Audience Levels
+Place emphasis near the end of a sentence or paragraph when possible. Readers naturally treat the ending as the destination of the thought.
 
-Most technical documents have a split audience: beginners who need everything explained, and experts who just need the reference. Structure accommodates both:
+## Build Coherence Across Paragraphs
 
-| Section | Serves | Content |
-|---------|--------|---------|
-| TL;DR + Quickstart | Both | Answer; simplest working example |
-| Overview / Concepts | Beginners | What it is, why it exists, core ideas |
-| How-To Guides | Intermediate | Task-based, realistic workflows |
-| API Reference | Experts | Complete, exhaustive parameter/type docs |
-| Architecture / Internals | Advanced | Design decisions, tradeoffs, implementation details |
+Give each paragraph a discernible job: make a claim, explain a mechanism, present evidence, qualify a rule, or derive a consequence.
 
-The key: a beginner reads top-to-bottom. An expert jumps to API Reference. Neither is forced to wade through content they don't need.
+Open with enough context to identify that job. Keep supporting sentences attached to it. Start a new paragraph when the discourse function changes, not when a numeric sentence target has been reached.
 
-## Error Messages as Documentation
+Maintain a visible line of reasoning:
 
-Error messages are the most-read documentation you'll ever write. A good error message:
+1. State the claim or question.
+2. Supply the reason, mechanism, or evidence.
+3. Address the condition that changes it.
+4. Connect the result to the reader's decision or action.
 
-1. **Says what happened** — in plain language, not error codes
-2. **Says why it happened** — what condition caused it
-3. **Says what to do** — the specific action that fixes it
+Use repeated key terms, parallel syntax, and explicit references to keep the subject stable. Do not rely on visual proximity alone to imply a logical relationship.
 
-**Bad**: `Error: EACCES: permission denied`
-**Good**: `Cannot write to /etc/config.json — you don't have permission. Run with sudo or change the file owner: chown $USER /etc/config.json`
+## Use Connectives to Expose Logic
 
-### Error Message Template
+Add connectives when the relationship between ideas is not already obvious.
 
-```
-[What happened]: [plain language description]
-[Symptoms]: [what the user sees]
-[Cause]: [why this happened]
-[Fix]: [specific action to resolve]
-[If that doesn't work]: [fallback / support link]
-```
+| Relationship | Useful signals |
+| --- | --- |
+| Cause | because, since, as a result |
+| Contrast | but, however, whereas |
+| Condition | if, unless, only when |
+| Evidence | for example, specifically, in the trace |
+| Consequence | therefore, so, which means |
+| Sequence | first, after, once, while |
+| Qualification | usually, except, in this case |
 
-## Formatting References and Further Reading
+Choose the connective that states the actual logic. Do not use "however" merely to vary prose or "therefore" when the conclusion does not follow.
 
-Every document should end with clear paths forward. Three levels:
+Remove connective clutter when order and syntax already make the relationship plain. Clarity comes from visible logic, not from filling every transition slot.
 
-1. **Next logical step**: If the reader completed this document, what should they do next?
-2. **Related topics**: Tangential documentation that provides context or alternatives.
-3. **External references**: Official docs, RFCs, seminal blog posts that informed the content.
+## Reduce Action Friction
 
-Format:
-```markdown
-## What's Next
+Writing for action requires more than explaining accurately. Make the desired behavior easy to identify, begin, complete, and verify.
 
-- **[Next Step: Add Role-Based Authorization](./authorization.md)** — now that authentication works, restrict what each user can do.
-- **[Alternative: OAuth 2.0](./oauth.md)** — if you need delegated auth instead of JWT.
-- **See also**: [JWT RFC 7519](https://tools.ietf.org/html/rfc7519), [jwt.io debugger](https://jwt.io)
-```
+Specify:
 
-## Voice and Tone
+- The action and responsible person
+- The object or location affected
+- The deadline or triggering condition
+- The required inputs
+- The expected result
+- The recovery path when the result differs
 
-Technical documentation is not academic writing. The best docs sound like a knowledgeable colleague explaining something to you directly. The voice is:
+High friction:
 
-- **Confident, not cold**: "Here's how it works" not "The system operates in the following manner"
-- **Direct, not distant**: Use "you" for the reader. "You'll need to install..." not "The user must install..."
-- **Honest about tradeoffs**: "This approach is simpler but slower" not "This approach may have performance implications"
-- **Respectful of the reader's intelligence**: Assume competence. Don't condescend. Don't over-explain the obvious.
+> Teams should consider updating ownership information where appropriate.
 
-## The 30-Second Test
+Lower friction:
 
-A reader should be able to determine, within 30 seconds of opening your document:
-1. What this page is about
-2. Whether it's relevant to them
-3. What they need to do
+> Service owners: update the `Owner` field in the catalog before Friday. The catalog displays a green check when the change is saved.
 
-If they cannot, the document has failed regardless of how good the deep content is.
+Put links at the action point. Name links by destination or task rather than "click here." Preserve context so readers know what will happen before selecting a link or running a command.
+
+Ask for the smallest meaningful next action. Separate required actions from optional improvements.
+
+## Write Instructions That Support Judgment
+
+Use imperative verbs for procedures: "Open," "Select," "Run," and "Verify."
+
+Explain why when the reason changes how readers execute the step, choose among paths, or recover from failure. Avoid narrating obvious interface mechanics.
+
+Pair consequential actions with boundaries:
+
+> Run the backfill once in each region. Do not rerun a completed region; the script does not deduplicate billing events.
+
+Show success cues after steps whose outcome may be ambiguous:
+
+> Wait until the revision reports `Ready: True`, then send traffic.
+
+Keep warnings before the hazardous action. State the consequence and the safer alternative.
+
+## Calibrate Voice and Tone
+
+Sound like a competent colleague who respects the reader's time.
+
+Use direct address when it clarifies responsibility. Use "we" only for a real shared actor, not as a vague institutional voice.
+
+Be confident about established facts and explicit about uncertainty:
+
+> The cache invalidates within 60 seconds under normal operation. We have not measured invalidation time during a regional failover.
+
+Avoid blame. Describe the state, cause, and remedy without labeling the reader careless or the task easy.
+
+Match urgency to consequence. Reserve forceful language for genuine risk so warnings remain credible.
+
+## Format for Cognitive Access
+
+Use formatting to reveal the prose's structure.
+
+- Use descriptive headings to expose questions, claims, and tasks.
+- Use lists for genuinely parallel items or steps.
+- Use tables when readers compare values across shared dimensions.
+- Use bold sparingly to surface a decisive phrase during scanning.
+- Use code style for literal names, values, commands, and symbols.
+- Keep related explanation beside the object it explains.
+
+Do not fragment a connected argument into bullets solely to make it look shorter. Do not bold complete paragraphs. Do not create visual variety that competes with the reading path.
+
+Treat line length, spacing, and paragraph shape as contextual design decisions. Test the actual rendering on the devices and surfaces readers use.
+
+## Edit in Behavioral Passes
+
+Separate editing goals so one pass does not hide another.
+
+### Outcome Pass
+
+Check whether the draft enables the intended knowledge, decision, or action. Remove interesting material that does not serve that outcome.
+
+### Point Pass
+
+Move the topic, recommendation, request, or consequence earlier. Confirm that qualifications remain visible and truthful.
+
+### Coherence Pass
+
+Trace the subjects and logic from sentence to sentence. Repair unexplained jumps, ambiguous pronouns, unstable terminology, and missing connectives.
+
+### Sentence Pass
+
+Find buried verbs, distant modifiers, overloaded clauses, empty abstractions, and false emphasis. Reshape the sentence rather than enforcing a word quota.
+
+### Friction Pass
+
+Follow every requested action. Add missing inputs, ownership, links, success cues, and recovery instructions.
+
+### Compression Pass
+
+Cut repetition, throat-clearing, redundant metadata, and detail readers can infer safely. Preserve necessary reasoning and conditions.
+
+Read the result aloud. Listen for breathless structures, accidental ambiguity, monotonous rhythm, and phrases that no colleague would naturally say.
+
+## Test With Readers
+
+Test comprehension and behavior, not preference alone.
+
+Give representative readers a realistic task without explaining the draft. Observe what they do.
+
+Ask them to:
+
+- State the document's point in their own words
+- Identify what applies to their situation
+- Predict what an instruction will do
+- Complete the target task
+- Explain how they know they succeeded
+- Find a specific fact later without rereading everything
+
+Record hesitations, wrong turns, repeated reading, external searches, and confidently wrong interpretations. These behaviors reveal more than a general rating.
+
+Avoid leading questions such as "Was the warning clear?" Ask "What risks do you see before running this command?"
+
+Revise the prose where several readers fail. Revise navigation or layout when they understand the words but cannot find them. Revise the product when the documentation accurately exposes unnecessary complexity.
+
+## Clarity Review Checklist
+
+- [ ] Name the intended reader and observable outcome.
+- [ ] Put the topic and central point where readers encounter them early.
+- [ ] Describe value with evidence and material conditions.
+- [ ] Use concrete actors, verbs, objects, and consequences.
+- [ ] Supply hidden prerequisites without explaining irrelevant basics.
+- [ ] Shape sentences around clear relationships rather than numeric limits.
+- [ ] Move from given information to new information.
+- [ ] Keep terminology stable and references unambiguous.
+- [ ] Use connectives where readers need the logic made explicit.
+- [ ] Make requested actions specific, located, and verifiable.
+- [ ] Use formatting to reveal meaning rather than decorate it.
+- [ ] Test whether representative readers understand and act.
+
+## Relationship to Document Structure
+
+Use this reference to decide what each sentence and paragraph must accomplish. Use `document-structure.md` after purpose and prose responsibilities are clear to arrange content for scanning, close reading, lookup, and task completion.

--- a/skills/crystal-clear-docs/tank.json
+++ b/skills/crystal-clear-docs/tank.json
@@ -1,7 +1,7 @@
 {
   "name": "@tank/crystal-clear-docs",
-  "version": "1.0.0",
-  "description": "Create crystal-clear technical documents (HTML + Markdown) with layered explanations (TL;DR to deep dive), progressive disclosure, SVG/Mermaid diagrams, scannable formatting, callout patterns, and word-level clarity. Synthesizes Minto, Tufte, Krug, Strunk & White, Zinsser, Google Tech Writing, Munroe, and Cognitive Load Theory.",
+  "version": "1.1.0",
+  "description": "Design technical documentation readers can find, understand, use, and transfer. Covers outcome-driven design, reader mental models, learning psychology, worked examples, multimedia explanation, behavioral writing, navigation, and validation.",
   "permissions": {
     "network": {
       "outbound": []


### PR DESCRIPTION
## Summary
- redesign crystal-clear-docs around observable reader outcomes and mental-model construction
- add dedicated outcome-driven design and reader psychology references
- replace rigid formatting quotas with evidence-informed explanation, multimedia, runbook, and validation guidance
- bump @tank/crystal-clear-docs to 1.1.0

## Validation
- `uv run --with pyyaml skills/skill-creator/scripts/quick_validate.py skills/crystal-clear-docs`
- `tank publish --dry-run`
- `git diff --check`
- behavioral evaluation for causal explanations, safety-critical runbooks, and asynchronous retry-boundary diagrams